### PR TITLE
fix(cli): handle errors gracefully in chat title update and startup banner display

### DIFF
--- a/.changeset/lovely-paws-study.md
+++ b/.changeset/lovely-paws-study.md
@@ -1,0 +1,6 @@
+---
+"@stagewise/agent-client": patch
+"stagewise": patch
+---
+
+Fix cli throws on insufficient credits.

--- a/agent/client/src/Agent.ts
+++ b/agent/client/src/Agent.ts
@@ -471,7 +471,9 @@ export class Agent {
               const chatExists = draft.chats[chatId] !== undefined;
               if (chatExists) draft.chats[chatId]!.title = result.title;
             });
-          });
+          })
+          // ignore errors here, there's a default chat title
+          .catch((_) => {});
       }
 
       // Emit prompt triggered event

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -227,15 +227,21 @@ async function main() {
     const { server, plugins } = await getServer();
 
     if (!config.bridgeMode && authState?.isAuthenticated) {
-      const subscription = await oauthManager.getSubscription();
+      try {
+        const subscription = await oauthManager.getSubscription();
 
-      startupBanner({
-        subscription,
-        loadedPlugins: plugins,
-        email: authState?.userEmail || '',
-        appPort: config.port,
-        proxyPort: config.appPort,
-      });
+        startupBanner({
+          subscription,
+          loadedPlugins: plugins,
+          email: authState?.userEmail || '',
+          appPort: config.port,
+          proxyPort: config.appPort,
+        });
+      } catch (error) {
+        log.error(
+          `Failed to display startup banner: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        );
+      }
     }
     // Start the server listening
     server.listen(config.port);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - CLI no longer throws when credits are insufficient.
  - Startup banner errors no longer block CLI startup; the server starts reliably.
  - Chat title generation failures no longer interrupt conversations; a default title is used.

- Chores
  - Patch releases for @stagewise/agent-client and stagewise.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->