### PR TITLE
fix(stagewise): fix windows-focus bugs on omnibox

### DIFF
--- a/apps/browser/src/backend/services/window-layout/focus-handling.md
+++ b/apps/browser/src/backend/services/window-layout/focus-handling.md
@@ -280,6 +280,16 @@ Chronological record of z-order/focus bugs and their fixes. Read these to unders
 - **Root cause:** The omnibox's combobox/popover component closes itself (`isOmniboxOpen = false`) on Enter **before** the `onSubmit` handler runs. The z-order `useEffect` observed the close, saw `didNavigateRef.current === false` (not yet set by `onSubmit`), and eagerly called `movePanelToForeground('tab-content')`. By the time `onSubmit` set `didNavigateRef.current = true`, the damage was done.
 - **Fix:** Removed the `'tab-content'` call from the omnibox close effect entirely. The omnibox now **only** fires `movePanelToForeground('stagewise-ui')` on open. On close, `WebContentsBoundsSyncer` handles restoring `'tab-content'` naturally via hover detection + `data-omnibox-modal-active` (which stays set via `navigationPending` during page load). This eliminates the race and aligns with invariant 6 — the syncer is the sole continuous z-order driver.
 
+### 9.9 Win32: Redundant `updateZOrder()` destroys native HWND keyboard focus
+
+- **Symptom:** On Windows, clicking the omnibox or pressing Ctrl+L appeared to give DOM focus (`document.activeElement === INPUT`), but the cursor didn't appear and keyboard input was silently dropped. The omnibox was completely non-functional.
+- **Root cause:** `handleMovePanelToForeground` had no short-circuit — it always called `updateZOrder()` even when `isWebContentInteractive` was already in the desired state. On Win32, `updateZOrder()` must `removeChildView`/`addChildView` all views to work around a hit-testing bug, and this remove/add cycle **destroys native HWND keyboard focus** every time it runs. The `WebContentsBoundsSyncer` fires `movePanelToForeground('stagewise-ui')` on every `mousemove` while the cursor is over the UI area (~every 100-200ms). Each redundant call triggered the destructive remove/add dance, immediately killing whatever native focus the omnibox had just acquired. The DOM layer (`document.activeElement`) was unaware of the native focus loss, creating a confusing disconnect between what the code reported and what the user experienced.
+- **Fix (three parts):**
+  1. **Short-circuit in `handleMovePanelToForeground`:** If `isWebContentInteractive` already equals the target value, return immediately without calling `updateZOrder()`. This is the primary fix — it eliminates the continuous focus destruction from `WebContentsBoundsSyncer` on mouse move.
+  2. **Focus restore in `updateZOrder()` Win32 path:** After the remove/add dance, check which view had native focus before and restore it (via `webContents.focus()`) if that view is the one ending up topmost. This preserves focus during *legitimate* z-order transitions.
+  3. **Win32 z-order in `handleTogglePanelKeyboardFocus`:** When `panel === 'stagewise-ui'` and `isWebContentInteractive` is `true` on Win32, set `isWebContentInteractive = false` and call `updateZOrder()` *before* `uiController.focus()`. This was documented in Invariant 3 and Bug 9.5 but had been lost during a code reset.
+- **Key insight:** On Win32, `removeChildView`/`addChildView` is not idempotent for keyboard focus. The operation is cheap for z-order but destructive for focus. Any call to `updateZOrder()` must be guarded against redundancy.
+
 ---
 
 ## 10. Invariants
@@ -301,3 +311,5 @@ Rules that must always hold. Violating any of these will cause regressions:
 7. **UI-forcing callers (`NotificationToaster`, `BasicAuthDialog`) only ever fire `'stagewise-ui'`** — they never fire `'tab-content'`. This ensures overlays are always visible.
 
 8. **The omnibox only fires `'stagewise-ui'` (on open) — never `'tab-content'`.** On close, `WebContentsBoundsSyncer` restores `'tab-content'` naturally via hover detection. This avoids race conditions between the popover closing and submit handlers running (see bug 9.8).
+
+9. **`handleMovePanelToForeground` must short-circuit when `isWebContentInteractive` already matches the target value.** On Win32, every `updateZOrder()` call destroys native HWND keyboard focus via the `removeChildView`/`addChildView` dance. The `WebContentsBoundsSyncer` fires `movePanelToForeground` on every mouse move, so without the short-circuit, any UI element with focus will lose it within ~100-200ms. See bug 9.9.

--- a/apps/browser/src/backend/services/window-layout/index.ts
+++ b/apps/browser/src/backend/services/window-layout/index.ts
@@ -833,6 +833,17 @@ export class WindowLayoutService extends DisposableService {
     });
 
     tab.on('tabFocused', (id) => {
+      // FIX: On Win32, webContents may auto-focus multiple times during page load
+      // (wc.on('focus') fires on visibility, DOM load, script execution, etc.).
+      // When isWebContentInteractive is false, the UI should have focus priority.
+      // Reclaim it immediately to prevent the tab from stealing keyboard input.
+      if (
+        process.platform === 'win32' &&
+        !this.isWebContentInteractive &&
+        id === this.activeTabId
+      ) {
+        this.uiController?.focus();
+      }
       this.uiController?.forwardFocusEvent(id);
     });
 
@@ -1142,7 +1153,14 @@ export class WindowLayoutService extends DisposableService {
     // event from pushing webcontents on top at startup, which would hide popups.
     if (panel === 'tab-content' && this.currentWebContentBounds === null)
       return;
-    this.isWebContentInteractive = panel === 'tab-content';
+    // FIX 1: Short-circuit when z-order already matches — prevents the continuous
+    // updateZOrder() calls from WebContentsBoundsSyncer (mousemove) from
+    // destroying native HWND keyboard focus via the Win32 removeChildView/addChildView dance.
+    const newValue = panel === 'tab-content';
+    if (this.isWebContentInteractive === newValue) {
+      return;
+    }
+    this.isWebContentInteractive = newValue;
     this.updateZOrder();
   };
 
@@ -1231,8 +1249,27 @@ export class WindowLayoutService extends DisposableService {
   private handleTogglePanelKeyboardFocus = async (
     panel: 'stagewise-ui' | 'tab-content',
   ) => {
-    if (panel === 'stagewise-ui') this.uiController?.focus();
-    else this.activeTab?.focus();
+    if (panel === 'stagewise-ui') {
+      // FIX 3 (Win32): On Windows, the tab's Win32 child window intercepts keyboard
+      // events when it is topmost. We must put the UI on top BEFORE calling focus().
+      // See focus-handling.md Invariant #3 and Bug 9.5.
+      if (process.platform === 'win32' && this.isWebContentInteractive) {
+        this.isWebContentInteractive = false;
+        this.updateZOrder();
+      }
+      this.uiController?.focus();
+    } else {
+      // FIX (Win32): Symmetric with the stagewise-ui path above.
+      // The tab must be topmost to receive keyboard events on Win32.
+      // Also required so the tabFocused auto-focus guard (which reclaims UI
+      // focus when isWebContentInteractive === false) doesn't interfere with
+      // intentional tab focus requests.
+      if (process.platform === 'win32' && !this.isWebContentInteractive) {
+        this.isWebContentInteractive = true;
+        this.updateZOrder();
+      }
+      this.activeTab?.focus();
+    }
   };
 
   private updateZOrder() {
@@ -1255,6 +1292,10 @@ export class WindowLayoutService extends DisposableService {
         this.baseWindow!.contentView.addChildView(this.uiController!.getView());
       }
     } else {
+      const uiFocusedBeforeZOrder =
+        this.uiController?.getView().webContents.isFocused() ?? false;
+      const tabFocusedBeforeZOrder =
+        this.activeTab?.getViewContainer().webContents.isFocused() ?? false;
       // On windows, we ne explicit re-adding to prevent bugy in hitbox testing
       if (this.isWebContentInteractive && this.activeTab) {
         this.baseWindow!.contentView.removeChildView(
@@ -1283,6 +1324,20 @@ export class WindowLayoutService extends DisposableService {
           );
         }
         this.baseWindow!.contentView.addChildView(this.uiController!.getView());
+      }
+      // FIX 2: Restore native focus after the Win32 remove/add dance.
+      // The removeChildView/addChildView cycle destroys ALL native HWND keyboard
+      // focus — even for the view that keeps its z-position. If ANY view had focus
+      // before, we must give focus to the TOPMOST view (the one that can actually
+      // receive keyboard events on Win32, since the topmost child HWND intercepts
+      // all keyboard input). This prevents the "dead zone" where neither view has
+      // focus and all hotkeys stop working (see focus-handling.md Bug 9.10).
+      if (uiFocusedBeforeZOrder || tabFocusedBeforeZOrder) {
+        if (!this.isWebContentInteractive) {
+          this.uiController!.getView().webContents.focus();
+        } else if (this.activeTab) {
+          this.activeTab.getViewContainer().webContents.focus();
+        }
       }
     }
   }

--- a/apps/browser/src/ui/screens/main/content/_components/omnibox/index.tsx
+++ b/apps/browser/src/ui/screens/main/content/_components/omnibox/index.tsx
@@ -261,8 +261,12 @@ export const Omnibox = ({
             placeholder="Search or type a URL"
             onFocus={onInputFocus}
             onKeyDown={onInputKeyDown}
+            // Windows: body { user-select: none } suppresses the mousedown
+            // default action that normally triggers focus on <input> elements.
+            // Explicitly calling focus() bypasses this platform-specific behavior.
+            onMouseDown={() => inputRef.current?.focus()}
             className={cn(
-              'h-8 w-full flex-1 rounded-full pr-5 pl-3 text-muted-foreground text-sm ring-1 ring-transparent hover:ring-derived-subtle focus:bg-surface-1 focus:text-foreground focus:outline-none focus:ring-derived-strong focus-visible:outline-none',
+              'h-8 w-full flex-1 select-text rounded-full pr-5 pl-3 text-muted-foreground text-sm ring-1 ring-transparent hover:ring-derived-subtle focus:bg-surface-1 focus:text-foreground focus:outline-none focus:ring-derived-strong focus-visible:outline-none',
               // Only apply transitions for mouse interactions, instant for keyboard
               isKeyboardInteraction
                 ? 'transition-none'

--- a/apps/browser/src/ui/screens/main/content/index.tsx
+++ b/apps/browser/src/ui/screens/main/content/index.tsx
@@ -53,6 +53,9 @@ export function MainSection({
   const activeTabId = useKartonState((s) => s.browser.activeTabId);
   const createTab = useKartonProcedure((p) => p.browser.createTab);
   const closeTab = useKartonProcedure((p) => p.browser.closeTab);
+  const togglePanelKeyboardFocus = useKartonProcedure(
+    (p) => p.browser.layout.togglePanelKeyboardFocus,
+  );
 
   const { setTabUiState } = useTabUIState();
 
@@ -99,6 +102,12 @@ export function MainSection({
         const ref = tabContentRefs.current[activeTabId];
         if (!ref) return false;
 
+        // FIX: On Win32, the new tab's webContents auto-focuses ~30-50ms after
+        // handleSwitchTab completes (Electron fires wc.on('focus') on page load).
+        // By the time this useEffect runs (~1-2s later), native HWND focus is on
+        // the tab, not the UI. Reclaim it before focusing the omnibox input.
+        // This mirrors what Ctrl+L does: togglePanelKeyboardFocus first, then focus.
+        void togglePanelKeyboardFocus('stagewise-ui');
         ref.focusOmnibox();
         pendingOmniboxFocusFromTabIdRef.current = null;
         return true;
@@ -113,7 +122,7 @@ export function MainSection({
         return () => clearTimeout(timeoutId);
       }
     }
-  }, [activeTabId, tabs]);
+  }, [activeTabId, tabs, togglePanelKeyboardFocus]);
 
   const handleCreateTab = useCallback(() => {
     // Store the current activeTabId - we'll focus when it changes to a new tab


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed keyboard focus issues on Windows when switching between tabs and UI panels
  * Improved keyboard shortcut behavior and focus restoration after panel switching on Windows
  * Enhanced omnibox input focus reliability on Windows with explicit focus handling

* **Documentation**
  * Added comprehensive Windows-specific focus handling documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->