### PR TITLE
fix(toolbar): improve error handling and async behavior in sendPrompt

### DIFF
--- a/.changeset/red-bags-kneel.md
+++ b/.changeset/red-bags-kneel.md
@@ -1,0 +1,5 @@
+---
+"@stagewise/toolbar": patch
+---
+
+Fix bridge connection error when using context.sendPrompt in plugins

--- a/toolbar/core/src/hooks/use-plugins.tsx
+++ b/toolbar/core/src/hooks/use-plugins.tsx
@@ -55,8 +55,9 @@ export function PluginProvider({
     return {
       plugins,
       toolbarContext: {
-        sendPrompt: (prompt: string) => {
-          bridge.call.triggerAgentPrompt(
+        sendPrompt: async (prompt: string) => {
+          if (!bridge) throw new Error('No connection to the agent');
+          const result = await bridge.call.triggerAgentPrompt(
             { prompt },
             {
               onUpdate: (update) => {},
@@ -65,7 +66,7 @@ export function PluginProvider({
         },
       },
     };
-  }, [plugins]);
+  }, [plugins, bridge]);
 
   return (
     <PluginContext.Provider value={value}>{children}</PluginContext.Provider>


### PR DESCRIPTION
- Updated the sendPrompt function to throw an error if the bridge connection is not established, enhancing robustness.
- Changed sendPrompt to be asynchronous, ensuring proper handling of the triggerAgentPrompt call.
- Added bridge as a dependency in the useEffect hook to ensure it is correctly monitored for changes.