### PR TITLE
fix(agent): skip assistant messages that contain only reasoning parts

### DIFF
--- a/agent/client/src/utils/karton-helpers.ts
+++ b/agent/client/src/utils/karton-helpers.ts
@@ -58,8 +58,10 @@ export function attachToolOutputToMessage(
 
       if (result.success) {
         toolPart.state = 'output-available';
+        toolPart.input = toolPart.input ?? {};
         toolPart.output = result.result;
       } else {
+        toolPart.input = toolPart.input ?? {};
         toolPart.state = 'output-error';
         toolPart.errorText = result.error?.message;
       }
@@ -102,7 +104,11 @@ export function findPendingToolCalls(
 
       // Only consider tool calls with 'input-available' state as pending
       // Other states like 'output-available' or 'output-error' are terminal
-      if (toolPart.state === 'input-available' && 'toolCallId' in part) {
+      if (
+        (toolPart.state === 'input-available' ||
+          toolPart.state === 'input-streaming') &&
+        'toolCallId' in part
+      ) {
         pendingToolCalls.push({
           toolCallId: toolPart.toolCallId,
         });

--- a/agent/client/src/utils/ui-messages-to-model-messages.ts
+++ b/agent/client/src/utils/ui-messages-to-model-messages.ts
@@ -18,8 +18,9 @@ export function uiMessagesToModelMessages(
         break;
       case 'assistant': {
         if (
-          message.parts.some((part) => part.type === 'reasoning') &&
-          !message.parts.some((part) => part.type === 'text')
+          message.parts.every(
+            (part) => part.type === 'reasoning' || part.type === 'step-start',
+          )
         )
           continue; // skip assistant messages with only reasoning parts
 

--- a/agent/client/src/utils/ui-messages-to-model-messages.ts
+++ b/agent/client/src/utils/ui-messages-to-model-messages.ts
@@ -17,6 +17,12 @@ export function uiMessagesToModelMessages(
         );
         break;
       case 'assistant': {
+        if (
+          message.parts.some((part) => part.type === 'reasoning') &&
+          !message.parts.some((part) => part.type === 'text')
+        )
+          continue; // skip assistant messages with only reasoning parts
+
         // Create a new message with cleaned tool outputs
         const cleanedMessage = {
           ...message,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Skips assistant messages that contain only internal reasoning so empty/blank assistant replies no longer appear.
  * Ensures tool-related inputs are always initialized to prevent errors or missing-data issues during tool handling.
  * Broadens detection of pending tool calls to include in-progress tool inputs, improving reliability of tool coordination.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->