### PR TITLE
refactor(cli): remove early agent access references from cli

### DIFF
--- a/.changeset/upset-walls-write.md
+++ b/.changeset/upset-walls-write.md
@@ -1,0 +1,5 @@
+---
+"stagewise": patch
+---
+
+Remove earlyAgentAccess references in the cli.

--- a/apps/cli/src/auth/oauth.ts
+++ b/apps/cli/src/auth/oauth.ts
@@ -28,7 +28,6 @@ interface AuthState {
   userEmail?: string;
   expiresAt?: string; // Access token expiry
   refreshExpiresAt?: string; // Refresh token expiry
-  hasEarlyAgentAccess?: boolean;
 }
 
 interface SessionValidationResponse {
@@ -38,7 +37,6 @@ interface SessionValidationResponse {
   extensionId: string;
   createdAt: string;
   isExpiringSoon: boolean;
-  hasEarlyAgentAccess: boolean;
 }
 
 export class OAuthManager {
@@ -154,9 +152,6 @@ export class OAuthManager {
       const sessionData: SessionValidationResponse = sessionResponse.data;
 
       log.debug(`Successfully authenticated as: ${sessionData.userEmail}`);
-      if (sessionData.hasEarlyAgentAccess) {
-        log.debug('✅ Early Agent Access enabled');
-      }
 
       const tokenData: TokenData = {
         accessToken: tokenPair.accessToken,
@@ -165,7 +160,6 @@ export class OAuthManager {
         refreshExpiresAt: tokenPair.refreshExpiresAt,
         userId: sessionData.userId,
         userEmail: sessionData.userEmail,
-        hasEarlyAgentAccess: sessionData.hasEarlyAgentAccess,
       };
 
       // Update cached access token
@@ -534,7 +528,6 @@ export class OAuthManager {
         refreshExpiresAt: tokenPair.refreshExpiresAt,
         userId: sessionData.userId,
         userEmail: sessionData.userEmail,
-        hasEarlyAgentAccess: sessionData.hasEarlyAgentAccess,
       };
 
       // Update cached access token
@@ -705,7 +698,6 @@ export class OAuthManager {
             ...storedToken,
             userId: sessionData.userId,
             userEmail: sessionData.userEmail,
-            hasEarlyAgentAccess: sessionData.hasEarlyAgentAccess,
           };
 
           if (JSON.stringify(updatedToken) !== JSON.stringify(storedToken)) {
@@ -720,7 +712,6 @@ export class OAuthManager {
             userEmail: updatedToken.userEmail,
             expiresAt: updatedToken.expiresAt,
             refreshExpiresAt: updatedToken.refreshExpiresAt,
-            hasEarlyAgentAccess: updatedToken.hasEarlyAgentAccess,
           };
 
           return authState;
@@ -755,7 +746,6 @@ export class OAuthManager {
         userEmail: storedToken.userEmail,
         expiresAt: storedToken.expiresAt,
         refreshExpiresAt: storedToken.refreshExpiresAt,
-        hasEarlyAgentAccess: storedToken.hasEarlyAgentAccess,
       };
       return authState;
     }
@@ -779,7 +769,6 @@ export class OAuthManager {
       userEmail: storedToken.userEmail,
       expiresAt: storedToken.expiresAt,
       refreshExpiresAt: storedToken.refreshExpiresAt,
-      hasEarlyAgentAccess: storedToken.hasEarlyAgentAccess,
     };
   }
 
@@ -831,14 +820,6 @@ export class OAuthManager {
     }
 
     return true;
-  }
-
-  /**
-   * Check if the authenticated user has early agent access
-   */
-  async hasEarlyAgentAccess(): Promise<boolean> {
-    const authState = await this.getAuthState();
-    return authState?.hasEarlyAgentAccess ?? false;
   }
 
   /**

--- a/apps/cli/src/auth/token-manager.ts
+++ b/apps/cli/src/auth/token-manager.ts
@@ -14,7 +14,6 @@ export interface TokenData {
   refreshExpiresAt?: string;
   userId?: string;
   userEmail?: string;
-  hasEarlyAgentAccess?: boolean;
 }
 
 export class TokenManager {

--- a/apps/cli/tests/unit/auth/oauth.test.ts
+++ b/apps/cli/tests/unit/auth/oauth.test.ts
@@ -82,7 +82,6 @@ describe('OAuthManager', () => {
           extensionId: 'test-extension',
           createdAt: '2024-01-01T00:00:00Z',
           isExpiringSoon: false,
-          hasEarlyAgentAccess: true,
         },
       });
 
@@ -231,7 +230,6 @@ describe('OAuthManager', () => {
         ).toISOString(),
         userId: 'test-user-id',
         userEmail: 'test@example.com',
-        hasEarlyAgentAccess: true,
       });
 
       vi.mocked(axios.get).mockResolvedValueOnce({
@@ -240,7 +238,6 @@ describe('OAuthManager', () => {
           valid: true,
           userId: 'test-user-id',
           userEmail: 'test@example.com',
-          hasEarlyAgentAccess: true,
         },
       });
 
@@ -404,7 +401,6 @@ describe('OAuthManager', () => {
           valid: true,
           userId: 'test-user-id',
           userEmail: 'test@example.com',
-          hasEarlyAgentAccess: true,
         },
       });
 
@@ -458,32 +454,6 @@ describe('OAuthManager', () => {
 
       const { oauthManager } = await import('../../../src/auth/oauth');
       const result = await oauthManager.isAuthenticated();
-      expect(result).toBe(false);
-    });
-  });
-
-  describe('hasEarlyAgentAccess', () => {
-    it('should return true if user has early access', async () => {
-      const { tokenManager } = await import('../../../src/auth/token-manager');
-      vi.mocked(tokenManager.getStoredToken).mockResolvedValue({
-        accessToken: 'valid-token',
-        hasEarlyAgentAccess: true,
-      });
-
-      const { oauthManager } = await import('../../../src/auth/oauth');
-      const result = await oauthManager.hasEarlyAgentAccess();
-      expect(result).toBe(true);
-    });
-
-    it('should return false if user does not have early access', async () => {
-      const { tokenManager } = await import('../../../src/auth/token-manager');
-      vi.mocked(tokenManager.getStoredToken).mockResolvedValue({
-        accessToken: 'valid-token',
-        hasEarlyAgentAccess: false,
-      });
-
-      const { oauthManager } = await import('../../../src/auth/oauth');
-      const result = await oauthManager.hasEarlyAgentAccess();
       expect(result).toBe(false);
     });
   });


### PR DESCRIPTION
Removing all early agent references from the cli since it is no longer used.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Removed all Early Agent Access handling from the CLI authentication flow.
  - Eliminated any user-facing output or behavior related to Early Agent Access.
  - No impact to standard login or token refresh behavior.

- Tests
  - Updated unit tests to reflect removal of Early Agent Access logic and scenarios.

- Chores
  - Added a changeset entry marking a patch update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->