### PR TITLE
fix(stagewise): make plan-view readonly

### DIFF
--- a/apps/browser/src/pages/routes/plan/$filename.tsx
+++ b/apps/browser/src/pages/routes/plan/$filename.tsx
@@ -1,8 +1,8 @@
 import { createFileRoute } from '@tanstack/react-router';
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useState, useEffect } from 'react';
 import type { CSSProperties } from 'react';
 import { OverlayScrollbar } from '@stagewise/stage-ui/components/overlay-scrollbar';
-import { useKartonProcedure, useKartonState } from '@pages/hooks/use-karton';
+import { useKartonState } from '@pages/hooks/use-karton';
 import { MarkdownEditor } from '@ui/components/markdown-editor/markdown-editor';
 import { Button } from '@stagewise/stage-ui/components/button';
 
@@ -15,8 +15,6 @@ function PlanPage() {
   const [content, setContent] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
-  const savePlanFile = useKartonProcedure((p) => p.savePlanFile);
-
   const fetchUrl = `plans://plans/${filename}`;
 
   // Subscribe to the plan metadata from Karton state.
@@ -27,11 +25,8 @@ function PlanPage() {
     return s.plans.find((p) => p.filename === filename);
   });
 
-  // Track the last content we saved ourselves so we can skip re-fetches
-  // triggered by our own writes (which also cause chokidar → metadata update).
-  const lastSavedContentRef = useRef<string | null>(null);
-
-  // Revision counter bumped on external changes to force PlanEditor remount.
+  // Revision counter bumped on external changes to force editor remount
+  // so the read-only editor picks up the latest content.
   const [revision, setRevision] = useState(0);
 
   // Fetch file content. Runs on initial load and whenever planMeta changes
@@ -46,10 +41,6 @@ function PlanPage() {
         const text = await response.text();
         if (cancelled) return;
 
-        // If the fetched content matches what we last saved, skip the update
-        // to avoid resetting the editor after the user's own edits.
-        if (lastSavedContentRef.current === text) return;
-
         setContent(text);
         setRevision((r) => r + 1);
       } catch (e) {
@@ -62,16 +53,6 @@ function PlanPage() {
       cancelled = true;
     };
   }, [fetchUrl, planMeta]);
-
-  const handleSave = useCallback(
-    async (fullContent: string) => {
-      // Record what we're saving so we can ignore the subsequent
-      // chokidar-triggered re-fetch for this exact content.
-      lastSavedContentRef.current = fullContent;
-      await savePlanFile(filename, fullContent);
-    },
-    [savePlanFile, filename],
-  );
 
   if (error) {
     return (
@@ -107,11 +88,7 @@ function PlanPage() {
       contentClassName="flex justify-center"
     >
       <div className="mt-8 mb-32 w-full max-w-3xl">
-        <MarkdownEditor
-          key={revision}
-          rawContent={content}
-          onSave={handleSave}
-        />
+        <MarkdownEditor key={revision} rawContent={content} readOnly />
       </div>
     </OverlayScrollbar>
   );

--- a/apps/browser/src/ui/components/markdown-editor/markdown-editor.css
+++ b/apps/browser/src/ui/components/markdown-editor/markdown-editor.css
@@ -6,6 +6,11 @@
   line-height: 1.6;
 }
 
+/* Allow text selection in read-only mode */
+.markdown-editor-content[contenteditable='false'] {
+  user-select: text;
+}
+
 /* Headings */
 .markdown-editor-content h1 {
   font-size: 1.5rem;

--- a/apps/browser/src/ui/components/markdown-editor/markdown-editor.tsx
+++ b/apps/browser/src/ui/components/markdown-editor/markdown-editor.tsx
@@ -14,8 +14,10 @@ const SAVED_DISPLAY_MS = 2000;
 interface MarkdownEditorProps {
   /** Raw markdown content */
   rawContent: string;
-  /** Callback to persist the markdown */
-  onSave: (content: string) => Promise<void>;
+  /** Callback to persist the markdown. Ignored when readOnly is true. */
+  onSave?: (content: string) => Promise<void>;
+  /** When true, the editor is non-editable and all save logic is disabled. */
+  readOnly?: boolean;
   className?: string;
 }
 
@@ -24,6 +26,7 @@ type SaveStatus = 'idle' | 'saving' | 'saved' | 'error';
 export function MarkdownEditor({
   rawContent,
   onSave,
+  readOnly = false,
   className,
 }: MarkdownEditorProps) {
   const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -51,7 +54,7 @@ export function MarkdownEditor({
   const save = useCallback(async (markdown: string) => {
     setSaveStatus('saving');
     try {
-      await onSaveRef.current(markdown);
+      await onSaveRef.current?.(markdown);
       if (isMountedRef.current) setSaveStatus('saved');
     } catch {
       if (isMountedRef.current) setSaveStatus('error');
@@ -83,10 +86,13 @@ export function MarkdownEditor({
       }),
     ],
     content: rawContent,
-    onUpdate: ({ editor: e }) => {
-      const md = (e.storage as any).markdown.getMarkdown();
-      debouncedSave(md);
-    },
+    editable: !readOnly,
+    onUpdate: readOnly
+      ? undefined
+      : ({ editor: e }) => {
+          const md = (e.storage as any).markdown.getMarkdown();
+          debouncedSave(md);
+        },
     editorProps: {
       attributes: {
         class: 'markdown-editor-content outline-none',
@@ -95,22 +101,23 @@ export function MarkdownEditor({
     },
   });
 
-  // Flush any pending save on unmount
+  // Flush any pending save on unmount (only relevant when editable)
   useEffect(() => {
+    if (readOnly) return;
     return () => {
       if (saveTimerRef.current && editor) {
         clearTimeout(saveTimerRef.current);
         const md = (editor.storage as any).markdown.getMarkdown();
         // Fire-and-forget save
-        onSaveRef.current(md).catch(() => {});
+        onSaveRef.current?.(md).catch(() => {});
       }
     };
-  }, [editor]);
+  }, [editor, readOnly]);
 
   return (
     <div className={cn('relative', className)}>
       <EditorContent editor={editor} />
-      <SaveIndicator status={saveStatus} />
+      {!readOnly && <SaveIndicator status={saveStatus} />}
     </div>
   );
 }

--- a/apps/browser/src/ui/components/markdown-editor/task-item-node-view.tsx
+++ b/apps/browser/src/ui/components/markdown-editor/task-item-node-view.tsx
@@ -5,7 +5,13 @@ import {
 } from '@tiptap/react';
 import { Checkbox } from '@stagewise/stage-ui/components/checkbox';
 
-export function TaskItemNodeView({ node, updateAttributes }: NodeViewProps) {
+export function TaskItemNodeView({
+  node,
+  updateAttributes,
+  editor,
+}: NodeViewProps) {
+  const isEditable = editor.isEditable;
+
   return (
     <NodeViewWrapper
       as="li"
@@ -16,9 +22,12 @@ export function TaskItemNodeView({ node, updateAttributes }: NodeViewProps) {
       <Checkbox
         size="xs"
         checked={node.attrs.checked}
-        onCheckedChange={(checked) =>
-          updateAttributes({ checked: checked === true })
+        onCheckedChange={
+          isEditable
+            ? (checked) => updateAttributes({ checked: checked === true })
+            : undefined
         }
+        disabled={!isEditable}
         className="mt-0.5 shrink-0"
         contentEditable={false}
       />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Plan file editor is now read-only; editing and saving changes are disabled.
  * Text selection is available in read-only mode.
  * Task item checkboxes are disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->