### PR TITLE
Add-use-config-hook-for-experimental-feature-flags

### DIFF
--- a/toolbar/core/src/components/context-providers.tsx
+++ b/toolbar/core/src/components/context-providers.tsx
@@ -5,6 +5,7 @@ import { LocationProvider } from '../hooks/use-location';
 import type { ComponentChildren } from 'preact';
 import { SRPCBridgeProvider } from '@/hooks/use-srpc-bridge';
 import { VSCodeProvider } from '@/hooks/use-vscode';
+import { ConfigProvider } from '@/hooks/use-config';
 
 export function ContextProviders({
   children,
@@ -14,14 +15,16 @@ export function ContextProviders({
   config?: ToolbarConfig;
 }) {
   return (
-    <LocationProvider>
-      <SRPCBridgeProvider>
-        <VSCodeProvider>
-          <PluginProvider plugins={config?.plugins || []}>
-            <ChatStateProvider>{children}</ChatStateProvider>
-          </PluginProvider>
-        </VSCodeProvider>
-      </SRPCBridgeProvider>
-    </LocationProvider>
+    <ConfigProvider config={config}>
+      <LocationProvider>
+        <SRPCBridgeProvider>
+          <VSCodeProvider>
+            <PluginProvider>
+              <ChatStateProvider>{children}</ChatStateProvider>
+            </PluginProvider>
+          </VSCodeProvider>
+        </SRPCBridgeProvider>
+      </LocationProvider>
+    </ConfigProvider>
   );
 }

--- a/toolbar/core/src/config.ts
+++ b/toolbar/core/src/config.ts
@@ -2,4 +2,14 @@ import type { ToolbarPlugin } from './plugin.ts';
 
 export interface ToolbarConfig {
   plugins: ToolbarPlugin[];
+  experimental: {
+    /**
+     * If true, the toolbar will use the stagewise MCP server.
+     */
+    enableStagewiseMCP: boolean;
+    /**
+     * If true, the toolbar will allow tool calls to sync progress with the agent.
+     */
+    enableToolCalls: boolean;
+  };
 }

--- a/toolbar/core/src/hooks/use-config.tsx
+++ b/toolbar/core/src/hooks/use-config.tsx
@@ -1,0 +1,66 @@
+import { type ComponentChildren, createContext } from 'preact';
+import { useContext, useMemo } from 'preact/hooks';
+import type { ToolbarConfig } from '@/config';
+
+export interface ConfigContextType {
+  config: ToolbarConfig | undefined;
+}
+
+const ConfigContext = createContext<ConfigContextType>({
+  config: undefined,
+});
+
+/**
+ * Provider component that makes toolbar configuration available throughout the component tree.
+ * This should be placed at the root of your toolbar application.
+ *
+ * @param children - Child components that will have access to the config
+ * @param config - The toolbar configuration object from initToolbar()
+ */
+export function ConfigProvider({
+  children,
+  config,
+}: {
+  children: ComponentChildren;
+  config?: ToolbarConfig;
+}) {
+  const value = useMemo(() => {
+    return {
+      config,
+    };
+  }, [config]);
+
+  return (
+    <ConfigContext.Provider value={value}>{children}</ConfigContext.Provider>
+  );
+}
+
+/**
+ * Hook to access the toolbar configuration throughout the application.
+ * Returns the config object that was passed to initToolbar().
+ *
+ * @returns Object containing the toolbar config
+ *
+ * @example
+ * ```tsx
+ * function MyComponent() {
+ *   const { config } = useConfig();
+ *
+ *   if (!config) {
+ *     return <div>No configuration available</div>;
+ *   }
+ *
+ *   return (
+ *     <div>
+ *       <h2>Available Plugins: {config.plugins.length}</h2>
+ *       {config.plugins.map(plugin => (
+ *         <div key={plugin.pluginName}>{plugin.displayName}</div>
+ *       ))}
+ *     </div>
+ *   );
+ * }
+ * ```
+ */
+export function useConfig() {
+  return useContext(ConfigContext);
+}

--- a/toolbar/core/src/hooks/use-plugins.tsx
+++ b/toolbar/core/src/hooks/use-plugins.tsx
@@ -4,6 +4,7 @@ import type { ToolbarContext, ToolbarPlugin } from '@/plugin';
 import { useSRPCBridge } from './use-srpc-bridge';
 import type { PromptRequest } from '@stagewise/extension-toolbar-srpc-contract';
 import { useVSCode } from './use-vscode';
+import { useConfig } from './use-config';
 
 export interface PluginContextType {
   plugins: ToolbarPlugin[];
@@ -19,13 +20,14 @@ const PluginContext = createContext<PluginContextType>({
 
 export function PluginProvider({
   children,
-  plugins,
 }: {
   children: ComponentChildren;
-  plugins: ToolbarPlugin[];
 }) {
   const { bridge } = useSRPCBridge();
   const { selectedSession } = useVSCode();
+  const { config } = useConfig();
+
+  const plugins = config?.plugins || [];
 
   const toolbarContext = useMemo(() => {
     return {


### PR DESCRIPTION
- Added useConfig hook to retrieve plugin configuration from the context.
- Updated PluginProvider to utilize the config for loading plugins, enhancing flexibility in plugin management.