### PR TITLE
feat(cli): add port validation during configuration setup

### DIFF
--- a/.changeset/silent-socks-cry.md
+++ b/.changeset/silent-socks-cry.md
@@ -1,0 +1,5 @@
+---
+"stagewise": patch
+---
+
+Add a port check to the cli onboarding to make sure the development server is running.

--- a/README.md
+++ b/README.md
@@ -1,85 +1,35 @@
 # <img src="https://github.com/stagewise-io/assets/blob/main/media/logo.png?raw=true" alt="stagewise logo" width="48" height="48" style="border-radius: 50%; vertical-align: middle; margin-right: 8px;" /> stagewise
 
-# The frontend coding agent for production codebases
+**The frontend coding agent for production codebases**
 
-![NPM Version](https://img.shields.io/npm/v/stagewise) ![NPM License](https://img.shields.io/npm/l/stagewise) [![GitHub Repo stars](https://img.shields.io/github/stars/stagewise-io/stagewise)](https://github.com/stagewise-io/stagewise)
-
-[![Join us on Discord](https://img.shields.io/discord/1229378372141056010?label=Discord&logo=discord&logoColor=white)](https://discord.gg/gkdGsDYaKA) [![X (formerly Twitter) Follow](https://img.shields.io/twitter/follow/stagewise_io)](https://x.com/stagewise_io)
+![NPM Version](https://img.shields.io/npm/v/stagewise) ![NPM License](https://img.shields.io/npm/l/stagewise) [![GitHub Repo stars](https://img.shields.io/github/stars/stagewise-io/stagewise)](https://github.com/stagewise-io/stagewise) [![Join us on Discord](https://img.shields.io/discord/1229378372141056010?label=Discord&logo=discord&logoColor=white)](https://discord.gg/gkdGsDYaKA)
 
 ![stagewise demo](https://github.com/stagewise-io/assets/blob/main/media/demo.gif?raw=true)
 
-## About the project
+stagewise lets you tell the agent what you want to change, click elements to provide context, and watch it work its magic. No more pasting element information or file paths—stagewise uses real-time, browser-powered context.
 
-Welcome to **stagewise** —  The frontend coding agent for production codebases
+**Features:**
+- ⚡ Works out of the box with any framework
+- 🧩 Extensible with plugins  
+- 📖 Open source (AGPLv3)
+- 🧠 Compatible with stagewise agent, Cursor, GitHub Copilot, Windsurf, Cline, and more
 
-- 💬 Tell the agent what you want to change
-- 🧠 Click on element(s) to let the agent know where a change should happen
-- 💡 Let stagewise do the magic!
+## 🚀 Quick Start
 
-> Perfect for devs tired of pasting element information and folder paths into prompts. stagewise uses real-time, browser-powered context.
-
-## Features
-
-- ⚡ Works out of the box
-- 🧩 Customize and extend functionality with Plugins
-- 📖 Open source
-- ⛓️ Compatible with all kinds of frameworks
-- 🧠 Use our dedicated frontend agent - or any other compatible agent through our open agent interface!
-
-## 📖 Getting Started
-
-### 1. Start your web app in development mode
-
-The first thing you should do is to start your app in regular development mode
-
-### 2. Start stagewise
-
-stagewise can be integrated into your workflow without requiring you to install anything!
-
-Simply open another terminal window **in the root of your app under development** and enter the following:
+1. Start your web app in development mode
+2. Run stagewise in your project root:
 
 ```bash
 npx stagewise@latest
+# or with pnpm: pnpm dlx stagewise@latest
 ```
 
-or (if you're using pnpm):
+Follow the CLI setup guide to create your stagewise account.
 
-```bash
-pnpm dlx stagewise@latest
-```
+## 📜 License & Contributing
 
-And simply follow the short guide of the CLI app to setup your stagewise account.
+stagewise is open source under AGPLv3. For commercial use outside this license, [contact us](mailto:sales@stagewise.io).
 
-## 🤖 Agent support
+**Contributing:** Check out [CONTRIBUTING.md](https://github.com/stagewise-io/stagewise/blob/main/CONTRIBUTING.md) | [Open issues](https://github.com/stagewise-io/stagewise/issues) | [Development guide](https://stagewise.io/docs/developer-guides/test-stagewise-locally)
 
-| **Agent**      | **Supported**  |
-| -------------- | -------------- |
-| stagewise agent| ✅⭐️           |
-| Cursor         | ✅             |
-| GitHub Copilot | ✅             |
-| Windsurf       | ✅             |
-| Cline          | ✅             |
-| Roo Code       | ✅             |
-| Kilo Code      | ✅             |
-| Trae           | ✅             |
-
-## 📜 License
-
-stagewise is developed by tiq UG (haftungsbeschränkt) and offered under the AGPLv3 license.
-
-For more information on the license model, visit the [FAQ about the GNU Licenses](https://www.gnu.org/licenses/gpl-faq.html).
-
-For use cases that fall outside the scope permitted by the AGPLv3 license, feel free to [📬 Contact Us](mailto:sales@stagewise.io).
-
-## 🤝 Contributing
-
-We love contributions! Check out our [CONTRIBUTING.md](https://github.com/stagewise-io/stagewise/blob/main/CONTRIBUTING.md) guide to get involved. For bugs and fresh ideas, take a look at our [open issues](https://github.com/stagewise-io/stagewise/issues) or [look at our community developments forum](https://discord.com/channels/1229378372141056010/1400917596727152701).
-
-## 💻 Development guide
-
-Follow the guides in our docs -> [Developer guides](https://stagewise.io/docs/developer-guides/test-stagewise-locally).
-
-## 💬 Community & Support
-
-- 👾 [Join our Discord](https://discord.gg/gkdGsDYaKA)
-- 📖 Open an [issue on GitHub](https://github.com/stagewise-io/stagewise/issues) for dev support.
+**Community:** [Discord](https://discord.gg/gkdGsDYaKA) | [GitHub Issues](https://github.com/stagewise-io/stagewise/issues)

--- a/apps/cli/specs/99-architecture.md
+++ b/apps/cli/specs/99-architecture.md
@@ -35,6 +35,7 @@ src/
 │   ├── config-path.ts      # Configuration path management
 │   ├── identifier.ts       # Machine identifier management
 │   ├── logger.ts           # Logging utilities
+│   ├── port-validator.ts   # Port validation utilities
 │   ├── telemetry.ts        # Telemetry utility functions
 │   └── user-input.ts       # User input handling
 └── index.ts                # Application entry point
@@ -130,6 +131,11 @@ src/
   3. Configuration file (stagewise.config.json)
   4. Default values
 - Handles authentication flow initialization and interactive setup
+- **Port Validation**: Validates user-specified port has a running application
+  - Makes HTTP HEAD request to verify app is reachable
+  - Provides retry mechanism (up to 3 attempts) for incorrect ports
+  - Allows users to continue without running app if needed
+  - Improves onboarding experience by catching common configuration errors
 - **Command Wrapping Support**: Provides minimal configuration for wrapped command execution
 - **Argument Parser**: Uses Commander.js with double-dash delimiter detection for command separation
 - **Cross-platform Validation**: Port conflict detection and path validation
@@ -175,6 +181,10 @@ src/
   - Automatic dev mode detection via NODE_ENV and tsx execution
 - **Identifier Manager**: Creates and manages persistent machine ID for analytics
 - **Telemetry Manager**: Centralized telemetry configuration and event tracking
+- **Port Validator**: Validates application ports during configuration
+  - HTTP HEAD request with 2-second timeout
+  - Handles various error conditions (ECONNREFUSED, timeout, network errors)
+  - Returns validation status and error messages for user feedback
 - **Command Executor**: Manages child process execution for command wrapping mode
   - Cross-platform command spawning with proper shell detection
   - Signal forwarding (SIGINT, SIGTERM) between parent and child processes

--- a/apps/cli/src/utils/port-validator.ts
+++ b/apps/cli/src/utils/port-validator.ts
@@ -1,0 +1,50 @@
+import axios from 'axios';
+import { log } from './logger';
+
+export interface PortValidationResult {
+  isRunning: boolean;
+  error?: string;
+}
+
+export async function validateAppPort(
+  port: number,
+): Promise<PortValidationResult> {
+  if (port <= 0 || port > 65535) {
+    return {
+      isRunning: false,
+      error: 'Invalid port number',
+    };
+  }
+
+  try {
+    await axios.head(`http://localhost:${port}`, {
+      timeout: 2000,
+      validateStatus: () => true,
+    });
+
+    log.debug(`Application detected on port ${port}`);
+    return { isRunning: true };
+  } catch (error: any) {
+    if (error.code === 'ECONNREFUSED') {
+      log.debug(`No application running on port ${port}`);
+      return {
+        isRunning: false,
+        error: `No application detected on port ${port}`,
+      };
+    }
+
+    if (error.code === 'ECONNABORTED') {
+      log.debug(`Request timed out for port ${port}`);
+      return {
+        isRunning: false,
+        error: `Request timed out - no application detected on port ${port}`,
+      };
+    }
+
+    log.debug(`Error checking port ${port}: ${error.message}`);
+    return {
+      isRunning: false,
+      error: `Could not connect to port ${port}`,
+    };
+  }
+}

--- a/apps/cli/tests/unit/config/config-resolver.test.ts
+++ b/apps/cli/tests/unit/config/config-resolver.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import * as args from '../../../src/config/argparse';
+import * as userInput from '../../../src/utils/user-input';
+import * as portValidator from '../../../src/utils/port-validator';
+import * as configFile from '../../../src/config/config-file';
+import * as logger from '../../../src/utils/logger';
+
+// Mock all dependencies
+vi.mock('../../../src/config/argparse');
+vi.mock('../../../src/utils/user-input');
+vi.mock('../../../src/utils/port-validator');
+vi.mock('../../../src/config/config-file');
+vi.mock('../../../src/utils/logger');
+vi.mock('../../../src/auth/token-manager', () => ({
+  tokenManager: {
+    getStoredToken: vi.fn(),
+  },
+}));
+vi.mock('../../../src/auth/oauth', () => ({
+  oauthManager: {
+    ensureValidAccessToken: vi.fn(),
+    initiateOAuthFlow: vi.fn(),
+  },
+}));
+vi.mock('../../../src/utils/telemetry', () => ({
+  telemetryManager: {
+    hasConfigured: vi.fn().mockResolvedValue(true),
+    promptForOptIn: vi.fn(),
+  },
+  analyticsEvents: {
+    storedConfigJson: vi.fn(),
+  },
+}));
+
+describe('ConfigResolver - Port Validation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    
+    // Setup default mocks
+    vi.mocked(args).workspace = '/test/dir';
+    vi.mocked(args).silent = false;
+    vi.mocked(args).verbose = false;
+    vi.mocked(args).bridgeMode = false;
+    vi.mocked(args).port = undefined;
+    vi.mocked(args).appPort = undefined;
+    vi.mocked(args).token = 'test-token';
+    
+    vi.mocked(configFile.loadConfigFile).mockResolvedValue(null);
+    vi.mocked(configFile.configFileExists).mockResolvedValue(false);
+    vi.mocked(configFile.saveConfigFile).mockResolvedValue();
+    
+    vi.mocked(logger.log).info = vi.fn();
+    vi.mocked(logger.log).warn = vi.fn();
+    vi.mocked(logger.log).error = vi.fn();
+    vi.mocked(logger.log).debug = vi.fn();
+    vi.mocked(logger.configureLogger).mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('Port validation flow', () => {
+    it('should validate port and continue when app is running', async () => {
+      vi.mocked(userInput.promptNumber).mockResolvedValueOnce(5714);
+      vi.mocked(userInput.promptConfirm).mockResolvedValueOnce(false); // Don't save config
+      vi.mocked(portValidator.validateAppPort).mockResolvedValueOnce({
+        isRunning: true,
+      });
+
+      const { ConfigResolver } = await import('../../../src/config');
+      const resolver = new ConfigResolver();
+      const config = await resolver.resolveConfig();
+
+      expect(config.appPort).toBe(5714);
+      expect(portValidator.validateAppPort).toHaveBeenCalledWith(5714);
+      expect(logger.log.info).toHaveBeenCalledWith(
+        expect.stringContaining('Application detected on port 5714')
+      );
+    });
+
+    it('should retry when port has no running app', async () => {
+      vi.mocked(userInput.promptNumber)
+        .mockResolvedValueOnce(9999) // First try - wrong port
+        .mockResolvedValueOnce(5714); // Second try - correct port
+      
+      vi.mocked(userInput.promptConfirm)
+        .mockResolvedValueOnce(true)  // Yes, retry
+        .mockResolvedValueOnce(false); // Don't save config
+      
+      vi.mocked(portValidator.validateAppPort)
+        .mockResolvedValueOnce({
+          isRunning: false,
+          error: 'No application detected on port 9999',
+        })
+        .mockResolvedValueOnce({
+          isRunning: true,
+        });
+
+      const { ConfigResolver } = await import('../../../src/config');
+      const resolver = new ConfigResolver();
+      const config = await resolver.resolveConfig();
+
+      expect(config.appPort).toBe(5714);
+      expect(portValidator.validateAppPort).toHaveBeenCalledTimes(2);
+      expect(logger.log.warn).toHaveBeenCalledWith(
+        expect.stringContaining('No application detected on port 9999')
+      );
+    });
+
+    it('should allow continuing without running app when user chooses', async () => {
+      vi.mocked(userInput.promptNumber).mockResolvedValueOnce(9999);
+      vi.mocked(userInput.promptConfirm)
+        .mockResolvedValueOnce(false) // Don't retry
+        .mockResolvedValueOnce(true)  // Continue anyway
+        .mockResolvedValueOnce(false); // Don't save config
+      
+      vi.mocked(portValidator.validateAppPort).mockResolvedValueOnce({
+        isRunning: false,
+        error: 'No application detected on port 9999',
+      });
+
+      const { ConfigResolver } = await import('../../../src/config');
+      const resolver = new ConfigResolver();
+      const config = await resolver.resolveConfig();
+
+      expect(config.appPort).toBe(9999);
+      expect(logger.log.info).toHaveBeenCalledWith(
+        expect.stringContaining('Continuing with port 9999 (application not currently running)')
+      );
+    });
+
+    it('should handle max retry attempts', async () => {
+      vi.mocked(userInput.promptNumber)
+        .mockResolvedValueOnce(8001)
+        .mockResolvedValueOnce(8002)
+        .mockResolvedValueOnce(8003);
+      
+      vi.mocked(userInput.promptConfirm)
+        .mockResolvedValueOnce(true)  // Retry 1
+        .mockResolvedValueOnce(true)  // Retry 2
+        .mockResolvedValueOnce(true)  // Continue anyway after max attempts
+        .mockResolvedValueOnce(false); // Don't save config
+      
+      vi.mocked(portValidator.validateAppPort)
+        .mockResolvedValue({
+          isRunning: false,
+          error: 'No application detected',
+        });
+
+      const { ConfigResolver } = await import('../../../src/config');
+      const resolver = new ConfigResolver();
+      const config = await resolver.resolveConfig();
+
+      expect(config.appPort).toBe(8003);
+      expect(portValidator.validateAppPort).toHaveBeenCalledTimes(3);
+      expect(userInput.promptNumber).toHaveBeenCalledTimes(3);
+    });
+
+    it('should work in bridge mode', async () => {
+      vi.mocked(args).bridgeMode = true;
+      vi.mocked(userInput.promptNumber).mockResolvedValueOnce(5714);
+      vi.mocked(userInput.promptConfirm).mockResolvedValueOnce(false); // Don't save config
+      vi.mocked(portValidator.validateAppPort).mockResolvedValueOnce({
+        isRunning: true,
+      });
+
+      const { ConfigResolver } = await import('../../../src/config');
+      const resolver = new ConfigResolver();
+      const config = await resolver.resolveConfig();
+
+      expect(config.appPort).toBe(5714);
+      expect(config.bridgeMode).toBe(true);
+      expect(portValidator.validateAppPort).toHaveBeenCalledWith(5714);
+    });
+  });
+});

--- a/apps/cli/tests/unit/utils/port-validator.test.ts
+++ b/apps/cli/tests/unit/utils/port-validator.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import axios from 'axios';
+
+// Mock axios
+vi.mock('axios');
+
+describe('port-validator', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  describe('validateAppPort', () => {
+    it('should return isRunning: true when port has a running service', async () => {
+      vi.mocked(axios.head).mockResolvedValue({ status: 200 });
+
+      const { validateAppPort } = await import(
+        '../../../src/utils/port-validator'
+      );
+      const result = await validateAppPort(3000);
+
+      expect(axios.head).toHaveBeenCalledWith('http://localhost:3000', {
+        timeout: 2000,
+        validateStatus: expect.any(Function),
+      });
+      expect(result).toEqual({ isRunning: true });
+    });
+
+    it('should return isRunning: true for any HTTP response (including errors)', async () => {
+      vi.mocked(axios.head).mockResolvedValue({ status: 404 });
+
+      const { validateAppPort } = await import(
+        '../../../src/utils/port-validator'
+      );
+      const result = await validateAppPort(3000);
+
+      expect(result).toEqual({ isRunning: true });
+    });
+
+    it('should return isRunning: false when connection is refused', async () => {
+      const error: any = new Error('Connection refused');
+      error.code = 'ECONNREFUSED';
+      vi.mocked(axios.head).mockRejectedValue(error);
+
+      const { validateAppPort } = await import(
+        '../../../src/utils/port-validator'
+      );
+      const result = await validateAppPort(3000);
+
+      expect(result).toEqual({
+        isRunning: false,
+        error: 'No application detected on port 3000',
+      });
+    });
+
+    it('should return isRunning: false when request times out', async () => {
+      const error: any = new Error('Timeout');
+      error.code = 'ECONNABORTED';
+      vi.mocked(axios.head).mockRejectedValue(error);
+
+      const { validateAppPort } = await import(
+        '../../../src/utils/port-validator'
+      );
+      const result = await validateAppPort(3000);
+
+      expect(result).toEqual({
+        isRunning: false,
+        error: 'Request timed out - no application detected on port 3000',
+      });
+    });
+
+    it('should return isRunning: false for network errors but log them', async () => {
+      const error = new Error('Network error');
+      vi.mocked(axios.head).mockRejectedValue(error);
+
+      const { validateAppPort } = await import(
+        '../../../src/utils/port-validator'
+      );
+      const result = await validateAppPort(3000);
+
+      expect(result).toEqual({
+        isRunning: false,
+        error: 'Could not connect to port 3000',
+      });
+    });
+
+    it('should handle port 0 gracefully', async () => {
+      const { validateAppPort } = await import(
+        '../../../src/utils/port-validator'
+      );
+      const result = await validateAppPort(0);
+
+      expect(result).toEqual({
+        isRunning: false,
+        error: 'Invalid port number',
+      });
+      expect(axios.head).not.toHaveBeenCalled();
+    });
+
+    it('should handle invalid port numbers', async () => {
+      const { validateAppPort } = await import(
+        '../../../src/utils/port-validator'
+      );
+      const result = await validateAppPort(70000);
+
+      expect(result).toEqual({
+        isRunning: false,
+        error: 'Invalid port number',
+      });
+      expect(axios.head).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
- Introduced a new port validation utility to check if the specified application port is running.
- Enhanced the configuration resolver to prompt users for the app port and validate it, allowing retries and options to continue without a running app.
- Updated README to reflect new features and improved onboarding experience.
- Added unit tests for port validation and configuration resolver logic.