### PR TITLE
docs: clarify framework-specific package naming

### DIFF
--- a/.changeset/new-cougars-read.md
+++ b/.changeset/new-cougars-read.md
@@ -1,0 +1,14 @@
+---
+"@stagewise/extension-toolbar-srpc-contract": patch
+"stagewise-vscode-extension": patch
+"@stagewise/plugin-example": patch
+"@stagewise-plugins/angular": patch
+"@stagewise-plugins/react": patch
+"@stagewise/toolbar-react": patch
+"@stagewise/toolbar": patch
+"@stagewise/toolbar-next": patch
+"@stagewise-plugins/vue": patch
+"@stagewise/toolbar-vue": patch
+---
+
+Updated the README to clarify how framework-specific packages are named

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -14,6 +14,7 @@ Without these guys, stagewise wouldn't be here. Huge props to:
 ## Special thanks to all the contributors
 
 - [denwaya34](https://github.com/denwaya34)
+- [hwanyoungChoi](https://github.com/hwanyoungChoi)
 
 ## I would like to join this list. How can I help the project?
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ setupStagewise();
 
 ### Framework-specific integration examples
 
-For easier integration, we provide framework-specific NPM packages that come with dedicated toolbar components (e.g., `<StagewiseToolbar>`). You can usually import these from `@stagewise/[framework-name]`.
+For easier integration, we provide framework-specific NPM packages that come with dedicated toolbar components (e.g., `<StagewiseToolbar>`). You can usually import these from `@stagewise/toolbar-[framework-name]`.
 
 <details>
 <summary>React.js</summary>

--- a/apps/vscode-extension/README.md
+++ b/apps/vscode-extension/README.md
@@ -89,7 +89,7 @@ setupStagewise();
 
 ### Framework-specific integration examples
 
-For easier integration, we provide framework-specific NPM packages that come with dedicated toolbar components (e.g., `<StagewiseToolbar>`). You can usually import these from `@stagewise/[framework-name]`.
+For easier integration, we provide framework-specific NPM packages that come with dedicated toolbar components (e.g., `<StagewiseToolbar>`). You can usually import these from `@stagewise/toolbar-[framework-name]`.
 
 <details>
 <summary>React.js</summary>

--- a/toolbar/core/README.md
+++ b/toolbar/core/README.md
@@ -87,7 +87,7 @@ setupStagewise();
 
 ### Framework-specific integration examples
 
-For easier integration, we provide framework-specific NPM packages that come with dedicated toolbar components (e.g., `<StagewiseToolbar>`). You can usually import these from `@stagewise/[framework-name]`.
+For easier integration, we provide framework-specific NPM packages that come with dedicated toolbar components (e.g., `<StagewiseToolbar>`). You can usually import these from `@stagewise/toolbar-[framework-name]`.
 
 <details>
 <summary>React.js</summary>

--- a/toolbar/next/README.md
+++ b/toolbar/next/README.md
@@ -88,7 +88,7 @@ setupStagewise();
 
 ### Framework-specific integration examples
 
-For easier integration, we provide framework-specific NPM packages that come with dedicated toolbar components (e.g., `<StagewiseToolbar>`). You can usually import these from `@stagewise/[framework-name]`.
+For easier integration, we provide framework-specific NPM packages that come with dedicated toolbar components (e.g., `<StagewiseToolbar>`). You can usually import these from `@stagewise/toolbar-[framework-name]`.
 
 <details>
 <summary>React.js</summary>

--- a/toolbar/react/README.md
+++ b/toolbar/react/README.md
@@ -88,7 +88,7 @@ setupStagewise();
 
 ### Framework-specific integration examples
 
-For easier integration, we provide framework-specific NPM packages that come with dedicated toolbar components (e.g., `<StagewiseToolbar>`). You can usually import these from `@stagewise/[framework-name]`.
+For easier integration, we provide framework-specific NPM packages that come with dedicated toolbar components (e.g., `<StagewiseToolbar>`). You can usually import these from `@stagewise/toolbar-[framework-name]`.
 
 <details>
 <summary>React.js</summary>

--- a/toolbar/vue/README.md
+++ b/toolbar/vue/README.md
@@ -88,7 +88,7 @@ setupStagewise();
 
 ### Framework-specific integration examples
 
-For easier integration, we provide framework-specific NPM packages that come with dedicated toolbar components (e.g., `<StagewiseToolbar>`). You can usually import these from `@stagewise/[framework-name]`.
+For easier integration, we provide framework-specific NPM packages that come with dedicated toolbar components (e.g., `<StagewiseToolbar>`). You can usually import these from `@stagewise/toolbar-[framework-name]`.
 
 <details>
 <summary>React.js</summary>


### PR DESCRIPTION
clarify framework-specific package naming