### PR TITLE
fix(vscode-extension): correct command names for GitHub Copilot agent and chat extension

### DIFF
--- a/.changeset/bright-apes-stick.md
+++ b/.changeset/bright-apes-stick.md
@@ -1,0 +1,5 @@
+---
+"stagewise-vscode-extension": patch
+---
+
+Update command names for GitHub Copilot agent and chat extension

--- a/apps/vscode-extension/src/utils/call-copilot-agent.ts
+++ b/apps/vscode-extension/src/utils/call-copilot-agent.ts
@@ -6,9 +6,9 @@ export async function callCopilotAgent(request: {
   images: string[];
 }): Promise<void> {
   const prompt = `${request.prompt}`;
-
-  await vscode.commands.executeCommand('workbench.action.chat.openAgent');
-  await vscode.commands.executeCommand('workbench.action.chat.sendToNewChat', {
+  
+  await vscode.commands.executeCommand('workbench.action.chat.openagent');
+  await vscode.commands.executeCommand('workbench.action.chat.submit', {
     inputValue: prompt,
   });
 }

--- a/apps/vscode-extension/src/utils/is-copilot-chat-installed.ts
+++ b/apps/vscode-extension/src/utils/is-copilot-chat-installed.ts
@@ -5,7 +5,7 @@ import * as vscode from 'vscode';
  * @returns True if the extension is installed, false otherwise.
  */
 export function isCopilotChatInstalled(): boolean {
-  const extensionId = 'gitHub.copilot-chat';
+  const extensionId = 'github.copilot-chat';
   const extension = vscode.extensions.getExtension(extensionId);
   return !!extension;
 }


### PR DESCRIPTION
### Description
This PR fixes the integration with the GitHub Copilot agent in the VS Code extension.

### Changes
- Updated the command ID for opening the chat agent from `workbench.action.chat.openAgent` to `workbench.action.chat.openagent`.
- Updated the command ID for submitting a chat message from `workbench.action.chat.sendToNewChat` to `workbench.action.chat.submit`.
- Corrected the extension ID check for Copilot Chat from `gitHub.copilot-chat` to `github.copilot-chat` (lowercase 'h').

### Impact
These changes ensure that the Stagewise extension can correctly detect and interact with the GitHub Copilot Chat extension, restoring functionality for users who select Copilot as their agent.

### Fixes #710 