### PR TITLE
feat: support trae ide

### DIFF
--- a/.changeset/tender-ties-fly.md
+++ b/.changeset/tender-ties-fly.md
@@ -1,5 +1,5 @@
 ---
-"stagewise-vscode-extension": major
+"stagewise-vscode-extension": minor
 ---
 
 Support Trae IDE

--- a/.changeset/tender-ties-fly.md
+++ b/.changeset/tender-ties-fly.md
@@ -1,0 +1,5 @@
+---
+"stagewise-vscode-extension": major
+---
+
+Support Trae IDE

--- a/apps/vscode-extension/src/utils/call-trae-agent.ts
+++ b/apps/vscode-extension/src/utils/call-trae-agent.ts
@@ -1,0 +1,20 @@
+import type { PromptRequest } from '@stagewise/extension-toolbar-srpc-contract';
+import * as vscode from 'vscode';
+
+/**
+ * Calls the Trae IDE agent with a formatted prompt.
+ * 
+ * This function formats the request object into a single string prompt and
+ * uses the command 'workbench.action.chat.icube.open' to send it to the
+ * Trae IDE's chat interface.
+ * 
+ * 
+ * @param request The prompt request containing the core prompt and context files.
+ */
+export async function callTraeAgent(request: PromptRequest): Promise<void> {
+  await vscode.commands.executeCommand('workbench.action.chat.icube.open', { 
+    query: request.prompt,
+    newChat: true,
+    keepOpen: true
+  });
+}

--- a/apps/vscode-extension/src/utils/call-trae-agent.ts
+++ b/apps/vscode-extension/src/utils/call-trae-agent.ts
@@ -15,6 +15,6 @@ export async function callTraeAgent(request: PromptRequest): Promise<void> {
   await vscode.commands.executeCommand('workbench.action.chat.icube.open', { 
     query: request.prompt,
     newChat: true,
-    keepOpen: true
+    keepOpen: true,
   });
 }

--- a/apps/vscode-extension/src/utils/dispatch-agent-call.ts
+++ b/apps/vscode-extension/src/utils/dispatch-agent-call.ts
@@ -9,10 +9,13 @@ import { callClineAgent } from './call-cline-agent';
 import * as vscode from 'vscode';
 import type { PromptRequest } from '@stagewise/extension-toolbar-srpc-contract';
 import { isClineInstalled } from './is-cline-installed';
+import { callTraeAgent } from './call-trae-agent';
 
 export async function dispatchAgentCall(request: PromptRequest) {
   const ide = getCurrentIDE();
   switch (ide) {
+    case 'TRAE':  
+      return await callTraeAgent(request);
     case 'CURSOR':
       return await callCursorAgent(request);
     case 'WINDSURF':

--- a/apps/vscode-extension/src/utils/get-current-ide.ts
+++ b/apps/vscode-extension/src/utils/get-current-ide.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 
-export type IDE = 'VSCODE' | 'WINDSURF' | 'CURSOR' | 'UNKNOWN';
+export type IDE = 'VSCODE' | 'WINDSURF' | 'CURSOR' | 'TRAE' | 'UNKNOWN';
 
 export function getCurrentIDE(): IDE {
   if (vscode.env.appName.toLowerCase().includes('windsurf')) {
@@ -9,6 +9,9 @@ export function getCurrentIDE(): IDE {
     return 'CURSOR';
   } else if (vscode.env.appName.toLowerCase().includes('visual studio code')) {
     return 'VSCODE';
+  } else if (vscode.env.appName.toLowerCase().includes('trae')) {
+    return 'TRAE';
   }
+
   return 'UNKNOWN';
 }


### PR DESCRIPTION
Need new version vscode extension package to test Trae IDE.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the Trae IDE in the VSCode extension, enabling detection and interaction with the Trae IDE environment.
  * The extension can now send prompts directly to the Trae IDE agent's chat interface.

* **Chores**
  * Declared a minor version update to reflect the new Trae IDE support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->