### PR TITLE
Loosen agent interface type validation

### DIFF
--- a/.changeset/silent-buttons-jog.md
+++ b/.changeset/silent-buttons-jog.md
@@ -1,0 +1,5 @@
+---
+"@stagewise/agent-interface": patch
+---
+
+Loosen type validation in selectedElements in agent-interface

--- a/packages/agent-interface/src/router/capabilities/messaging/types.ts
+++ b/packages/agent-interface/src/router/capabilities/messaging/types.ts
@@ -27,27 +27,29 @@ export const baseSelectedElementSchema = z.object({
     }),
     // Custom attributes could also help massively
     z
-      .record(z.string().max(256))
-      .refine((value) => Object.keys(value).length <= 100, {
-        message: 'Attributes must be less than 100 entries.',
+      .record(z.string().transform((val) => val.slice(0, 256)))
+      .transform((obj) => {
+        // Truncate to first 100 entries
+        const entries = Object.entries(obj).slice(0, 100);
+        return Object.fromEntries(entries);
       })
-      // TODO: Add proper truncation logic
       .describe(
         'A list of attributes of the element. Will be truncated after 100 entries.',
       ),
   ),
   textContent: z
     .string()
-    .max(512)
+    .transform((val) => val.slice(0, 2048))
     .describe(
-      'Text content of the element. Will be truncated after 512 characters.',
+      'Text content of the element. Will be truncated after 2048 characters.',
     ),
   ownProperties: z
     .record(z.any())
-    .refine((value) => Object.keys(value).length <= 500, {
-      message: 'Own properties must be less than 500 entries.',
+    .transform((obj) => {
+      // Truncate to first 500 entries
+      const entries = Object.entries(obj).slice(0, 500);
+      return Object.fromEntries(entries);
     })
-    // TODO: Add proper truncation logic
     .describe(
       'Custom properties that the underlying object may have. Will be truncated after 500 entries. Object are only copied up to 3 levels deep, all children and levels will be truncated equally. Only elements that are serializable will be sent over',
     ),

--- a/packages/agent-interface/src/router/capabilities/messaging/types.ts
+++ b/packages/agent-interface/src/router/capabilities/messaging/types.ts
@@ -27,11 +27,26 @@ export const baseSelectedElementSchema = z.object({
     }),
     // Custom attributes could also help massively
     z
-      .record(z.string().transform((val) => val.slice(0, 256)))
+      .record(
+        z.string().transform((val) => {
+          if (val.length > 256) {
+            return `${val.slice(0, 256)}...[truncated]`;
+          }
+          return val;
+        }),
+      )
       .transform((obj) => {
         // Truncate to first 100 entries
-        const entries = Object.entries(obj).slice(0, 100);
-        return Object.fromEntries(entries);
+        const entries = Object.entries(obj);
+        const truncatedEntries = entries.slice(0, 100);
+        const result = Object.fromEntries(truncatedEntries);
+
+        // Add truncation indicator if we truncated entries
+        if (entries.length > 100) {
+          result.__truncated__ = `...[${entries.length - 100} more entries truncated]`;
+        }
+
+        return result;
       })
       .describe(
         'A list of attributes of the element. Will be truncated after 100 entries.',
@@ -39,7 +54,12 @@ export const baseSelectedElementSchema = z.object({
   ),
   textContent: z
     .string()
-    .transform((val) => val.slice(0, 2048))
+    .transform((val) => {
+      if (val.length > 2048) {
+        return `${val.slice(0, 2048)}...[truncated]`;
+      }
+      return val;
+    })
     .describe(
       'Text content of the element. Will be truncated after 2048 characters.',
     ),
@@ -47,8 +67,16 @@ export const baseSelectedElementSchema = z.object({
     .record(z.any())
     .transform((obj) => {
       // Truncate to first 500 entries
-      const entries = Object.entries(obj).slice(0, 500);
-      return Object.fromEntries(entries);
+      const entries = Object.entries(obj);
+      const truncatedEntries = entries.slice(0, 500);
+      const result = Object.fromEntries(truncatedEntries);
+
+      // Add truncation indicator if we truncated entries
+      if (entries.length > 500) {
+        result.__truncated__ = `...[${entries.length - 500} more entries truncated]`;
+      }
+
+      return result;
     })
     .describe(
       'Custom properties that the underlying object may have. Will be truncated after 500 entries. Object are only copied up to 3 levels deep, all children and levels will be truncated equally. Only elements that are serializable will be sent over',


### PR DESCRIPTION
This pull request introduces changes to the `@stagewise/agent-interface` package to loosen type validation in `selectedElements`. The main updates involve refining the truncation logic for attributes, text content, and own properties in the schema definition, ensuring data is appropriately constrained and transformed.

### Type validation improvements:

* [`.changeset/silent-buttons-jog.md`](diffhunk://#diff-b2097e1da0e0d8cc62d4ac53a919f04e8090fec7a5f99441a4b04bbafe72b71eR1-R5): Documented a patch update for `@stagewise/agent-interface` to loosen type validation in `selectedElements`.

* `packages/agent-interface/src/router/capabilities/messaging/types.ts`:
  - Updated `baseSelectedElementSchema` to truncate string attributes to a maximum of 256 characters and limit attributes to the first 100 entries.
  - Increased the maximum length for `textContent` from 512 to 2048 characters and added truncation logic.
  - Enhanced `ownProperties` by truncating to the first 500 entries and ensuring proper handling of nested objects up to 3 levels deep.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Increased the maximum allowed length for text content to 2048 characters.
  * Expanded the maximum number of own properties to 500 and attributes to 100 for selected elements.

* **Refactor**
  * Inputs that exceed limits for text content, attributes, or own properties are now automatically truncated instead of being rejected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->