### PR TITLE
fix(toolbar): adjust max height of draggable box for better layout

### DIFF
--- a/toolbar/core/src/components/toolbar/desktop-only/draggable-box.tsx
+++ b/toolbar/core/src/components/toolbar/desktop-only/draggable-box.tsx
@@ -96,7 +96,7 @@ export function ToolbarDraggableBox() {
       {/* This is the complete toolbar area where we can stack different stuff. The main toolbar content stands out. */}
       <div
         className={cn(
-          'absolute flex h-[calc(100vh-32px)] w-96 max-w-[40vw] items-stretch justify-end transition-all duration-300 ease-out',
+          'absolute flex max-h-[calc(100vh-32px)] w-96 max-w-[40vw] items-stretch justify-end transition-all duration-300 ease-out',
           draggable.position.isTopHalf
             ? 'top-0 flex-col-reverse'
             : 'bottom-0 flex-col',


### PR DESCRIPTION
This pull request makes a small but important adjustment to the `ToolbarDraggableBox` component to improve its layout behavior. Specifically, it modifies the height constraint from `h-[calc(100vh-32px)]` to `max-h-[calc(100vh-32px)]`, ensuring that the toolbar does not exceed the available viewport height.

* **Layout improvement for `ToolbarDraggableBox`:**
  - Changed the height property from `h-[calc(100vh-32px)]` to `max-h-[calc(100vh-32px)]` in the `className` definition to prevent the toolbar from exceeding the viewport height. (`[toolbar/core/src/components/toolbar/desktop-only/draggable-box.tsxL99-R99](diffhunk://#diff-8ff9510e687e4906a236515f8b9b6997410adba11bab05cc043baacd9b54f815L99-R99)`)