### PR TITLE
feat(plugin): add onPromptTransmit hook for plugins before prompt transmission

### DIFF
--- a/examples/angular-example/src/main.ts
+++ b/examples/angular-example/src/main.ts
@@ -7,7 +7,15 @@ import { AngularPlugin } from '@stagewise-plugins/angular';
 // Only initialize in development mode (customize as needed)
 if (!('production' in window) || !window.production) {
   initToolbar({
-    plugins: [AngularPlugin],
+    plugins: [
+      {
+        ...AngularPlugin,
+        onPromptTransmit: (prompt) => {
+          // copy to clipboard
+          void navigator.clipboard.writeText(`prompt: ${prompt}`);
+        },
+      } satisfies typeof AngularPlugin,
+    ],
   });
 }
 

--- a/toolbar/core/src/hooks/use-chat-state.tsx
+++ b/toolbar/core/src/hooks/use-chat-state.tsx
@@ -341,6 +341,12 @@ export const ChatStateProvider = ({ children }: ChatStateProviderProps) => {
         pluginContextSnippets,
       );
 
+      for (const plugin of plugins) {
+        if (plugin.onPromptTransmit) {
+          await plugin.onPromptTransmit(prompt);
+        }
+      }
+
       const newMessage: Message = {
         id: generateId(),
         content: content.trim(),

--- a/toolbar/core/src/plugin.ts
+++ b/toolbar/core/src/plugin.ts
@@ -221,6 +221,11 @@ export interface ToolbarPlugin {
     | ((prompt: UserMessage) => PromptContext | Promise<PromptContext> | null)
     | null;
 
+  /** Called immediately before the prompt is transmitted to the agent via SRPC. */
+  onPromptTransmit?:
+      | ((prompt: string) => void | Promise<void>)
+      | null;
+
   /** Called when a context element is hovered in the context menu. This only happens in prompting mode. */
   onContextElementHover?:
     | ((element: HTMLElement) => ContextElementContext)


### PR DESCRIPTION
Add a new plugin lifecycle hook `onPromptTransmit` that is called immediately
  before the prompt is sent to the AI agent via SRPC. This allows plugins to
  perform actions with the final prompt string, such as logging, analytics, or
  copying to clipboard.

  ### Motivation

  When developing with Claude Code, there's a need to copy prompts to the clipboard
  for easier integration with the AI assistant. This hook enables developers to
  intercept and manipulate the final prompt before transmission, supporting various
  workflows including clipboard-based development patterns.

  ### Changes

  The hook signature:
  - Receives the complete prompt string as a parameter
  - Can be async (returns `Promise<void>`) or sync (returns `void`)
  - Executes after all context has been assembled but before SRPC transmission

  ### Implementation

  - Added `onPromptTransmit?: ((prompt: string) => void | Promise<void>) | null` to `ToolbarPlugin` interface
  - Integrated the hook into `use-chat-state.tsx` to call all plugin hooks before SRPC transmission
  - Updated Angular example to demonstrate copying prompt to clipboard

  ### Example Usage

  ```typescript
  {
    ...AngularPlugin,
    onPromptTransmit: (prompt) => {
      // copy to clipboard
      void navigator.clipboard.writeText(`prompt: ${prompt}`);
    },
  }
```
  
### Use Cases

  - Clipboard Integration: Copy prompts for use with Claude Code or other AI assistants
  - Analytics: Track prompt usage and patterns
  - Logging: Debug prompt generation and content
  - External Integration: Send prompts to third-party services
  