### PR TITLE
Rework-tooling

### DIFF
--- a/toolbar/next/vite.config.ts
+++ b/toolbar/next/vite.config.ts
@@ -17,7 +17,7 @@
 
 import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { defineConfig } from 'vite';
+import { defineConfig, type PluginOption } from 'vite';
 import dts from 'vite-plugin-dts';
 import react from '@vitejs/plugin-react-swc';
 import preserveDirectives from 'rollup-preserve-directives';
@@ -30,7 +30,7 @@ export default defineConfig({
     react(),
     dts({
       rollupTypes: true,
-    }),
+    }) as PluginOption,
     preserveDirectives(),
   ],
   resolve: {

--- a/toolbar/react/vite.config.ts
+++ b/toolbar/react/vite.config.ts
@@ -17,7 +17,7 @@
 
 import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { defineConfig } from 'vite';
+import { defineConfig, type PluginOption } from 'vite';
 import dts from 'vite-plugin-dts';
 import react from '@vitejs/plugin-react-swc';
 
@@ -29,7 +29,7 @@ export default defineConfig({
     react(),
     dts({
       rollupTypes: true,
-    }),
+    }) as PluginOption,
   ],
   resolve: {
     alias: {

--- a/toolbar/vue/vite.config.ts
+++ b/toolbar/vue/vite.config.ts
@@ -17,7 +17,7 @@
 
 import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { defineConfig } from 'vite';
+import { defineConfig, type PluginOption } from 'vite';
 import dts from 'vite-plugin-dts';
 import vue from '@vitejs/plugin-vue';
 
@@ -29,7 +29,7 @@ export default defineConfig({
     vue(),
     dts({
       rollupTypes: true,
-    }),
+    }) as PluginOption,
   ],
   resolve: {
     alias: {


### PR DESCRIPTION
- Updated the Vite configuration to explicitly cast the plugins array as `PluginOption`, reinforcing type safety and compatibility with TypeScript.
- This change enhances the clarity and correctness of the plugin configuration in the project.