### PR TITLE
fix(docs): update contributing guidelines and vscode-extension titles…

### DIFF
--- a/.changeset/little-peaches-think.md
+++ b/.changeset/little-peaches-think.md
@@ -1,0 +1,5 @@
+---
+"stagewise-vscode-extension": patch
+---
+
+Fix spelling of stagewise.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,12 +1,12 @@
-# Contributing to Stagewise
+# Contributing to stagewise
 
-Welcome! This document provides an in-depth overview of the structure and architecture of the Stagewise project. Understanding this layout will help you quickly find your way around the codebase and identify where to contribute.
+Welcome! This document provides an in-depth overview of the structure and architecture of the stagewise project. Understanding this layout will help you quickly find your way around the codebase and identify where to contribute.
 
 ---
 
 ## Project Structure & Architecture
 
-Stagewise is organized as a **monorepo** using [pnpm workspaces](https://pnpm.io/workspaces) and [turborepo](https://turbo.build/). The repository is divided into several key areas:
+stagewise is organized as a **monorepo** using [pnpm workspaces](https://pnpm.io/workspaces) and [turborepo](https://turbo.build/). The repository is divided into several key areas:
 
 ### 1. Applications (`apps/`)
 
@@ -17,7 +17,7 @@ Stagewise is organized as a **monorepo** using [pnpm workspaces](https://pnpm.io
 * **vscode-extension/**
 
   * The official VSCode (and Cursor) extension.
-  * Integrates the Stagewise toolbar with code editors, enabling communication between the browser and your local AI agent.
+  * Integrates the stagewise toolbar with code editors, enabling communication between the browser and your local AI agent.
   * Contains extension source code, packaging scripts, and related assets.
 
 ### 2. Packages (`packages/`)
@@ -29,11 +29,11 @@ Stagewise is organized as a **monorepo** using [pnpm workspaces](https://pnpm.io
         * The fundamental browser toolbar package, providing the core UI and logic for DOM element selection, prompt sending, and plugin support.
         * Contains the main React components, hooks, utilities, and configuration for the toolbar's core functionality.
     * **next/** (`@toolbar/next`)
-        * The specific package for integrating the Stagewise toolbar with Next.js applications.
+        * The specific package for integrating the stagewise toolbar with Next.js applications.
     * **vue/** (`@toolbar/vue`)
-        * The specific package for integrating the Stagewise toolbar with Vue.js applications.
+        * The specific package for integrating the stagewise toolbar with Vue.js applications.
     * **react/** (`@toolbar/react`)
-        * The specific package for integrating the Stagewise toolbar with React applications (outside of Next.js, or for generic React usage).
+        * The specific package for integrating the stagewise toolbar with React applications (outside of Next.js, or for generic React usage).
 * **ui/**
 
   * Shared React component library.
@@ -52,7 +52,7 @@ Stagewise is organized as a **monorepo** using [pnpm workspaces](https://pnpm.io
   * **next-example/** (Next.js)
   * **svelte-kit-example/** (SvelteKit)
   * **nuxt-example/** (Nuxt)
-* These serve as reference implementations for integrating the Stagewise toolbar into different frontend stacks.
+* These serve as reference implementations for integrating the stagewise toolbar into different frontend stacks.
 
 ### 4. Playgrounds (`playgrounds/`)
 

--- a/apps/vscode-extension/package.json
+++ b/apps/vscode-extension/package.json
@@ -35,12 +35,12 @@
       },
       {
         "command": "stagewise.authenticate",
-        "title": "Authenticate with Stagewise",
+        "title": "Authenticate with stagewise",
         "category": "stagewise"
       },
       {
         "command": "stagewise.logout",
-        "title": "Logout from Stagewise",
+        "title": "Logout from stagewise",
         "category": "stagewise"
       },
       {


### PR DESCRIPTION
… to use lowercase "stagewise"

- Revised the contributing document to consistently use "stagewise" in lowercase.
- Updated titles in the vscode-extension package.json to reflect the correct casing for "stagewise".