### PR TITLE
feat(security): add security policy document for vulnerability reporting

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,9 @@
+# Security Policy
+
+If you believe you have found a security vulnerability, we encourage you to let us know right away.
+
+We will investigate all legitimate reports and do our best to quickly fix the problem.
+
+Our preference is that you make use of GitHub's private vulnerability reporting feature to disclose potential security vulnerabilities in our Open Source Software. 
+
+To do this, please visit the security tab of the repository and click the "Report a vulnerability" button.


### PR DESCRIPTION
Proposal for #34.

Alternatively we could go much more in depth like [Cal.com](https://github.com/calcom/cal.com/blob/main/SECURITY.md) or route the security reports to our email like at [TRPC](https://github.com/trpc/trpc/blob/main/SECURITY.md).

I think the proposed solution works totally fine for v1.0 and we can adjust iteratively. Since we don't save any vulnerable / user data at the moment we can keep it chill anyways.