### PR TITLE
Extend-srpc-contract

### DIFF
--- a/.changeset/calm-phones-build.md
+++ b/.changeset/calm-phones-build.md
@@ -1,0 +1,6 @@
+---
+"@stagewise/extension-toolbar-srpc-contract": minor
+"stagewise-vscode-extension": minor
+---
+
+Add images, files, mode and model properties to the srpc contract and agent call dispatches

--- a/apps/vscode-extension/src/activation/activate.ts
+++ b/apps/vscode-extension/src/activation/activate.ts
@@ -1,5 +1,4 @@
 import * as vscode from 'vscode';
-import { dispatchAgentCall } from 'src/utils/dispatch-agent-call';
 import { startServer, stopServer } from '../http-server/server';
 import { findAvailablePort } from '../utils/find-available-port';
 import {
@@ -8,6 +7,7 @@ import {
 } from '@stagewise/extension-toolbar-srpc-contract';
 import { setupToolbar } from './setup-toolbar';
 import { getCurrentIDE } from 'src/utils/get-current-ide';
+import { dispatchAgentCall } from 'src/utils/dispatch-agent-call';
 
 // Diagnostic collection specifically for our fake prompt
 const fakeDiagCollection =
@@ -41,7 +41,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
     bridge.register({
       triggerAgentPrompt: async (request, sendUpdate) => {
-        await dispatchAgentCall(request.prompt);
+        await dispatchAgentCall(request);
         sendUpdate.sendUpdate({ updateText: 'Called the agent' });
 
         return { result: { success: true } };

--- a/apps/vscode-extension/src/activation/setup-toolbar.ts
+++ b/apps/vscode-extension/src/activation/setup-toolbar.ts
@@ -119,5 +119,7 @@ export async function setupToolbar() {
   3. Does not lead to any linting errors
 </expected_outcome>`;
 
-  await dispatchAgentCall(prompt);
+  await dispatchAgentCall({
+    prompt,
+  });
 }

--- a/apps/vscode-extension/src/utils/call-cursor-agent.ts
+++ b/apps/vscode-extension/src/utils/call-cursor-agent.ts
@@ -1,11 +1,23 @@
 import * as vscode from 'vscode';
 import { injectPromptDiagnosticWithCallback } from './inject-prompt-diagnostic-with-callback';
+import type { TriggerAgentPromptRequest } from '@stagewise/extension-toolbar-srpc-contract';
 
 const CURSOR_PROMPT_PREFIX = `\`\`\`
     Ah, sorry, it wasn't an error. The user has submitted a change request. Here is the request, please implement it:
     \`\`\``;
 
-export async function callCursorAgent(prompt: string): Promise<void> {
+export async function callCursorAgent(
+  request: TriggerAgentPromptRequest,
+): Promise<void> {
+  const prompt =
+    `${request.prompt}` +
+    `${request.files ? `\n\n use the following files: ${request.files.join('\n')}` : ''}` +
+    `${request.images ? `\n\n use the following images: ${request.images.join('\n')}` : ''}`;
+  // model: request.model, not supported yet
+  // `${request.model ? `\n\n use the following model: ${request.model}` : ''}` +
+  // mode: request.mode, not supported yet
+  // `${request.mode ? `\n\n use the following mode: ${request.mode}` : ''}`;
+
   const promptWithPrefix = `${CURSOR_PROMPT_PREFIX}\n${prompt}`;
   await injectPromptDiagnosticWithCallback({
     prompt: promptWithPrefix,

--- a/apps/vscode-extension/src/utils/call-windsurf-agent.ts
+++ b/apps/vscode-extension/src/utils/call-windsurf-agent.ts
@@ -1,10 +1,21 @@
 import * as vscode from 'vscode';
 import { injectPromptDiagnosticWithCallback } from './inject-prompt-diagnostic-with-callback';
+import type { TriggerAgentPromptRequest } from '@stagewise/extension-toolbar-srpc-contract';
 
 const WINDSURF_PROMPT_PREFIX =
   "Ah wait, it's not a problem. The user has instead submitted a change request. Please implement it: \n\n";
 
-export async function callWindsurfAgent(prompt: string): Promise<void> {
+export async function callWindsurfAgent(
+  request: TriggerAgentPromptRequest,
+): Promise<void> {
+  const prompt =
+    `${request.prompt}` +
+    `${request.files ? `\n\n use the following files: ${request.files.join('\n')}` : ''}` +
+    `${request.images ? `\n\n use the following images: ${request.images.join('\n')}` : ''}`;
+  // model: request.model, not supported yet
+  // `${request.model ? `\n\n use the following model: ${request.model}` : ''}` +
+  // mode: request.mode, not supported yet
+  // `${request.mode ? `\n\n use the following mode: ${request.mode}` : ''}`;
   const promptWithPrefix = `${WINDSURF_PROMPT_PREFIX}\n${prompt}`;
   await injectPromptDiagnosticWithCallback({
     prompt: promptWithPrefix,

--- a/apps/vscode-extension/src/utils/dispatch-agent-call.ts
+++ b/apps/vscode-extension/src/utils/dispatch-agent-call.ts
@@ -2,14 +2,15 @@ import { getCurrentIDE } from './get-current-ide';
 import { callCursorAgent } from './call-cursor-agent';
 import { callWindsurfAgent } from './call-windsurf-agent';
 import * as vscode from 'vscode';
+import type { TriggerAgentPromptRequest } from '@stagewise/extension-toolbar-srpc-contract';
 
-export async function dispatchAgentCall(prompt: string) {
+export async function dispatchAgentCall(request: TriggerAgentPromptRequest) {
   const ide = getCurrentIDE();
   switch (ide) {
     case 'CURSOR':
-      return await callCursorAgent(prompt);
+      return await callCursorAgent(request);
     case 'WINDSURF':
-      return await callWindsurfAgent(prompt);
+      return await callWindsurfAgent(request);
     case 'VSCODE':
       vscode.window.showErrorMessage(
         'Currently, only Cursor and Windsurf are supported with stagewise.',

--- a/packages/extension-toolbar-srpc-contract/index.ts
+++ b/packages/extension-toolbar-srpc-contract/index.ts
@@ -18,3 +18,4 @@
 export { getExtensionBridge, getToolbarBridge } from './src/bridge';
 export { contract } from './src/contract';
 export { DEFAULT_PORT, PING_ENDPOINT, PING_RESPONSE } from './src/contract';
+export type { TriggerAgentPromptRequest } from './src/contract';

--- a/packages/extension-toolbar-srpc-contract/src/contract.ts
+++ b/packages/extension-toolbar-srpc-contract/src/contract.ts
@@ -29,6 +29,22 @@ export const contract = createBridgeContract({
     triggerAgentPrompt: {
       request: z.object({
         prompt: z.string(),
+        model: z
+          .string()
+          .optional()
+          .describe('The model to use for the agent prompt'),
+        files: z
+          .array(z.string())
+          .optional()
+          .describe('Link project files to the agent prompt'),
+        mode: z
+          .enum(['agent', 'ask', 'manual'])
+          .optional()
+          .describe('The mode to use for the agent prompt'),
+        images: z
+          .array(z.string())
+          .optional()
+          .describe('Upload files like images, videos, etc.'),
       }),
       response: z.object({
         result: z.object({
@@ -43,3 +59,7 @@ export const contract = createBridgeContract({
     },
   },
 });
+
+export type TriggerAgentPromptRequest = z.infer<
+  typeof contract.server.triggerAgentPrompt.request
+>;


### PR DESCRIPTION
- Modified the `dispatchAgentCall`, `callCursorAgent`, and `callWindsurfAgent` functions to accept a `TriggerAgentPromptRequest` object instead of a string prompt.
- Enhanced the prompt construction to include optional parameters such as files and images, improving the functionality of agent calls.