### PR TITLE
fix(toolbar): simplify chat panel layout and resolve chat overflow

### DIFF
--- a/.changeset/cold-lizards-draw.md
+++ b/.changeset/cold-lizards-draw.md
@@ -1,0 +1,6 @@
+---
+"@stagewise/toolbar-bridged": patch
+"@stagewise/toolbar": patch
+---
+
+Resolve chat overflow in the chatbox

--- a/toolbar/bridged/src/panels/chat.tsx
+++ b/toolbar/bridged/src/panels/chat.tsx
@@ -344,14 +344,14 @@ export function ChatPanel() {
       className={cn(
         anyMessageInChat
           ? 'h-[35vh] max-h-[50vh] min-h-[20vh]'
-          : '!h-[calc-size(auto,size)] h-auto min-h-0',
+          : 'h-auto min-h-0',
       )}
     >
       <PanelHeader
         className={cn(
           'mb-0 origin-bottom transition-all duration-300 ease-out',
           agentState.state !== AgentStateType.IDLE
-            ? '!h-[calc-size(auto,size)] h-auto'
+            ? 'h-auto'
             : 'h-0 scale-x-75 scale-y-0 p-0 opacity-0 blur-md',
         )}
         title={
@@ -407,7 +407,7 @@ export function ChatPanel() {
       <PanelContent
         className={cn(
           'flex basis-[initial] flex-col gap-0 px-1 py-0',
-          anyMessageInChat ? '!h-[calc-size(auto,size)] h-auto flex-1' : 'h-0',
+          anyMessageInChat ? 'h-auto flex-1' : 'h-0',
           agentState.state === AgentStateType.IDLE
             ? 'rounded-t-[inherit]'
             : 'rounded-t-none',

--- a/toolbar/core/src/panels/chat/chat-history.tsx
+++ b/toolbar/core/src/panels/chat/chat-history.tsx
@@ -92,7 +92,7 @@ export function ChatHistory({ ref }: { ref: React.RefObject<HTMLDivElement> }) {
     <section
       ref={ref}
       aria-label="Agent message display"
-      className="scrollbar-thin scrollbar-thumb-black/15 scrollbar-track-transparent pointer-events-auto block h-full min-h-[inherit] overflow-y-scroll overscroll-contain py-4 pt-16 pr-0 pb-14 pl-3 text-foreground text-sm focus-within:outline-none hover:bg-white/0 focus:outline-none"
+      className="scrollbar-thin scrollbar-thumb-black/15 scrollbar-track-transparent pointer-events-auto block h-48 overflow-y-scroll overscroll-contain pt-16 pr-0 pb-4 pl-3 text-foreground text-sm focus-within:outline-none hover:bg-white/0 focus:outline-none"
       onScroll={handleScroll}
       onMouseEnter={() => {
         ref.current?.focus();

--- a/toolbar/core/src/panels/chat/index.tsx
+++ b/toolbar/core/src/panels/chat/index.tsx
@@ -192,16 +192,18 @@ export function ChatPanel() {
   useEffect(() => {
     if (chatHistoryRef.current && footerRef.current) {
       const resizeObserver = new ResizeObserver(() => {
-        // calculate the height difference because we will need to apply that to the scroll position
-        const heightDifference =
-          Number.parseInt(
-            window
-              .getComputedStyle(footerRef.current)
-              .getPropertyValue('padding-bottom'),
-          ) - chatHistoryRef.current.clientHeight;
+        // Add a small padding (16px) instead of the full footer height
+        const desiredPadding = 16;
+        const currentPadding = Number.parseInt(
+          window
+            .getComputedStyle(chatHistoryRef.current)
+            .getPropertyValue('padding-bottom'),
+        ) || 0;
 
-        // scroll the chat history by the height difference after applying the updated padding
-        chatHistoryRef.current.style.paddingBottom = `${footerRef.current.clientHeight}px`;
+        // Calculate height difference for scroll adjustment
+        const heightDifference = desiredPadding - currentPadding;
+        // Apply minimal padding and adjust scroll position
+        chatHistoryRef.current.style.paddingBottom = `${desiredPadding}px`;
         chatHistoryRef.current.scrollTop -= heightDifference;
       });
       resizeObserver.observe(footerRef.current);

--- a/toolbar/core/src/panels/chat/panel-header.tsx
+++ b/toolbar/core/src/panels/chat/panel-header.tsx
@@ -45,7 +45,7 @@ export function ChatPanelHeader() {
         'pointer-events-none absolute top-px right-px left-px z-20 mb-0 origin-bottom px-3 py-3 pl-4.5 transition-all duration-300 ease-out *:pointer-events-auto',
         chatListOpen
           ? 'h-[calc(100%-2px)] rounded-[inherit] bg-white/60 backdrop-blur-lg'
-          : '!h-[calc-size(auto,size)] h-auto',
+          : 'h-auto',
       )}
       title={chatListOpen && <span className="mt-0.5">Chats</span>}
       clear


### PR DESCRIPTION
This pull request addresses a chat overflow issue in the chatbox by refining the sizing and padding logic for chat-related UI components.

**Chat panel sizing and overflow fixes:**

* Removed custom CSS calculations like `calc-size(auto,size)` from the height and header styles in `ChatPanel` and `ChatPanelHeader`, switching to simpler `h-auto` and related classes for more reliable sizing.
* Updated the chat history panel (`ChatHistory`) to use a fixed height (`h-48`) and simplified padding, replacing the previous dynamic `min-h-[inherit]` approach.

**Chat panel padding and scroll adjustment:**

* Refined the resize logic in `ChatPanel` to apply a minimal fixed bottom padding (16px) to the chat history, rather than matching the footer height, and adjusted the scroll position accordingly for a smoother user experience.

**Result**

<img width="465" height="247" alt="image" src="https://github.com/user-attachments/assets/8b16e268-2070-414c-b19e-c471ae8f63b9" />
<img width="465" height="247" alt="image" src="https://github.com/user-attachments/assets/16b610d6-3d3b-4b82-8c2b-1bccb42be39a" />


**Release notes:**

* Added a changeset to document these fixes as a patch release for both `@stagewise/toolbar-bridged` and `@stagewise/toolbar`.

**Fixes:** #699 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved chat overflow issues in the chatbox by optimizing panel layout and height handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->