### PR TITLE
fix(agent-provider): update agent connection to use dynamic hostname

### DIFF
--- a/.changeset/fifty-windows-exist.md
+++ b/.changeset/fifty-windows-exist.md
@@ -1,0 +1,5 @@
+---
+"@stagewise/toolbar": minor
+---
+
+Allow cross-network access of dev mode! Toolbar now looks for agents on hostname of hosted page.

--- a/toolbar/core/src/hooks/agent/use-agent-provider.tsx
+++ b/toolbar/core/src/hooks/agent/use-agent-provider.tsx
@@ -161,7 +161,9 @@ function findPersistedAgent(availableAgents: AgentInfo[]): AgentInfo | null {
 async function checkAgentOnPort(port: number): Promise<AgentInfo | null> {
   console.debug(`[AgentProvider] Checking for agent on port ${port}...`);
   try {
-    const response = await fetch(`http://localhost:${port}/stagewise/info`, {
+    // We use the hostname of the open page to connec tto the agent
+    const hostname = window.parent.location.hostname;
+    const response = await fetch(`http://${hostname}:${port}/stagewise/info`, {
       method: 'GET',
       headers: {
         'Content-Type': 'application/json',
@@ -289,8 +291,9 @@ function createWebSocketClient(
   let isConnectionStable = false;
   let connectionFailedCalled = false;
 
+  const hostname = window.parent.location.hostname;
   const wsClient = createWSClient({
-    url: `ws://localhost:${port}/stagewise/ws`,
+    url: `ws://${hostname}:${port}/stagewise/ws`,
     onClose(cause) {
       console.debug(
         `[AgentProvider] WebSocket closed for port ${port}: ${cause}`,


### PR DESCRIPTION
- Modified the agent connection logic to use the hostname of the current page instead of hardcoding 'localhost', ensuring proper connectivity in different environments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The toolbar now supports detecting and connecting to agents across different network hosts in development mode, improving cross-network access and agent discovery when not limited to localhost.

* **Chores**
  * Updated documentation to reflect the minor update and new cross-network capabilities for the toolbar package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->