### PR TITLE
fix(element-selector): prevent default behavior on element selection …

### DIFF
--- a/toolbar/core/src/components/dom-context/element-selector.tsx
+++ b/toolbar/core/src/components/dom-context/element-selector.tsx
@@ -39,9 +39,13 @@ export function ElementSelector(props: ElementSelectorProps) {
 
   const handleMouseClick = useCallback<
     MouseEventHandler<HTMLDivElement>
-  >(() => {
+  >((event) => {
     if (!lastHoveredElement.current) return;
     if (props.ignoreList.includes(lastHoveredElement.current)) return;
+    
+    event.preventDefault();
+    event.stopPropagation();
+    
     props.onElementSelected(lastHoveredElement.current);
   }, [props]);
 


### PR DESCRIPTION
This PR resolves an issue where activating the element selector with Cmd+Option+C (or Ctrl+Alt+C) and clicking an element within a modal would cause the modal to close. This was happening because the click event was propagating up to the modal's backdrop handler, which interpreted it as a "click outside" event.

I've updated the ElementSelector component to call event.preventDefault() and event.stopPropagation() on click. This ensures that the click event is handled exclusively by the element selector, preventing it from interfering with other UI components like modals.

**How to test:**
1. Open a modal in your application.
2. Press Cmd+Option+C to activate the element selector.
3. Click on any element inside the modal.
4. The modal should remain open and the element should be selected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved element selection to prevent default browser actions and stop event propagation when selecting elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->