### PR TITLE
fix overflow issue

### DIFF
--- a/toolbar/core/src/panels/chat/chat-bubble.tsx
+++ b/toolbar/core/src/panels/chat/chat-bubble.tsx
@@ -178,7 +178,7 @@ export function ChatBubble({
         <div className="flex max-w-full flex-col items-end gap-2">
           <div
             className={cn(
-              'group relative min-h-8 max-w-full animate-chat-bubble-appear space-y-3 break-words rounded-2xl bg-white/5 px-2.5 py-1.5 font-normal text-sm shadow-lg shadow-zinc-950/10 ring-1 ring-inset last:mb-0.5',
+              'group relative min-h-8 max-w-[85%] animate-chat-bubble-appear space-y-3 break-words rounded-2xl bg-white/5 px-2.5 py-1.5 font-normal text-sm shadow-lg shadow-zinc-950/10 ring-1 ring-inset last:mb-0.5',
               msg.role === 'assistant'
                 ? 'min-w-48 origin-bottom-left rounded-bl-xs bg-zinc-100/60 text-zinc-950 ring-zinc-950/5'
                 : 'origin-bottom-right rounded-br-xs bg-blue-600/90 text-white ring-white/5',


### PR DESCRIPTION
I tried to fix the overflow issue by making some changes in the Toolbar/ChatBubble.tsx:-
Changes
Toolbar Core
chat-bubble.tsx
I updated the 
ChatBubble
 component to restrict the maximum width of the message bubbles.

Changed max-w-full to max-w-[85%] to ensure the bubble fits within the chat view with appropriate spacing.
// Before
className="group relative min-h-8 max-w-full ..."
// After
className="group relative min-h-8 max-w-[85%] ..."

Please confirm the changes 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated chat message bubble styling to constrain maximum width to 85% instead of full width, improving visual layout and presentation of messages within the chat interface.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->