### PR TITLE
fix(stagewise): fix windows build signing

### DIFF
--- a/.github/workflows/_release-browser.yml
+++ b/.github/workflows/_release-browser.yml
@@ -182,7 +182,7 @@ jobs:
           # Install Azure.CodeSigning.Dlib via NuGet
           $nugetDir = "${{ runner.temp }}\nuget"
           New-Item -ItemType Directory -Force -Path $nugetDir | Out-Null
-          nuget install Microsoft.Trusted.Signing.Client -OutputDirectory $nugetDir -Source https://api.nuget.org/v3/index.json
+          nuget install Microsoft.Trusted.Signing.Client -Version 1.0.95 -OutputDirectory $nugetDir -Source https://api.nuget.org/v3/index.json
 
           # Find the installed dlib
           $dlibPath = Get-ChildItem -Path $nugetDir -Recurse -Filter "Azure.CodeSigning.Dlib.dll" |


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Windows code signing build process dependency to a pinned version for improved stability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->