### PR TITLE
feat(cli): add HTTPS proxy support for development apps

### DIFF
--- a/.changeset/funky-nails-rush.md
+++ b/.changeset/funky-nails-rush.md
@@ -1,0 +1,5 @@
+---
+"stagewise": minor
+---
+
+Add HTTPS proxy support for development apps with self-signed certificates

--- a/apps/cli/src/config/argparse.ts
+++ b/apps/cli/src/config/argparse.ts
@@ -46,6 +46,10 @@ program
     myParsePath,
     process.cwd(),
   )
+  .option(
+    '--app-https',
+    'Use HTTPS when proxying the development app (for apps with self-signed certificates)',
+  )
   .option('-s, --silent', 'Will not request user input or guide through setup')
   .option('-v, --verbose', 'Output debug information to the CLI')
   .option(
@@ -146,6 +150,7 @@ program.parse([...process.argv.slice(0, 2), ...stagewiseArgs]);
 // Initialize variables
 let port: number | undefined;
 let appPort: number | undefined;
+let appHttps: boolean;
 let workspace: string;
 let silent: boolean;
 let verbose: boolean;
@@ -160,6 +165,7 @@ if (commandExecuted === 'auth' || commandExecuted === 'telemetry') {
   // Set default values for auth and telemetry commands
   port = undefined;
   appPort = undefined;
+  appHttps = false;
   workspace = process.cwd();
   silent = false;
   verbose = false;
@@ -169,6 +175,7 @@ if (commandExecuted === 'auth' || commandExecuted === 'telemetry') {
   const {
     port: parsedPort,
     appPort: parsedAppPort,
+    appHttps: parsedAppHttps,
     workspace: parsedWorkspace,
     silent: parsedSilent,
     verbose: parsedVerbose,
@@ -177,6 +184,7 @@ if (commandExecuted === 'auth' || commandExecuted === 'telemetry') {
   } = options as {
     port?: number;
     appPort?: number;
+    appHttps?: boolean;
     workspace: string;
     silent: boolean;
     verbose: boolean;
@@ -191,6 +199,7 @@ if (commandExecuted === 'auth' || commandExecuted === 'telemetry') {
 
   port = parsedPort;
   appPort = parsedAppPort;
+  appHttps = parsedAppHttps || false;
   workspace = parsedWorkspace;
   silent = parsedSilent;
   verbose = parsedVerbose;
@@ -202,6 +211,7 @@ if (commandExecuted === 'auth' || commandExecuted === 'telemetry') {
 export {
   port,
   appPort,
+  appHttps,
   workspace,
   silent,
   verbose,

--- a/apps/cli/src/config/config-file.ts
+++ b/apps/cli/src/config/config-file.ts
@@ -33,6 +33,10 @@ const configFileSchema = z.object({
     .max(65535)
     .optional()
     .describe('Port number for your development app'),
+  appHttps: z
+    .boolean()
+    .optional()
+    .describe('Whether the development app uses HTTPS'),
   autoPlugins: z.boolean().optional(),
   plugins: z.array(pluginSchema).optional(),
 });

--- a/apps/cli/src/config/index.ts
+++ b/apps/cli/src/config/index.ts
@@ -82,6 +82,7 @@ export class ConfigResolver {
       this.config = {
         port: args.port || 3100,
         appPort,
+        appHttps: args.appHttps || configFile?.appHttps || false,
         dir: args.workspace,
         silent: args.silent,
         verbose: args.verbose,
@@ -120,6 +121,7 @@ export class ConfigResolver {
     // Merge configurations (CLI args override config file)
     const port = args.port || configFile?.port || 3100;
     let appPort = args.appPort || configFile?.appPort;
+    const appHttps = args.appHttps || configFile?.appHttps || false;
     const autoPlugins = configFile?.autoPlugins ?? true;
     const plugins = configFile?.plugins ?? [];
 
@@ -232,6 +234,7 @@ export class ConfigResolver {
     this.config = {
       port,
       appPort,
+      appHttps,
       dir: args.workspace,
       silent: args.silent,
       verbose: args.verbose,

--- a/apps/cli/src/config/types.ts
+++ b/apps/cli/src/config/types.ts
@@ -11,6 +11,7 @@ export interface CliArgs {
 export interface ConfigFile {
   port?: number;
   appPort?: number;
+  appHttps?: boolean;
   autoPlugins?: boolean;
   plugins?: Array<string | { name: string; path?: string; url?: string }>;
   eddyMode?: string;
@@ -19,6 +20,7 @@ export interface ConfigFile {
 export interface Config {
   port: number;
   appPort: number;
+  appHttps: boolean;
   dir: string;
   silent: boolean;
   verbose: boolean;

--- a/apps/cli/src/server/proxy.ts
+++ b/apps/cli/src/server/proxy.ts
@@ -7,6 +7,7 @@ import { applyHeaderRewrites } from './proxy-utils/headers-rewrites';
 
 export const proxy = createProxyMiddleware({
   changeOrigin: true,
+  secure: false, // Allow self-signed certificates
   pathFilter: (pathname: string, req: IncomingMessage) => {
     // Don't proxy if:
     // - path starts with "stagewise-toolbar-app" (including agent server routes)
@@ -28,7 +29,9 @@ export const proxy = createProxyMiddleware({
   followRedirects: false, // Don't automatically follow redirects to prevent loops
   router: () => {
     const config = configResolver.getConfig();
-    return `http://localhost:${config.appPort}`;
+    // Use HTTPS if configured, otherwise HTTP
+    const protocol = config.appHttps ? 'https' : 'http';
+    return `${protocol}://localhost:${config.appPort}`;
   },
   ws: false, // we handle websocket upgrades manually because we have multiple potential websocket servers
   cookieDomainRewrite: {


### PR DESCRIPTION
## Description of Changes

Added support for proxying HTTPS development applications with self-signed certificates through a new `--app-https` CLI flag and `appHttps` configuration option.

**Changes include:**
- New `--app-https` CLI flag to enable HTTPS proxying
- New `appHttps` boolean option in `stagewise.json` config file
- Updated proxy middleware to use HTTPS protocol when configured
- Added `secure: false` to accept self-signed certificates
- Defaults to `false` (HTTP) for backward compatibility

## Motivation and Context

Fixes #689

Some development setups require HTTPS, particularly:
- Host applications running on HTTPS (e.g., enterprise apps with Module Federation)
- Apps with self-signed certificates for local development
- Micro-frontend architectures where the host app must use HTTPS

Previously, the CLI could only proxy HTTP applications. When users tried to proxy HTTPS apps (like a host app on port 8181), the connection would fail with "socket hang up" errors because the proxy was hardcoded to use HTTP.

This change enables the CLI to work with HTTPS development apps, making it compatible with more complex development setups like Module Federation micro-frontends.

**Usage:**
```bash
# Via CLI flag
stagewise --app-port 8181 --app-https

# Via config file
{
  "appPort": 8181,
  "appHttps": true
}

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added HTTPS proxy support for local development, enabling apps with self-signed certificates to run through the dev proxy.
  * Introduced a new CLI option --app-https and a corresponding config setting (appHttps) to opt into HTTPS proxying. Disabled by default.
  * Proxy now accepts self-signed certificates without extra setup.

* **Chores**
  * Added changeset entry for a minor release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->