### PR TITLE
refactor(vscode-extension): remove early access references 

### DIFF
--- a/.changeset/gentle-worms-cough.md
+++ b/.changeset/gentle-worms-cough.md
@@ -1,0 +1,5 @@
+---
+"stagewise-vscode-extension": patch
+---
+
+Remove early access checks.

--- a/apps/vscode-extension/TELEMETRY.md
+++ b/apps/vscode-extension/TELEMETRY.md
@@ -42,7 +42,7 @@ We collect the following types of telemetry data:
 #### Feature Usage Events
 - `agent_prompt_triggered`: Triggered when the AI agent is invoked
   - No additional properties collected
-- `stagewise_agent_prompt_triggered`: Triggered when the Stagewise Agent (early access feature) is invoked
+- `stagewise_agent_prompt_triggered`: Triggered when the Stagewise Agent is invoked
   - Includes: agent type ('stagewise'), whether user included a message, message ID, current URL, number of selected elements, number of prompt snippets
 - `stagewise_agent_tool_call_requested`: Triggered when the Stagewise Agent requests a tool execution
   - Includes: agent type ('stagewise'), tool name, whether it's a client-side tool, whether it's a browser runtime tool

--- a/apps/vscode-extension/TELEMETRY.md
+++ b/apps/vscode-extension/TELEMETRY.md
@@ -42,9 +42,9 @@ We collect the following types of telemetry data:
 #### Feature Usage Events
 - `agent_prompt_triggered`: Triggered when the AI agent is invoked
   - No additional properties collected
-- `stagewise_agent_prompt_triggered`: Triggered when the Stagewise Agent is invoked
+- `stagewise_agent_prompt_triggered`: Triggered when the stagewise Agent is invoked
   - Includes: agent type ('stagewise'), whether user included a message, message ID, current URL, number of selected elements, number of prompt snippets
-- `stagewise_agent_tool_call_requested`: Triggered when the Stagewise Agent requests a tool execution
+- `stagewise_agent_tool_call_requested`: Triggered when the stagewise Agent requests a tool execution
   - Includes: agent type ('stagewise'), tool name, whether it's a client-side tool, whether it's a browser runtime tool
 - `toolbar_auto_setup_started`: Triggered when the automatic toolbar setup process is initiated
   - No additional properties collected
@@ -93,7 +93,7 @@ We collect the following types of telemetry data:
   - Includes: Error message (scrubbed of PII)
 - `toolbar_setup_failed`: Triggered when the toolbar setup process fails
   - Includes: Error message (scrubbed of PII)
-- `stagewise_agent_auth_refresh_failed`: Triggered when automatic token refresh fails in the Stagewise Agent
+- `stagewise_agent_auth_refresh_failed`: Triggered when automatic token refresh fails in the stagewise Agent
   - Includes: reason (expired/invalid/missing), retry attempt number, error message (scrubbed of PII)
 
 ### Data Collection Method
@@ -136,10 +136,10 @@ To disable telemetry for all extensions:
 3. Set `telemetry.telemetryLevel` to "off"
 
 ### 2. Extension-Specific Setting
-To disable telemetry just for Stagewise:
+To disable telemetry just for stagewise:
 1. Open VS Code Settings (Ctrl+,/Cmd+,)
 2. Search for "stagewise telemetry"
-3. Uncheck "Stagewise: Telemetry Enabled"
+3. Uncheck "stagewise: Telemetry Enabled"
 
 ## Data Usage
 
@@ -172,7 +172,7 @@ We are committed to GDPR compliance:
 
 - [VS Code Telemetry Documentation](https://code.visualstudio.com/docs/getstarted/telemetry)
 - [Microsoft Privacy Statement](https://privacy.microsoft.com/privacystatement)
-- [Stagewise Privacy Policy](https://stagewise.io/privacy)
+- [stagewise Privacy Policy](https://stagewise.io/privacy)
 
 ## Questions or Concerns?
 

--- a/apps/vscode-extension/package.json
+++ b/apps/vscode-extension/package.json
@@ -35,17 +35,17 @@
       },
       {
         "command": "stagewise.authenticate",
-        "title": "(early access only) Login to stagewise",
+        "title": "Login to stagewise",
         "category": "stagewise"
       },
       {
         "command": "stagewise.logout",
-        "title": "(early access only) Logout from stagewise",
+        "title": "Logout from stagewise",
         "category": "stagewise"
       },
       {
         "command": "stagewise.checkAuthStatus",
-        "title": "(early access only) Check login status",
+        "title": "Check login status",
         "category": "stagewise"
       },
       {

--- a/apps/vscode-extension/src/activation/activate.ts
+++ b/apps/vscode-extension/src/activation/activate.ts
@@ -209,8 +209,8 @@ export async function activate(context: vscode.ExtensionContext) {
       }
 
       // Handle stagewise agent based on auth state (IDE agent always runs)
-      if (authState.isAuthenticated && authState.hasEarlyAgentAccess) {
-        // User has auth and early access - initialize stagewise agent
+      if (authState.isAuthenticated) {
+        // User is authenticated - initialize stagewise agent
         if (
           stagewiseAgentServiceInstance &&
           !stagewiseAgentInitialized &&
@@ -252,15 +252,14 @@ export async function activate(context: vscode.ExtensionContext) {
       }
     });
 
-    // Initialize stagewise agent if authenticated with early access
+    // Initialize stagewise agent if authenticated
     const authState = await authService.getAuthState();
     if (
       authState?.isAuthenticated &&
       authState?.accessToken &&
-      authState?.hasEarlyAgentAccess &&
       agentSelectorService.getPreferredAgent() === 'stagewise-agent'
     ) {
-      // User has auth and early access - initialize stagewise agent in addition to IDE agent
+      // User is authenticated - initialize stagewise agent
       try {
         await initializeStagewiseAgent(stagewiseAgentServiceInstance);
       } catch (error) {

--- a/apps/vscode-extension/src/services/agent-selector.ts
+++ b/apps/vscode-extension/src/services/agent-selector.ts
@@ -59,10 +59,7 @@ export class AgentSelectorService {
     const agentPicker = vscode.window.createQuickPick();
     const items: vscode.QuickPickItem[] = [];
 
-    if (
-      (await this.authService.isAuthenticated()) &&
-      (await this.authService.hasEarlyAgentAccess())
-    ) {
+    if (await this.authService.isAuthenticated()) {
       items.push({
         label: '$(stagewise-icon) stagewise agent',
         description:

--- a/apps/vscode-extension/src/services/auth-service.ts
+++ b/apps/vscode-extension/src/services/auth-service.ts
@@ -26,7 +26,6 @@ interface AuthState {
   userEmail?: string;
   expiresAt?: string; // Access token expiry
   refreshExpiresAt?: string; // Refresh token expiry
-  hasEarlyAgentAccess?: boolean;
 }
 
 interface SessionValidationResponse {
@@ -36,7 +35,6 @@ interface SessionValidationResponse {
   extensionId: string;
   createdAt: string;
   isExpiringSoon: boolean;
-  hasEarlyAgentAccess: boolean;
 }
 
 /**
@@ -199,7 +197,6 @@ export class AuthService {
         refreshExpiresAt: tokenPair.refreshExpiresAt,
         userId: sessionData.userId,
         userEmail: sessionData.userEmail,
-        hasEarlyAgentAccess: sessionData.hasEarlyAgentAccess,
       };
 
       await this.storageService.set(this.AUTH_STATE_KEY, authState);
@@ -478,7 +475,6 @@ export class AuthService {
             ...authState,
             userId: sessionData.userId,
             userEmail: sessionData.userEmail,
-            hasEarlyAgentAccess: sessionData.hasEarlyAgentAccess,
           };
 
           if (JSON.stringify(updatedAuthState) !== JSON.stringify(authState)) {
@@ -492,7 +488,7 @@ export class AuthService {
           }
 
           await vscode.window.showInformationMessage(
-            `Authenticated as: ${updatedAuthState.userEmail} - Early Agent Access: ${updatedAuthState.hasEarlyAgentAccess}`,
+            `Authenticated as: ${updatedAuthState.userEmail}`,
           );
 
           return updatedAuthState;
@@ -636,14 +632,6 @@ export class AuthService {
     }
 
     return true;
-  }
-
-  /**
-   * Check if the authenticated user has early agent access
-   */
-  public async hasEarlyAgentAccess(): Promise<boolean> {
-    const authState = await this.getAuthState();
-    return authState?.hasEarlyAgentAccess ?? false;
   }
 
   /**

--- a/apps/vscode-extension/telemetry.json
+++ b/apps/vscode-extension/telemetry.json
@@ -186,7 +186,7 @@
     "stagewise_agent_prompt_triggered": {
       "classification": "EndUserPseudonymizedInformation",
       "purpose": "FeatureInsight",
-      "comment": "Tracks when the Stagewise Agent (early access feature) is invoked",
+      "comment": "Tracks when the Stagewise Agent is invoked",
       "properties": {
         "agentType": {
           "classification": "SystemMetaData",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Stagewise Agent is now available to all authenticated users, without early access restrictions.

* **Improvements**
  * Updated command titles and documentation to remove early access references, providing a clearer user experience.
  * Telemetry and event descriptions no longer reference early access status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->