### PR TITLE
docs(readme): remove roadmap section from README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,10 +247,6 @@ You would then use `StagewiseToolbarLoader` in your `src/routes/+layout.svelte`.
 | Trae           | ✅             |
 
 
-## 🛣️ Roadmap
-
-Check out our [project roadmap](./.github/ROADMAP.md) for upcoming features, bug fixes, and progress.
-
 ## 📜 License
 
 stagewise is developed by tiq UG (haftungsbeschränkt) and offered under the AGPLv3 license.

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -247,10 +247,6 @@ You would then use `StagewiseToolbarLoader` in your `src/routes/+layout.svelte`.
 | Trae           | ✅             |
 
 
-## 🛣️ Roadmap
-
-Check out our [project roadmap](./.github/ROADMAP.md) for upcoming features, bug fixes, and progress.
-
 ## 📜 License
 
 stagewise is developed by tiq UG (haftungsbeschränkt) and offered under the AGPLv3 license.

--- a/apps/vscode-extension/README.md
+++ b/apps/vscode-extension/README.md
@@ -247,10 +247,6 @@ You would then use `StagewiseToolbarLoader` in your `src/routes/+layout.svelte`.
 | Trae           | ✅             |
 
 
-## 🛣️ Roadmap
-
-Check out our [project roadmap](./.github/ROADMAP.md) for upcoming features, bug fixes, and progress.
-
 ## 📜 License
 
 stagewise is developed by tiq UG (haftungsbeschränkt) and offered under the AGPLv3 license.


### PR DESCRIPTION
closes #464 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed the "Roadmap" section from all relevant README files. No other documentation content was changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->