### PR TITLE
refactor(agent-interface): enhance attribute handling and truncation 

### DIFF
--- a/.changeset/rotten-parks-enter.md
+++ b/.changeset/rotten-parks-enter.md
@@ -1,0 +1,5 @@
+---
+"@stagewise/agent-interface": patch
+---
+
+Fixing zod validation intersection issue.


### PR DESCRIPTION
This pull request refactors the `attributes` schema in `baseSelectedElementSchema` to improve handling of element attributes by separating important attributes from others, ensuring they are never truncated, and applying stricter truncation logic to less critical attributes.

### Schema refactor for `attributes`:

* Updated the `attributes` schema to use `z.record` with a union type (`z.string`, `z.boolean`, `z.number`) for attribute values, allowing more flexibility in supported data types.
* Introduced logic to separate important attributes (e.g., `class`, `id`, `style`, etc.) from other attributes, ensuring important attributes are always preserved while truncating others if necessary.
* Enhanced truncation logic: important attributes are truncated at 4096 characters, while other attributes are truncated at 256 characters, with a maximum of 100 non-important attributes retained.
* Added a truncation indicator (`__truncated__`) to the resulting object when non-important attributes are truncated, providing clarity on omitted data.
* Updated the schema description to reflect the new behavior, emphasizing that important attributes are never truncated while others may be limited.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the handling of element attributes by distinguishing important attributes (such as class, id, style, and aria*), ensuring they are always included and properly truncated, while limiting and truncating other attributes for better consistency and clarity.

* **Documentation**
  * Updated attribute field descriptions to accurately reflect the new attribute handling and truncation logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->