### PR TITLE
fix(toolbar): disable ownProperties

### DIFF
--- a/.changeset/honest-donuts-study.md
+++ b/.changeset/honest-donuts-study.md
@@ -1,0 +1,5 @@
+---
+"@stagewise/toolbar": patch
+---
+
+Removing own properties from selected elements to fix abort errors.

--- a/toolbar/core/src/utils.tsx
+++ b/toolbar/core/src/utils.tsx
@@ -326,10 +326,11 @@ const truncateAttributes = (
 };
 
 const truncateOwnProperties = (
-  properties: Record<string, unknown>,
+  _properties: Record<string, unknown>,
 ): Record<string, unknown> => {
   const result: Record<string, unknown> = {};
-  const entries = Object.entries(properties);
+  // const entries = Object.entries(properties);
+  const entries = []; // disable for now - the amount of data might have caused abort errors
 
   // Limit to 500 entries max
   const limitedEntries = entries.slice(0, 500);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents occasional abort errors when working with selected elements by temporarily omitting their own properties.
  * Improves stability and reliability of toolbar interactions during selection.

* **Chores**
  * Adds a patch release entry for the toolbar package with updated release notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->