### PR TITLE
feat(cli): add command-wrapping functionality to the stagewise CLI

### DIFF
--- a/.changeset/lovely-glasses-prove.md
+++ b/.changeset/lovely-glasses-prove.md
@@ -1,0 +1,5 @@
+---
+"stagewise": minor
+---
+
+Add command-wrapping functionality - you can now use the stagewise cli like: 'npx stagewise -- pnpm next start' which consolidates the whole dev setup of your app into one command.

--- a/apps/cli/src/config/argparse.ts
+++ b/apps/cli/src/config/argparse.ts
@@ -113,10 +113,24 @@ program.action(() => {
 
 // Parse arguments but store raw values for validation
 const rawArgs = process.argv.slice(2);
+
+// Check for wrapped commands (double-dash delimiter)
+const doubleDashIndex = rawArgs.indexOf('--');
+let stagewiseArgs = rawArgs;
+let wrappedCommand: string[] = [];
+let hasWrappedCommand = false;
+
+if (doubleDashIndex !== -1) {
+  hasWrappedCommand = true;
+  stagewiseArgs = rawArgs.slice(0, doubleDashIndex);
+  wrappedCommand = rawArgs.slice(doubleDashIndex + 1);
+}
+
 const _hasWorkspaceArg =
-  rawArgs.includes('-w') || rawArgs.includes('--workspace');
-const hasTokenArg = rawArgs.includes('-t') || rawArgs.includes('--token');
-const hasBridgeMode = rawArgs.includes('-b');
+  stagewiseArgs.includes('-w') || stagewiseArgs.includes('--workspace');
+const hasTokenArg =
+  stagewiseArgs.includes('-t') || stagewiseArgs.includes('--token');
+const hasBridgeMode = stagewiseArgs.includes('-b');
 
 // Validate bridge mode conflicts before parsing (to avoid path validation)
 if (hasBridgeMode && hasTokenArg) {
@@ -126,8 +140,8 @@ if (hasBridgeMode && hasTokenArg) {
   process.exit(1);
 }
 
-// Parse with Commander
-program.parse(process.argv);
+// Parse with Commander using only stagewise args
+program.parse([...process.argv.slice(0, 2), ...stagewiseArgs]);
 
 // Initialize variables
 let port: number | undefined;
@@ -196,6 +210,8 @@ export {
   commandExecuted,
   authSubcommand,
   telemetrySubcommand,
+  wrappedCommand,
+  hasWrappedCommand,
 };
 
 // Export telemetry level if set command was used

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -172,6 +172,7 @@ async function main() {
       workspace_configured_manually: !hasConfigFile,
       auto_plugins_enabled: config.autoPlugins,
       manual_plugins_count: config.plugins.length,
+      has_wrapped_command: hasWrappedCommand,
     });
 
     // Track if config file was found

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -11,6 +11,8 @@ import {
   authSubcommand,
   telemetrySubcommand,
   telemetryLevel,
+  wrappedCommand,
+  hasWrappedCommand,
 } from './config/argparse';
 import { printBanner } from './utils/banner';
 import { oauthManager } from './auth/oauth';
@@ -19,6 +21,7 @@ import {
   getDependencyList,
 } from './dependency-parser/index.js';
 import open from 'open';
+import { commandExecutor } from './utils/command-executor';
 
 // Suppress util._extend deprecation warnings
 // Set NODE_NO_DEPRECATION to suppress all deprecation warnings, then restore other warnings
@@ -296,6 +299,12 @@ async function main() {
       log.error(`Unhandled rejection at: ${promise}, reason: ${reason}`);
       process.exit(1);
     });
+
+    if (hasWrappedCommand && wrappedCommand.length > 0) {
+      // Execute the wrapped command
+      const result = await commandExecutor.executeCommand(wrappedCommand);
+      process.exit(result.exitCode);
+    }
   } catch (error) {
     if (error instanceof Error) {
       // Only log once using the logger if available

--- a/apps/cli/src/utils/command-executor.ts
+++ b/apps/cli/src/utils/command-executor.ts
@@ -1,0 +1,134 @@
+import { spawn, type ChildProcess } from 'node:child_process';
+import { log } from './logger';
+
+export interface CommandExecutionResult {
+  exitCode: number;
+  signal?: string;
+}
+
+export class CommandExecutor {
+  private childProcess: ChildProcess | null = null;
+  private isShuttingDown = false;
+
+  async executeCommand(
+    commandParts: string[],
+  ): Promise<CommandExecutionResult> {
+    if (commandParts.length === 0) {
+      throw new Error('No command provided');
+    }
+
+    const [command, ...args] = commandParts;
+
+    if (!command) {
+      throw new Error('No command provided');
+    }
+
+    log.debug(`Executing proxy command: ${command} ${args.join(' ')}`);
+
+    return new Promise((resolve, reject) => {
+      try {
+        // Spawn the child process
+        this.childProcess = spawn(command, args, {
+          stdio: 'inherit', // Forward stdin, stdout, stderr to parent
+          shell: process.platform === 'win32', // Use shell on Windows
+        });
+
+        const childProcess = this.childProcess;
+
+        // Handle process exit
+        childProcess.on('exit', (code, signal) => {
+          log.debug(
+            `Proxy command exited with code: ${code}, signal: ${signal || 'none'}`,
+          );
+          this.childProcess = null;
+
+          if (signal) {
+            resolve({ exitCode: code || 1, signal });
+          } else {
+            resolve({ exitCode: code || 0 });
+          }
+        });
+
+        // Handle process errors
+        childProcess.on('error', (error) => {
+          log.error(`Failed to execute proxy command: ${error.message}`);
+          this.childProcess = null;
+          reject(error);
+        });
+
+        // Forward signals to child process
+        this.setupSignalHandling();
+      } catch (error) {
+        reject(error);
+      }
+    });
+  }
+
+  private setupSignalHandling(): void {
+    if (!this.childProcess) return;
+
+    const forwardSignal = (signal: NodeJS.Signals) => {
+      return () => {
+        if (
+          this.childProcess &&
+          !this.isShuttingDown &&
+          !this.childProcess.killed
+        ) {
+          log.debug(`Forwarding ${signal} to proxy command`);
+          this.childProcess.kill(signal);
+        }
+      };
+    };
+
+    process.on('SIGINT', forwardSignal('SIGINT'));
+    process.on('SIGTERM', forwardSignal('SIGTERM'));
+
+    // Handle Windows signals
+    if (process.platform === 'win32') {
+      process.on('SIGBREAK', forwardSignal('SIGTERM'));
+    }
+  }
+
+  async shutdown(): Promise<void> {
+    if (!this.childProcess || this.isShuttingDown) {
+      return;
+    }
+
+    this.isShuttingDown = true;
+    log.debug('Shutting down proxy command');
+
+    return new Promise((resolve) => {
+      if (!this.childProcess) {
+        resolve();
+        return;
+      }
+
+      // Set up timeout for forceful termination
+      const timeout = setTimeout(() => {
+        if (this.childProcess && !this.childProcess.killed) {
+          log.debug('Force killing proxy command');
+          this.childProcess.kill('SIGKILL');
+        }
+      }, 5000);
+
+      // Listen for child process exit
+      this.childProcess.on('exit', () => {
+        clearTimeout(timeout);
+        this.childProcess = null;
+        resolve();
+      });
+
+      // Try graceful shutdown first
+      if (!this.childProcess.killed) {
+        this.childProcess.kill('SIGTERM');
+      }
+    });
+  }
+
+  isRunning(): boolean {
+    return this.childProcess !== null && !this.childProcess.killed;
+  }
+}
+
+// Export a singleton instance for global use
+export const commandExecutor = new CommandExecutor();

--- a/apps/cli/src/utils/telemetry.ts
+++ b/apps/cli/src/utils/telemetry.ts
@@ -25,6 +25,7 @@ export interface CliStartProperties {
   workspace_configured_manually: boolean;
   auto_plugins_enabled: boolean;
   manual_plugins_count: number;
+  has_wrapped_command: boolean;
 }
 
 const TELEMETRY_CONFIG_FILE = 'telemetry.json';

--- a/apps/cli/tests/integration/cli-workflow.test.ts
+++ b/apps/cli/tests/integration/cli-workflow.test.ts
@@ -102,7 +102,7 @@ describe('CLI Workflow Integration Tests', () => {
     it('should succeed in bridge mode with workspace argument', async () => {
       const child = spawn(
         'tsx',
-        ['src/index.ts', '-b', '-w', testDir, '-a', '3000', '-s'],
+        ['src/index.ts', '-b', '-w', testDir, '-a', '3000', '-p', '3101', '-s'],
         {
           cwd: process.cwd(),
           shell: false,
@@ -125,7 +125,7 @@ describe('CLI Workflow Integration Tests', () => {
       if (errorOutput) {
         console.error('Test stderr:', errorOutput);
       }
-      expect(output).toContain('Running in bridge mode');
+      expect(output).toContain('✓ Running in bridge mode');
 
       await killProcess(child);
     });

--- a/apps/cli/tests/integration/command-wrapping.test.ts
+++ b/apps/cli/tests/integration/command-wrapping.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { spawn, type ChildProcess } from 'node:child_process';
+import { CommandExecutor } from '../../src/utils/command-executor';
+
+// Mock the logger to avoid test output noise
+vi.mock('../../src/utils/logger', () => ({
+  log: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+describe('Command Wrapping Integration Tests', () => {
+  let commandExecutor: CommandExecutor;
+
+  beforeEach(() => {
+    commandExecutor = new CommandExecutor();
+  });
+
+  afterEach(async () => {
+    await commandExecutor.shutdown();
+  });
+
+  describe('CommandExecutor', () => {
+    it('should execute simple command successfully', async () => {
+      const result = await commandExecutor.executeCommand(['echo', 'hello world']);
+      expect(result.exitCode).toBe(0);
+    });
+
+    it('should handle command with arguments', async () => {
+      const result = await commandExecutor.executeCommand(['node', '-e', 'console.log("test")']);
+      expect(result.exitCode).toBe(0);
+    });
+
+    it('should return correct exit code for failing command', async () => {
+      const result = await commandExecutor.executeCommand(['node', '-e', 'process.exit(42)']);
+      expect(result.exitCode).toBe(42);
+    });
+
+    it('should handle nonexistent command', async () => {
+      await expect(
+        commandExecutor.executeCommand(['nonexistent-command-12345'])
+      ).rejects.toThrow();
+    });
+
+    it('should handle empty command array', async () => {
+      await expect(
+        commandExecutor.executeCommand([])
+      ).rejects.toThrow('No command provided');
+    });
+
+    it('should be able to shutdown gracefully', async () => {
+      // Start a long-running command
+      const resultPromise = commandExecutor.executeCommand(['node', '-e', 'setTimeout(() => {}, 10000)']);
+      
+      // Wait a bit then shutdown
+      setTimeout(async () => {
+        await commandExecutor.shutdown();
+      }, 100);
+
+      const result = await resultPromise;
+      // The command should be terminated, so exit code will be non-zero
+      expect(result.exitCode).not.toBe(0);
+    });
+
+    it('should track running status correctly', async () => {
+      expect(commandExecutor.isRunning()).toBe(false);
+
+      // Start a command that takes some time
+      const resultPromise = commandExecutor.executeCommand(['node', '-e', 'setTimeout(() => {}, 500)']);
+      
+      // Should be running now
+      expect(commandExecutor.isRunning()).toBe(true);
+
+      await resultPromise;
+      
+      // Should not be running anymore
+      expect(commandExecutor.isRunning()).toBe(false);
+    });
+
+    it('should handle commands with special characters in arguments', async () => {
+      const result = await commandExecutor.executeCommand([
+        'node', 
+        '-e', 
+        'console.log(process.argv[2])', 
+        'hello & echo "injected"'
+      ]);
+      expect(result.exitCode).toBe(0);
+    });
+
+    it('should handle multiple sequential commands', async () => {
+      const result1 = await commandExecutor.executeCommand(['echo', 'first']);
+      expect(result1.exitCode).toBe(0);
+
+      const result2 = await commandExecutor.executeCommand(['echo', 'second']);
+      expect(result2.exitCode).toBe(0);
+
+      const result3 = await commandExecutor.executeCommand(['node', '-e', 'process.exit(3)']);
+      expect(result3.exitCode).toBe(3);
+    });
+  });
+
+  describe('Signal Handling', () => {
+    // Note: These tests are more complex to implement in a test environment
+    // as they involve process signals. For now, we test the basic structure.
+    
+    it('should setup signal handlers without throwing', () => {
+      expect(() => {
+        const executor = new CommandExecutor();
+        // The constructor should set up signal handlers without issues
+      }).not.toThrow();
+    });
+  });
+
+  describe('Platform Compatibility', () => {
+    it('should handle cross-platform command execution', async () => {
+      // Use a command that works on all platforms
+      const command = process.platform === 'win32' ? 'echo' : 'echo';
+      const args = ['test-message'];
+      
+      const result = await commandExecutor.executeCommand([command, ...args]);
+      expect(result.exitCode).toBe(0);
+    });
+  });
+});

--- a/apps/cli/tests/unit/utils/command-executor.test.ts
+++ b/apps/cli/tests/unit/utils/command-executor.test.ts
@@ -1,0 +1,229 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { spawn } from 'node:child_process';
+import { EventEmitter } from 'node:events';
+import { CommandExecutor } from '../../../src/utils/command-executor';
+
+// Mock child_process
+vi.mock('node:child_process');
+
+// Mock logger
+vi.mock('../../../src/utils/logger', () => ({
+  log: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+// Create a mock child process
+function createMockChildProcess() {
+  const mockProcess = new EventEmitter();
+  (mockProcess as any).kill = vi.fn();
+  (mockProcess as any).killed = false;
+  return mockProcess;
+}
+
+describe('CommandExecutor Unit Tests', () => {
+  let commandExecutor: CommandExecutor;
+  let mockChildProcess: any;
+
+  beforeEach(() => {
+    commandExecutor = new CommandExecutor();
+    mockChildProcess = createMockChildProcess();
+    vi.mocked(spawn).mockReturnValue(mockChildProcess);
+  });
+
+  afterEach(async () => {
+    await commandExecutor.shutdown();
+    vi.resetAllMocks();
+  });
+
+  describe('executeCommand', () => {
+    it('should spawn command with correct arguments', async () => {
+      const resultPromise = commandExecutor.executeCommand(['npm', 'run', 'build']);
+      
+      // Wait a tick for spawn to be called
+      await new Promise(resolve => setImmediate(resolve));
+      
+      expect(spawn).toHaveBeenCalledWith('npm', ['run', 'build'], {
+        stdio: 'inherit',
+        shell: process.platform === 'win32',
+      });
+
+      // Simulate successful exit
+      mockChildProcess.emit('exit', 0, null);
+      
+      const result = await resultPromise;
+      expect(result.exitCode).toBe(0);
+    });
+
+    it('should handle command exit with signal', async () => {
+      const resultPromise = commandExecutor.executeCommand(['test-command']);
+      
+      // Simulate exit with signal
+      mockChildProcess.emit('exit', null, 'SIGTERM');
+      
+      const result = await resultPromise;
+      expect(result.exitCode).toBe(1);
+      expect(result.signal).toBe('SIGTERM');
+    });
+
+    it('should handle command execution error', async () => {
+      const resultPromise = commandExecutor.executeCommand(['invalid-command']);
+      
+      // Simulate spawn error
+      const error = new Error('Command not found');
+      mockChildProcess.emit('error', error);
+      
+      await expect(resultPromise).rejects.toThrow('Command not found');
+    });
+
+    it('should reject when no command provided', async () => {
+      await expect(
+        commandExecutor.executeCommand([])
+      ).rejects.toThrow('No command provided');
+    });
+
+    it('should handle Windows shell mode', async () => {
+      const originalPlatform = process.platform;
+      Object.defineProperty(process, 'platform', { value: 'win32' });
+
+      const resultPromise = commandExecutor.executeCommand(['test']);
+      
+      expect(spawn).toHaveBeenCalledWith('test', [], {
+        stdio: 'inherit',
+        shell: true,
+      });
+
+      // Complete the mock command
+      mockChildProcess.emit('exit', 0, null);
+      await resultPromise;
+
+      Object.defineProperty(process, 'platform', { value: originalPlatform });
+    });
+
+    it('should handle non-Windows platforms', async () => {
+      const originalPlatform = process.platform;
+      Object.defineProperty(process, 'platform', { value: 'linux' });
+
+      const resultPromise = commandExecutor.executeCommand(['test']);
+      
+      expect(spawn).toHaveBeenCalledWith('test', [], {
+        stdio: 'inherit',
+        shell: false,
+      });
+
+      // Complete the mock command
+      mockChildProcess.emit('exit', 0, null);
+      await resultPromise;
+
+      Object.defineProperty(process, 'platform', { value: originalPlatform });
+    });
+  });
+
+  describe('isRunning', () => {
+    it('should return false when no command is running', () => {
+      expect(commandExecutor.isRunning()).toBe(false);
+    });
+
+    it('should return true when command is running', async () => {
+      const resultPromise = commandExecutor.executeCommand(['test-command']);
+      
+      // Wait for spawn to be called
+      await new Promise(resolve => setImmediate(resolve));
+      
+      expect(commandExecutor.isRunning()).toBe(true);
+
+      // Finish the command
+      mockChildProcess.emit('exit', 0, null);
+      await resultPromise;
+      
+      expect(commandExecutor.isRunning()).toBe(false);
+    });
+
+    it('should return false when command is killed', async () => {
+      const resultPromise = commandExecutor.executeCommand(['test-command']);
+      
+      // Wait for spawn to be called
+      await new Promise(resolve => setImmediate(resolve));
+      
+      // Mark as killed
+      mockChildProcess.killed = true;
+      
+      expect(commandExecutor.isRunning()).toBe(false);
+
+      // Clean up
+      mockChildProcess.emit('exit', 1, 'SIGTERM');
+      await resultPromise;
+    });
+  });
+
+  describe('shutdown', () => {
+    it('should resolve immediately when no command is running', async () => {
+      await expect(commandExecutor.shutdown()).resolves.toBeUndefined();
+    });
+
+    it('should kill running command on shutdown', async () => {
+      const resultPromise = commandExecutor.executeCommand(['test-command']);
+      
+      // Wait for spawn to be called
+      await new Promise(resolve => setImmediate(resolve));
+      
+      const shutdownPromise = commandExecutor.shutdown();
+      
+      expect(mockChildProcess.kill).toHaveBeenCalledWith('SIGTERM');
+      
+      // Simulate process exit
+      mockChildProcess.emit('exit', 143, 'SIGTERM');
+      
+      await shutdownPromise;
+      await resultPromise;
+    });
+
+    it('should force kill after timeout', async () => {
+      const resultPromise = commandExecutor.executeCommand(['test-command']);
+      
+      // Wait for spawn to be called
+      await new Promise(resolve => setImmediate(resolve));
+      
+      // Mock setTimeout to trigger immediately
+      const originalSetTimeout = global.setTimeout;
+      global.setTimeout = ((callback: any) => {
+        setImmediate(callback);
+        return 123 as any;
+      }) as any;
+      
+      const shutdownPromise = commandExecutor.shutdown();
+      
+      // Don't emit exit, so timeout triggers
+      await new Promise(resolve => setImmediate(resolve));
+      
+      expect(mockChildProcess.kill).toHaveBeenCalledWith('SIGKILL');
+      
+      // Now emit exit
+      mockChildProcess.emit('exit', 137, 'SIGKILL');
+      
+      await shutdownPromise;
+      await resultPromise;
+      
+      global.setTimeout = originalSetTimeout;
+    });
+  });
+
+  describe('signal forwarding', () => {
+    it('should set up signal handlers when command is running', async () => {
+      const resultPromise = commandExecutor.executeCommand(['test']);
+      
+      // Wait for spawn to be called and signal handlers to be set up
+      await new Promise(resolve => setImmediate(resolve));
+      
+      // Check that the setup method was called (indirectly by checking for child process)
+      expect(commandExecutor.isRunning()).toBe(true);
+
+      // Complete the mock command
+      mockChildProcess.emit('exit', 0, null);
+      await resultPromise;
+    });
+  });
+});

--- a/apps/cli/tests/unit/utils/logger.test.ts
+++ b/apps/cli/tests/unit/utils/logger.test.ts
@@ -74,7 +74,7 @@ describe('logger', () => {
       const lastCall = vi.mocked(winston.createLogger).mock.calls[
         vi.mocked(winston.createLogger).mock.calls.length - 1
       ];
-      expect(lastCall[0].level).toBe('info');
+      expect(lastCall?.[0]?.level).toBe('info');
     });
 
     it('should create logger with debug level when verbose is true', () => {
@@ -84,7 +84,7 @@ describe('logger', () => {
       const lastCall = vi.mocked(winston.createLogger).mock.calls[
         vi.mocked(winston.createLogger).mock.calls.length - 1
       ];
-      expect(lastCall[0].level).toBe('debug');
+      expect(lastCall?.[0]?.level).toBe('debug');
     });
   });
 
@@ -96,7 +96,7 @@ describe('logger', () => {
       const lastCall = vi.mocked(winston.createLogger).mock.calls[
         vi.mocked(winston.createLogger).mock.calls.length - 1
       ];
-      expect(lastCall[0].level).toBe('debug');
+      expect(lastCall?.[0]?.level).toBe('debug');
     });
   });
 });

--- a/apps/cli/tests/unit/utils/telemetry/telemetry.test.ts
+++ b/apps/cli/tests/unit/utils/telemetry/telemetry.test.ts
@@ -335,6 +335,7 @@ describe('Unified TelemetryManager', () => {
         workspace_configured_manually: true,
         auto_plugins_enabled: false,
         manual_plugins_count: 2,
+        has_wrapped_command: false,
       });
 
       expect(mockPostHogInstance.capture).toHaveBeenCalledWith({
@@ -345,6 +346,7 @@ describe('Unified TelemetryManager', () => {
           workspace_configured_manually: true,
           auto_plugins_enabled: false,
           manual_plugins_count: 2,
+          has_wrapped_command: false,
           telemetry_level: 'anonymous',
         },
       });

--- a/apps/website/content/docs/advanced-usage/cli-deep-dive.mdx
+++ b/apps/website/content/docs/advanced-usage/cli-deep-dive.mdx
@@ -73,6 +73,28 @@ npx stagewise -a 3002 # Set the port on which your dev app is hosted on
 pnpm dlx stagewise -a 3002
 ```
 
+### Wrap your dev command with stagewise
+
+Instead of running stagewise and your dev server in separate terminals, you can use the double-dash syntax to run both together:
+
+```bash
+# Wrap your dev command
+npx stagewise -- pnpm dev
+
+# You can still use stagewise options before the double-dash
+npx stagewise -p 3100 -a 3000 -- pnpm dev
+```
+
+Or wrap the dev script in your package.json:
+
+```json
+{
+  "scripts": {
+    "dev": "npx stagewise -- next dev"
+  }
+}
+```
+
 ## How the CLI works
 
 This section focuses on what capabilities the CLI has and how it actually works.
@@ -234,6 +256,16 @@ Provide an authentication token for the stagewise agent directly via the command
 Enable bridge mode, which disables the built-in stagewise agent server. In this mode, stagewise only provides the toolbar and proxy functionality, allowing you to connect to external agents or use stagewise with other AI coding assistants.
 
 > **Note**: Bridge mode is incompatible with the `--token` option.
+
+### `--`
+
+Use the double-dash to wrap your development command with stagewise, running both in a single terminal:
+
+```bash
+npx stagewise [options] -- <your-dev-command>
+```
+
+This allows you to run `npm run dev`, `pnpm dev`, or any other command while stagewise operates in the background.
 
 ## Authentication commands
 


### PR DESCRIPTION
Introduce a new proxy mode that allows users to run external commands while the stagewise server runs in the background. This feature supports real-time output, signal forwarding, and minimal configuration. Update documentation and tests to reflect these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for running external commands through the CLI using a double-dash (`--`), enabling workflows like `npx stagewise -- pnpm next start`.
  * Introduced a new command wrapping mode allowing concurrent execution of the Stagewise server and user commands with real-time output, exit code forwarding, and signal handling.

* **Documentation**
  * Updated CLI documentation with detailed explanations, usage examples, and descriptions of execution modes including the new command wrapping mode.

* **Bug Fixes**
  * Enhanced argument parsing to correctly separate wrapped commands from CLI options.

* **Tests**
  * Added comprehensive integration and unit tests covering command execution, argument parsing, signal forwarding, and shutdown behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->