### PR TITLE
Add agent selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ You would then use `StagewiseToolbarLoader` in your `src/routes/+layout.svelte`.
 | -------------- | -------------- |
 | Cursor         | ✅              |
 | Windsurf       | ✅              |
-| GitHub Copilot | 🚧 In Progress |
+| GitHub Copilot | ✅              |
 | Cline          | ❌              |
 | BLACKBOXAI     | ❌              |
 | Console Ninja  | ❌              |

--- a/apps/vscode-extension/README.md
+++ b/apps/vscode-extension/README.md
@@ -293,7 +293,7 @@ You would then use `StagewiseToolbarLoader` in your `src/routes/+layout.svelte`.
 | -------------- | -------------- |
 | Cursor         | ✅              |
 | Windsurf       | ✅              |
-| GitHub Copilot | 🚧 In Progress |
+| GitHub Copilot | ✅              |
 | Cline          | ❌              |
 | BLACKBOXAI     | ❌              |
 | Console Ninja  | ❌              |

--- a/apps/vscode-extension/src/constants.ts
+++ b/apps/vscode-extension/src/constants.ts
@@ -1,6 +1,12 @@
 export const DIAGNOSTIC_COLLECTION_NAME = 'stagewise';
 export const MCP_SERVER_NAME = 'stagewise';
 export const MCP_SERVER_VERSION = '1.0.0';
+export const AGENTS = {
+  CURSOR: 'CURSOR',
+  WINDSURF: 'WINDSURF',
+  GITHUB_COPILOT: 'GITHUB_COPILOT',
+  UNKNOWN: 'UNKNOWN',
+} as const;
 
 // Analytics constants
 export const ANALYTICS_OPT_OUT_NOTIFICATION_SHOWN =

--- a/apps/vscode-extension/src/mcp/server.ts
+++ b/apps/vscode-extension/src/mcp/server.ts
@@ -1,5 +1,4 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp';
-import { registerConsoleLogsTool } from './tools';
 import { MCP_SERVER_NAME, MCP_SERVER_VERSION } from '../constants';
 
 export function createMcpServer() {
@@ -16,7 +15,8 @@ export function createMcpServer() {
     },
   });
 
-  registerConsoleLogsTool(mcpServer);
+  // TODO: Add tools here
+  // registerConsoleLogsTool(mcpServer);
 
   return mcpServer;
 }

--- a/apps/vscode-extension/src/utils/call-copilot-agent.ts
+++ b/apps/vscode-extension/src/utils/call-copilot-agent.ts
@@ -1,0 +1,8 @@
+import * as vscode from 'vscode';
+
+export async function callCopilotAgent(prompt: string): Promise<void> {
+  return await vscode.commands.executeCommand('workbench.action.chat.open', {
+    query: prompt,
+    previousRequests: [],
+  });
+}

--- a/apps/vscode-extension/src/utils/call-copilot-agent.ts
+++ b/apps/vscode-extension/src/utils/call-copilot-agent.ts
@@ -1,8 +1,14 @@
+import type { PromptRequest } from '@stagewise/extension-toolbar-srpc-contract';
 import * as vscode from 'vscode';
 
-export async function callCopilotAgent(prompt: string): Promise<void> {
-  return await vscode.commands.executeCommand('workbench.action.chat.open', {
-    query: prompt,
-    previousRequests: [],
+export async function callCopilotAgent(request: PromptRequest): Promise<void> {
+  const prompt =
+    `${request.prompt}` +
+    `${request.files ? `\n\n use the following files: ${request.files.join('\n')}` : ''}` +
+    `${request.images ? `\n\n use the following images: ${request.images.join('\n')}` : ''}`;
+
+  await vscode.commands.executeCommand('workbench.action.chat.openAgent');
+  await vscode.commands.executeCommand('workbench.action.chat.sendToNewChat', {
+    inputValue: prompt,
   });
 }

--- a/apps/vscode-extension/src/utils/dispatch-agent-call.ts
+++ b/apps/vscode-extension/src/utils/dispatch-agent-call.ts
@@ -1,5 +1,7 @@
 import { getCurrentIDE } from './get-current-ide';
 import { callCursorAgent } from './call-cursor-agent';
+import { isCopilotChatInstalled } from './is-copilot-chat-installed';
+import { callCopilotAgent } from './call-copilot-agent';
 import { callWindsurfAgent } from './call-windsurf-agent';
 import * as vscode from 'vscode';
 import type { PromptRequest } from '@stagewise/extension-toolbar-srpc-contract';
@@ -12,10 +14,13 @@ export async function dispatchAgentCall(request: PromptRequest) {
     case 'WINDSURF':
       return await callWindsurfAgent(request);
     case 'VSCODE':
-      vscode.window.showErrorMessage(
-        'Currently, only Cursor and Windsurf are supported with stagewise.',
-      );
-      break;
+      if (isCopilotChatInstalled()) return await callCopilotAgent(prompt);
+      else {
+        vscode.window.showErrorMessage(
+          'Currently, only Copilot Chat is supported for VSCode. Please install it from the marketplace to use stagewise with VSCode.',
+        );
+        break;
+      }
     case 'UNKNOWN':
       vscode.window.showErrorMessage(
         'Failed to call agent: IDE is not supported',

--- a/apps/vscode-extension/src/utils/dispatch-agent-call.ts
+++ b/apps/vscode-extension/src/utils/dispatch-agent-call.ts
@@ -14,7 +14,7 @@ export async function dispatchAgentCall(request: PromptRequest) {
     case 'WINDSURF':
       return await callWindsurfAgent(request);
     case 'VSCODE':
-      if (isCopilotChatInstalled()) return await callCopilotAgent(prompt);
+      if (isCopilotChatInstalled()) return await callCopilotAgent(request);
       else {
         vscode.window.showErrorMessage(
           'Currently, only Copilot Chat is supported for VSCode. Please install it from the marketplace to use stagewise with VSCode.',

--- a/apps/vscode-extension/src/utils/dispatch-agent-call.ts
+++ b/apps/vscode-extension/src/utils/dispatch-agent-call.ts
@@ -7,6 +7,30 @@ import * as vscode from 'vscode';
 import type { PromptRequest } from '@stagewise/extension-toolbar-srpc-contract';
 
 export async function dispatchAgentCall(request: PromptRequest) {
+  // If a specific agent is requested, try to use it
+  if (request.agent) {
+    switch (request.agent) {
+      case 'Cursor Agent':
+        return await callCursorAgent(request);
+      case 'Windsurf Agent':
+        return await callWindsurfAgent(request);
+      case 'GitHub Copilot':
+        if (isCopilotChatInstalled()) {
+          return await callCopilotAgent(request);
+        } else {
+          vscode.window.showErrorMessage(
+            'GitHub Copilot Chat is not installed. Please install it from the marketplace.',
+          );
+          return;
+        }
+      default:
+        vscode.window.showWarningMessage(
+          `Unknown agent "${request.agent}". Falling back to IDE-based detection.`,
+        );
+    }
+  }
+
+  // Fallback to IDE-based detection if no agent specified or unknown agent
   const ide = getCurrentIDE();
   switch (ide) {
     case 'CURSOR':

--- a/apps/vscode-extension/src/utils/get-agents.ts
+++ b/apps/vscode-extension/src/utils/get-agents.ts
@@ -1,0 +1,21 @@
+// There are two kinds of agents
+// 1. IDE agents - these are agents that are built into the IDE and can be used directly.
+// 2. Extension agents
+
+import { AGENTS } from 'src/constants';
+import * as vscode from 'vscode';
+
+const agents: string[] = [];
+
+export function getAgents() {
+  const appName = vscode.env.appName.toLowerCase();
+  if (appName.includes('cursor')) {
+    agents.push(AGENTS.CURSOR);
+  } else if (appName.includes('windsurf')) {
+    agents.push(AGENTS.WINDSURF);
+  }
+
+  if (vscode.extensions.getExtension('gitHub.copilot-chat')) {
+    agents.push(AGENTS.GITHUB_COPILOT);
+  }
+}

--- a/apps/vscode-extension/src/utils/get-available-agents.ts
+++ b/apps/vscode-extension/src/utils/get-available-agents.ts
@@ -5,9 +5,9 @@
 import { AGENTS } from 'src/constants';
 import * as vscode from 'vscode';
 
-const agents: string[] = [];
+const agents: (keyof typeof AGENTS)[] = [];
 
-export function getAgents() {
+export function getAvailableAgents(): (keyof typeof AGENTS)[] {
   const appName = vscode.env.appName.toLowerCase();
   if (appName.includes('cursor')) {
     agents.push(AGENTS.CURSOR);
@@ -18,4 +18,5 @@ export function getAgents() {
   if (vscode.extensions.getExtension('gitHub.copilot-chat')) {
     agents.push(AGENTS.GITHUB_COPILOT);
   }
+  return agents;
 }

--- a/apps/vscode-extension/src/utils/get-available-agents.ts
+++ b/apps/vscode-extension/src/utils/get-available-agents.ts
@@ -8,15 +8,19 @@ import * as vscode from 'vscode';
 const agents: (keyof typeof AGENTS)[] = [];
 
 export function getAvailableAgents(): (keyof typeof AGENTS)[] {
+  agents.pop(); // Clear previous agents
   const appName = vscode.env.appName.toLowerCase();
   if (appName.includes('cursor')) {
     agents.push(AGENTS.CURSOR);
+    console.log('[Stagewise] Detected Cursor IDE');
   } else if (appName.includes('windsurf')) {
     agents.push(AGENTS.WINDSURF);
+    console.log('[Stagewise] Detected WindSurf IDE');
   }
 
   if (vscode.extensions.getExtension('gitHub.copilot-chat')) {
     agents.push(AGENTS.GITHUB_COPILOT);
+    console.log('[Stagewise] Detected GitHub Copilot');
   }
   return agents;
 }

--- a/apps/vscode-extension/src/utils/get-available-agents.ts
+++ b/apps/vscode-extension/src/utils/get-available-agents.ts
@@ -5,22 +5,29 @@
 import { AGENTS } from 'src/constants';
 import * as vscode from 'vscode';
 
-const agents: (keyof typeof AGENTS)[] = [];
+// Agent display names mapping
+const AGENT_DISPLAY_NAMES = {
+  [AGENTS.CURSOR]: 'Cursor Agent',
+  [AGENTS.WINDSURF]: 'Windsurf Agent',
+  [AGENTS.GITHUB_COPILOT]: 'GitHub Copilot',
+} as const;
 
-export function getAvailableAgents(): (keyof typeof AGENTS)[] {
-  agents.pop(); // Clear previous agents
+export function getAvailableAgents(): string[] {
+  const agents: string[] = [];
+
   const appName = vscode.env.appName.toLowerCase();
   if (appName.includes('cursor')) {
-    agents.push(AGENTS.CURSOR);
+    agents.push(AGENT_DISPLAY_NAMES[AGENTS.CURSOR]);
     console.log('[Stagewise] Detected Cursor IDE');
   } else if (appName.includes('windsurf')) {
-    agents.push(AGENTS.WINDSURF);
+    agents.push(AGENT_DISPLAY_NAMES[AGENTS.WINDSURF]);
     console.log('[Stagewise] Detected WindSurf IDE');
   }
 
   if (vscode.extensions.getExtension('gitHub.copilot-chat')) {
-    agents.push(AGENTS.GITHUB_COPILOT);
+    agents.push(AGENT_DISPLAY_NAMES[AGENTS.GITHUB_COPILOT]);
     console.log('[Stagewise] Detected GitHub Copilot');
   }
+
   return agents;
 }

--- a/apps/vscode-extension/src/utils/inject-prompt-diagnostic-with-callback.ts
+++ b/apps/vscode-extension/src/utils/inject-prompt-diagnostic-with-callback.ts
@@ -1,6 +1,17 @@
 import * as vscode from 'vscode';
 import { DIAGNOSTIC_COLLECTION_NAME } from '../constants';
 
+/**
+ * Injects a diagnostic with a prompt into the active editor and executes a callback.
+ * If no editor is active, it attempts to open the first file in the workspace.
+ * The diagnostic is displayed as an error, and the cursor is moved to the diagnostic's range.
+ * After the callback is executed, the diagnostic is cleared.
+ *
+ * @param params - The parameters for the function.
+ * @param params.prompt - The prompt message to display in the diagnostic.
+ * @param params.callback - The callback function to execute after injecting the diagnostic.
+ * @returns A promise that resolves when the operation is complete.
+ */
 export async function injectPromptDiagnosticWithCallback(params: {
   prompt: string;
   callback: () => Promise<any>;

--- a/apps/vscode-extension/src/utils/is-copilot-chat-installed.ts
+++ b/apps/vscode-extension/src/utils/is-copilot-chat-installed.ts
@@ -1,0 +1,11 @@
+import * as vscode from 'vscode';
+
+/**
+ * Checks if the GitHub Copilot Chat extension is installed.
+ * @returns True if the extension is installed, false otherwise.
+ */
+export function isCopilotChatInstalled(): boolean {
+  const extensionId = 'gitHub.copilot-chat';
+  const extension = vscode.extensions.getExtension(extensionId);
+  return !!extension;
+}

--- a/apps/vscode-extension/src/utils/window-discovery.ts
+++ b/apps/vscode-extension/src/utils/window-discovery.ts
@@ -6,6 +6,10 @@ import { getAvailableAgents } from './get-available-agents';
  * This is used by the getSessionInfo RPC method
  */
 export function getCurrentWindowInfo(port: number): VSCodeContext {
+  const availableAgents = getAvailableAgents();
+  console.log(
+    `[Stagewise] getCurrentWindowInfo: sessionId=${vscode.env.sessionId}, appName=${vscode.env.appName}, availableAgents=${availableAgents.join(', ')}`,
+  );
   return {
     sessionId: vscode.env.sessionId,
     appName: vscode.env.appName,

--- a/apps/vscode-extension/src/utils/window-discovery.ts
+++ b/apps/vscode-extension/src/utils/window-discovery.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import type { VSCodeContext } from '@stagewise/extension-toolbar-srpc-contract';
+import { getAvailableAgents } from './get-available-agents';
 /**
  * Get detailed information about the current VS Code window
  * This is used by the getSessionInfo RPC method
@@ -9,6 +10,7 @@ export function getCurrentWindowInfo(port: number): VSCodeContext {
     sessionId: vscode.env.sessionId,
     appName: vscode.env.appName,
     displayName: `${vscode.workspace.name} (${vscode.env.appName})`,
+    availableAgents: getAvailableAgents(), // Placeholder, can be extended to include other agents
     port,
   };
 }

--- a/packages/extension-toolbar-srpc-contract/src/contract.ts
+++ b/packages/extension-toolbar-srpc-contract/src/contract.ts
@@ -54,6 +54,7 @@ export const contract = createBridgeContract({
           .array(z.string())
           .optional()
           .describe('Upload files like images, videos, etc.'),
+        agent: z.string().optional(),
       }),
       response: z.object({
         sessionId: z.string().optional(),

--- a/packages/extension-toolbar-srpc-contract/src/contract.ts
+++ b/packages/extension-toolbar-srpc-contract/src/contract.ts
@@ -22,6 +22,15 @@ export const contract = createBridgeContract({
         port: z
           .number()
           .describe('Port number this VS Code instance is running on'),
+        availableAgents: z
+          .array(
+            z
+              .string()
+              .describe(
+                'The name of the agent, e.g. "Cursor Agent" or "GitHub Copilot"',
+              ),
+          )
+          .describe('List of available agents in this VS Code instance'),
       }),
       update: z.object({}),
     },

--- a/toolbar/core/README.md
+++ b/toolbar/core/README.md
@@ -293,7 +293,7 @@ You would then use `StagewiseToolbarLoader` in your `src/routes/+layout.svelte`.
 | -------------- | -------------- |
 | Cursor         | ✅              |
 | Windsurf       | ✅              |
-| GitHub Copilot | 🚧 In Progress |
+| GitHub Copilot | ✅              |
 | Cline          | ❌              |
 | BLACKBOXAI     | ❌              |
 | Console Ninja  | ❌              |

--- a/toolbar/core/src/components/toolbar/desktop-only/draggable-box.tsx
+++ b/toolbar/core/src/components/toolbar/desktop-only/draggable-box.tsx
@@ -23,7 +23,7 @@ import { cn } from '@/utils';
 import { useAppState } from '@/hooks/use-app-state';
 import { Logo } from '@/components/ui/logo';
 import type { VNode } from 'preact';
-import { SettingsButton, SettingsPanel } from '../settings';
+import { SettingsButton, SettingsPanel } from './panels/settings';
 import { useVSCode } from '@/hooks/use-vscode';
 import { DisconnectedStatePanel } from './panels/disconnected';
 

--- a/toolbar/core/src/components/toolbar/desktop-only/panels/settings.tsx
+++ b/toolbar/core/src/components/toolbar/desktop-only/panels/settings.tsx
@@ -40,6 +40,7 @@ const ConnectionSettings = () => {
     availableAgents,
     selectedAgent,
     selectAgent,
+    discoverAgents,
     appName,
   } = useVSCode();
 
@@ -60,6 +61,14 @@ const ConnectionSettings = () => {
     discover();
   };
 
+  const handleRefreshAgents = () => {
+    if (selectedSession) {
+      discoverAgents(selectedSession.sessionId);
+    } else {
+      discoverAgents();
+    }
+  };
+
   return (
     <div className="space-y-4 pb-4">
       <div>
@@ -74,7 +83,7 @@ const ConnectionSettings = () => {
             id="session-select"
             value={selectedSession?.sessionId || ''}
             onChange={handleSessionChange}
-            className="h-8 flex-1 rounded-lg border border-zinc-300 bg-zinc-500/10 px-3 text-sm backdrop-saturate-150 focus:border-zinc-500 focus:outline-none"
+            className="h-8 w-fit flex-1 rounded-lg border border-zinc-300 bg-zinc-500/10 px-3 text-sm backdrop-saturate-150 focus:border-zinc-500 focus:outline-none"
             disabled={isDiscovering}
           >
             <option value="">Auto-detect (any window)</option>
@@ -121,19 +130,32 @@ const ConnectionSettings = () => {
               ? `(${availableAgents.length} available)`
               : ''}
           </label>
-          <select
-            id="agent-select"
-            value={selectedAgent || 'auto'}
-            onChange={handleAgentChange}
-            className="h-8 w-full rounded-lg border border-zinc-300 bg-zinc-500/10 px-3 text-sm backdrop-saturate-150 focus:border-zinc-500 focus:outline-none"
-          >
-            <option value="auto">Auto (IDE detection)</option>
-            {availableAgents.map((agent) => (
-              <option key={agent} value={agent}>
-                {agent}
-              </option>
-            ))}
-          </select>
+          <div className="flex items-center space-x-2">
+            <select
+              id="agent-select"
+              value={selectedAgent || 'auto'}
+              onChange={handleAgentChange}
+              className="h-8 flex-1 rounded-lg border border-zinc-300 bg-zinc-500/10 px-3 text-sm backdrop-saturate-150 focus:border-zinc-500 focus:outline-none"
+            >
+              <option value="auto">Auto (IDE detection)</option>
+              {availableAgents.map((agent) => (
+                <option key={agent} value={agent}>
+                  {agent}
+                </option>
+              ))}
+            </select>
+            <button
+              type="button"
+              onClick={handleRefreshAgents}
+              disabled={isDiscovering}
+              className="flex h-8 w-8 items-center justify-center rounded-lg bg-zinc-500/10 backdrop-saturate-150 transition-colors hover:bg-zinc-500/20 disabled:opacity-50"
+              title="Refresh available agents"
+            >
+              <RefreshCwIcon
+                className={`size-4 ${isDiscovering ? 'animate-spin' : ''}`}
+              />
+            </button>
+          </div>
           {!selectedAgent && (
             <p className="mt-1 text-gray-500 text-xs">
               Auto mode will select the appropriate agent based on your IDE

--- a/toolbar/core/src/components/toolbar/desktop-only/panels/settings.tsx
+++ b/toolbar/core/src/components/toolbar/desktop-only/panels/settings.tsx
@@ -1,6 +1,6 @@
 import { Panel } from '@/plugin-ui/components/panel';
-import { ToolbarButton } from './button';
-import { ToolbarSection } from './section';
+import { ToolbarButton } from '../../button';
+import { ToolbarSection } from '../../section';
 import { SettingsIcon, RefreshCwIcon } from 'lucide-react';
 import { useVSCode } from '@/hooks/use-vscode';
 

--- a/toolbar/core/src/components/toolbar/desktop-only/panels/settings.tsx
+++ b/toolbar/core/src/components/toolbar/desktop-only/panels/settings.tsx
@@ -37,6 +37,10 @@ const ConnectionSettings = () => {
     discover,
     selectedSession,
     selectSession,
+    availableAgents = [],
+    selectedAgent,
+    selectAgent,
+    appName,
   } = useVSCode();
 
   const handleSessionChange = (e: Event) => {
@@ -45,7 +49,13 @@ const ConnectionSettings = () => {
     selectSession(selectedSessionId);
   };
 
-  const { appName } = useVSCode();
+  console.log('Available agents:', availableAgents);
+
+  const handleAgentChange = (e: Event) => {
+    const target = e.target as HTMLSelectElement;
+    const agent = target.value || undefined;
+    selectAgent(agent);
+  };
 
   const handleRefresh = () => {
     discover();
@@ -99,6 +109,30 @@ const ConnectionSettings = () => {
           </p>
         )}
       </div>
+
+      {/* Agent selector */}
+      {availableAgents.length > 1 && (
+        <div>
+          <label
+            htmlFor="agent-select"
+            className="mb-2 block font-medium text-gray-700 text-sm"
+          >
+            Agent
+          </label>
+          <select
+            id="agent-select"
+            value={selectedAgent || ''}
+            onChange={handleAgentChange}
+            className="h-8 w-full rounded-lg border border-zinc-300 bg-zinc-500/10 px-3 text-sm backdrop-saturate-150 focus:border-zinc-500 focus:outline-none"
+          >
+            {availableAgents.map((agent) => (
+              <option key={agent} value={agent}>
+                {agent}
+              </option>
+            ))}
+          </select>
+        </div>
+      )}
 
       {selectedSession && (
         <div className="rounded-lg bg-blue-50 p-3">

--- a/toolbar/core/src/components/toolbar/desktop-only/panels/settings.tsx
+++ b/toolbar/core/src/components/toolbar/desktop-only/panels/settings.tsx
@@ -37,7 +37,7 @@ const ConnectionSettings = () => {
     discover,
     selectedSession,
     selectSession,
-    availableAgents = [],
+    availableAgents,
     selectedAgent,
     selectAgent,
     appName,
@@ -49,11 +49,10 @@ const ConnectionSettings = () => {
     selectSession(selectedSessionId);
   };
 
-  console.log('Available agents:', availableAgents);
-
   const handleAgentChange = (e: Event) => {
     const target = e.target as HTMLSelectElement;
-    const agent = target.value || undefined;
+    const agent =
+      target.value === 'auto' ? undefined : target.value || undefined;
     selectAgent(agent);
   };
 
@@ -110,27 +109,41 @@ const ConnectionSettings = () => {
         )}
       </div>
 
-      {/* Agent selector */}
+      {/* Agent selector - show if we have agents available */}
       {availableAgents.length > 1 && (
         <div>
           <label
             htmlFor="agent-select"
             className="mb-2 block font-medium text-gray-700 text-sm"
           >
-            Agent
+            Agent{' '}
+            {availableAgents.length > 1
+              ? `(${availableAgents.length} available)`
+              : ''}
           </label>
           <select
             id="agent-select"
-            value={selectedAgent || ''}
+            value={selectedAgent || 'auto'}
             onChange={handleAgentChange}
             className="h-8 w-full rounded-lg border border-zinc-300 bg-zinc-500/10 px-3 text-sm backdrop-saturate-150 focus:border-zinc-500 focus:outline-none"
           >
+            <option value="auto">Auto (IDE detection)</option>
             {availableAgents.map((agent) => (
               <option key={agent} value={agent}>
                 {agent}
               </option>
             ))}
           </select>
+          {!selectedAgent && (
+            <p className="mt-1 text-gray-500 text-xs">
+              Auto mode will select the appropriate agent based on your IDE
+            </p>
+          )}
+          {selectedAgent && availableAgents.length === 1 && (
+            <p className="mt-1 text-gray-500 text-xs">
+              Only one agent available in this session
+            </p>
+          )}
         </div>
       )}
 
@@ -140,8 +153,15 @@ const ConnectionSettings = () => {
             <strong>Selected:</strong> {selectedSession.displayName}
           </p>
           <p className="mt-1 text-blue-600 text-xs">
-            Session ID: {selectedSession.sessionId.substring(0, 8)}...
+            Session ID: {selectedSession.sessionId?.substring(0, 8)}...
           </p>
+          {selectedAgent ? (
+            <p className="mt-1 text-blue-600 text-xs">Agent: {selectedAgent}</p>
+          ) : (
+            <p className="mt-1 text-blue-600 text-xs">
+              Agent: Auto (IDE detection)
+            </p>
+          )}
         </div>
       )}
 
@@ -151,6 +171,15 @@ const ConnectionSettings = () => {
             <strong>Auto-detect mode:</strong> Commands will be sent to any
             available VS Code window.
           </p>
+          {selectedAgent ? (
+            <p className="mt-1 text-gray-500 text-xs">
+              Using agent: {selectedAgent}
+            </p>
+          ) : (
+            <p className="mt-1 text-gray-500 text-xs">
+              Using agent: Auto (IDE detection)
+            </p>
+          )}
         </div>
       )}
     </div>

--- a/toolbar/core/src/hooks/use-chat-state.tsx
+++ b/toolbar/core/src/hooks/use-chat-state.tsx
@@ -113,7 +113,7 @@ export const ChatStateProvider = ({ children }: ChatStateProviderProps) => {
 
   const isMinimized = useAppState((state) => state.minimized);
 
-  const { selectedSession } = useVSCode();
+  const { selectedSession, selectedAgent } = useVSCode();
 
   useEffect(() => {
     if (isMinimized) {
@@ -351,7 +351,11 @@ export const ChatStateProvider = ({ children }: ChatStateProviderProps) => {
         if (bridge) {
           try {
             const result = await bridge.call.triggerAgentPrompt(
-              { prompt, sessionId: selectedSession?.sessionId },
+              {
+                prompt,
+                sessionId: selectedSession?.sessionId,
+                agent: selectedAgent,
+              },
               { onUpdate: (update) => {} },
             );
 
@@ -440,6 +444,7 @@ export const ChatStateProvider = ({ children }: ChatStateProviderProps) => {
       setIsPromptCreationMode,
       internalSetChatAreaState,
       selectedSession,
+      selectedAgent,
       promptState,
       setPromptState,
       plugins,

--- a/toolbar/core/src/hooks/use-plugins.tsx
+++ b/toolbar/core/src/hooks/use-plugins.tsx
@@ -25,7 +25,7 @@ export function PluginProvider({
   plugins: ToolbarPlugin[];
 }) {
   const { bridge } = useSRPCBridge();
-  const { selectedSession } = useVSCode();
+  const { selectedSession, selectedAgent } = useVSCode();
 
   const toolbarContext = useMemo(() => {
     return {
@@ -36,6 +36,7 @@ export function PluginProvider({
           typeof prompt === 'string'
             ? {
                 prompt,
+                agent: selectedAgent,
                 ...(selectedSession && {
                   sessionId: selectedSession.sessionId,
                 }),
@@ -46,6 +47,7 @@ export function PluginProvider({
                 files: prompt.files,
                 images: prompt.images,
                 mode: prompt.mode,
+                agent: prompt.agent || selectedAgent,
                 ...(selectedSession && {
                   sessionId: selectedSession.sessionId,
                 }),
@@ -56,7 +58,7 @@ export function PluginProvider({
         );
       },
     };
-  }, [bridge, selectedSession]);
+  }, [bridge, selectedSession, selectedAgent]);
 
   // call plugins once on initial load
   const pluginsLoadedRef = useRef(false);

--- a/toolbar/core/src/hooks/use-vscode.tsx
+++ b/toolbar/core/src/hooks/use-vscode.tsx
@@ -19,9 +19,15 @@ interface VSCodeContextType {
   discover: () => Promise<void>;
   selectSession: (sessionId: string | undefined) => void;
   refreshSession: () => Promise<void>;
+  selectAgent: (agent: string | undefined) => void;
 
   // App name
   appName: string | undefined;
+  displayName?: string; // Optional display name for the current window
+
+  // Available agents
+  availableAgents?: string[];
+  selectedAgent?: string;
 }
 
 const VSCodeContext = createContext<VSCodeContextType>({
@@ -33,6 +39,10 @@ const VSCodeContext = createContext<VSCodeContextType>({
   selectSession: () => {},
   refreshSession: async () => {},
   appName: undefined,
+  displayName: undefined,
+  availableAgents: [],
+  selectAgent: () => {},
+  selectedAgent: undefined,
 });
 
 export function VSCodeProvider({ children }: { children: ComponentChildren }) {
@@ -42,6 +52,9 @@ export function VSCodeProvider({ children }: { children: ComponentChildren }) {
   const [selectedSessionId, setSelectedSessionId] = useState<
     string | undefined
   >(undefined);
+  const [selectedAgent, setSelectedAgent] = useState<string | undefined>(
+    undefined,
+  );
 
   const discover = async () => {
     setIsDiscovering(true);
@@ -71,6 +84,10 @@ export function VSCodeProvider({ children }: { children: ComponentChildren }) {
     setSelectedSessionId(sessionId);
   };
 
+  const selectAgent = (agent: string | undefined) => {
+    setSelectedAgent(agent);
+  };
+
   const refreshSession = async () => {
     if (selectedSessionId) {
       // Re-discover to get fresh session info
@@ -96,6 +113,10 @@ export function VSCodeProvider({ children }: { children: ComponentChildren }) {
     selectSession,
     refreshSession,
     appName: selectedSession?.appName,
+    displayName: selectedSession?.displayName,
+    availableAgents: selectedSession?.availableAgents,
+    selectAgent,
+    selectedAgent,
   };
 
   return (

--- a/toolbar/next/README.md
+++ b/toolbar/next/README.md
@@ -293,7 +293,7 @@ You would then use `StagewiseToolbarLoader` in your `src/routes/+layout.svelte`.
 | -------------- | -------------- |
 | Cursor         | ✅              |
 | Windsurf       | ✅              |
-| GitHub Copilot | 🚧 In Progress |
+| GitHub Copilot | ✅              |
 | Cline          | ❌              |
 | BLACKBOXAI     | ❌              |
 | Console Ninja  | ❌              |

--- a/toolbar/react/README.md
+++ b/toolbar/react/README.md
@@ -293,7 +293,7 @@ You would then use `StagewiseToolbarLoader` in your `src/routes/+layout.svelte`.
 | -------------- | -------------- |
 | Cursor         | ✅              |
 | Windsurf       | ✅              |
-| GitHub Copilot | 🚧 In Progress |
+| GitHub Copilot | ✅              |
 | Cline          | ❌              |
 | BLACKBOXAI     | ❌              |
 | Console Ninja  | ❌              |

--- a/toolbar/vue/README.md
+++ b/toolbar/vue/README.md
@@ -293,7 +293,7 @@ You would then use `StagewiseToolbarLoader` in your `src/routes/+layout.svelte`.
 | -------------- | -------------- |
 | Cursor         | ✅              |
 | Windsurf       | ✅              |
-| GitHub Copilot | 🚧 In Progress |
+| GitHub Copilot | ✅              |
 | Cline          | ❌              |
 | BLACKBOXAI     | ❌              |
 | Console Ninja  | ❌              |


### PR DESCRIPTION
This pull request introduces support for the Windsurf IDE in the Stagewise VSCode extension and refactors the agent-calling logic to improve extensibility. It also includes utility functions to detect the current IDE and handle agent-specific diagnostics. Below are the key changes grouped by theme:

### GitHub Copilot Integration
* Added a `callCopilotAgent` function to handle prompts for VSCode when GitHub Copilot Chat is installed. (`apps/vscode-extension/src/utils/call-copilot-agent.ts`, [apps/vscode-extension/src/utils/call-copilot-agent.tsR1-R8](diffhunk://#diff-a984afc7addf89bc551b08624e1b1d70c7d92d0a1c67222f0ff7fdded0ed48c8R1-R8))
* Introduced an `isCopilotChatInstalled` utility to check for the presence of the Copilot Chat extension. (`apps/vscode-extension/src/utils/is-copilot-chat-installed.ts`, [apps/vscode-extension/src/utils/is-copilot-chat-installed.tsR1-R11](diffhunk://#diff-ea1794d217fbe7bc9f6123289f25b298627555205371fa39438bb0a5186c0fd6R1-R11))

### Miscellaneous
* Commented out the `registerConsoleLogsTool` in the MCP server setup as a placeholder for future tools. (`apps/vscode-extension/src/mcp/server.ts`, [apps/vscode-extension/src/mcp/server.tsL19-R19](diffhunk://#diff-e1308a22bfb33cec0af9f61a492d1324b2a1e4d086f101d7a9371a913c336dadL19-R19))