### PR TITLE
Fix agent interface implementation

### DIFF
--- a/.changeset/orange-trains-refuse.md
+++ b/.changeset/orange-trains-refuse.md
@@ -1,0 +1,5 @@
+---
+"@stagewise/agent-interface": minor
+---
+
+Adapt agent-interface implementation to allow updateParts without existing part.

--- a/packages/agent-interface/src/agent/adapter.ts
+++ b/packages/agent-interface/src/agent/adapter.ts
@@ -331,28 +331,26 @@ export class AgentTransportAdapter implements TransportInterface {
             if (!self._currentMessageId) {
               self._clearMessage();
             }
-            
+
             // Handle union type - if content is an array, only take the first element
             const contentPart = Array.isArray(content) ? content[0] : content;
             if (!contentPart) {
               throw new Error('Content cannot be empty');
             }
-            
+
             // Add the new part
             self._messageContent.push(contentPart);
-            
+
             const update: AgentMessageUpdate = {
               messageId: self._currentMessageId!,
-              updateParts: [
-                { contentIndex: index, part: contentPart },
-              ],
+              updateParts: [{ contentIndex: index, part: contentPart }],
               createdAt: new Date(),
               resync: false,
             };
             self._messageController.push(update);
             return;
           }
-          
+
           if (index < 0 || index >= self._messageContent.length) {
             throw new Error(
               `Invalid index ${index} for message content update.`,

--- a/packages/agent-interface/src/agent/interface.ts
+++ b/packages/agent-interface/src/agent/interface.ts
@@ -70,9 +70,9 @@ export type AgentInterface = {
       content: AgentMessageContentItemPart | AgentMessageContentItemPart[],
     ) => void;
 
-    /** 
+    /**
      * Update a part of the current message.
-     * 
+     *
      * @param content - The content to update with
      * @param index - The index of the part to update. If index equals the current
      *                message length (highest index + 1), a new part will be added.

--- a/packages/agent-interface/src/agent/interface.ts
+++ b/packages/agent-interface/src/agent/interface.ts
@@ -70,7 +70,14 @@ export type AgentInterface = {
       content: AgentMessageContentItemPart | AgentMessageContentItemPart[],
     ) => void;
 
-    /** Update a part of the current message */
+    /** 
+     * Update a part of the current message.
+     * 
+     * @param content - The content to update with
+     * @param index - The index of the part to update. If index equals the current
+     *                message length (highest index + 1), a new part will be added.
+     * @param type - 'replace' to replace the part, 'append' to append text (text parts only)
+     */
     updatePart: (
       content: AgentMessageContentItemPart | AgentMessageContentItemPart[],
       index: number,
@@ -82,6 +89,12 @@ export type AgentInterface = {
 
     /** Get current message ID */
     getCurrentId: () => string | null;
+
+    /** Get current message state as an object (returns by value, not reference) */
+    getCurrentMessage: () => {
+      id: string | null;
+      parts: AgentMessageContentItemPart[];
+    };
 
     /** Add a listener for user messages */
     addUserMessageListener: (listener: (message: UserMessage) => void) => void;

--- a/packages/agent-interface/test/adapter/messaging.test.ts
+++ b/packages/agent-interface/test/adapter/messaging.test.ts
@@ -730,8 +730,14 @@ describe('AgentTransportAdapterMessaging', () => {
 
         expect(currentMessage.id).toBe(messageId);
         expect(currentMessage.parts).toHaveLength(2);
-        expect(currentMessage.parts[0]).toEqual({ type: 'text', text: 'Part 1' });
-        expect(currentMessage.parts[1]).toEqual({ type: 'text', text: 'Part 2' });
+        expect(currentMessage.parts[0]).toEqual({
+          type: 'text',
+          text: 'Part 1',
+        });
+        expect(currentMessage.parts[1]).toEqual({
+          type: 'text',
+          text: 'Part 2',
+        });
 
         // Verify it returns by value (modifications don't affect internal state)
         currentMessage.parts[0].text = 'Modified';
@@ -744,7 +750,7 @@ describe('AgentTransportAdapterMessaging', () => {
 
       it('should return empty message state with getCurrentMessage when no message', () => {
         const currentMessage = agentInterface.messaging.getCurrentMessage();
-        
+
         expect(currentMessage.id).toBeNull();
         expect(currentMessage.parts).toEqual([]);
       });


### PR DESCRIPTION
This pull request introduces enhancements to the `agent-interface` package, focusing on improving message handling capabilities. Key changes include allowing the addition of new message parts via `updatePart`, introducing a method to retrieve the current message state by value, and adding extensive test coverage for these functionalities.

### Enhancements to message handling:

* **Support for adding new parts via `updatePart`:** Modified the `updatePart` method in `AgentTransportAdapter` to allow adding a new part if the specified index equals the current message length. This includes handling union types for content and creating a message ID if none exists.
* **Retrieving current message state by value:** Added a `getCurrentMessage` method to `AgentTransportAdapter` and `AgentInterface` to return the current message state as an object, ensuring it is returned by value for immutability. [[1]](diffhunk://#diff-7e06b64a4ce74b2f45b542ccd033827fcdf72cf7249606b676ef750f8483c70fR272-R278) [[2]](diffhunk://#diff-09d04f34eeed391e140fe8ed58f11d3ef1c66ae38a4af7136932534d8dfc77b9R93-R98)

### Documentation updates:

* **Enhanced `updatePart` API documentation:** Updated comments for the `updatePart` method in `AgentInterface` to clarify its behavior, including the ability to add new parts and the supported types of updates.

### Test coverage improvements:

* **Tests for `updatePart` functionality:** Added unit tests to verify that `updatePart` can add new parts, handles adding to empty messages, and throws appropriate errors for invalid indices.
* **Tests for `getCurrentMessage`:** Added tests to ensure `getCurrentMessage` correctly returns the current message state by value and handles cases where no message exists.

### Minor version bump:

* **Version update:** Declared a minor version bump for the `agent-interface` package due to the addition of new functionality.