### PR TITLE
feat(stagewise): support global skills

### DIFF
--- a/apps/browser/src/backend/agents/shared/prompts/system/environment.md
+++ b/apps/browser/src/backend/agents/shared/prompts/system/environment.md
@@ -42,6 +42,8 @@ The directory consist of symlinks to folders in the users machine
 | `att/` | Agent-specific folder for exchanging data between user and agent | Read-only access. Write only via dedicated API |
 | `apps/` | Stores Mini-apps you build in individual folders | Directory is internal and not known to user |
 | `plugins/` | Built-in plugin skills | **Intrinsic knowledge** — highest priority. Directory is internal and not visible to user |
+| `globalskills-sw/` | User-level global skills from `~/.stagewise/skills/` | Read-only. Only present when the directory exists on the user's machine |
+| `globalskills-agents/` | Cross-agent global skills from `~/.agents/skills/` | Read-only. Only present when the directory exists on the user's machine |
 | `plans/` | Work/implementation plans you build with the user | **Not a workspace directory.** Path not visible to user; user can reference files inside |
 | `w{4_CHAR_ID}/` | Mounted workspaces the user gave the agent access to | The 4 char id is unique and based on the original path and serves as a shorter alias. The original path is defined in the env-snapshot |
 
@@ -199,8 +201,10 @@ Each skill is a folder with a `SKILL.md` file and optional supporting files.
 ### Priority Hierarchy
 
 1. **`plugins/{id}/SKILL.md`** — Core intrinsic knowledge. Always prefer.
-2. **`{WORKSPACE}/.stagewise/skills/*`** — Workspace-specific, created for you. Overrides general skills.
-3. **`{WORKSPACE}/.agents/skills/*`** — General skills shared with other agents.
+2. **`globalskills-sw/*`** — User-level skills from `~/.stagewise/skills/`. Personal defaults across all workspaces.
+3. **`{WORKSPACE}/.stagewise/skills/*`** — Workspace-specific, created for you. Overrides general skills.
+4. **`globalskills-agents/*`** — Cross-agent user-level skills from `~/.agents/skills/`.
+5. **`{WORKSPACE}/.agents/skills/*`** — General skills shared with other agents.
 
 ### Workflow
 

--- a/apps/browser/src/backend/agents/shared/prompts/utils/environment-renderer.ts
+++ b/apps/browser/src/backend/agents/shared/prompts/utils/environment-renderer.ts
@@ -31,17 +31,15 @@ export function renderFullEnvironmentContext(
   // All symlinks — user workspaces + always-available — in one table
   const { workspace } = snapshot;
   const systemPrefixes = new Set(['att', 'plugins', 'apps']);
-  const userMounts = workspace.mounts.filter(
-    (m) => !systemPrefixes.has(m.prefix),
-  );
-  const systemMounts = workspace.mounts.filter((m) =>
-    systemPrefixes.has(m.prefix),
-  );
+  const isSystemMount = (prefix: string) =>
+    systemPrefixes.has(prefix) || prefix.startsWith('globalskills-');
+  const userMounts = workspace.mounts.filter((m) => !isSystemMount(m.prefix));
+  const systemMounts = workspace.mounts.filter((m) => isSystemMount(m.prefix));
   const allMounts = [...userMounts, ...systemMounts];
 
   if (allMounts.length > 0) {
     const rows = allMounts.map((m) => {
-      const isUser = !systemPrefixes.has(m.prefix);
+      const isUser = !isSystemMount(m.prefix);
       const addr = isUser ? `use '${m.prefix}/...' to address files` : '';
       const perms = m.permissions ? m.permissions.join(', ') : '';
       return `| ${m.prefix} | ${m.path} | ${addr} | ${perms} |`;

--- a/apps/browser/src/backend/agents/shared/prompts/utils/get-skills.ts
+++ b/apps/browser/src/backend/agents/shared/prompts/utils/get-skills.ts
@@ -2,6 +2,7 @@ import { existsSync } from 'node:fs';
 import { readFile, readdir } from 'node:fs/promises';
 import type { ClientRuntimeNode } from '@stagewise/agent-runtime-node';
 import { resolve } from 'node:path';
+import { homedir } from 'node:os';
 import matter from 'gray-matter';
 
 export interface Skill {
@@ -66,6 +67,34 @@ export async function discoverSkills(skillsDir: string): Promise<Skill[]> {
   }
 
   return skills;
+}
+
+/**
+ * Discover user-level global skills from ~/.stagewise/skills/
+ * and ~/.agents/skills/. Does not require a workspace runtime.
+ * Deduplicates by name; .stagewise wins over .agents.
+ */
+export async function discoverGlobalSkills(): Promise<Skill[]> {
+  const home = homedir();
+  const stagewisePath = resolve(home, '.stagewise', 'skills');
+  const agentsPath = resolve(home, '.agents', 'skills');
+
+  const [stagewiseSkills, agentsSkills] = await Promise.all([
+    discoverSkills(stagewisePath),
+    discoverSkills(agentsPath),
+  ]);
+
+  stagewiseSkills.sort((a, b) => a.name.localeCompare(b.name));
+  agentsSkills.sort((a, b) => a.name.localeCompare(b.name));
+
+  const seen = new Set<string>();
+  const result: Skill[] = [];
+  for (const skill of [...stagewiseSkills, ...agentsSkills]) {
+    if (seen.has(skill.name)) continue;
+    seen.add(skill.name);
+    result.push(skill);
+  }
+  return result;
 }
 
 export async function getSkills(

--- a/apps/browser/src/backend/services/toolbox/index.ts
+++ b/apps/browser/src/backend/services/toolbox/index.ts
@@ -1226,29 +1226,9 @@ export class ToolboxService extends DisposableService {
     const result: SkillDefinition[] = [...this.builtinSkills];
     const seen = new Set(result.map((c) => c.id));
 
-    // Global (user-level) skills
-    const globalSkills = await discoverGlobalSkills();
-    const globalMounts = getGlobalSkillsMounts();
-    for (const skill of globalSkills) {
-      const id = `skill:${skill.name}`;
-      if (seen.has(id)) continue;
-      seen.add(id);
-      const isStagewise = skill.path.includes('.stagewise');
-      const mount = isStagewise ? globalMounts[0] : globalMounts[1];
-      const relativePath = path.relative(mount.absolutePath, skill.path);
-      result.push({
-        id,
-        displayName: skill.name,
-        description: skill.description,
-        source: 'global',
-        contentPath: path.resolve(skill.path, 'SKILL.md'),
-        skillPath: `${mount.prefix}/${relativePath}`,
-        userInvocable: skill.userInvocable,
-        agentInvocable: skill.agentInvocable,
-      });
-    }
-
-    // Workspace skills
+    // Workspace skills first — workspace overrides global.
+    // Also collect disabled skill names so globals can be suppressed.
+    const allDisabled = new Set<string>();
     const mounts =
       this.mountManagerService?.getMountedPathsWithRuntimes(agentInstanceId);
     if (mounts) {
@@ -1259,6 +1239,7 @@ export class ToolboxService extends DisposableService {
           disabledSkills: [],
         };
         const disabled = new Set(settings.disabledSkills);
+        for (const name of disabled) allDisabled.add(name);
         const skills = await getSkills(mount.clientRuntime);
 
         for (const skill of skills) {
@@ -1280,6 +1261,34 @@ export class ToolboxService extends DisposableService {
           });
         }
       }
+    }
+
+    // Global (user-level) skills — after workspace so workspace wins on dupes.
+    // Also suppressed by workspace-level disabledSkills.
+    const globalSkills = await discoverGlobalSkills();
+    const globalMounts = getGlobalSkillsMounts();
+    for (const skill of globalSkills) {
+      if (allDisabled.has(skill.name)) continue;
+      const id = `skill:${skill.name}`;
+      if (seen.has(id)) continue;
+      seen.add(id);
+      const mount = globalMounts.find(
+        (m) =>
+          skill.path === m.absolutePath ||
+          skill.path.startsWith(m.absolutePath + path.sep),
+      );
+      if (!mount) continue;
+      const relativePath = path.relative(mount.absolutePath, skill.path);
+      result.push({
+        id,
+        displayName: skill.name,
+        description: skill.description,
+        source: 'global',
+        contentPath: path.resolve(skill.path, 'SKILL.md'),
+        skillPath: `${mount.prefix}/${relativePath}`,
+        userInvocable: skill.userInvocable,
+        agentInvocable: skill.agentInvocable,
+      });
     }
 
     // Plugin skills

--- a/apps/browser/src/backend/services/toolbox/index.ts
+++ b/apps/browser/src/backend/services/toolbox/index.ts
@@ -32,7 +32,7 @@ import { createAuthenticatedClient } from './utils/create-authenticated-client';
 import { createFileDiffHandler } from './utils/sandbox-callbacks';
 import { deleteAgentBlobs, getAgentBlobDir } from '@/utils/attachment-blobs';
 import { getDataRoot, getPlansDir, getTempRoot } from '@/utils/paths';
-import { mkdirSync } from 'node:fs';
+import { existsSync, mkdirSync } from 'node:fs';
 import fsPromises from 'node:fs/promises';
 import type { ApiClient } from '@stagewise/api-client';
 import {
@@ -105,6 +105,7 @@ import type { ContextFilesResult } from '@shared/karton-contracts/pages-api/type
 import {
   getSkills,
   discoverSkills,
+  discoverGlobalSkills,
 } from '@/agents/shared/prompts/utils/get-skills';
 import type { SkillDefinition } from '@shared/skills';
 import { toSkillDefinitionUI } from '@shared/skills';
@@ -114,9 +115,27 @@ import { resolveMountedRelativePath } from './utils/path-mounting';
 import { normalizePath } from '@shared/path-utils';
 import { ClientRuntimeNode } from '@stagewise/agent-runtime-node';
 import chokidar, { type FSWatcher } from 'chokidar';
+import { homedir } from 'node:os';
 
 type MountedPrefix = string;
 type MountedPath = string;
+
+function getGlobalSkillsMounts(): Array<{
+  prefix: string;
+  absolutePath: string;
+}> {
+  const home = homedir();
+  return [
+    {
+      prefix: 'globalskills-sw',
+      absolutePath: path.resolve(home, '.stagewise', 'skills'),
+    },
+    {
+      prefix: 'globalskills-agents',
+      absolutePath: path.resolve(home, '.agents', 'skills'),
+    },
+  ];
+}
 
 export class ToolboxService extends DisposableService {
   private readonly logger: Logger;
@@ -133,6 +152,7 @@ export class ToolboxService extends DisposableService {
   private sandboxService: SandboxService | null = null;
   private shellService: ShellService | null = null;
   private pluginsRuntime: ClientRuntimeNode | null = null;
+  private globalSkillsRuntimes = new Map<string, ClientRuntimeNode>();
   private appsRuntimes = new Map<string, ClientRuntimeNode>();
   private attRuntimes = new Map<string, ClientRuntimeNode>();
 
@@ -158,6 +178,13 @@ export class ToolboxService extends DisposableService {
       this.mountManagerService?.getMountedRuntimes(agentInstanceId);
     if (!runtimes) return undefined;
     if (this.pluginsRuntime) runtimes.set('plugins', this.pluginsRuntime);
+    for (const mount of getGlobalSkillsMounts()) {
+      const rt = this.getOrCreateGlobalSkillsRuntime(
+        mount.prefix,
+        mount.absolutePath,
+      );
+      if (rt) runtimes.set(mount.prefix, rt);
+    }
     runtimes.set('apps', this.getOrCreateAppsRuntime(agentInstanceId));
     runtimes.set(PLANS_PREFIX, this.getOrCreatePlansRuntime());
     runtimes.set('att', this.getOrCreateAttRuntime(agentInstanceId));
@@ -180,6 +207,21 @@ export class ToolboxService extends DisposableService {
       rgBinaryBasePath: getRipgrepBasePath(),
     });
     return this.plansRuntime;
+  }
+
+  private getOrCreateGlobalSkillsRuntime(
+    prefix: string,
+    absolutePath: string,
+  ): ClientRuntimeNode | null {
+    const existing = this.globalSkillsRuntimes.get(prefix);
+    if (existing) return existing;
+    if (!existsSync(absolutePath)) return null;
+    const runtime = new ClientRuntimeNode({
+      workingDirectory: absolutePath,
+      rgBinaryBasePath: getRipgrepBasePath(),
+    });
+    this.globalSkillsRuntimes.set(prefix, runtime);
+    return runtime;
   }
 
   private getOrCreateAppsRuntime(agentInstanceId: string): ClientRuntimeNode {
@@ -935,6 +977,16 @@ export class ToolboxService extends DisposableService {
       permissions: READ_ONLY_PERMISSIONS,
     });
 
+    for (const gs of getGlobalSkillsMounts()) {
+      if (existsSync(gs.absolutePath)) {
+        mounts.push({
+          prefix: gs.prefix,
+          absolutePath: gs.absolutePath,
+          permissions: READ_ONLY_PERMISSIONS,
+        });
+      }
+    }
+
     const appsDir = getAgentAppsDir(agentInstanceId);
     mkdirSync(appsDir, { recursive: true });
     mounts.push({
@@ -1039,6 +1091,13 @@ export class ToolboxService extends DisposableService {
         path: getPluginsPath(),
         permissions: [...READ_ONLY_PERMISSIONS] as MountPermission[],
       },
+      ...getGlobalSkillsMounts()
+        .filter((gs) => existsSync(gs.absolutePath))
+        .map((gs) => ({
+          prefix: gs.prefix,
+          path: gs.absolutePath,
+          permissions: [...READ_ONLY_PERMISSIONS] as MountPermission[],
+        })),
       {
         prefix: 'apps',
         path: getAgentAppsDir(agentInstanceId),
@@ -1166,6 +1225,28 @@ export class ToolboxService extends DisposableService {
   ): Promise<SkillDefinition[]> {
     const result: SkillDefinition[] = [...this.builtinSkills];
     const seen = new Set(result.map((c) => c.id));
+
+    // Global (user-level) skills
+    const globalSkills = await discoverGlobalSkills();
+    const globalMounts = getGlobalSkillsMounts();
+    for (const skill of globalSkills) {
+      const id = `skill:${skill.name}`;
+      if (seen.has(id)) continue;
+      seen.add(id);
+      const isStageiwse = skill.path.includes('.stagewise');
+      const mount = isStageiwse ? globalMounts[0] : globalMounts[1];
+      const relativePath = path.relative(mount.absolutePath, skill.path);
+      result.push({
+        id,
+        displayName: skill.name,
+        description: skill.description,
+        source: 'global',
+        contentPath: path.resolve(skill.path, 'SKILL.md'),
+        skillPath: `${mount.prefix}/${relativePath}`,
+        userInvocable: skill.userInvocable,
+        agentInvocable: skill.agentInvocable,
+      });
+    }
 
     // Workspace skills
     const mounts =
@@ -1405,6 +1486,12 @@ export class ToolboxService extends DisposableService {
     result.set('apps', getAgentAppsDir(agentInstanceId));
     result.set('att', getAgentBlobDir(agentInstanceId));
     result.set(PLANS_PREFIX, getPlansDir());
+
+    for (const gs of getGlobalSkillsMounts()) {
+      if (existsSync(gs.absolutePath)) {
+        result.set(gs.prefix, gs.absolutePath);
+      }
+    }
 
     return result;
   }

--- a/apps/browser/src/backend/services/toolbox/index.ts
+++ b/apps/browser/src/backend/services/toolbox/index.ts
@@ -1233,8 +1233,8 @@ export class ToolboxService extends DisposableService {
       const id = `skill:${skill.name}`;
       if (seen.has(id)) continue;
       seen.add(id);
-      const isStageiwse = skill.path.includes('.stagewise');
-      const mount = isStageiwse ? globalMounts[0] : globalMounts[1];
+      const isStagewise = skill.path.includes('.stagewise');
+      const mount = isStagewise ? globalMounts[0] : globalMounts[1];
       const relativePath = path.relative(mount.absolutePath, skill.path);
       result.push({
         id,

--- a/apps/browser/src/backend/services/toolbox/index.ts
+++ b/apps/browser/src/backend/services/toolbox/index.ts
@@ -198,6 +198,10 @@ export class ToolboxService extends DisposableService {
   private plansWatcher: FSWatcher | null = null;
   private plansWatcherDebounce: ReturnType<typeof setTimeout> | null = null;
 
+  private globalSkillsWatchers: FSWatcher[] = [];
+  private globalSkillsWatcherDebounce: ReturnType<typeof setTimeout> | null =
+    null;
+
   private getOrCreatePlansRuntime(): ClientRuntimeNode {
     if (this.plansRuntime) return this.plansRuntime;
     const plansDir = getPlansDir();
@@ -1643,6 +1647,9 @@ export class ToolboxService extends DisposableService {
     // Start watching the global plans directory
     this.startPlansWatcher();
 
+    // Start watching global skills directories (~/.stagewise/skills, ~/.agents/skills)
+    this.startGlobalSkillsWatchers();
+
     const fileDiffHandler = createFileDiffHandler({
       mountManager: this.mountManagerService,
       diffHistoryService: this.diffHistoryService,
@@ -1814,6 +1821,77 @@ export class ToolboxService extends DisposableService {
       });
   }
 
+  /**
+   * Watch parent dirs (`~/.stagewise/`, `~/.agents/`) for changes to their
+   * `skills/` subdirectories. Follows the workspace watcher pattern: watch
+   * parents with an ignored filter so we detect `skills/` being created
+   * for the first time.
+   */
+  private startGlobalSkillsWatchers(): void {
+    const scheduleRefresh = () => {
+      if (this.globalSkillsWatcherDebounce)
+        clearTimeout(this.globalSkillsWatcherDebounce);
+      this.globalSkillsWatcherDebounce = setTimeout(() => {
+        this.globalSkillsWatcherDebounce = null;
+        // Evict stale runtimes for directories that were removed.
+        for (const mount of getGlobalSkillsMounts()) {
+          if (
+            this.globalSkillsRuntimes.has(mount.prefix) &&
+            !existsSync(mount.absolutePath)
+          )
+            this.globalSkillsRuntimes.delete(mount.prefix);
+        }
+        // Rebuild skills list for all active agents.
+        const activeIds = Object.keys(this.uiKarton.state.agents.instances);
+        for (const id of activeIds) void this.rebuildSkillsList(id);
+      }, 400);
+    };
+
+    for (const mount of getGlobalSkillsMounts()) {
+      const parentDir = path.dirname(mount.absolutePath);
+      if (!existsSync(parentDir)) continue;
+
+      const watcher = chokidar.watch(parentDir, {
+        persistent: true,
+        ignoreInitial: true,
+        depth: 3,
+        awaitWriteFinish: { stabilityThreshold: 150, pollInterval: 50 },
+        ignored: (filePath: string) => {
+          if (filePath === parentDir) return false;
+          const rel = path.relative(parentDir, filePath);
+          const segments = rel.split(path.sep);
+          // Only allow the 'skills' subdirectory.
+          if (segments.length === 1) return segments[0] !== 'skills';
+          return segments[0] !== 'skills';
+        },
+      });
+
+      watcher
+        .on('add', scheduleRefresh)
+        .on('change', scheduleRefresh)
+        .on('unlink', scheduleRefresh)
+        .on('addDir', scheduleRefresh)
+        .on('unlinkDir', scheduleRefresh)
+        .on('error', (error) => {
+          this.logger.debug('[ToolboxService] Global skills watcher error', {
+            error,
+          });
+        });
+
+      this.globalSkillsWatchers.push(watcher);
+    }
+  }
+
+  private stopGlobalSkillsWatchers(): void {
+    if (this.globalSkillsWatcherDebounce) {
+      clearTimeout(this.globalSkillsWatcherDebounce);
+      this.globalSkillsWatcherDebounce = null;
+    }
+    for (const watcher of this.globalSkillsWatchers) void watcher.close();
+
+    this.globalSkillsWatchers = [];
+  }
+
   private stopPlansWatcher(): void {
     if (this.plansWatcherDebounce) {
       clearTimeout(this.plansWatcherDebounce);
@@ -1854,6 +1932,7 @@ export class ToolboxService extends DisposableService {
     this.apiClient = null;
 
     this.stopPlansWatcher();
+    this.stopGlobalSkillsWatchers();
 
     void this.mountManagerService?.teardown();
     this.mountManagerService = null;

--- a/apps/browser/src/shared/skills.ts
+++ b/apps/browser/src/shared/skills.ts
@@ -2,9 +2,10 @@
  * Source of a skill definition.
  * - `builtin` — shipped with the app (bundled/skills/)
  * - `workspace` — discovered from a mounted workspace skill
+ * - `global` — user-level skills from ~/.stagewise/skills/ or ~/.agents/skills/
  * - `plugin` — discovered from a bundled plugin skill
  */
-export type SkillSource = 'builtin' | 'workspace' | 'plugin';
+export type SkillSource = 'builtin' | 'workspace' | 'global' | 'plugin';
 
 /**
  * Full skill definition used by the backend.

--- a/apps/browser/src/ui/screens/main/sidebar/chat/_components/rich-text/slash/provider.ts
+++ b/apps/browser/src/ui/screens/main/sidebar/chat/_components/rich-text/slash/provider.ts
@@ -56,7 +56,8 @@ export function querySlashItems(query: string): SlashItem[] {
   // Bucket by group, preserving discovery order within each bucket.
   const buckets = new Map<string, SlashItem[]>();
   for (const item of all) {
-    const group = item.group || 'builtin';
+    const group =
+      item.group === 'global' ? 'workspace' : item.group || 'builtin';
     let bucket = buckets.get(group);
     if (!bucket) {
       bucket = [];

--- a/apps/browser/src/ui/screens/main/sidebar/chat/_components/rich-text/slash/suggestion-popup.tsx
+++ b/apps/browser/src/ui/screens/main/sidebar/chat/_components/rich-text/slash/suggestion-popup.tsx
@@ -250,7 +250,8 @@ function useGroupedItems(items: SlashItem[]) {
   return useMemo(() => {
     const buckets = new Map<string, SlashItem[]>();
     for (const item of items) {
-      const group = item.group || 'builtin';
+      const group =
+        item.group === 'global' ? 'workspace' : item.group || 'builtin';
       let bucket = buckets.get(group);
       if (!bucket) {
         bucket = [];


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Discover and integrate user-level global skills from two home directories into the unified skills list; exposed as read-only mounts and included in environment snapshots when present.

* **Behavior Changes**
  * Skill resolution priority updated so global skills sit between plugins and workspace, and workspace-disabled skills suppress corresponding global skills.

* **UI**
  * Global skills appear alongside workspace items in slash suggestion lists.

* **Documentation**
  * Environment docs updated to list the new global mounts and revised priority ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->