### PR TITLE
chore(docs): remove redundant title from 'test-locally' documentation

### DIFF
--- a/apps/website/content/docs/test-locally.mdx
+++ b/apps/website/content/docs/test-locally.mdx
@@ -7,8 +7,6 @@ export const metadata = {
   description: "Learn how to test and debug stagewise locally.",
 };
 
-# Testing stagewise Locally
-
 Want to contribute to stagewise or test your changes locally? Follow these steps to get the development environment up and running.
 
 ## Quick Setup


### PR DESCRIPTION
This pull request includes a minor update to the `apps/website/content/docs/test-locally.mdx` file. The change removes the redundant heading "Testing stagewise Locally" to streamline the document structure.