### PR TITLE
Refactor: Change chat input to submit with Command/Ctrl + Enter

### DIFF
--- a/toolbar/core/src/components/toolbar/chat-box.tsx
+++ b/toolbar/core/src/components/toolbar/chat-box.tsx
@@ -49,10 +49,12 @@ export function ToolbarChatArea() {
 
   const handleKeyDown = useCallback(
     (e: KeyboardEvent) => {
-      if (e.key === 'Enter' && !e.shiftKey) {
+      if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
         e.preventDefault();
         handleSubmit();
       }
+      // Allow Shift+Enter for newlines, do nothing for Enter alone (for IME)
+      // The original condition for Enter alone submitting the form is now removed.
     },
     [handleSubmit],
   );


### PR DESCRIPTION
This change modifies the chat input behavior to prevent premature submission when using Japanese Input Method Editors (IMEs).

Previously, pressing Enter to confirm Kanji conversion would also submit the message. This change makes Command + Enter (on macOS) or Ctrl + Enter (on other operating systems) the default way to send messages. Pressing Enter alone will now only confirm IME conversions, and Shift + Enter will create a new line, as expected.

This also aims to address an issue where Japanese messages could be cut off during submission. The input field clearing after submission remains unchanged.