### PR TITLE
Fix message repitition

### DIFF
--- a/.changeset/shiny-signs-beg.md
+++ b/.changeset/shiny-signs-beg.md
@@ -1,0 +1,5 @@
+---
+"@stagewise/agent-interface": patch
+---
+
+Fix message repition in update-parts (update-parts now contain only the update, as expected)

--- a/packages/agent-interface/src/agent/adapter.ts
+++ b/packages/agent-interface/src/agent/adapter.ts
@@ -365,6 +365,13 @@ export class AgentTransportAdapter implements TransportInterface {
 
           if (type === 'replace') {
             self._messageContent[index] = contentPart;
+            const update: AgentMessageUpdate = {
+              messageId: self._currentMessageId!,
+              updateParts: [{ contentIndex: index, part: contentPart }],
+              createdAt: new Date(),
+              resync: false,
+            };
+            self._messageController.push(update);
           } else if (type === 'append') {
             const existingPart = self._messageContent[index];
             if (existingPart.type !== 'text' || contentPart.type !== 'text') {
@@ -373,17 +380,14 @@ export class AgentTransportAdapter implements TransportInterface {
               );
             }
             existingPart.text += contentPart.text;
+            const update: AgentMessageUpdate = {
+              messageId: self._currentMessageId!,
+              updateParts: [{ contentIndex: index, part: contentPart }],
+              createdAt: new Date(),
+              resync: false,
+            };
+            self._messageController.push(update);
           }
-
-          const update: AgentMessageUpdate = {
-            messageId: self._currentMessageId!,
-            updateParts: [
-              { contentIndex: index, part: self._messageContent[index] },
-            ],
-            createdAt: new Date(),
-            resync: false,
-          };
-          self._messageController.push(update);
         },
       },
       toolCalling: {

--- a/packages/agent-interface/src/agent/adapter.ts
+++ b/packages/agent-interface/src/agent/adapter.ts
@@ -345,7 +345,7 @@ export class AgentTransportAdapter implements TransportInterface {
               messageId: self._currentMessageId!,
               updateParts: [{ contentIndex: index, part: contentPart }],
               createdAt: new Date(),
-              resync: false,
+              resync: type === 'replace',
             };
             self._messageController.push(update);
             return;
@@ -369,7 +369,7 @@ export class AgentTransportAdapter implements TransportInterface {
               messageId: self._currentMessageId!,
               updateParts: [{ contentIndex: index, part: contentPart }],
               createdAt: new Date(),
-              resync: false,
+              resync: true,
             };
             self._messageController.push(update);
           } else if (type === 'append') {

--- a/packages/agent-interface/src/agent/interface.ts
+++ b/packages/agent-interface/src/agent/interface.ts
@@ -76,7 +76,9 @@ export type AgentInterface = {
      * @param content - The content to update with
      * @param index - The index of the part to update. If index equals the current
      *                message length (highest index + 1), a new part will be added.
-     * @param type - 'replace' to replace the part, 'append' to append text (text parts only)
+     * @param type - 'replace' to replace the part, 'append' to append text (text parts only).
+     *               When using 'append', only the delta (new text) is sent in the update,
+     *               not the entire content.
      */
     updatePart: (
       content: AgentMessageContentItemPart | AgentMessageContentItemPart[],


### PR DESCRIPTION
@glenntws 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where message updates in the update-parts functionality could be duplicated, ensuring only the intended update content is sent.

* **Documentation**
  * Clarified the behavior of the append mode in message updates, specifying that only the new delta text is included.

* **Tests**
  * Added tests to verify correct behavior for append and replace update modes, including handling of consecutive appends and message state accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->