### PR TITLE
feat(id-generation): implement generateId function for ID creation

### DIFF
--- a/.changeset/nasty-turtles-shine.md
+++ b/.changeset/nasty-turtles-shine.md
@@ -1,0 +1,6 @@
+---
+"@stagewise/srpc": patch
+"@stagewise/toolbar": patch
+---
+
+Replace randomUUID calls with (unsafer, but universally working) Math.random generated IDs

--- a/packages/srpc/src/core.ts
+++ b/packages/srpc/src/core.ts
@@ -1,4 +1,11 @@
 import type { WebSocket as NodeWebSocket, ErrorEvent } from 'ws';
+
+const generateId = (length = 16): string => {
+  return Math.random()
+    .toString(36)
+    .substring(2, length + 2);
+};
+
 // Define a union type for both browser and Node.js WebSocket
 type WebSocketType = NodeWebSocket | WebSocket;
 
@@ -121,7 +128,7 @@ export abstract class WebSocketRpcBridge {
       throw new Error('WebSocket is not connected');
     }
 
-    const id = crypto.randomUUID();
+    const id = generateId();
     const requestMessage: RequestMessage<TRequest> = {
       id,
       messageType: 'request',

--- a/toolbar/core/src/hooks/use-chat-state.tsx
+++ b/toolbar/core/src/hooks/use-chat-state.tsx
@@ -6,6 +6,7 @@ import { useAppState } from './use-app-state';
 import { usePlugins } from './use-plugins';
 import type { ContextElementContext } from '@/plugin';
 import { useVSCode } from './use-vscode';
+import { generateId } from '@/utils';
 
 interface Message {
   id: string;
@@ -125,7 +126,7 @@ export const ChatStateProvider = ({ children }: ChatStateProviderProps) => {
   const { bridge } = useSRPCBridge();
 
   const createChat = useCallback(() => {
-    const newChatId = crypto.randomUUID();
+    const newChatId = generateId();
     const newChat: Chat = {
       id: newChatId,
       title: null,
@@ -282,7 +283,7 @@ export const ChatStateProvider = ({ children }: ChatStateProviderProps) => {
 
       const pluginProcessingPromises = plugins.map(async (plugin) => {
         const userMessagePayload = {
-          id: crypto.randomUUID(),
+          id: generateId(),
           text: content,
           contextElements:
             chat?.domContextElements.map((el) => el.element) || [],
@@ -340,7 +341,7 @@ export const ChatStateProvider = ({ children }: ChatStateProviderProps) => {
       );
 
       const newMessage: Message = {
-        id: crypto.randomUUID(),
+        id: generateId(),
         content: content.trim(),
         sender: 'user',
         type: 'regular',

--- a/toolbar/core/src/utils.tsx
+++ b/toolbar/core/src/utils.tsx
@@ -260,3 +260,9 @@ const customTwMerge = extendTailwindMerge({
 export function cn(...inputs: ClassValue[]) {
   return customTwMerge(clsx(inputs));
 }
+
+export const generateId = (length = 16): string => {
+  return Math.random()
+    .toString(36)
+    .substring(2, length + 2);
+};


### PR DESCRIPTION
- Does not need secure contexts
- Added a new generateId function to generate unique IDs using Math.random().
- Updated the WebSocketRpcBridge class to use generateId instead of crypto.randomUUID() for generating request IDs.
- Integrated the generateId function in the ChatStateProvider for creating chat and message IDs.
- Updated pnpm-lock.yaml to include nanoid as a dependency.

closes #191 