### PR TITLE
Add roocode and cline support

### DIFF
--- a/.changeset/famous-bars-train.md
+++ b/.changeset/famous-bars-train.md
@@ -1,0 +1,5 @@
+---
+"stagewise-vscode-extension": patch
+---
+
+Add roo-code and cline support

--- a/.changeset/fifty-spies-travel.md
+++ b/.changeset/fifty-spies-travel.md
@@ -1,0 +1,8 @@
+---
+"@stagewise/toolbar-react": patch
+"@stagewise/toolbar": patch
+"@stagewise/toolbar-next": patch
+"@stagewise/toolbar-vue": patch
+---
+
+Update README.md to include roocode and cline support

--- a/README.md
+++ b/README.md
@@ -24,13 +24,9 @@
 The stagewise Toolbar makes it incredibly easy to edit your frontend code with AI agents:
 
 * ⚡ Works out of the box
-* 🛠️ Customise using your own configuration file
-* 📦 Does not impact bundle size
-* 🧠 Sends DOM elements, screenshots & metadata to your AI agent
-* 👇 Comment directly on live elements in the browser
-* 🧪 Comes with playgrounds for React, Vue, and Svelte (`./playgrounds`)
-
-
+* 🧩 Customise and extend functionality with Plugins
+* 🧠 Sends DOM elements & more metadata to your AI agent
+* 🧪 Comes with examples for React, Vue, Svelte and more
 
 
 ## 📖 Quickstart 
@@ -276,7 +272,8 @@ You would then use `StagewiseToolbarLoader` in your `src/routes/+layout.svelte`.
 | Cursor          | ✅             |
 | GitHub Copilot  | ✅             |
 | Windsurf        | ✅             |
-| Cline           | 🚧 [See issue](https://github.com/stagewise-io/stagewise/issues/186)            |
+| Cline           | ✅             |
+| Roo-code        | ✅             |
 
 
 ## 🛣️ Roadmap

--- a/apps/vscode-extension/README.md
+++ b/apps/vscode-extension/README.md
@@ -24,13 +24,9 @@
 The stagewise Toolbar makes it incredibly easy to edit your frontend code with AI agents:
 
 * ⚡ Works out of the box
-* 🛠️ Customise using your own configuration file
-* 📦 Does not impact bundle size
-* 🧠 Sends DOM elements, screenshots & metadata to your AI agent
-* 👇 Comment directly on live elements in the browser
-* 🧪 Comes with playgrounds for React, Vue, and Svelte (`./playgrounds`)
-
-
+* 🧩 Customise and extend functionality with Plugins
+* 🧠 Sends DOM elements & more metadata to your AI agent
+* 🧪 Comes with examples for React, Vue, Svelte and more
 
 
 ## 📖 Quickstart 
@@ -276,7 +272,8 @@ You would then use `StagewiseToolbarLoader` in your `src/routes/+layout.svelte`.
 | Cursor          | ✅             |
 | GitHub Copilot  | ✅             |
 | Windsurf        | ✅             |
-| Cline           | 🚧 [See issue](https://github.com/stagewise-io/stagewise/issues/186)            |
+| Cline           | ✅             |
+| Roo-code        | ✅             |
 
 
 ## 🛣️ Roadmap

--- a/apps/vscode-extension/src/utils/call-cline-agent.ts
+++ b/apps/vscode-extension/src/utils/call-cline-agent.ts
@@ -1,0 +1,79 @@
+import * as vscode from 'vscode';
+import type { PromptRequest } from '@stagewise/extension-toolbar-srpc-contract';
+
+const CLINE_PROMPT_PREFIX = `\n\n
+    Ah sorry, my apologies. There are no problems and no fixes to be made. Instead, implement the following request:
+    `;
+
+export async function callClineAgent(request: PromptRequest): Promise<void> {
+  const prompt =
+    `${request.prompt}` +
+    `${request.files ? `\n\n use the following files: ${request.files.join('\n')}` : ''}` +
+    `${request.images ? `\n\n use the following images: ${request.images.join('\n')}` : ''}`;
+  // model: request.model, not supported yet
+  // `${request.model ? `\n\n use the following model: ${request.model}` : ''}` +
+  // mode: request.mode, not supported yet
+  // `${request.mode ? `\n\n use the following mode: ${request.mode}` : ''}`;
+
+  const promptWithPrefix = `${CLINE_PROMPT_PREFIX}\n${prompt}`;
+
+  await callClineWithDiagnostic(promptWithPrefix);
+}
+
+/**
+ * Creates a diagnostic with the prompt and calls the fixWithCline command with the proper signature.
+ */
+async function callClineWithDiagnostic(prompt: string): Promise<void> {
+  let editor = vscode.window.activeTextEditor;
+
+  if (!editor) {
+    try {
+      // Get all workspace files
+      const files = await vscode.workspace.findFiles(
+        '**/*',
+        '**/node_modules/**',
+      );
+
+      if (files.length === 0) {
+        vscode.window.showErrorMessage('No files found in workspace to open.');
+        return;
+      }
+
+      // Open the first file found
+      const document = await vscode.workspace.openTextDocument(files[0]);
+      editor = await vscode.window.showTextDocument(document);
+    } catch (error) {
+      vscode.window.showErrorMessage(
+        'Failed to open existing file for cline agent.',
+      );
+      return;
+    }
+    // Sleep 150ms to ensure editor is ready
+    await new Promise((resolve) => setTimeout(resolve, 150));
+  }
+
+  const document = editor.document;
+
+  try {
+    // Use the current selection or just the current line
+    const expandedRange = editor.selection.isEmpty
+      ? document.lineAt(editor.selection.active.line).range // Use current line if no selection
+      : new vscode.Range(editor.selection.start, editor.selection.end); // Use actual selection if available
+
+    // Create the diagnostic object with the prompt
+    const diagnostic = new vscode.Diagnostic(
+      expandedRange,
+      prompt,
+      vscode.DiagnosticSeverity.Error,
+    );
+
+    // Call the fixWithCline command with the proper signature
+    await vscode.commands.executeCommand('cline.fixWithCline', expandedRange, [
+      diagnostic,
+    ]);
+
+    vscode.window.showInformationMessage('Triggered Cline agent for prompt.');
+  } catch (error) {
+    vscode.window.showErrorMessage(`Failed to call Cline agent: ${error}`);
+  }
+}

--- a/apps/vscode-extension/src/utils/call-roocode-agent.ts
+++ b/apps/vscode-extension/src/utils/call-roocode-agent.ts
@@ -1,0 +1,30 @@
+import * as vscode from 'vscode';
+import { injectPromptDiagnosticWithCallback } from './inject-prompt-diagnostic-with-callback';
+import type { PromptRequest } from '@stagewise/extension-toolbar-srpc-contract';
+
+const ROOCODE_PROMPT_PREFIX = `\n\n
+    Ah sorry, ignore the "Fix any issues" statement and the "Current problems detected" statement.
+    Instead, implement the following request:
+    `;
+
+const ROOCODE_PROMPT_SUFFIX = `\n
+    Ignore the following line of code:
+    `;
+
+export async function callRoocodeAgent(request: PromptRequest): Promise<void> {
+  const prompt =
+    `${request.prompt}` +
+    `${request.files ? `\n\n use the following files: ${request.files.join('\n')}` : ''}` +
+    `${request.images ? `\n\n use the following images: ${request.images.join('\n')}` : ''}`;
+  // model: request.model, not supported yet
+  // `${request.model ? `\n\n use the following model: ${request.model}` : ''}` +
+  // mode: request.mode, not supported yet
+  // `${request.mode ? `\n\n use the following mode: ${request.mode}` : ''}`;
+
+  const promptWithPrefix = `${ROOCODE_PROMPT_PREFIX}\n${prompt}${ROOCODE_PROMPT_SUFFIX}`;
+  await injectPromptDiagnosticWithCallback({
+    prompt: promptWithPrefix,
+    callback: () =>
+      vscode.commands.executeCommand('roo-cline.fixCode') as Promise<any>,
+  });
+}

--- a/apps/vscode-extension/src/utils/dispatch-agent-call.ts
+++ b/apps/vscode-extension/src/utils/dispatch-agent-call.ts
@@ -3,8 +3,12 @@ import { callCursorAgent } from './call-cursor-agent';
 import { isCopilotChatInstalled } from './is-copilot-chat-installed';
 import { callCopilotAgent } from './call-copilot-agent';
 import { callWindsurfAgent } from './call-windsurf-agent';
+import { isRoocodeInstalled } from './is-roocode-installed';
+import { callRoocodeAgent } from './call-roocode-agent';
+import { callClineAgent } from './call-cline-agent';
 import * as vscode from 'vscode';
 import type { PromptRequest } from '@stagewise/extension-toolbar-srpc-contract';
+import { isClineInstalled } from './is-cline-installed';
 
 export async function dispatchAgentCall(request: PromptRequest) {
   const ide = getCurrentIDE();
@@ -14,6 +18,8 @@ export async function dispatchAgentCall(request: PromptRequest) {
     case 'WINDSURF':
       return await callWindsurfAgent(request);
     case 'VSCODE':
+      if (isClineInstalled()) return await callClineAgent(request);
+      if (isRoocodeInstalled()) return await callRoocodeAgent(request);
       if (isCopilotChatInstalled()) return await callCopilotAgent(request);
       else {
         vscode.window.showErrorMessage(

--- a/apps/vscode-extension/src/utils/inject-prompt-diagnostic-with-callback.ts
+++ b/apps/vscode-extension/src/utils/inject-prompt-diagnostic-with-callback.ts
@@ -52,13 +52,13 @@ export async function injectPromptDiagnosticWithCallback(params: {
   );
 
   try {
-    // Use a large range or the current selection - using full doc range here
-    const selectionOrFullDocRange = editor.selection.isEmpty
-      ? new vscode.Range(0, 0, document.lineCount, 0) // Fallback to full doc if no selection
+    // Use the current selection or just the current line
+    const selectionOrCurrentLine = editor.selection.isEmpty
+      ? document.lineAt(editor.selection.active.line).range // Use current line if no selection
       : editor.selection; // Use actual selection if available
     // 1. Create the fake diagnostic object
     const fakeDiagnostic = new vscode.Diagnostic(
-      selectionOrFullDocRange,
+      selectionOrCurrentLine,
       params.prompt,
       vscode.DiagnosticSeverity.Error,
     );
@@ -69,8 +69,8 @@ export async function injectPromptDiagnosticWithCallback(params: {
 
     // 3. Ensure cursor is within the diagnostic range (e.g., start)
     editor.selection = new vscode.Selection(
-      selectionOrFullDocRange.start,
-      selectionOrFullDocRange.start,
+      selectionOrCurrentLine.start,
+      selectionOrCurrentLine.start,
     );
 
     // 5. Execute the callback command

--- a/apps/vscode-extension/src/utils/is-cline-installed.ts
+++ b/apps/vscode-extension/src/utils/is-cline-installed.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 
 /**
- * Checks if the GitHub Copilot Chat extension is installed.
+ * Checks if the Cline extension is installed.
  * @returns True if the extension is installed, false otherwise.
  */
 export function isClineInstalled(): boolean {

--- a/apps/vscode-extension/src/utils/is-cline-installed.ts
+++ b/apps/vscode-extension/src/utils/is-cline-installed.ts
@@ -1,0 +1,11 @@
+import * as vscode from 'vscode';
+
+/**
+ * Checks if the GitHub Copilot Chat extension is installed.
+ * @returns True if the extension is installed, false otherwise.
+ */
+export function isClineInstalled(): boolean {
+  const extensionId = 'saoudrizwan.claude-dev';
+  const extension = vscode.extensions.getExtension(extensionId);
+  return !!extension;
+}

--- a/apps/vscode-extension/src/utils/is-roocode-installed.ts
+++ b/apps/vscode-extension/src/utils/is-roocode-installed.ts
@@ -1,0 +1,11 @@
+import * as vscode from 'vscode';
+
+/**
+ * Checks if the GitHub Copilot Chat extension is installed.
+ * @returns True if the extension is installed, false otherwise.
+ */
+export function isRoocodeInstalled(): boolean {
+  const extensionId = 'RooVeterinaryInc.roo-cline';
+  const extension = vscode.extensions.getExtension(extensionId);
+  return !!extension;
+}

--- a/apps/vscode-extension/src/utils/is-roocode-installed.ts
+++ b/apps/vscode-extension/src/utils/is-roocode-installed.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 
 /**
- * Checks if the GitHub Copilot Chat extension is installed.
+ * Checks if the Roo-code extension is installed.
  * @returns True if the extension is installed, false otherwise.
  */
 export function isRoocodeInstalled(): boolean {

--- a/toolbar/core/README.md
+++ b/toolbar/core/README.md
@@ -29,8 +29,6 @@ The stagewise Toolbar makes it incredibly easy to edit your frontend code with A
 * 🧪 Comes with examples for React, Vue, Svelte and more
 
 
-
-
 ## 📖 Quickstart 
 
 ### 1. 🧩 **Install the vs-code extension** 
@@ -274,7 +272,8 @@ You would then use `StagewiseToolbarLoader` in your `src/routes/+layout.svelte`.
 | Cursor          | ✅             |
 | GitHub Copilot  | ✅             |
 | Windsurf        | ✅             |
-| Cline           | 🚧 [See issue](https://github.com/stagewise-io/stagewise/issues/186)            |
+| Cline           | ✅             |
+| Roo-code        | ✅             |
 
 
 ## 🛣️ Roadmap

--- a/toolbar/next/README.md
+++ b/toolbar/next/README.md
@@ -19,7 +19,6 @@
 > Perfect for devs tired of pasting folder paths into prompts. stagewise gives your AI real-time, browser-powered context.
 
 
-
 ## ✨ Features
 
 The stagewise Toolbar makes it incredibly easy to edit your frontend code with AI agents:
@@ -28,8 +27,6 @@ The stagewise Toolbar makes it incredibly easy to edit your frontend code with A
 * 🧩 Customise and extend functionality with Plugins
 * 🧠 Sends DOM elements & more metadata to your AI agent
 * 🧪 Comes with examples for React, Vue, Svelte and more
-
-
 
 
 ## 📖 Quickstart 
@@ -275,7 +272,8 @@ You would then use `StagewiseToolbarLoader` in your `src/routes/+layout.svelte`.
 | Cursor          | ✅             |
 | GitHub Copilot  | ✅             |
 | Windsurf        | ✅             |
-| Cline           | 🚧 [See issue](https://github.com/stagewise-io/stagewise/issues/186)            |
+| Cline           | ✅             |
+| Roo-code        | ✅             |
 
 
 ## 🛣️ Roadmap

--- a/toolbar/react/README.md
+++ b/toolbar/react/README.md
@@ -19,7 +19,6 @@
 > Perfect for devs tired of pasting folder paths into prompts. stagewise gives your AI real-time, browser-powered context.
 
 
-
 ## ✨ Features
 
 The stagewise Toolbar makes it incredibly easy to edit your frontend code with AI agents:
@@ -28,8 +27,6 @@ The stagewise Toolbar makes it incredibly easy to edit your frontend code with A
 * 🧩 Customise and extend functionality with Plugins
 * 🧠 Sends DOM elements & more metadata to your AI agent
 * 🧪 Comes with examples for React, Vue, Svelte and more
-
-
 
 
 ## 📖 Quickstart 
@@ -275,7 +272,8 @@ You would then use `StagewiseToolbarLoader` in your `src/routes/+layout.svelte`.
 | Cursor          | ✅             |
 | GitHub Copilot  | ✅             |
 | Windsurf        | ✅             |
-| Cline           | 🚧 [See issue](https://github.com/stagewise-io/stagewise/issues/186)            |
+| Cline           | ✅             |
+| Roo-code        | ✅             |
 
 
 ## 🛣️ Roadmap

--- a/toolbar/vue/README.md
+++ b/toolbar/vue/README.md
@@ -19,7 +19,6 @@
 > Perfect for devs tired of pasting folder paths into prompts. stagewise gives your AI real-time, browser-powered context.
 
 
-
 ## ✨ Features
 
 The stagewise Toolbar makes it incredibly easy to edit your frontend code with AI agents:
@@ -28,8 +27,6 @@ The stagewise Toolbar makes it incredibly easy to edit your frontend code with A
 * 🧩 Customise and extend functionality with Plugins
 * 🧠 Sends DOM elements & more metadata to your AI agent
 * 🧪 Comes with examples for React, Vue, Svelte and more
-
-
 
 
 ## 📖 Quickstart 
@@ -275,7 +272,8 @@ You would then use `StagewiseToolbarLoader` in your `src/routes/+layout.svelte`.
 | Cursor          | ✅             |
 | GitHub Copilot  | ✅             |
 | Windsurf        | ✅             |
-| Cline           | 🚧 [See issue](https://github.com/stagewise-io/stagewise/issues/186)            |
+| Cline           | ✅             |
+| Roo-code        | ✅             |
 
 
 ## 🛣️ Roadmap


### PR DESCRIPTION
This pull request introduces support for two new AI agents, Cline and Roo-code, across multiple components, and updates documentation to reflect these additions. It also includes enhancements to the VS Code extension's functionality for interacting with these agents.

closes #186 
closes #135 
closes #133 

### New AI Agent Support:

* **Cline Agent Integration**:
  - Added `callClineAgent` function to handle prompts for the Cline agent in `apps/vscode-extension/src/utils/call-cline-agent.ts`.
  - Implemented `isClineInstalled` utility to check for the presence of the Cline extension in `apps/vscode-extension/src/utils/is-cline-installed.ts`.

* **Roo-code Agent Integration**:
  - Added `callRoocodeAgent` function to handle prompts for the Roo-code agent in `apps/vscode-extension/src/utils/call-roocode-agent.ts`.
  - Implemented `isRoocodeInstalled` utility to check for the presence of the Roo-code extension in `apps/vscode-extension/src/utils/is-roocode-installed.ts`.

### Enhancements to VS Code Extension:

* Updated `dispatch-agent-call.ts` to route requests to Cline or Roo-code agents if their respective extensions are installed. [[1]](diffhunk://#diff-2bca262360c39ca7a008a8bbafaca93988ec624c325f4761f8e8be282de88a59R6-R11) [[2]](diffhunk://#diff-2bca262360c39ca7a008a8bbafaca93988ec624c325f4761f8e8be282de88a59R21-R22)
* Improved diagnostic range handling for injected prompts in `inject-prompt-diagnostic-with-callback.ts`. [[1]](diffhunk://#diff-3a955a1de559effbd7c06c4aa40e09fb875b56ffd17088a17e2ff1617329d010L55-R61) [[2]](diffhunk://#diff-3a955a1de559effbd7c06c4aa40e09fb875b56ffd17088a17e2ff1617329d010L72-R73)

### Documentation Updates:

* Modified README files across multiple components (`README.md`, `apps/vscode-extension/README.md`, `toolbar/core/README.md`, `toolbar/next/README.md`, `toolbar/react/README.md`, `toolbar/vue/README.md`) to include information about Cline and Roo-code support and updated feature descriptions. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L27-R29) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L279-R276) [[3]](diffhunk://#diff-ff01a85a7633931d9e1f293e508383d7e914ea20bf729e5530dc558ad322354fL22) [[4]](diffhunk://#diff-ff01a85a7633931d9e1f293e508383d7e914ea20bf729e5530dc558ad322354fL33-L34) [[5]](diffhunk://#diff-ff01a85a7633931d9e1f293e508383d7e914ea20bf729e5530dc558ad322354fL278-R276)

### Changeset Updates:

* Added changesets to document the addition of Cline and Roo-code support (`.changeset/famous-bars-train.md`, `.changeset/fifty-spies-travel.md`). [[1]](diffhunk://#diff-b5e034ce95a45433b892cae95714d7c29ee351bc380b279547bbe554059425d6R1-R5) [[2]](diffhunk://#diff-5fad8ceee077cadb82a88e3a5a938d77f2175cf1c0e72c684ff8f7a510392659R1-R8)