### PR TITLE
chore(toolbar-next): update pnpm-lock and configuration files

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 patchedDependencies:
   '@headlessui/react@2.2.2':
-    hash: 058c956527a7ce89f57a9b19b87837155dd2b3c21e1293af7d9e8cd9b790d072
+    hash: p2t5fm6sudlfgt4egmyp3nenvu
     path: patches/@headlessui__react.patch
 
 importers:
@@ -118,7 +118,7 @@ importers:
     dependencies:
       '@headlessui/react':
         specifier: 2.2.2
-        version: 2.2.2(patch_hash=058c956527a7ce89f57a9b19b87837155dd2b3c21e1293af7d9e8cd9b790d072)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 2.2.2(patch_hash=p2t5fm6sudlfgt4egmyp3nenvu)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@radix-ui/react-accordion':
         specifier: ^1.2.10
         version: 1.2.10(@types/react-dom@19.1.3(@types/react@19.1.3))(@types/react@19.1.3)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -731,7 +731,7 @@ importers:
     dependencies:
       '@headlessui/react':
         specifier: 2.2.2
-        version: 2.2.2(patch_hash=058c956527a7ce89f57a9b19b87837155dd2b3c21e1293af7d9e8cd9b790d072)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 2.2.2(patch_hash=p2t5fm6sudlfgt4egmyp3nenvu)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@preact/compat':
         specifier: 18.3.1
         version: 18.3.1(preact@10.26.6)
@@ -817,6 +817,9 @@ importers:
       '@stagewise/toolbar':
         specifier: latest
         version: 0.1.0-alpha.3(@microsoft/api-extractor@7.52.7(@types/node@22.15.17))(@swc/core@1.11.24(@swc/helpers@0.5.17))(@types/react@19.1.3)(jiti@2.4.2)(postcss@8.5.3)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(tsx@4.19.4)(typescript@5.8.3)(use-sync-external-store@1.5.0(react@19.1.0))(vite@6.3.5(@types/node@22.15.17)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1))(yaml@2.7.1)
+      '@stagewise/toolbar-react':
+        specifier: latest
+        version: 0.1.0-alpha.0(@microsoft/api-extractor@7.52.7(@types/node@22.15.17))(@swc/core@1.11.24(@swc/helpers@0.5.17))(@types/react@19.1.3)(jiti@2.4.2)(postcss@8.5.3)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(tsx@4.19.4)(typescript@5.8.3)(use-sync-external-store@1.5.0(react@19.1.0))(vite@6.3.5(@types/node@22.15.17)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1))(yaml@2.7.1)
       next:
         specifier: '>=14.0.0'
         version: 15.3.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -827,9 +830,6 @@ importers:
       '@eslint/js':
         specifier: ^9.26.0
         version: 9.26.0
-      '@stagewise/toolbar-react':
-        specifier: workspace:*
-        version: link:../react
       '@types/react':
         specifier: ^19.1.3
         version: 19.1.3
@@ -2970,8 +2970,17 @@ packages:
   '@speed-highlight/core@1.2.7':
     resolution: {integrity: sha512-0dxmVj4gxg3Jg879kvFS/msl4s9F3T9UXC1InxgOf7t5NvcPD97u/WTA5vL/IxWHMn7qSxBozqrnnE2wvl1m8g==}
 
+  '@stagewise/toolbar-react@0.1.0-alpha.0':
+    resolution: {integrity: sha512-ZJoe80F4KYj5gG6qt2N/q1zfCVifMBcS0GNDBEfquMEGJUsVkBD0PJNY1lo7yfb7Gd4skrTvUwMKrSq9XbaCzw==}
+    peerDependencies:
+      '@types/react': '>=18.0.0'
+      react: '>=18.0.0'
+
   '@stagewise/toolbar@0.1.0-alpha.3':
     resolution: {integrity: sha512-EnqxiAHeWMwqe+XJvqbpEg9KIuYMh6DZ5J8mR72Espc5Cu8wLFcZPrtf3+eltSSG7g9avcpGWyk7TU7BrATkww==}
+
+  '@stagewise/toolbar@0.1.0-alpha.4':
+    resolution: {integrity: sha512-+HhDsPsZ1/7DbBFdkiKFsh+fBfLRD1V7gpawhRTEpXKYyfAYP9fM3buvLmyJb1X9BWRIIyanLNfb/d01EMh97Q==}
 
   '@standard-schema/spec@1.0.0':
     resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
@@ -9677,7 +9686,7 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@headlessui/react@2.2.2(patch_hash=058c956527a7ce89f57a9b19b87837155dd2b3c21e1293af7d9e8cd9b790d072)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+  '@headlessui/react@2.2.2(patch_hash=p2t5fm6sudlfgt4egmyp3nenvu)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@floating-ui/react': 0.26.28(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@react-aria/focus': 3.20.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -11438,9 +11447,64 @@ snapshots:
 
   '@speed-highlight/core@1.2.7': {}
 
+  '@stagewise/toolbar-react@0.1.0-alpha.0(@microsoft/api-extractor@7.52.7(@types/node@22.15.17))(@swc/core@1.11.24(@swc/helpers@0.5.17))(@types/react@19.1.3)(jiti@2.4.2)(postcss@8.5.3)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(tsx@4.19.4)(typescript@5.8.3)(use-sync-external-store@1.5.0(react@19.1.0))(vite@6.3.5(@types/node@22.15.17)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1))(yaml@2.7.1)':
+    dependencies:
+      '@stagewise/toolbar': 0.1.0-alpha.4(@microsoft/api-extractor@7.52.7(@types/node@22.15.17))(@swc/core@1.11.24(@swc/helpers@0.5.17))(@types/react@19.1.3)(jiti@2.4.2)(postcss@8.5.3)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(tsx@4.19.4)(typescript@5.8.3)(use-sync-external-store@1.5.0(react@19.1.0))(vite@6.3.5(@types/node@22.15.17)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1))(yaml@2.7.1)
+      '@types/react': 19.1.3
+      react: 19.1.0
+    transitivePeerDependencies:
+      - '@microsoft/api-extractor'
+      - '@swc/core'
+      - encoding
+      - immer
+      - jiti
+      - postcss
+      - react-dom
+      - supports-color
+      - tsx
+      - typescript
+      - use-sync-external-store
+      - vite
+      - yaml
+
   '@stagewise/toolbar@0.1.0-alpha.3(@microsoft/api-extractor@7.52.7(@types/node@22.15.17))(@swc/core@1.11.24(@swc/helpers@0.5.17))(@types/react@19.1.3)(jiti@2.4.2)(postcss@8.5.3)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(tsx@4.19.4)(typescript@5.8.3)(use-sync-external-store@1.5.0(react@19.1.0))(vite@6.3.5(@types/node@22.15.17)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1))(yaml@2.7.1)':
     dependencies:
-      '@headlessui/react': 2.2.2(patch_hash=058c956527a7ce89f57a9b19b87837155dd2b3c21e1293af7d9e8cd9b790d072)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@headlessui/react': 2.2.2(patch_hash=p2t5fm6sudlfgt4egmyp3nenvu)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@preact/compat': 18.3.1(preact@10.26.6)
+      clsx: 2.1.1
+      javascript-time-ago: 2.5.11
+      lucide-react: 0.503.0(react@19.1.0)
+      postcss-prefix-selector: 2.1.1(postcss@8.5.3)
+      preact: 10.26.6
+      react-remove-scroll: 2.6.3(@types/react@19.1.3)(react@19.1.0)
+      superjson: 2.2.2
+      tailwind-merge: 3.2.0
+      tailwindcss: 4.1.5
+      tsup: 8.4.0(@microsoft/api-extractor@7.52.7(@types/node@22.15.17))(@swc/core@1.11.24(@swc/helpers@0.5.17))(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.7.1)
+      ua-parser-js: 2.0.3
+      vite-plugin-css-injected-by-js: 3.5.2(vite@6.3.5(@types/node@22.15.17)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1))
+      zod: 3.24.4
+      zustand: 5.0.4(@types/react@19.1.3)(react@19.1.0)(use-sync-external-store@1.5.0(react@19.1.0))
+    transitivePeerDependencies:
+      - '@microsoft/api-extractor'
+      - '@swc/core'
+      - '@types/react'
+      - encoding
+      - immer
+      - jiti
+      - postcss
+      - react
+      - react-dom
+      - supports-color
+      - tsx
+      - typescript
+      - use-sync-external-store
+      - vite
+      - yaml
+
+  '@stagewise/toolbar@0.1.0-alpha.4(@microsoft/api-extractor@7.52.7(@types/node@22.15.17))(@swc/core@1.11.24(@swc/helpers@0.5.17))(@types/react@19.1.3)(jiti@2.4.2)(postcss@8.5.3)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(tsx@4.19.4)(typescript@5.8.3)(use-sync-external-store@1.5.0(react@19.1.0))(vite@6.3.5(@types/node@22.15.17)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1))(yaml@2.7.1)':
+    dependencies:
+      '@headlessui/react': 2.2.2(patch_hash=p2t5fm6sudlfgt4egmyp3nenvu)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@preact/compat': 18.3.1(preact@10.26.6)
       clsx: 2.1.1
       javascript-time-ago: 2.5.11

--- a/toolbar/next/src/client.tsx
+++ b/toolbar/next/src/client.tsx
@@ -1,12 +1,15 @@
 'use client';
 
 import dynamic from 'next/dynamic';
+import type { ComponentType } from 'react';
+import type { ToolbarConfig } from './types';
 
 // Using dynamic import in a client component context
-export const StagewiseToolbar = dynamic(
-  () =>
-    import('@stagewise/toolbar-react').then((mod: any) => ({
-      default: mod.StagewiseToolbar,
-    })),
-  { ssr: false },
-);
+export const StagewiseToolbar: ComponentType<{ config: ToolbarConfig }> =
+  dynamic(
+    () =>
+      import('@stagewise/toolbar-react').then((mod: any) => ({
+        default: mod.StagewiseToolbar,
+      })),
+    { ssr: false },
+  );

--- a/toolbar/next/src/types.ts
+++ b/toolbar/next/src/types.ts
@@ -1,3 +1,1 @@
-// Import and re-export the type directly
-import type { ToolbarConfig as OriginalToolbarConfig } from '@stagewise/toolbar';
-export type ToolbarConfig = OriginalToolbarConfig;
+export type { ToolbarConfig } from '@stagewise/toolbar';

--- a/toolbar/next/turbo.json
+++ b/toolbar/next/turbo.json
@@ -4,6 +4,10 @@
     "dev": {
       "persistent": false,
       "dependsOn": ["^dev"]
+    },
+    "build": {
+      "dependsOn": ["^build"],
+      "outputs": ["dist/**"]
     }
   }
 }

--- a/toolbar/next/vite.config.ts
+++ b/toolbar/next/vite.config.ts
@@ -30,8 +30,6 @@ export default defineConfig({
     react(),
     dts({
       rollupTypes: true,
-      include: ['src/**/*.ts', 'src/**/*.tsx'],
-      logLevel: 'info',
     }),
     preserveDirectives(),
   ],


### PR DESCRIPTION
- Updated the pnpm-lock.yaml to reflect changes in the @headlessui/react dependency hash and added @stagewise/toolbar-react as a new dependency.
- Modified turbo.json to include build outputs for better build management.
- Cleaned up vite.config.ts by removing unnecessary options from the dts plugin.
- Enhanced client.tsx to specify the component type for StagewiseToolbar, improving type safety.
- Simplified types.ts by directly exporting ToolbarConfig from @stagewise/toolbar.