### PR TITLE
Add undo functionality

### DIFF
--- a/.changeset/hot-rules-enter.md
+++ b/.changeset/hot-rules-enter.md
@@ -1,0 +1,9 @@
+---
+"@stagewise/agent-client": minor
+"@stagewise/toolbar": minor
+"@stagewise/agent-tools": minor
+"@stagewise/agent-types": minor
+"stagewise": minor
+---
+
+Implement undo functionality - it is now possible to restore a checkpoint and revert all file modifications to this point.

--- a/agent/client/src/Agent.ts
+++ b/agent/client/src/Agent.ts
@@ -550,11 +550,13 @@ export class Agent {
         this.karton?.state.chats[chatId]!.messages ?? [],
         this.timeoutManager,
         (result) => {
-          this.undoToolCallStack.get(chatId)?.push({
-            toolName: result.toolName,
-            toolCallId: result.toolCallId,
-            undoExecute: result.result?.undoExecute,
-          });
+          if (result.result?.undoExecute) {
+            this.undoToolCallStack.get(chatId)?.push({
+              toolName: result.toolName,
+              toolCallId: result.toolCallId,
+              undoExecute: result.result?.undoExecute,
+            });
+          }
           attachToolOutputToMessage(
             this.karton!,
             [result],
@@ -692,11 +694,11 @@ export class Agent {
           toolCallIdsAfterUserMessage.push(content.toolCallId);
     }
 
+    const idsAfter = new Set(toolCallIdsAfterUserMessage);
+
     while (
       this.undoToolCallStack.get(chatId)?.at(-1)?.toolCallId &&
-      toolCallIdsAfterUserMessage.includes(
-        this.undoToolCallStack.get(chatId)?.at(-1)?.toolCallId ?? '',
-      )
+      idsAfter.has(this.undoToolCallStack.get(chatId)?.at(-1)?.toolCallId!)
     ) {
       const undo = this.undoToolCallStack.get(chatId)?.pop();
       if (!undo) break;

--- a/agent/client/src/utils/tool-call-utils.ts
+++ b/agent/client/src/utils/tool-call-utils.ts
@@ -30,7 +30,7 @@ export interface ToolCallProcessingResult {
     type: 'error' | 'user_interaction_required';
     message: string;
   };
-  result?: any;
+  result?: ToolResult;
 }
 
 /**
@@ -54,7 +54,8 @@ export async function processBrowserToolCall(
 
   try {
     // TODO: call
-    const toolCallResult = {
+    const toolCallResult: ToolResult = {
+      success: true,
       result: {
         type: 'tool-result' as const,
         toolName,

--- a/agent/tools/src/delete-file-tool.ts
+++ b/agent/tools/src/delete-file-tool.ts
@@ -24,7 +24,6 @@ export async function deleteFileTool(
   // Validate required parameters
   if (!relPath) {
     return {
-      undoExecute: () => Promise.resolve(),
       success: false,
       message: 'Missing required parameter: path',
       error: 'MISSING_PATH',
@@ -38,7 +37,6 @@ export async function deleteFileTool(
     const fileExists = await clientRuntime.fileSystem.fileExists(absolutePath);
     if (!fileExists) {
       return {
-        undoExecute: () => Promise.resolve(),
         success: false,
         message: `File not found: ${relPath}`,
         error: 'FILE_NOT_FOUND',
@@ -50,7 +48,6 @@ export async function deleteFileTool(
       await clientRuntime.fileSystem.readFile(absolutePath);
     if (!originalContent.success || originalContent.content === undefined) {
       return {
-        undoExecute: () => Promise.resolve(),
         success: false,
         message: `Failed to read file before deletion: ${relPath}`,
         error: 'READ_ERROR',
@@ -65,7 +62,6 @@ export async function deleteFileTool(
       await clientRuntime.fileSystem.deleteFile(absolutePath);
     if (!deleteResult.success) {
       return {
-        undoExecute: () => Promise.resolve(),
         success: false,
         message: `Failed to delete file: ${relPath}`,
         error: deleteResult.error || 'DELETE_ERROR',
@@ -96,7 +92,6 @@ export async function deleteFileTool(
     };
   } catch (error) {
     return {
-      undoExecute: () => Promise.resolve(),
       success: false,
       message: `Failed to delete file: ${relPath}`,
       error: error instanceof Error ? error.message : 'Unknown error',

--- a/agent/tools/src/glob-tool.ts
+++ b/agent/tools/src/glob-tool.ts
@@ -27,7 +27,6 @@ export async function globTool(
   // Validate required parameters
   if (!pattern) {
     return {
-      undoExecute: () => Promise.resolve(),
       success: false,
       message: 'Missing required parameter: pattern',
       error: 'MISSING_PATTERN',
@@ -48,7 +47,6 @@ export async function globTool(
 
     if (!globResult.success) {
       return {
-        undoExecute: () => Promise.resolve(),
         success: false,
         message: `Glob search failed: ${globResult.message}`,
         error: globResult.error || 'GLOB_ERROR',
@@ -60,7 +58,6 @@ export async function globTool(
     const message = `Found ${globResult.totalMatches || 0} matches for pattern "${pattern}"${searchLocation}`;
 
     return {
-      undoExecute: () => Promise.resolve(),
       success: true,
       message,
       result: {
@@ -70,7 +67,6 @@ export async function globTool(
     };
   } catch (error) {
     return {
-      undoExecute: () => Promise.resolve(),
       success: false,
       message: `Glob search failed: ${error instanceof Error ? error.message : 'Unknown error'}`,
       error: error instanceof Error ? error.message : 'Unknown error',

--- a/agent/tools/src/grep-search-tool.ts
+++ b/agent/tools/src/grep-search-tool.ts
@@ -65,7 +65,6 @@ export async function grepSearchTool(
   // Validate required parameters
   if (!query) {
     return {
-      undoExecute: () => Promise.resolve(),
       success: false,
       message: 'Missing required parameter: query',
       error: 'MISSING_QUERY',
@@ -74,7 +73,6 @@ export async function grepSearchTool(
 
   if (!explanation) {
     return {
-      undoExecute: () => Promise.resolve(),
       success: false,
       message: 'Missing required parameter: explanation',
       error: 'MISSING_EXPLANATION',
@@ -104,7 +102,6 @@ export async function grepSearchTool(
 
     if (!grepResult.success) {
       return {
-        undoExecute: () => Promise.resolve(),
         success: false,
         message: `Grep search failed: ${grepResult.message}`,
         error: grepResult.error || 'GREP_ERROR',
@@ -133,7 +130,6 @@ export async function grepSearchTool(
     }
 
     return {
-      undoExecute: () => Promise.resolve(),
       success: true,
       message,
       result: {
@@ -145,7 +141,6 @@ export async function grepSearchTool(
     };
   } catch (error) {
     return {
-      undoExecute: () => Promise.resolve(),
       success: false,
       message: `Grep search failed: ${error instanceof Error ? error.message : 'Unknown error'}`,
       error: error instanceof Error ? error.message : 'Unknown error',

--- a/agent/tools/src/list-files-tool.ts
+++ b/agent/tools/src/list-files-tool.ts
@@ -40,7 +40,6 @@ export async function listFilesTool(
   if (maxDepth !== undefined) {
     if (!Number.isInteger(maxDepth) || maxDepth < 0) {
       return {
-        undoExecute: () => Promise.resolve(),
         success: false,
         message: 'maxDepth must be a non-negative integer',
         error: 'INVALID_MAX_DEPTH',
@@ -50,7 +49,6 @@ export async function listFilesTool(
 
   if (!includeFiles && !includeDirectories) {
     return {
-      undoExecute: () => Promise.resolve(),
       success: false,
       message:
         'At least one of includeFiles or includeDirectories must be true',
@@ -65,7 +63,6 @@ export async function listFilesTool(
     const pathExists = await clientRuntime.fileSystem.fileExists(absolutePath);
     if (!pathExists) {
       return {
-        undoExecute: () => Promise.resolve(),
         success: false,
         message: `Path does not exist or is not accessible: ${relPath}`,
         error: 'PATH_NOT_FOUND',
@@ -76,7 +73,6 @@ export async function listFilesTool(
     const isDir = await clientRuntime.fileSystem.isDirectory(absolutePath);
     if (!isDir) {
       return {
-        undoExecute: () => Promise.resolve(),
         success: false,
         message: `Path is not a directory: ${relPath}`,
         error: 'NOT_A_DIRECTORY',
@@ -95,7 +91,6 @@ export async function listFilesTool(
 
     if (!result.success) {
       return {
-        undoExecute: () => Promise.resolve(),
         success: false,
         message: `Failed to list files in: ${relPath}`,
         error: result.error,
@@ -113,7 +108,6 @@ export async function listFilesTool(
     message += ` - ${result.totalFiles || 0} files, ${result.totalDirectories || 0} directories`;
 
     return {
-      undoExecute: () => Promise.resolve(),
       success: true,
       message,
       result: {
@@ -124,7 +118,6 @@ export async function listFilesTool(
     };
   } catch (error) {
     return {
-      undoExecute: () => Promise.resolve(),
       success: false,
       message: `Failed to list files in: ${relPath}`,
       error: error instanceof Error ? error.message : 'Unknown error',

--- a/agent/tools/src/multi-edit-tool.ts
+++ b/agent/tools/src/multi-edit-tool.ts
@@ -39,7 +39,6 @@ export async function multiEditTool(
   // Validate required parameters
   if (!file_path) {
     return {
-      undoExecute: () => Promise.resolve(),
       success: false,
       message: 'Missing required parameter: file_path',
       error: 'MISSING_FILE_PATH',
@@ -48,7 +47,6 @@ export async function multiEditTool(
 
   if (!edits || edits.length === 0) {
     return {
-      undoExecute: () => Promise.resolve(),
       success: false,
       message:
         'Missing required parameter: edits (must contain at least one edit)',
@@ -61,7 +59,6 @@ export async function multiEditTool(
     const edit = edits[i];
     if (!edit) {
       return {
-        undoExecute: () => Promise.resolve(),
         success: false,
         message: `Edit at index ${i} is undefined`,
         error: 'INVALID_EDIT',
@@ -69,7 +66,6 @@ export async function multiEditTool(
     }
     if (!edit.old_string) {
       return {
-        undoExecute: () => Promise.resolve(),
         success: false,
         message: `Edit at index ${i} missing required field: old_string`,
         error: 'INVALID_EDIT',
@@ -77,7 +73,6 @@ export async function multiEditTool(
     }
     if (edit.new_string === undefined) {
       return {
-        undoExecute: () => Promise.resolve(),
         success: false,
         message: `Edit at index ${i} missing required field: new_string`,
         error: 'INVALID_EDIT',
@@ -85,7 +80,6 @@ export async function multiEditTool(
     }
     if (edit.old_string === edit.new_string) {
       return {
-        undoExecute: () => Promise.resolve(),
         success: false,
         message: `Edit at index ${i} has identical old_string and new_string`,
         error: 'INVALID_EDIT',
@@ -100,7 +94,6 @@ export async function multiEditTool(
     const fileExists = await clientRuntime.fileSystem.fileExists(absolutePath);
     if (!fileExists) {
       return {
-        undoExecute: () => Promise.resolve(),
         success: false,
         message: `File does not exist: ${file_path}`,
         error: 'FILE_NOT_FOUND',
@@ -116,7 +109,6 @@ export async function multiEditTool(
 
     if (!sizeCheck.isWithinLimit) {
       return {
-        undoExecute: () => Promise.resolve(),
         success: false,
         message: sizeCheck.error || `File is too large to edit: ${file_path}`,
         error: 'FILE_TOO_LARGE',
@@ -127,7 +119,6 @@ export async function multiEditTool(
     const readResult = await clientRuntime.fileSystem.readFile(absolutePath);
     if (!readResult.success || !readResult.content) {
       return {
-        undoExecute: () => Promise.resolve(),
         success: false,
         message: `Failed to read file: ${file_path}`,
         error: readResult.error || 'READ_ERROR',
@@ -180,7 +171,6 @@ export async function multiEditTool(
       );
       if (!writeResult.success) {
         return {
-          undoExecute: () => Promise.resolve(),
           success: false,
           message: `Failed to write file: ${file_path}`,
           error: writeResult.error || 'WRITE_ERROR',
@@ -212,7 +202,6 @@ export async function multiEditTool(
     }
 
     return {
-      undoExecute: () => Promise.resolve(),
       success: true,
       message: `Successfully applied ${totalEditsApplied} edits to ${file_path}`,
       result: {
@@ -221,7 +210,6 @@ export async function multiEditTool(
     };
   } catch (error) {
     return {
-      undoExecute: () => Promise.resolve(),
       success: false,
       message: `MultiEdit failed: ${error instanceof Error ? error.message : 'Unknown error'}`,
       error: error instanceof Error ? error.message : 'Unknown error',

--- a/agent/tools/src/overwrite-file-tool.ts
+++ b/agent/tools/src/overwrite-file-tool.ts
@@ -26,7 +26,6 @@ export async function overwriteFileTool(
   // Validate required parameters
   if (!relPath) {
     return {
-      undoExecute: () => Promise.resolve(),
       success: false,
       message: 'Missing required parameter: path',
       error: 'MISSING_PATH',
@@ -35,7 +34,6 @@ export async function overwriteFileTool(
 
   if (content === undefined) {
     return {
-      undoExecute: () => Promise.resolve(),
       success: false,
       message: 'Missing required parameter: content',
       error: 'MISSING_CONTENT',
@@ -53,7 +51,6 @@ export async function overwriteFileTool(
       const readResult = await clientRuntime.fileSystem.readFile(absolutePath);
       if (!readResult.success || readResult.content === undefined) {
         return {
-          undoExecute: () => Promise.resolve(),
           success: false,
           message: `Failed to read existing file: ${relPath}`,
           error: 'READ_ERROR',
@@ -92,7 +89,6 @@ export async function overwriteFileTool(
     );
     if (!writeResult.success) {
       return {
-        undoExecute: () => Promise.resolve(),
         success: false,
         message: `Failed to write file: ${relPath}`,
         error: writeResult.error || 'WRITE_ERROR',
@@ -135,7 +131,6 @@ export async function overwriteFileTool(
     };
   } catch (error) {
     return {
-      undoExecute: () => Promise.resolve(),
       success: false,
       message: `Failed to overwrite file: ${relPath}`,
       error: error instanceof Error ? error.message : 'Unknown error',

--- a/agent/tools/src/read-file-tool.ts
+++ b/agent/tools/src/read-file-tool.ts
@@ -49,7 +49,6 @@ export async function readFileTool(
   // Validate required parameters
   if (!target_file) {
     return {
-      undoExecute: () => Promise.resolve(),
       success: false,
       message: 'Missing required parameter: target_file',
       error: 'MISSING_TARGET_FILE',
@@ -63,7 +62,6 @@ export async function readFileTool(
       start_line_one_indexed < 1
     ) {
       return {
-        undoExecute: () => Promise.resolve(),
         success: false,
         message:
           'start_line_one_indexed must be a positive integer (1-indexed)',
@@ -76,7 +74,6 @@ export async function readFileTool(
       end_line_one_indexed_inclusive < 1
     ) {
       return {
-        undoExecute: () => Promise.resolve(),
         success: false,
         message:
           'end_line_one_indexed_inclusive must be a positive integer (1-indexed)',
@@ -86,7 +83,6 @@ export async function readFileTool(
 
     if (end_line_one_indexed_inclusive < start_line_one_indexed) {
       return {
-        undoExecute: () => Promise.resolve(),
         success: false,
         message:
           'end_line_one_indexed_inclusive must be greater than or equal to start_line_one_indexed',
@@ -102,7 +98,6 @@ export async function readFileTool(
     const fileExists = await clientRuntime.fileSystem.fileExists(absolutePath);
     if (!fileExists) {
       return {
-        undoExecute: () => Promise.resolve(),
         success: false,
         message: `File does not exist: ${target_file}`,
         error: 'FILE_NOT_FOUND',
@@ -119,7 +114,6 @@ export async function readFileTool(
 
       if (!sizeCheck.isWithinLimit) {
         return {
-          undoExecute: () => Promise.resolve(),
           success: false,
           message:
             sizeCheck.error || `File is too large to read: ${target_file}`,
@@ -143,7 +137,6 @@ export async function readFileTool(
 
     if (!readResult.success) {
       return {
-        undoExecute: () => Promise.resolve(),
         success: false,
         message: `Failed to read file: ${target_file}`,
         error: readResult.error || 'READ_ERROR',
@@ -162,7 +155,6 @@ export async function readFileTool(
     }
 
     return {
-      undoExecute: () => Promise.resolve(),
       success: true,
       message,
       result: {
@@ -172,7 +164,6 @@ export async function readFileTool(
     };
   } catch (error) {
     return {
-      undoExecute: () => Promise.resolve(),
       success: false,
       message: `Failed to read file: ${target_file}`,
       error: error instanceof Error ? error.message : 'Unknown error',

--- a/agent/types/src/tools.ts
+++ b/agent/types/src/tools.ts
@@ -11,7 +11,7 @@ export const stagewiseToolMetadataSchema = z.object({
 export type StagewiseToolMetadata = z.infer<typeof stagewiseToolMetadataSchema>;
 
 export type ToolResult = {
-  undoExecute: () => Promise<void>;
+  undoExecute?: () => Promise<void>;
   success: boolean;
   error?: string;
   message?: string;

--- a/packages/karton-contract/src/index.ts
+++ b/packages/karton-contract/src/index.ts
@@ -58,5 +58,9 @@ export type KartonContract = {
     approveToolCall: (toolCallId: string) => Promise<void>;
     rejectToolCall: (toolCallId: string) => Promise<void>;
     refreshSubscription: () => Promise<void>;
+    undoToolCallsUntilUserMessage: (
+      userMessageId: string,
+      chatId: string,
+    ) => Promise<void>;
   };
 };

--- a/toolbar/core/src/panels/chat/chat-bubble.tsx
+++ b/toolbar/core/src/panels/chat/chat-bubble.tsx
@@ -54,7 +54,7 @@ export function ChatBubble({
   const isWorking = useKartonState((s) => s.isWorking);
   const { setChatInput, addChatDomContext } = useChatState();
 
-  const confirmRestore = useCallback(() => {
+  const confirmRestore = useCallback(async () => {
     if (!msg.id || !activeChatId) return;
 
     // Extract text content from message parts
@@ -97,7 +97,7 @@ export function ChatBubble({
     }
 
     // Call the undo procedure to revert changes
-    undoToolCallsUntilUserMessage(msg.id, activeChatId);
+    await undoToolCallsUntilUserMessage(msg.id, activeChatId);
   }, [
     msg,
     activeChatId,
@@ -189,7 +189,7 @@ export function ChatBubble({
                 >
                   <PopoverPanel
                     anchor="top start"
-                    className="z-[9999] w-64 [--anchor-gap:8px]"
+                    className="overflow-visible! z-[9999] w-64 p-1 [--anchor-gap:8px]"
                   >
                     <div className="rounded-xl bg-white/95 p-3 shadow-xl ring-1 ring-zinc-950/10 ring-inset backdrop-blur-lg">
                       <p className="font-medium text-sm text-zinc-950">


### PR DESCRIPTION
This PR adds an undo-functionality to the stagewise agent.

It allows the user to restore a previous checkpoint (which can be any user message in the history).

An undo will clear all messages to this point and undo the file edits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - “Restore checkpoint” for any user message: revert tool actions since that message, repopulate the input, and attempt to reselect previously chosen elements.
  - Per-chat undo history so undos apply only to the current conversation.

- Refactor
  - Undo hooks tightened: undo is now available only when an action actually changed state; non-success/no-op/error paths no longer expose undo.
  - Improved type safety for tool result payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->