### PR TITLE
feat(website): add CopyMarkdownButton component and integrate into do…

### DIFF
--- a/apps/website/src/app/docs/[[...slug]]/page.tsx
+++ b/apps/website/src/app/docs/[[...slug]]/page.tsx
@@ -8,6 +8,9 @@ import {
 import { notFound } from 'next/navigation';
 import { createRelativeLink } from 'fumadocs-ui/mdx';
 import { getMDXComponents } from '@/mdx-components';
+import { CopyMarkdownButton } from '@/components/copy-markdown-button';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 
 export default async function Page(props: {
   params: Promise<{ slug?: string[] }>;
@@ -18,10 +21,27 @@ export default async function Page(props: {
 
   const MDXContent = page.data.body;
 
+  // Get the raw markdown content for the copy button
+  let markdownContent = '';
+  try {
+    const slug = params.slug?.join('/') || 'index';
+    const filePath = join(process.cwd(), 'content/docs', `${slug}.mdx`);
+    markdownContent = readFileSync(filePath, 'utf-8');
+    // Remove frontmatter and export statements
+  } catch (_error) {
+    // Fallback if file reading fails
+    markdownContent = page.data.title || '';
+  }
+
   return (
     <DocsPage toc={page.data.toc} full={page.data.full}>
-      <DocsTitle>{page.data.title}</DocsTitle>
-      <DocsDescription>{page.data.description}</DocsDescription>
+      <div className="relative">
+        <div className="absolute top-0 right-0 z-10">
+          <CopyMarkdownButton content={markdownContent} />
+        </div>
+        <DocsTitle>{page.data.title}</DocsTitle>
+        <DocsDescription>{page.data.description}</DocsDescription>
+      </div>
       <DocsBody>
         <MDXContent
           components={getMDXComponents({

--- a/apps/website/src/components/copy-markdown-button.tsx
+++ b/apps/website/src/components/copy-markdown-button.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import { useState } from 'react';
+import { CopyIcon, CheckIcon } from 'lucide-react';
+import { usePostHog } from 'posthog-js/react';
+import { cn } from '@stagewise/ui/lib/utils';
+
+export function CopyMarkdownButton({
+  content,
+  className,
+}: {
+  content: string;
+  className?: string;
+}) {
+  const [copied, setCopied] = useState(false);
+  const posthog = usePostHog();
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(content);
+      setCopied(true);
+      posthog?.capture('docs_copy_markdown_click');
+      setTimeout(() => setCopied(false), 2000);
+    } catch (_e) {
+      // Optionally handle error
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      className={cn(
+        'flex items-center gap-2 rounded-md border border-zinc-200 bg-white px-3 py-2 font-medium text-sm text-zinc-700 transition-colors hover:bg-zinc-50 hover:text-zinc-900 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-300 dark:hover:bg-zinc-700 dark:hover:text-zinc-100',
+        className,
+      )}
+      onClick={handleCopy}
+      aria-label="Copy page as markdown"
+      title="Copy as markdown"
+    >
+      {copied ? (
+        <>
+          <CheckIcon className="h-4 w-4 text-green-500" />
+          <span>Copied!</span>
+        </>
+      ) : (
+        <>
+          <CopyIcon className="h-4 w-4" />
+          <span>Copy as markdown</span>
+        </>
+      )}
+    </button>
+  );
+}


### PR DESCRIPTION
…cumentation pages

- Introduced a new CopyMarkdownButton component for copying markdown content to clipboard.
- Integrated the button into the documentation page layout, allowing users to easily copy the raw markdown of the displayed content.
- Implemented file reading logic to fetch markdown content, with fallback handling for errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Copy as markdown" button to documentation pages, allowing users to easily copy the original markdown source of the page.
  * Button provides instant feedback when content is copied and is accessible from the top-right corner above the page title.

* **User Experience**
  * Improved accessibility and convenience for users who wish to reuse or reference documentation markdown content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->