### PR TITLE
chore(dependabot): configure daily npm updates with specific ignore rules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,11 @@
-
 version: 2
 updates:
   - package-ecosystem: "npm"
     directory: "/"
-    version: 
     schedule:
       interval: "daily"
-    update-types: "minor"
+    allow:
+      - update-types: ["minor"]
     reviewers:
       - "juliangoetze"
     ignore:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    version: 
+    schedule:
+      interval: "daily"
+    update-types: "minor"
+    reviewers:
+      - "juliangoetze"
+    ignore:
+      # Ignore updates to @headlessui/react since we patched it to 2.2.2
+      - dependency-name: "@headlessui/react"


### PR DESCRIPTION
- Added a new dependabot configuration file to schedule daily updates for npm packages.
- Set to ignore updates for @headlessui/react due to a custom patch applied.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added automated checks for npm package updates, with daily scans and minor version updates only.
  - Updates for "@headlessui/react" will be ignored due to a manual patch.
  - Designated a reviewer for update approvals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->