### PR TITLE
feat(toolbar): open chat by default on initialization 

### DIFF
--- a/.changeset/clear-steaks-enter.md
+++ b/.changeset/clear-steaks-enter.md
@@ -1,0 +1,5 @@
+---
+"@stagewise/toolbar": patch
+---
+
+Open the toolbar agent chat on first initialize.

--- a/.changeset/clear-steaks-enter.md
+++ b/.changeset/clear-steaks-enter.md
@@ -2,4 +2,4 @@
 "@stagewise/toolbar": patch
 ---
 
-Open the toolbar agent chat on first initialize.
+Open the Toolbar agent chat by default on first load (when no persisted panel state exists).

--- a/toolbar/core/src/hooks/use-panels.tsx
+++ b/toolbar/core/src/hooks/use-panels.tsx
@@ -127,7 +127,7 @@ export const PanelsProvider = ({
     persistedState.isSettingsOpen ?? false,
   );
   const [isChatOpenInternal, setIsChatOpen] = useState(
-    persistedState.isChatOpen ?? false,
+    persistedState.isChatOpen ?? true,
   );
   const [openPluginInternal, setOpenPlugin] = useState<string | null>(
     persistedState.openPlugin ?? null,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The toolbar’s agent chat now opens automatically on first initialization when no prior preference is saved, making the chat immediately accessible to users.

* **Chores**
  * Added a changeset entry to publish a patch release and document the new default behavior for the toolbar agent chat opening state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->