### PR TITLE
Fix documentation typos and formatting inconsistencies

### DIFF
--- a/apps/website/content/docs/debug.mdx
+++ b/apps/website/content/docs/debug.mdx
@@ -71,4 +71,4 @@ stagewise toolbar fails to initialize or send prompts when connecting via SSH re
 **Next Steps:**
 
 * Tracked under issue [#172](https://github.com/stagewise-io/stagewise/issues/172).
-* We are working on compatibility support for SSH‑remote workflows.
+* We are working on compatibility support for SSH-remote workflows.

--- a/apps/website/content/docs/plugins.mdx
+++ b/apps/website/content/docs/plugins.mdx
@@ -200,7 +200,7 @@ export const ExampleComponent = () => {
 };
 ```
 
-Using the plugin in your next-app:
+Using the plugin in your Next.js app:
 
 ```tsx
 // app/layout.tsx

--- a/apps/website/content/docs/quickstart.mdx
+++ b/apps/website/content/docs/quickstart.mdx
@@ -138,7 +138,7 @@ import { StagewiseToolbar } from '@stagewise/toolbar-vue';
   <div>
     <NuxtRouteAnnouncer />
     <ClientOnly>
-      <StagewiseToolbar/>
+      <StagewiseToolbar />
     </ClientOnly>
     <NuxtWelcome />
   </div>


### PR DESCRIPTION
## Summary

This PR fixes several typos and formatting inconsistencies found in the documentation within `apps/website/content/docs/`.

## Changes

### Fixed Typos:
1. **debug.mdx**: Replaced special en-dash character in "SSH‑remote" with regular hyphen "SSH-remote"
2. **plugins.mdx**: Changed "next-app" to "Next.js app" for consistency with framework naming conventions
3. **quickstart.mdx**: Added space in self-closing `<StagewiseToolbar/>` tag for formatting consistency

### Files Modified:
- `apps/website/content/docs/debug.mdx`
- `apps/website/content/docs/plugins.mdx` 
- `apps/website/content/docs/quickstart.mdx`

## Testing

- [x] Reviewed all changes for accuracy
- [x] Verified formatting consistency across documentation
- [x] Ensured no functional changes to code examples

These are minor documentation improvements that enhance readability and maintain consistency across the project.