### PR TITLE
feat(agent): implement abort handling for agent calls and cleanup of …

### DIFF
--- a/.changeset/hip-cameras-refuse.md
+++ b/.changeset/hip-cameras-refuse.md
@@ -1,0 +1,7 @@
+---
+"@stagewise/agent-client": patch
+"@stagewise/agent-types": patch
+"stagewise": patch
+---
+
+Fixing tool-call aborts mid execution!

--- a/agent/client/package.json
+++ b/agent/client/package.json
@@ -43,7 +43,7 @@
     "@stagewise/agent-runtime-interface": "workspace:*",
     "@stagewise/agent-tools": "workspace:*",
     "@stagewise/agent-types": "workspace:*",
-    "@stagewise/api-client": "1.3.0",
+    "@stagewise/api-client": "1.4.0",
     "@stagewise/karton": "workspace:*",
     "@stagewise/karton-contract": "workspace:*",
     "esbuild": "0.25.9",

--- a/agent/client/src/Agent.ts
+++ b/agent/client/src/Agent.ts
@@ -632,7 +632,7 @@ export class Agent {
       return;
     } catch (error) {
       if (isAbortError(error)) {
-        console.log('abort error');
+        this.cleanupPendingOperations('Agent call aborted', false);
         return;
       }
 

--- a/agent/client/src/Agent.ts
+++ b/agent/client/src/Agent.ts
@@ -87,7 +87,6 @@ export class Agent {
   private undoToolCallStack: Map<
     ChatId,
     {
-      toolName: string;
       toolCallId: string;
       undoExecute?: () => Promise<void>;
     }[]
@@ -255,9 +254,8 @@ export class Agent {
       const pendingToolCalls = findPendingToolCalls(this.karton!, chatId);
       if (pendingToolCalls.length > 0) {
         const abortedResults: ToolCallProcessingResult[] = pendingToolCalls.map(
-          ({ toolCallId, toolName }) => ({
+          ({ toolCallId }) => ({
             success: false,
-            toolName,
             toolCallId,
             duration: 0,
             error: {
@@ -607,7 +605,6 @@ export class Agent {
         (result) => {
           if (result.result?.undoExecute) {
             this.undoToolCallStack.get(chatId)?.push({
-              toolName: result.toolName,
               toolCallId: result.toolCallId,
               undoExecute: result.result?.undoExecute,
             });

--- a/agent/client/src/Agent.ts
+++ b/agent/client/src/Agent.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from 'node:crypto';
 import { cliTools } from '@stagewise/agent-tools';
+import { isAbortError } from './utils/is-abort-error.js';
 import { AgentErrorType } from '@stagewise/karton-contract';
 import { convertCreditsToSubscriptionCredits } from './utils/convert-credits-to-subscription-credits.js';
 import type { KartonContract, History } from '@stagewise/karton-contract';
@@ -18,7 +19,10 @@ import type {
 } from '@stagewise/api-client';
 
 import { TimeoutManager } from './utils/time-out-manager.js';
-import { processParallelToolCalls } from './utils/tool-call-utils.js';
+import {
+  processParallelToolCalls,
+  type ToolCallProcessingResult,
+} from './utils/tool-call-utils.js';
 import {
   createEventEmitter,
   EventFactories,
@@ -36,8 +40,8 @@ import {
   attachToolOutputToMessage,
   createAndActivateNewChat,
   appendToolInputToMessage,
+  findPendingToolCalls,
 } from './utils/karton-helpers.js';
-import { isAbortError } from './utils/is-abort-error.js';
 import { isInsufficientCreditsError } from './utils/is-insufficient-credits-error.js';
 import type { ToolUIPart } from 'ai';
 
@@ -106,6 +110,17 @@ export class Agent {
     this.agentTimeout = config.agentTimeout || DEFAULT_AGENT_TIMEOUT;
     this.timeoutManager = new TimeoutManager();
     this.abortController = new AbortController();
+    this.abortController.signal.addEventListener(
+      'abort',
+      () => {
+        this.cleanupPendingOperations(
+          'Agent call aborted',
+          false,
+          this.karton?.state.activeChatId || undefined,
+        );
+      },
+      { once: true },
+    );
   }
 
   public shutdown() {
@@ -228,11 +243,39 @@ export class Agent {
    * Cleans up any pending operations and resets the agent state
    * @param reason - Optional reason for the cleanup
    * @param resetRecursionDepth - Whether to reset recursion depth to 0 (default: true)
+   * @param chatId - Optional chat ID to clean up pending tool calls for
    */
   private cleanupPendingOperations(
     _reason?: string,
     resetRecursionDepth = true,
+    chatId?: string,
   ): void {
+    // Clean up any pending tool calls if chatId is provided
+    if (chatId && this.lastMessageId) {
+      const pendingToolCalls = findPendingToolCalls(this.karton!, chatId);
+      if (pendingToolCalls.length > 0) {
+        const abortedResults: ToolCallProcessingResult[] = pendingToolCalls.map(
+          ({ toolCallId, toolName }) => ({
+            success: false,
+            toolName,
+            toolCallId,
+            duration: 0,
+            error: {
+              type: 'error' as const,
+              message: 'Tool execution aborted by user',
+            },
+          }),
+        );
+
+        // Attach the aborted results to the message
+        attachToolOutputToMessage(
+          this.karton!,
+          abortedResults,
+          this.lastMessageId,
+        );
+      }
+    }
+
     // Clear all timeouts
     this.timeoutManager.clearAll();
 
@@ -333,6 +376,17 @@ export class Agent {
         abortAgentCall: async () => {
           this.abortController.abort();
           this.abortController = new AbortController();
+          this.abortController.signal.addEventListener(
+            'abort',
+            () => {
+              this.cleanupPendingOperations(
+                'Agent call aborted',
+                false,
+                this.karton?.state.activeChatId || undefined,
+              );
+            },
+            { once: true },
+          );
         },
         approveToolCall: async (_toolCallId, _callingClientId) => {},
         rejectToolCall: async (_toolCallId, _callingClientId) => {},
@@ -523,21 +577,15 @@ export class Agent {
       const agentResponse = await this.callAgentWithRetry(request);
 
       let lastResponse: LastResponse | undefined;
-
-      try {
-        await this.parseUiStream(
-          agentResponse,
-          (message) => {
-            lastResponse = message;
-          },
-          (messageId) => {
-            this.lastMessageId = messageId;
-          },
-        );
-      } catch (error) {
-        if (isAbortError(error)) return;
-        throw error;
-      }
+      await this.parseUiStream(
+        agentResponse,
+        (message) => {
+          lastResponse = message;
+        },
+        (messageId) => {
+          this.lastMessageId = messageId;
+        },
+      );
 
       if (!lastResponse) throw new Error('Unknown error, please try again');
 
@@ -586,9 +634,8 @@ export class Agent {
       this.cleanupPendingOperations('Agent task completed successfully', false);
       return;
     } catch (error) {
-      // If the user has aborted the agent, set the agent to idle
       if (isAbortError(error)) {
-        this.setAgentWorking(false);
+        console.log('abort error');
         return;
       }
 
@@ -619,6 +666,10 @@ export class Agent {
     } finally {
       // Ensure recursion depth is decremented
       this.recursionDepth = Math.max(0, this.recursionDepth - 1);
+      // Clear the message ID if we're back to the top level
+      if (this.recursionDepth === 0) {
+        this.lastMessageId = null;
+      }
     }
   }
 

--- a/agent/client/src/utils/karton-helpers.ts
+++ b/agent/client/src/utils/karton-helpers.ts
@@ -225,14 +225,11 @@ export function findPendingToolCalls(
   // Check each part of the assistant message
   for (const part of lastAssistantMessage.parts) {
     if (part.type === 'dynamic-tool' || part.type.startsWith('tool-')) {
-      const toolPart = part as Extract<
-        ToolUIPart,
-        { state: 'input-available' }
-      >;
-      // Check if this tool call has a result
-      const hasResult = toolPart.output !== undefined;
+      const toolPart = part as ToolUIPart;
 
-      if (!hasResult && 'toolCallId' in part) {
+      // Only consider tool calls with 'input-available' state as pending
+      // Other states like 'output-available' or 'output-error' are terminal
+      if (toolPart.state === 'input-available' && 'toolCallId' in part) {
         pendingToolCalls.push({
           toolCallId: toolPart.toolCallId,
         });

--- a/agent/client/src/utils/tool-call-utils.ts
+++ b/agent/client/src/utils/tool-call-utils.ts
@@ -23,7 +23,6 @@ interface ToolCallContext {
 
 export interface ToolCallProcessingResult {
   success: boolean;
-  toolName: string;
   toolCallId: string;
   duration: number;
   error?: {
@@ -69,7 +68,6 @@ export async function processBrowserToolCall(
 
     const result: ToolCallProcessingResult = {
       success: true,
-      toolName,
       toolCallId,
       duration: 0, // Browser tools don't track duration currently
       result: toolCallResult.result,
@@ -85,7 +83,6 @@ export async function processBrowserToolCall(
 
     const result: ToolCallProcessingResult = {
       success: false,
-      toolName,
       toolCallId,
       duration: 0,
       error: {
@@ -158,7 +155,6 @@ export async function processClientSideToolCall(
 
     const processResult: ToolCallProcessingResult = {
       success: false,
-      toolName,
       toolCallId,
       duration,
       error: {
@@ -175,7 +171,6 @@ export async function processClientSideToolCall(
   } else if (result.userInteractionRequired) {
     const processResult: ToolCallProcessingResult = {
       success: false,
-      toolName,
       toolCallId,
       duration,
       error: {
@@ -193,7 +188,6 @@ export async function processClientSideToolCall(
     // Successful completion
     const processResult: ToolCallProcessingResult = {
       success: true,
-      toolName,
       toolCallId,
       duration,
       result: result.result,

--- a/agent/types/package.json
+++ b/agent/types/package.json
@@ -25,7 +25,7 @@
     "rimraf": "^5.0.0",
     "typescript": "^5.8.3",
     "zod": "4.0.17",
-    "@stagewise/api-client": "1.3.0"
+    "@stagewise/api-client": "1.4.0"
   },
   "dependencies": {
     "ai": "5.0.9"

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -39,7 +39,7 @@
     "@stagewise-plugins/vue": "workspace:*",
     "@stagewise/agent-client": "workspace:*",
     "@stagewise/agent-runtime-node": "workspace:*",
-    "@stagewise/api-client": "1.3.0",
+    "@stagewise/api-client": "1.4.0",
     "@stagewise/toolbar": "workspace:*",
     "@stagewise/toolbar-bridged": "workspace:*",
     "@types/express": "^4.17.21",

--- a/packages/karton-contract/package.json
+++ b/packages/karton-contract/package.json
@@ -26,6 +26,6 @@
   },
   "devDependencies": {
     "typescript": "^5.9.2",
-    "@stagewise/api-client": "1.3.0"
+    "@stagewise/api-client": "1.4.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,8 +74,8 @@ importers:
         specifier: workspace:*
         version: link:../types
       '@stagewise/api-client':
-        specifier: 1.3.0
-        version: 1.3.0(typescript@5.9.2)
+        specifier: 1.4.0
+        version: 1.4.0(typescript@5.9.2)
       '@stagewise/karton':
         specifier: workspace:*
         version: link:../../packages/karton
@@ -245,8 +245,8 @@ importers:
         version: 5.0.9(zod@4.0.17)
     devDependencies:
       '@stagewise/api-client':
-        specifier: 1.3.0
-        version: 1.3.0(typescript@5.9.2)
+        specifier: 1.4.0
+        version: 1.4.0(typescript@5.9.2)
       rimraf:
         specifier: ^5.0.0
         version: 5.0.10
@@ -278,8 +278,8 @@ importers:
         specifier: workspace:*
         version: link:../../agent/runtime-node
       '@stagewise/api-client':
-        specifier: 1.3.0
-        version: 1.3.0(typescript@5.9.2)
+        specifier: 1.4.0
+        version: 1.4.0(typescript@5.9.2)
       '@stagewise/karton':
         specifier: workspace:*
         version: link:../../packages/karton
@@ -918,8 +918,8 @@ importers:
         version: 4.0.17
     devDependencies:
       '@stagewise/api-client':
-        specifier: 1.3.0
-        version: 1.3.0(typescript@5.9.2)
+        specifier: 1.4.0
+        version: 1.4.0(typescript@5.9.2)
       typescript:
         specifier: ^5.9.2
         version: 5.9.2
@@ -5757,8 +5757,8 @@ packages:
   '@speed-highlight/core@1.2.7':
     resolution: {integrity: sha512-0dxmVj4gxg3Jg879kvFS/msl4s9F3T9UXC1InxgOf7t5NvcPD97u/WTA5vL/IxWHMn7qSxBozqrnnE2wvl1m8g==}
 
-  '@stagewise/api-client@1.3.0':
-    resolution: {integrity: sha512-1la0mPWBUByspE1Ke1pbNlB+CN0kOqMAntkgOl9tX4fECfBUJWC2jr4g8o8/srboJXElMk+YCvqNU1psKEq6Yg==}
+  '@stagewise/api-client@1.4.0':
+    resolution: {integrity: sha512-eYp42eNFDQdts5yCo2gTMVpYBB6EXfkDZrejsx84bYvG8ukHMIwtnKtbdvhXTSaqf+La1r5W/7tpBNtaU7ppjA==}
 
   '@standard-schema/spec@1.0.0':
     resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
@@ -19503,7 +19503,7 @@ snapshots:
 
   '@speed-highlight/core@1.2.7': {}
 
-  '@stagewise/api-client@1.3.0(typescript@5.9.2)':
+  '@stagewise/api-client@1.4.0(typescript@5.9.2)':
     dependencies:
       '@trpc/client': 11.4.4(@trpc/server@11.4.4(typescript@5.9.2))(typescript@5.9.2)
       '@trpc/server': 11.4.4(typescript@5.9.2)


### PR DESCRIPTION
…pending operations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Aborting a chat now cancels its in-progress tool runs and marks them as “aborted by user” on the latest message.
  - Per-chat abort handling ensures other chats continue unaffected and report their own results.

- Bug Fixes
  - Clears stale last-message references after top-level completions for consistent chat state.
  - More reliable cleanup on aborts, reducing stray loading indicators and partial updates.
  - Tool outputs (including aborted results) are consistently attached to messages for better traceability.

- Chores
  - Dev dependency bumps and a patch release metadata update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->