### PR TITLE
chore(dependencies): update @stagewise/toolbar references to use workspace links

### DIFF
--- a/examples/next-example/package.json
+++ b/examples/next-example/package.json
@@ -14,7 +14,7 @@
     "react-dom": "^19.1.0"
   },
   "devDependencies": {
-    "@stagewise/toolbar": "latest",
+    "@stagewise/toolbar": "workspace:*",
     "@tailwindcss/postcss": "^4.1.4",
     "@types/node": "22.15.2",
     "@types/react": "^19.1.2",

--- a/examples/nuxt-example/package.json
+++ b/examples/nuxt-example/package.json
@@ -10,7 +10,7 @@
     "postinstall": "nuxt prepare"
   },
   "dependencies": {
-    "@stagewise/toolbar": "latest",
+    "@stagewise/toolbar": "workspace:*",
     "nuxt": "^3.17.1",
     "vue": "^3.5.13",
     "vue-router": "^4.5.1"

--- a/examples/svelte-kit-example/package.json
+++ b/examples/svelte-kit-example/package.json
@@ -12,7 +12,7 @@
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch"
   },
   "devDependencies": {
-    "@stagewise/toolbar": "0.1.0-alpha.1",
+    "@stagewise/toolbar": "workspace:*",
     "@sveltejs/adapter-auto": "^6.0.0",
     "@sveltejs/kit": "^2.16.0",
     "@sveltejs/vite-plugin-svelte": "^5.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -198,8 +198,8 @@ importers:
         version: 19.1.0(react@19.1.0)
     devDependencies:
       '@stagewise/toolbar':
-        specifier: latest
-        version: 0.1.0-alpha.2(@microsoft/api-extractor@7.52.5(@types/node@22.15.2))(@types/react@19.1.2)(jiti@2.4.2)(postcss@8.5.3)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(tsx@4.19.4)(typescript@5.8.3)(use-sync-external-store@1.5.0(react@19.1.0))(vite@6.3.3(@types/node@22.15.2)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1))(yaml@2.7.1)
+        specifier: workspace:*
+        version: link:../../packages/toolbar
       '@tailwindcss/postcss':
         specifier: ^4.1.4
         version: 4.1.4
@@ -222,8 +222,8 @@ importers:
   examples/nuxt-example:
     dependencies:
       '@stagewise/toolbar':
-        specifier: latest
-        version: 0.1.0-alpha.2(@microsoft/api-extractor@7.52.5(@types/node@22.15.2))(@types/react@19.1.2)(jiti@2.4.2)(postcss@8.5.3)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(tsx@4.19.4)(typescript@5.8.3)(use-sync-external-store@1.5.0(react@19.1.0))(vite@6.3.3(@types/node@22.15.2)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1))(yaml@2.7.1)
+        specifier: workspace:*
+        version: link:../../packages/toolbar
       nuxt:
         specifier: ^3.17.1
         version: 3.17.1(@biomejs/biome@1.9.4)(@parcel/watcher@2.5.1)(@types/node@22.15.2)(db0@0.3.2)(eslint@9.25.0(jiti@2.4.2))(ioredis@5.6.1)(lightningcss@1.29.2)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.40.0)(terser@5.39.0)(tsx@4.19.4)(typescript@5.8.3)(vite@6.3.3(@types/node@22.15.2)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1))(yaml@2.7.1)
@@ -237,8 +237,8 @@ importers:
   examples/svelte-kit-example:
     devDependencies:
       '@stagewise/toolbar':
-        specifier: 0.1.0-alpha.1
-        version: 0.1.0-alpha.1(@microsoft/api-extractor@7.52.5(@types/node@22.15.2))(@types/react@19.1.2)(jiti@2.4.2)(postcss@8.5.3)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(tsx@4.19.4)(typescript@5.8.3)(use-sync-external-store@1.5.0(react@19.1.0))(vite@6.3.3(@types/node@22.15.2)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1))(yaml@2.7.1)
+        specifier: workspace:*
+        version: link:../../packages/toolbar
       '@sveltejs/adapter-auto':
         specifier: ^6.0.0
         version: 6.0.0(@sveltejs/kit@2.20.8(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.28.2)(vite@6.3.3(@types/node@22.15.2)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1)))(svelte@5.28.2)(vite@6.3.3(@types/node@22.15.2)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1)))
@@ -288,8 +288,6 @@ importers:
       vitest:
         specifier: 3.1.2
         version: 3.1.2(@types/debug@4.1.12)(@types/node@22.15.2)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1)
-
-  packages/extension-websocket-contract: {}
 
   packages/srpc:
     dependencies:
@@ -568,8 +566,6 @@ importers:
       typescript:
         specifier: ^5.8.3
         version: 5.8.3
-
-  packages/websocket-client-sdk: {}
 
   playgrounds/next-playground:
     dependencies:
@@ -3019,12 +3015,6 @@ packages:
 
   '@speed-highlight/core@1.2.7':
     resolution: {integrity: sha512-0dxmVj4gxg3Jg879kvFS/msl4s9F3T9UXC1InxgOf7t5NvcPD97u/WTA5vL/IxWHMn7qSxBozqrnnE2wvl1m8g==}
-
-  '@stagewise/toolbar@0.1.0-alpha.1':
-    resolution: {integrity: sha512-Y2Wekuw83HIuVHDkxsxB3G8VilaedlEQjkUVxLo4XNQpdhXr+1p1YjrzPYbrB1BzzQksRU3Mpz0GLlx7s1yvMQ==}
-
-  '@stagewise/toolbar@0.1.0-alpha.2':
-    resolution: {integrity: sha512-fr5XqJp2HVq9mqRxfwp+ccgkmnR/+Isa25+x4TUbbYxTtiuUnrD/145Q3RByKSfhMgssn8k04ajbgNyHP2o58g==}
 
   '@standard-schema/spec@1.0.0':
     resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
@@ -11711,76 +11701,6 @@ snapshots:
   '@sindresorhus/merge-streams@2.3.0': {}
 
   '@speed-highlight/core@1.2.7': {}
-
-  '@stagewise/toolbar@0.1.0-alpha.1(@microsoft/api-extractor@7.52.5(@types/node@22.15.2))(@types/react@19.1.2)(jiti@2.4.2)(postcss@8.5.3)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(tsx@4.19.4)(typescript@5.8.3)(use-sync-external-store@1.5.0(react@19.1.0))(vite@6.3.3(@types/node@22.15.2)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1))(yaml@2.7.1)':
-    dependencies:
-      '@headlessui/react': 2.2.2(patch_hash=058c956527a7ce89f57a9b19b87837155dd2b3c21e1293af7d9e8cd9b790d072)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@preact/compat': 18.3.1(preact@10.26.5)
-      clsx: 2.1.1
-      javascript-time-ago: 2.5.11
-      lucide-react: 0.503.0(react@19.1.0)
-      postcss-prefix-selector: 2.1.1(postcss@8.5.3)
-      preact: 10.26.5
-      react-remove-scroll: 2.6.3(@types/react@19.1.2)(react@19.1.0)
-      superjson: 2.2.2
-      tailwind-merge: 3.2.0
-      tailwindcss: 4.1.4
-      tsup: 8.4.0(@microsoft/api-extractor@7.52.5(@types/node@22.15.2))(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.7.1)
-      ua-parser-js: 2.0.3
-      vite-plugin-css-injected-by-js: 3.5.2(vite@6.3.3(@types/node@22.15.2)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1))
-      zod: 3.24.3
-      zustand: 5.0.3(@types/react@19.1.2)(react@19.1.0)(use-sync-external-store@1.5.0(react@19.1.0))
-    transitivePeerDependencies:
-      - '@microsoft/api-extractor'
-      - '@swc/core'
-      - '@types/react'
-      - encoding
-      - immer
-      - jiti
-      - postcss
-      - react
-      - react-dom
-      - supports-color
-      - tsx
-      - typescript
-      - use-sync-external-store
-      - vite
-      - yaml
-
-  '@stagewise/toolbar@0.1.0-alpha.2(@microsoft/api-extractor@7.52.5(@types/node@22.15.2))(@types/react@19.1.2)(jiti@2.4.2)(postcss@8.5.3)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(tsx@4.19.4)(typescript@5.8.3)(use-sync-external-store@1.5.0(react@19.1.0))(vite@6.3.3(@types/node@22.15.2)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1))(yaml@2.7.1)':
-    dependencies:
-      '@headlessui/react': 2.2.2(patch_hash=058c956527a7ce89f57a9b19b87837155dd2b3c21e1293af7d9e8cd9b790d072)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@preact/compat': 18.3.1(preact@10.26.5)
-      clsx: 2.1.1
-      javascript-time-ago: 2.5.11
-      lucide-react: 0.503.0(react@19.1.0)
-      postcss-prefix-selector: 2.1.1(postcss@8.5.3)
-      preact: 10.26.5
-      react-remove-scroll: 2.6.3(@types/react@19.1.2)(react@19.1.0)
-      superjson: 2.2.2
-      tailwind-merge: 3.2.0
-      tailwindcss: 4.1.4
-      tsup: 8.4.0(@microsoft/api-extractor@7.52.5(@types/node@22.15.2))(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.7.1)
-      ua-parser-js: 2.0.3
-      vite-plugin-css-injected-by-js: 3.5.2(vite@6.3.3(@types/node@22.15.2)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1))
-      zod: 3.24.3
-      zustand: 5.0.3(@types/react@19.1.2)(react@19.1.0)(use-sync-external-store@1.5.0(react@19.1.0))
-    transitivePeerDependencies:
-      - '@microsoft/api-extractor'
-      - '@swc/core'
-      - '@types/react'
-      - encoding
-      - immer
-      - jiti
-      - postcss
-      - react
-      - react-dom
-      - supports-color
-      - tsx
-      - typescript
-      - use-sync-external-store
-      - vite
-      - yaml
 
   '@standard-schema/spec@1.0.0': {}
 


### PR DESCRIPTION
- Changed the version specification of @stagewise/toolbar in examples and pnpm-lock.yaml from specific versions to workspace links for better local development and consistency across projects.