### PR TITLE
fix(stagewise): add delete-confirmation-popup for agents

### DIFF
--- a/apps/browser/src/ui/screens/main/sidebar/_components/delete-confirm-popover.tsx
+++ b/apps/browser/src/ui/screens/main/sidebar/_components/delete-confirm-popover.tsx
@@ -1,0 +1,47 @@
+import {
+  Popover,
+  PopoverTrigger,
+  PopoverContent,
+  PopoverTitle,
+  PopoverDescription,
+  PopoverFooter,
+  PopoverClose,
+} from '@stagewise/stage-ui/components/popover';
+import { Button } from '@stagewise/stage-ui/components/button';
+
+/**
+ * Confirmation popover for permanently deleting an agent.
+ * Controlled by the parent via `open` / `onOpenChange`.
+ */
+export function DeleteConfirmPopover({
+  open,
+  onOpenChange,
+  onConfirm,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: () => void;
+}) {
+  return (
+    <Popover open={open} onOpenChange={onOpenChange}>
+      <PopoverTrigger nativeButton={false}>
+        <span className="pointer-events-none absolute right-0 bottom-0 size-0" />
+      </PopoverTrigger>
+      <PopoverContent>
+        <PopoverTitle>Delete agent?</PopoverTitle>
+        <PopoverDescription>
+          This will permanently delete this agent and its chat history.
+        </PopoverDescription>
+        <PopoverClose />
+        <PopoverFooter>
+          <Button variant="primary" size="xs" onClick={onConfirm} autoFocus>
+            Delete
+          </Button>
+          <Button variant="ghost" size="xs" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+        </PopoverFooter>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/apps/browser/src/ui/screens/main/sidebar/active-agents/_components/agent-card.tsx
+++ b/apps/browser/src/ui/screens/main/sidebar/active-agents/_components/agent-card.tsx
@@ -1,4 +1,4 @@
-import { memo } from 'react';
+import { memo, useState } from 'react';
 import { cn } from '@ui/utils';
 import {
   Tooltip,
@@ -8,6 +8,7 @@ import {
 import { Button } from '@stagewise/stage-ui/components/button';
 import { IconTrash2Outline24 } from 'nucleo-core-outline-24';
 import { IconSleepingTimeOutline18 } from 'nucleo-ui-outline-18';
+import { DeleteConfirmPopover } from '../../_components/delete-confirm-popover';
 import TimeAgo from 'javascript-time-ago';
 import en from 'javascript-time-ago/locale/en';
 
@@ -56,6 +57,7 @@ export const AgentCard = memo(
     onDelete,
   }: AgentCardProps) {
     const subtitle = hasError ? 'Error' : activityText;
+    const [deleteOpen, setDeleteOpen] = useState(false);
 
     return (
       <div
@@ -143,7 +145,7 @@ export const AgentCard = memo(
                 aria-label="Delete agent permanently"
                 onClick={(e) => {
                   e.stopPropagation();
-                  onDelete(id);
+                  setDeleteOpen(true);
                 }}
               >
                 <IconTrash2Outline24 className="size-4 cursor-pointer" />
@@ -153,6 +155,14 @@ export const AgentCard = memo(
               <span>Delete agent permanently</span>
             </TooltipContent>
           </Tooltip>
+          <DeleteConfirmPopover
+            open={deleteOpen}
+            onOpenChange={setDeleteOpen}
+            onConfirm={() => {
+              setDeleteOpen(false);
+              onDelete(id);
+            }}
+          />
         </div>
       </div>
     );

--- a/apps/browser/src/ui/screens/main/sidebar/top/_components/agents-selector.tsx
+++ b/apps/browser/src/ui/screens/main/sidebar/top/_components/agents-selector.tsx
@@ -20,6 +20,7 @@ import { Switch } from '@stagewise/stage-ui/components/switch';
 import { IconHistoryFill18 } from 'nucleo-ui-fill-18';
 import { IconTrash2Outline24 } from 'nucleo-core-outline-24';
 import { cn } from '@ui/utils';
+import { DeleteConfirmPopover } from '../../_components/delete-confirm-popover';
 import { useKartonProcedure, useKartonState } from '@ui/hooks/use-karton';
 import type React from 'react';
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
@@ -120,6 +121,7 @@ export const AgentsSelector = memo(
     onEndReached,
   }: AgentsSelectorProps) {
     const [inputValue, setInputValue] = useState('');
+    const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null);
     const [isOpen, setIsOpen] = useState(false);
     const listRef = useRef<HTMLDivElement>(null);
     const sentinelRef = useRef<HTMLDivElement>(null);
@@ -168,14 +170,17 @@ export const AgentsSelector = memo(
       (e: React.MouseEvent<HTMLButtonElement>) => {
         e.stopPropagation();
         const agentId = e.currentTarget.dataset.agentId;
-        if (agentId) onDelete(agentId);
+        if (agentId) setPendingDeleteId(agentId);
       },
-      [onDelete],
+      [],
     );
 
     const handleOpenChange = useCallback((open: boolean) => {
       setIsOpen(open);
-      if (!open) setInputValue('');
+      if (!open) {
+        setInputValue('');
+        setPendingDeleteId(null);
+      }
     }, []);
 
     const showActiveAgents = useKartonState(
@@ -272,14 +277,28 @@ export const AgentsSelector = memo(
                               />
                             </span>
                           </span>
-                          <button
-                            type="button"
-                            className="col-start-3 flex size-5 shrink-0 cursor-pointer items-center justify-center rounded-full text-muted-foreground opacity-0 transition-colors hover:text-foreground focus-visible:opacity-100 group-hover/item:opacity-100"
-                            data-agent-id={agent.id}
-                            onClick={handleDeleteClick}
-                          >
-                            <IconTrash2Outline24 className="size-3" />
-                          </button>
+                          <div className="relative col-start-3">
+                            <button
+                              type="button"
+                              className="flex size-5 shrink-0 cursor-pointer items-center justify-center rounded-full text-muted-foreground opacity-0 transition-colors hover:text-foreground focus-visible:opacity-100 group-hover/item:opacity-100"
+                              data-agent-id={agent.id}
+                              onClick={handleDeleteClick}
+                            >
+                              <IconTrash2Outline24 className="size-3" />
+                            </button>
+                            {pendingDeleteId === agent.id && (
+                              <DeleteConfirmPopover
+                                open={true}
+                                onOpenChange={(open) => {
+                                  if (!open) setPendingDeleteId(null);
+                                }}
+                                onConfirm={() => {
+                                  setPendingDeleteId(null);
+                                  onDelete(agent.id);
+                                }}
+                              />
+                            )}
+                          </div>
                         </ComboboxItem>
                       );
                     })}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Added a confirmation popover for permanent deletions that warns about chat history loss and requires explicit confirmation.
  * Integrated the confirmation into agent list items and the agents selector so deletes are paused for user confirmation and only proceed after confirming.
  * Canceling the popover safely dismisses the prompt without performing the delete.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->