### PR TITLE
Prevent dialog closing on click

### DIFF
--- a/.changeset/new-melons-press.md
+++ b/.changeset/new-melons-press.md
@@ -1,0 +1,5 @@
+---
+"@stagewise/toolbar": patch
+---
+
+Fixing the issue that popups close after selecting them with stagewise.

--- a/toolbar/core/src/components/dom-context/element-selector.tsx
+++ b/toolbar/core/src/components/dom-context/element-selector.tsx
@@ -37,13 +37,18 @@ export function ElementSelector(props: ElementSelectorProps) {
     props.onElementUnhovered();
   }, [props]);
 
-  const handleMouseClick = useCallback<
-    MouseEventHandler<HTMLDivElement>
-  >(() => {
-    if (!lastHoveredElement.current) return;
-    if (props.ignoreList.includes(lastHoveredElement.current)) return;
-    props.onElementSelected(lastHoveredElement.current);
-  }, [props]);
+  const handleMouseClick = useCallback<MouseEventHandler<HTMLDivElement>>(
+    (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+
+      if (!lastHoveredElement.current) return;
+      if (props.ignoreList.includes(lastHoveredElement.current)) return;
+
+      props.onElementSelected(lastHoveredElement.current);
+    },
+    [props],
+  );
 
   return (
     <div


### PR DESCRIPTION
This pull request addresses a bug fix for the `@stagewise/toolbar` package and improves the `ElementSelector` component's event handling logic. The most important changes include documenting the patch in the changelog and modifying the `handleMouseClick` function to prevent unintended event propagation.

### Bug Fix:
* [`.changeset/new-melons-press.md`](diffhunk://#diff-d250d20df782ce2a9dda3f15019fd53b53cbd4df022cbdab4eebc87ec346976dR1-R5): Added a patch note for the `@stagewise/toolbar` package to document the fix for an issue where popups were closing after being selected.

### Code Improvement:
* [`toolbar/core/src/components/dom-context/element-selector.tsx`](diffhunk://#diff-d7ea855c33acc25272e5db92fe74700333216016bdb966e6e060d64b8e3ddc2eL40-R51): Updated the `handleMouseClick` function in the `ElementSelector` component to include `event.preventDefault()` and `event.stopPropagation()`, ensuring that click events do not propagate unintentionally and interfere with other elements.