### PR TITLE
Fix plugin hang when no elements are selected

### DIFF
--- a/.changeset/stale-yaks-yawn.md
+++ b/.changeset/stale-yaks-yawn.md
@@ -1,0 +1,7 @@
+---
+"@stagewise-plugins/angular": patch
+"@stagewise-plugins/react": patch
+"@stagewise-plugins/vue": patch
+---
+
+Fix plugin hang when no elements are selected

--- a/plugins/angular/src/index.tsx
+++ b/plugins/angular/src/index.tsx
@@ -13,12 +13,20 @@ export const AngularPlugin: ToolbarPlugin = {
   pluginName: 'angular',
   onContextElementHover: getSelectedElementAnnotation,
   onContextElementSelect: getSelectedElementAnnotation,
-  onPromptSend: (prompt) => ({
-    contextSnippets: [
-      {
-        promptContextName: 'elements-angular-component-info',
-        content: getSelectedElementsPrompt(prompt.contextElements),
-      },
-    ],
-  }),
+  onPromptSend: (prompt) => {
+    const content = getSelectedElementsPrompt(prompt.contextElements);
+
+    if (!content) {
+      return { contextSnippets: [] };
+    }
+
+    return {
+      contextSnippets: [
+        {
+          promptContextName: 'elements-angular-component-info',
+          content: content,
+        },
+      ],
+    };
+  },
 };

--- a/plugins/react/src/index.tsx
+++ b/plugins/react/src/index.tsx
@@ -14,12 +14,20 @@ export const ReactPlugin: ToolbarPlugin = {
   pluginName: 'react',
   onContextElementHover: getSelectedElementAnnotation,
   onContextElementSelect: getSelectedElementAnnotation,
-  onPromptSend: (prompt) => ({
-    contextSnippets: [
-      {
-        promptContextName: 'elements-react-component-info',
-        content: getSelectedElementsPrompt(prompt.contextElements),
-      },
-    ],
-  }),
+  onPromptSend: (prompt) => {
+    const content = getSelectedElementsPrompt(prompt.contextElements);
+
+    if (!content) {
+      return { contextSnippets: [] };
+    }
+
+    return {
+      contextSnippets: [
+        {
+          promptContextName: 'elements-react-component-info',
+          content: content,
+        },
+      ],
+    };
+  },
 };

--- a/plugins/vue/src/index.tsx
+++ b/plugins/vue/src/index.tsx
@@ -13,12 +13,21 @@ export const VuePlugin: ToolbarPlugin = {
   pluginName: 'vue',
   onContextElementHover: getSelectedElementAnnotation,
   onContextElementSelect: getSelectedElementAnnotation,
-  onPromptSend: (prompt) => ({
-    contextSnippets: [
-      {
-        promptContextName: 'elements-vue-component-info',
-        content: getSelectedElementsPrompt(prompt.contextElements),
-      },
-    ],
-  }),
+  onPromptSend: (prompt) => {
+    const content = getSelectedElementsPrompt(prompt.contextElements);
+
+    // contentがnullの場合は空配列を返す
+    if (!content) {
+      return { contextSnippets: [] };
+    }
+
+    return {
+      contextSnippets: [
+        {
+          promptContextName: 'elements-vue-component-info',
+          content: content,
+        },
+      ],
+    };
+  },
 };


### PR DESCRIPTION
This PR fixes a problem with toolbar/core/src/hooks/use-chat-state.tsx L:309 that caused an error in toolbar/core/src/hooks/use-chat-state.tsx L:309 due to content being null when using a plugin and a prompt is sent without an element selected.