### PR TITLE
Add-svg-as-vnode-to-toolbar

### DIFF
--- a/toolbar/core/src/components/dom-context/item.tsx
+++ b/toolbar/core/src/components/dom-context/item.tsx
@@ -83,14 +83,9 @@ export function ContextItem({ refElement, ...props }: ContextItemProps) {
       <div className="absolute bottom-[100%] flex w-full flex-row items-start justify-start gap-1 py-1">
         {props.pluginContext.map((plugin) => (
           <div className="flex flex-row items-center justify-center gap-0.5 rounded-md bg-blue-500 px-1 py-0 font-medium text-white text-xs">
-            <img
-              className="size-3 rounded-sm bg-white"
-              alt=""
-              src={
-                plugins.find((p) => p.pluginName === plugin.pluginName)
-                  ?.iconSvg ?? ''
-              }
-            />
+            <span className="size-3 rounded-sm bg-white">
+              {plugins.find((p) => p.pluginName === plugin.pluginName)?.iconSvg}
+            </span>
             <span>{plugin.context.annotation}</span>
           </div>
         ))}

--- a/toolbar/core/src/components/toolbar/desktop-only/draggable-box.tsx
+++ b/toolbar/core/src/components/toolbar/desktop-only/draggable-box.tsx
@@ -183,7 +183,7 @@ export function ToolbarDraggableBox() {
                   active={pluginBox?.pluginName === plugin.pluginName}
                 >
                   {plugin.iconSvg ? (
-                    <img src={plugin.iconSvg} alt={plugin.displayName} />
+                    <span>{plugin.iconSvg}</span>
                   ) : (
                     <PuzzleIcon className="size-4" />
                   )}

--- a/toolbar/core/src/plugin.ts
+++ b/toolbar/core/src/plugin.ts
@@ -197,7 +197,7 @@ export interface ToolbarPlugin {
   description: string;
 
   /** A monochrome svg icon that will be rendered in places where the plugin is shown */
-  iconSvg: string | null;
+  iconSvg: VNode | null;
 
   onActionClick?: () => undefined | VNode;
 


### PR DESCRIPTION
- Changed iconSvg type from string to VNode in ToolbarPlugin interface for better flexibility.
- Updated rendering of iconSvg in ContextItem and ToolbarDraggableBox components to use span instead of img for improved compatibility with VNode.