### PR TITLE
feat(toolbar): wrap UI in closed Shadow DOM and remove postcss-prefix-selector

### DIFF
--- a/.changeset/silver-doodles-admire.md
+++ b/.changeset/silver-doodles-admire.md
@@ -1,0 +1,5 @@
+---
+"@stagewise/toolbar": patch
+---
+
+wrap toolbar UI in closed Shadow DOM

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -910,9 +910,6 @@ importers:
       postcss:
         specifier: ^8.5.3
         version: 8.5.3
-      postcss-prefix-selector:
-        specifier: ^2.1.1
-        version: 2.1.1(postcss@8.5.3)
       preact:
         specifier: ^10.26.6
         version: 10.26.6
@@ -10422,11 +10419,6 @@ packages:
     engines: {node: ^18.12.0 || ^20.9.0 || >=22.0}
     peerDependencies:
       postcss: ^8.4.32
-
-  postcss-prefix-selector@2.1.1:
-    resolution: {integrity: sha512-ZBgf427Et6+XnrnJ9VXtJEKCjJwTvn2wn/qMg+wvvlRhIeFIAxdbrlZZ0CSsWYMJfcyPLBh8ogj5O1kb/Mcx3g==}
-    peerDependencies:
-      postcss: ^8.0.0
 
   postcss-reduce-initial@7.0.3:
     resolution: {integrity: sha512-RFvkZaqiWtGMlVjlUHpaxGqEL27lgt+Q2Ixjf83CRAzqdo+TsDyGPtJUbPx2MuYIJ+sCQc2TrOvRnhcXQfgIVA==}
@@ -24269,10 +24261,6 @@ snapshots:
       cssnano-utils: 5.0.1(postcss@8.5.3)
       postcss: 8.5.3
       postcss-value-parser: 4.2.0
-
-  postcss-prefix-selector@2.1.1(postcss@8.5.3):
-    dependencies:
-      postcss: 8.5.3
 
   postcss-reduce-initial@7.0.3(postcss@8.5.3):
     dependencies:

--- a/toolbar/core/package.json
+++ b/toolbar/core/package.json
@@ -70,7 +70,6 @@
     "clsx": "^2.1.1",
     "lucide-react": "^0.503.0",
     "postcss": "^8.5.3",
-    "postcss-prefix-selector": "^2.1.1",
     "preact": "^10.26.6",
     "tailwind-merge": "^3.2.0",
     "tailwindcss": "^4.1.5",

--- a/toolbar/core/postcss.config.js
+++ b/toolbar/core/postcss.config.js
@@ -1,29 +1,6 @@
-const prefixWhereOverrideList = ['html', 'body'];
-const prefixElementOverrideList = [':root', ':host'];
-
 export default {
   plugins: {
     '@tailwindcss/postcss': {},
     autoprefixer: {},
-    'postcss-prefix-selector': {
-      prefix: 'stagewise-companion-anchor',
-      transform: (prefix, selector, prefixedSelector, filePath, rule) => {
-        if (prefixWhereOverrideList.includes(selector)) {
-          return `:where(${prefix})`;
-        } else if (
-          prefixElementOverrideList.some((sel) => selector.includes(sel))
-        ) {
-          const cleanedSelector = prefixElementOverrideList.reduce(
-            (acc, sel) => {
-              return acc.replace(sel, prefix);
-            },
-            selector,
-          );
-          return cleanedSelector;
-        } else {
-          return prefixedSelector;
-        }
-      },
-    },
   },
 };

--- a/toolbar/core/src/app.css
+++ b/toolbar/core/src/app.css
@@ -13,7 +13,7 @@
   100% { background-position: 0% 50%; }
 }
 
-stagewise-companion-anchor {
+:host {
   all: initial;
   @apply text-zinc-950;
   font-family: "Inter", "Noto Color Emoji", -apple-system, BlinkMacSystemFont,
@@ -28,7 +28,7 @@ stagewise-companion-anchor {
 }
 
 @layer base {
-  stagewise-companion-anchor * {
+  * {
     min-height: 0;
     min-width: 0;
     position: relative;
@@ -80,7 +80,7 @@ stagewise-companion-anchor {
 }
 
 @supports (font-variation-settings: normal) {
-  stagewise-companion-anchor {
+  :host {
     font-family: "InterVariable", "Noto Color Emoji", -apple-system,
       BlinkMacSystemFont, "Segoe UI", Roboto, "SF Compact", "SF Pro",
       "Helvetica Neue", sans-serif !important;
@@ -94,12 +94,4 @@ stagewise-companion-anchor {
   --color-muted: var(--color-zinc-100);
   --color-muted-foreground: var(--color-zinc-700);
   --color-border: var(--color-zinc-500);
-}
-
-#headlessui-portal-root {
-  @apply fixed h-screen w-screen z-50;
-}
-
-#headlessui-portal-root > * {
-  @apply pointer-events-auto;
 }

--- a/toolbar/core/src/index.ts
+++ b/toolbar/core/src/index.ts
@@ -46,16 +46,30 @@ export function initToolbar(config?: ToolbarConfig) {
   shadowDomAnchor.onfocus = eventBlocker;
   shadowDomAnchor.onblur = eventBlocker;
 
+  const shadowRoot = shadowDomAnchor.attachShadow({ mode: 'closed' });
+
   document.body.appendChild(shadowDomAnchor);
+
+  const portalRoot = document.getElementById('headlessui-portal-root');
+  if (portalRoot) {
+    portalRoot.style.position = 'fixed';
+    portalRoot.style.height = '100vh';
+    portalRoot.style.width = '100vw';
+    portalRoot.style.zIndex = '50';
+    Array.from(portalRoot.children).forEach((child) => {
+      (child as HTMLElement).style.pointerEvents = 'auto';
+    });
+  }
 
   const fontLinkNode = document.createElement('link');
   fontLinkNode.rel = 'stylesheet';
   fontLinkNode.href = `https://rsms.me/inter/inter.css`;
-  document.head.appendChild(fontLinkNode);
+  shadowRoot.appendChild(fontLinkNode);
 
   /** Insert generated css into shadow dom */
   const styleNode = document.createElement('style');
   styleNode.append(document.createTextNode(appStyle));
-  document.head.appendChild(styleNode);
-  render(createElement(App, config), shadowDomAnchor);
+  shadowRoot.appendChild(styleNode);
+
+  render(createElement(App, config), shadowRoot);
 }


### PR DESCRIPTION
This PR isolates the stagewise toolbar’s styles from the parent application by introducing a closed Shadow DOM for the toolbar container.
Key changes:
- Removed the postcss-prefix-selector plugin and corresponding namespaced CSS rules.
- In initToolbar(), we now:
    - Attach a closed shadowRoot to the toolbar anchor.
    - Append the Inter font <link> and compiled CSS into this shadowRoot.
    - Render the toolbar React app into the shadowRoot.
- We also adjust the headlessui-portal-root styles at runtime if present, ensuring tooltips, modals, etc., still function correctly in a fixed overlay.
- CSS rules now use :host and global selectors only within the shadow context.

This ensures the toolbar’s styles are fully encapsulated, avoiding any style leakage or collision with the host app.