### PR TITLE
chore(package.json): update version to 0.3.0

### DIFF
--- a/apps/vscode-extension/package.json
+++ b/apps/vscode-extension/package.json
@@ -3,7 +3,7 @@
   "displayName": "stagewise",
   "private": true,
   "description": "Eyesight for your AI-powered Code Editor.",
-  "version": "0.3.0-alpha.0",
+  "version": "0.3.0",
   "publisher": "stagewise",
   "icon": "icon.png",
   "engines": {


### PR DESCRIPTION
Since vsce doesn't support publishing alpha tags and only supports semver, the version will be updated to 0.3.0 and pre-released manually.