### PR TITLE
fix(cli): resolve "octal sequence not allowed" error on Windows and i…

### DIFF
--- a/.changeset/tricky-seals-hang.md
+++ b/.changeset/tricky-seals-hang.md
@@ -1,0 +1,5 @@
+---
+"stagewise": patch
+---
+
+Fixing "octal sequence not allowed" error in normal mode on windows.

--- a/apps/cli/src/server/index.ts
+++ b/apps/cli/src/server/index.ts
@@ -68,7 +68,7 @@ try {
   console.debug('[stagewise] Successfully loaded plugin: ${plugin.name}');
 } catch (error) {
   console.error('[stagewise] Failed to load plugin ${plugin.name}:', error.message);
-  console.error('[stagewise] Plugin path: ${plugin.path || plugin.url}');
+  console.error('[stagewise] Plugin path: ${JSON.stringify(plugin.path || plugin.url)}');
 }`);
         pluginExports.push(`plugin${index}`);
       });


### PR DESCRIPTION
…mprove plugin path logging

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages for plugin loading failures to display plugin paths or URLs more clearly, especially on Windows systems.
* **Chores**
  * Added a changeset file documenting the patch-level update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->