### PR TITLE
chore(deps): reorganize dependencies in pnpm-lock.yaml and package.json

### DIFF
--- a/.changeset/giant-masks-repeat.md
+++ b/.changeset/giant-masks-repeat.md
@@ -1,0 +1,5 @@
+---
+"@stagewise/toolbar": patch
+---
+
+Remove all dependencies from toolbar/core

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -623,13 +623,31 @@ importers:
         version: 4.5.3(@types/node@22.15.17)(rollup@4.40.2)(typescript@5.8.3)(vite@6.3.5(@types/node@22.15.17)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1))
 
   toolbar/core:
-    dependencies:
+    devDependencies:
       '@headlessui/react':
         specifier: 2.2.2
         version: 2.2.2(patch_hash=058c956527a7ce89f57a9b19b87837155dd2b3c21e1293af7d9e8cd9b790d072)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@preact/compat':
         specifier: 18.3.1
         version: 18.3.1(preact@10.26.6)
+      '@preact/preset-vite':
+        specifier: ^2.10.1
+        version: 2.10.1(@babel/core@7.27.1)(preact@10.26.6)(vite@6.3.5(@types/node@22.15.2)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1))
+      '@stagewise/extension-toolbar-srpc-contract':
+        specifier: workspace:*
+        version: link:../../packages/extension-toolbar-srpc-contract
+      '@stagewise/srpc':
+        specifier: workspace:*
+        version: link:../../packages/srpc
+      '@tailwindcss/postcss':
+        specifier: ^4.1.5
+        version: 4.1.5
+      '@types/node':
+        specifier: 22.15.2
+        version: 22.15.2
+      autoprefixer:
+        specifier: ^10.4.21
+        version: 10.4.21(postcss@8.5.3)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -642,6 +660,9 @@ importers:
       lucide-react:
         specifier: ^0.503.0
         version: 0.503.0(react@19.1.0)
+      postcss:
+        specifier: ^8.5.3
+        version: 8.5.3
       postcss-prefix-selector:
         specifier: ^2.1.1
         version: 2.1.1(postcss@8.5.3)
@@ -663,52 +684,30 @@ importers:
       tsup:
         specifier: ^8.4.0
         version: 8.4.0(@microsoft/api-extractor@7.52.7(@types/node@22.15.2))(@swc/core@1.11.24(@swc/helpers@0.5.17))(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.7.1)
-      ua-parser-js:
-        specifier: ^2.0.3
-        version: 2.0.3
-      vite-plugin-css-injected-by-js:
-        specifier: ^3.5.2
-        version: 3.5.2(vite@6.3.5(@types/node@22.15.2)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1))
-      zod:
-        specifier: ^3.24.4
-        version: 3.24.4
-      zustand:
-        specifier: ^5.0.4
-        version: 5.0.4(@types/react@19.1.3)(react@19.1.0)(use-sync-external-store@1.5.0(react@19.1.0))
-    devDependencies:
-      '@preact/preset-vite':
-        specifier: ^2.10.1
-        version: 2.10.1(@babel/core@7.27.1)(preact@10.26.6)(vite@6.3.5(@types/node@22.15.2)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1))
-      '@stagewise/extension-toolbar-srpc-contract':
-        specifier: workspace:*
-        version: link:../../packages/extension-toolbar-srpc-contract
-      '@stagewise/srpc':
-        specifier: workspace:*
-        version: link:../../packages/srpc
-      '@tailwindcss/postcss':
-        specifier: ^4.1.5
-        version: 4.1.5
-      '@types/node':
-        specifier: 22.15.2
-        version: 22.15.2
-      autoprefixer:
-        specifier: ^10.4.21
-        version: 10.4.21(postcss@8.5.3)
-      postcss:
-        specifier: ^8.5.3
-        version: 8.5.3
       typescript:
         specifier: ^5.8.3
         version: 5.8.3
+      ua-parser-js:
+        specifier: ^2.0.3
+        version: 2.0.3
       vite:
         specifier: ^6.3.5
         version: 6.3.5(@types/node@22.15.2)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1)
       vite-bundle-analyzer:
         specifier: ^0.19.0
         version: 0.19.0
+      vite-plugin-css-injected-by-js:
+        specifier: ^3.5.2
+        version: 3.5.2(vite@6.3.5(@types/node@22.15.2)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1))
       vite-plugin-dts:
         specifier: ^4.5.3
         version: 4.5.3(@types/node@22.15.2)(rollup@4.40.2)(typescript@5.8.3)(vite@6.3.5(@types/node@22.15.2)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1))
+      zod:
+        specifier: ^3.24.4
+        version: 3.24.4
+      zustand:
+        specifier: ^5.0.4
+        version: 5.0.4(@types/react@19.1.3)(react@19.1.0)(use-sync-external-store@1.5.0(react@19.1.0))
 
   toolbar/next:
     dependencies:

--- a/toolbar/core/package.json
+++ b/toolbar/core/package.json
@@ -44,9 +44,9 @@
     "build:toolbar": "tsc -b && vite build --mode production",
     "build": "tsc -b && vite build --mode production"
   },
-  "dependencies": {
+  "dependencies": {},
+  "devDependencies": {
     "@headlessui/react": "2.2.2",
-    "@preact/compat": "18.3.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "javascript-time-ago": "^2.5.11",
@@ -61,9 +61,7 @@
     "ua-parser-js": "^2.0.3",
     "vite-plugin-css-injected-by-js": "^3.5.2",
     "zod": "^3.24.4",
-    "zustand": "^5.0.4"
-  },
-  "devDependencies": {
+    "zustand": "^5.0.4",
     "@preact/compat": "18.3.1",
     "@preact/preset-vite": "^2.10.1",
     "@stagewise/extension-toolbar-srpc-contract": "workspace:*",


### PR DESCRIPTION
- Moved dependencies to devDependencies in toolbar/core/package.json for better clarity.
- Added new dependencies including '@preact/preset-vite', '@stagewise/extension-toolbar-srpc-contract', and others in pnpm-lock.yaml.
- Removed unused dependencies from the previous structure to streamline the package management.