### PR TITLE
fix(website): update image class for dark mode compatibility

### DIFF
--- a/apps/website/src/app/(home)/page.tsx
+++ b/apps/website/src/app/(home)/page.tsx
@@ -676,7 +676,7 @@ export default function Home() {
                 <Image
                   src={framework.logo}
                   alt={framework.name}
-                  className="h-6 w-6"
+                  className="h-6 w-6 dark:invert"
                 />
                 <span className="font-medium">{framework.name}</span>
               </div>

--- a/apps/website/src/app/(home)/page.tsx
+++ b/apps/website/src/app/(home)/page.tsx
@@ -577,7 +577,7 @@ export default function Home() {
                     <p className="font-medium text-zinc-700 dark:text-zinc-300">
                       🪄 Auto-Install the toolbar (AI-guided):
                     </p>
-                    <ol className="mt-2 list-decimal pl-5 text-zinc-600 dark:text-zinc-400">
+                    <ol className="mt-2 list-decimal pl-5 text-start text-zinc-600 dark:text-zinc-400">
                       <li>
                         In Cursor, Press{' '}
                         <code className="rounded bg-zinc-200 px-1 dark:bg-zinc-800">


### PR DESCRIPTION
Prev:
<img width="970" alt="Screenshot 2025-06-30 at 22 21 59" src="https://github.com/user-attachments/assets/b5e98560-0f70-44d9-9d91-02cabe90c991" />

Now:
<img width="977" alt="Screenshot 2025-06-30 at 22 22 31" src="https://github.com/user-attachments/assets/28624fa2-38b8-44ad-924f-df3c0bf7eff3" />


Prev:
<img width="584" alt="Screenshot 2025-06-30 at 22 23 40" src="https://github.com/user-attachments/assets/111da07d-79d6-46e4-b258-d890200e82a2" />


Now:
<img width="623" alt="Screenshot 2025-06-30 at 22 23 51" src="https://github.com/user-attachments/assets/34eaa089-b2de-4ca3-8872-e0b04ac31b84" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved text alignment in the "Auto-Install the toolbar (AI-guided)" section for better readability.
  * Enhanced visibility of AI assistant logos in dark mode by inverting their colors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->