### PR TITLE
chore(examples): remove version fields from package.json in example projects

### DIFF
--- a/examples/react-example/package.json
+++ b/examples/react-example/package.json
@@ -1,7 +1,6 @@
 {
   "name": "react-example",
   "private": true,
-  "version": "0.0.0",
   "type": "module",
   "scripts": {
     "clean": "rm -rf .turbo dist node_modules",

--- a/examples/svelte-kit-example/package.json
+++ b/examples/svelte-kit-example/package.json
@@ -1,7 +1,6 @@
 {
   "name": "svelte-kit-example",
   "private": true,
-  "version": "0.0.1",
   "type": "module",
   "scripts": {
     "clean": "rm -rf .turbo .svelte-kit node_modules",

--- a/examples/vue-example/package.json
+++ b/examples/vue-example/package.json
@@ -1,7 +1,6 @@
 {
   "name": "vue-example",
   "private": true,
-  "version": "0.0.0",
   "type": "module",
   "scripts": {
     "dev": "vite --port 3004",


### PR DESCRIPTION
- Eliminated the "version" field from package.json in the react, svelte-kit, and vue example projects for consistency and to avoid confusion in private packages.