### PR TITLE
docs(readme): add local testing instructions to README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,19 @@ For use cases that fall outside the scope permitted by the AGPLv3 license, feel 
 
 We're just getting started and love contributions! Check out our [CONTRIBUTING.md](https://github.com/stagewise-io/stagewise/blob/main/CONTRIBUTING.md) guide to get involved. For bugs and fresh ideas, please [Open an issue!](https://github.com/stagewise-io/stagewise/issues) 
 
+## 💻 Test stagewise locally
+
+1. `git clone https://github.com/stagewise-io/stagewise && cd stagewise` 
+2. `pnpm i && pnpm dev`
+3. Open the `stagewise` project in your IDE
+4. Uninstall/ Disable the official `stagewise` extension
+5. Press F5 (a new IDE window with the local extension-version installed will open up)
+6. Visit `http://localhost:3002` 
+> You will see a next.js example application with the `stagewise`-toolbar already set up.
+> It will be connected to the local vscode-extension in `apps/vscode-extension` and reflect all the extension-changes you apply locally.
+
+
+
 ## 💬 Community & Support 
 
 * 👾 [Join our Discord](https://discord.gg/gkdGsDYaKA)
@@ -303,5 +316,3 @@ We're just getting started and love contributions! Check out our [CONTRIBUTING.m
 Got questions or want to license stagewise for commercial or enterprise use?
 
 📧 **[sales@stagewise.io](mailto:sales@stagewise.io)**
-
-

--- a/apps/vscode-extension/README.md
+++ b/apps/vscode-extension/README.md
@@ -292,6 +292,19 @@ For use cases that fall outside the scope permitted by the AGPLv3 license, feel 
 
 We're just getting started and love contributions! Check out our [CONTRIBUTING.md](https://github.com/stagewise-io/stagewise/blob/main/CONTRIBUTING.md) guide to get involved. For bugs and fresh ideas, please [Open an issue!](https://github.com/stagewise-io/stagewise/issues) 
 
+## 💻 Test stagewise locally
+
+1. `git clone https://github.com/stagewise-io/stagewise && cd stagewise` 
+2. `pnpm i && pnpm dev`
+3. Open the `stagewise` project in your IDE
+4. Uninstall/ Disable the official `stagewise` extension
+5. Press F5 (a new IDE window with the local extension-version installed will open up)
+6. Visit `http://localhost:3002` 
+> You will see a next.js example application with the `stagewise`-toolbar already set up.
+> It will be connected to the local vscode-extension in `apps/vscode-extension` and reflect all the extension-changes you apply locally.
+
+
+
 ## 💬 Community & Support 
 
 * 👾 [Join our Discord](https://discord.gg/gkdGsDYaKA)
@@ -303,5 +316,3 @@ We're just getting started and love contributions! Check out our [CONTRIBUTING.m
 Got questions or want to license stagewise for commercial or enterprise use?
 
 📧 **[sales@stagewise.io](mailto:sales@stagewise.io)**
-
-

--- a/toolbar/core/README.md
+++ b/toolbar/core/README.md
@@ -292,6 +292,19 @@ For use cases that fall outside the scope permitted by the AGPLv3 license, feel 
 
 We're just getting started and love contributions! Check out our [CONTRIBUTING.md](https://github.com/stagewise-io/stagewise/blob/main/CONTRIBUTING.md) guide to get involved. For bugs and fresh ideas, please [Open an issue!](https://github.com/stagewise-io/stagewise/issues) 
 
+## 💻 Test stagewise locally
+
+1. `git clone https://github.com/stagewise-io/stagewise && cd stagewise` 
+2. `pnpm i && pnpm dev`
+3. Open the `stagewise` project in your IDE
+4. Uninstall/ Disable the official `stagewise` extension
+5. Press F5 (a new IDE window with the local extension-version installed will open up)
+6. Visit `http://localhost:3002` 
+> You will see a next.js example application with the `stagewise`-toolbar already set up.
+> It will be connected to the local vscode-extension in `apps/vscode-extension` and reflect all the extension-changes you apply locally.
+
+
+
 ## 💬 Community & Support 
 
 * 👾 [Join our Discord](https://discord.gg/gkdGsDYaKA)
@@ -303,5 +316,3 @@ We're just getting started and love contributions! Check out our [CONTRIBUTING.m
 Got questions or want to license stagewise for commercial or enterprise use?
 
 📧 **[sales@stagewise.io](mailto:sales@stagewise.io)**
-
-

--- a/toolbar/next/README.md
+++ b/toolbar/next/README.md
@@ -292,6 +292,19 @@ For use cases that fall outside the scope permitted by the AGPLv3 license, feel 
 
 We're just getting started and love contributions! Check out our [CONTRIBUTING.md](https://github.com/stagewise-io/stagewise/blob/main/CONTRIBUTING.md) guide to get involved. For bugs and fresh ideas, please [Open an issue!](https://github.com/stagewise-io/stagewise/issues) 
 
+## 💻 Test stagewise locally
+
+1. `git clone https://github.com/stagewise-io/stagewise && cd stagewise` 
+2. `pnpm i && pnpm dev`
+3. Open the `stagewise` project in your IDE
+4. Uninstall/ Disable the official `stagewise` extension
+5. Press F5 (a new IDE window with the local extension-version installed will open up)
+6. Visit `http://localhost:3002` 
+> You will see a next.js example application with the `stagewise`-toolbar already set up.
+> It will be connected to the local vscode-extension in `apps/vscode-extension` and reflect all the extension-changes you apply locally.
+
+
+
 ## 💬 Community & Support 
 
 * 👾 [Join our Discord](https://discord.gg/gkdGsDYaKA)
@@ -303,5 +316,3 @@ We're just getting started and love contributions! Check out our [CONTRIBUTING.m
 Got questions or want to license stagewise for commercial or enterprise use?
 
 📧 **[sales@stagewise.io](mailto:sales@stagewise.io)**
-
-

--- a/toolbar/react/README.md
+++ b/toolbar/react/README.md
@@ -292,6 +292,19 @@ For use cases that fall outside the scope permitted by the AGPLv3 license, feel 
 
 We're just getting started and love contributions! Check out our [CONTRIBUTING.md](https://github.com/stagewise-io/stagewise/blob/main/CONTRIBUTING.md) guide to get involved. For bugs and fresh ideas, please [Open an issue!](https://github.com/stagewise-io/stagewise/issues) 
 
+## 💻 Test stagewise locally
+
+1. `git clone https://github.com/stagewise-io/stagewise && cd stagewise` 
+2. `pnpm i && pnpm dev`
+3. Open the `stagewise` project in your IDE
+4. Uninstall/ Disable the official `stagewise` extension
+5. Press F5 (a new IDE window with the local extension-version installed will open up)
+6. Visit `http://localhost:3002` 
+> You will see a next.js example application with the `stagewise`-toolbar already set up.
+> It will be connected to the local vscode-extension in `apps/vscode-extension` and reflect all the extension-changes you apply locally.
+
+
+
 ## 💬 Community & Support 
 
 * 👾 [Join our Discord](https://discord.gg/gkdGsDYaKA)
@@ -303,5 +316,3 @@ We're just getting started and love contributions! Check out our [CONTRIBUTING.m
 Got questions or want to license stagewise for commercial or enterprise use?
 
 📧 **[sales@stagewise.io](mailto:sales@stagewise.io)**
-
-

--- a/toolbar/vue/README.md
+++ b/toolbar/vue/README.md
@@ -292,6 +292,19 @@ For use cases that fall outside the scope permitted by the AGPLv3 license, feel 
 
 We're just getting started and love contributions! Check out our [CONTRIBUTING.md](https://github.com/stagewise-io/stagewise/blob/main/CONTRIBUTING.md) guide to get involved. For bugs and fresh ideas, please [Open an issue!](https://github.com/stagewise-io/stagewise/issues) 
 
+## 💻 Test stagewise locally
+
+1. `git clone https://github.com/stagewise-io/stagewise && cd stagewise` 
+2. `pnpm i && pnpm dev`
+3. Open the `stagewise` project in your IDE
+4. Uninstall/ Disable the official `stagewise` extension
+5. Press F5 (a new IDE window with the local extension-version installed will open up)
+6. Visit `http://localhost:3002` 
+> You will see a next.js example application with the `stagewise`-toolbar already set up.
+> It will be connected to the local vscode-extension in `apps/vscode-extension` and reflect all the extension-changes you apply locally.
+
+
+
 ## 💬 Community & Support 
 
 * 👾 [Join our Discord](https://discord.gg/gkdGsDYaKA)
@@ -303,5 +316,3 @@ We're just getting started and love contributions! Check out our [CONTRIBUTING.m
 Got questions or want to license stagewise for commercial or enterprise use?
 
 📧 **[sales@stagewise.io](mailto:sales@stagewise.io)**
-
-


### PR DESCRIPTION
This pull request updates the documentation across multiple `README.md` files to include instructions for testing the `stagewise` project locally. Additionally, it removes unnecessary blank lines in the "Community & Support" sections.

### Documentation Updates:

* Added a new "Test stagewise locally" section in the `README.md` files for the main project and its submodules (`apps/vscode-extension`, `toolbar/core`, `toolbar/next`, `toolbar/react`, `toolbar/vue`). This section provides step-by-step instructions for cloning the repository, running the development environment, and testing the local version of the `stagewise` extension.

### Code Cleanup:

* Removed redundant blank lines in the "Community & Support" sections of the same `README.md` files to improve formatting consistency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new section to multiple README files with step-by-step instructions for testing stagewise locally, including setup and usage details.
  * Performed minor formatting and whitespace cleanup in documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->