### PR TITLE
fix(stagewise): use chat-model as compression fallback

### DIFF
--- a/apps/browser/src/backend/agents/shared/base-agent/base-agent.ts
+++ b/apps/browser/src/backend/agents/shared/base-agent/base-agent.ts
@@ -969,6 +969,7 @@ export abstract class BaseAgent<
       history,
       this.modelProviderService,
       this.instanceId,
+      this.state.get().activeModelId,
     );
   }
 

--- a/apps/browser/src/backend/agents/shared/base-agent/history-compression/index.test.ts
+++ b/apps/browser/src/backend/agents/shared/base-agent/history-compression/index.test.ts
@@ -1224,6 +1224,99 @@ describe('generateSimpleCompressedHistory', () => {
       'The assistant provided a provider-fallback summary of events.',
     );
   });
+
+  // -----------------------------------------------------------------------
+  // fallbackModelId (active chat model as last resort)
+  // -----------------------------------------------------------------------
+
+  it('tries fallbackModelId after all cheap models fail', async () => {
+    generateTextMock
+      .mockRejectedValueOnce(new Error('Gemini failed'))
+      .mockRejectedValueOnce(new Error('GPT failed'))
+      .mockRejectedValueOnce(new Error('Haiku failed'))
+      .mockResolvedValueOnce({
+        text: 'The assistant provided a fallback-model summary of events.',
+      } as any);
+
+    const mps = makeMockModelProviderService();
+    const result = await generateSimpleCompressedHistory(
+      makeMessages(4),
+      mps,
+      'agent-1',
+      'claude-sonnet-4-6' as any,
+    );
+
+    expect(result).toBe(
+      'The assistant provided a fallback-model summary of events.',
+    );
+    expect(generateTextMock).toHaveBeenCalledTimes(4);
+    expect(mps.getModelWithOptions).toHaveBeenNthCalledWith(
+      4,
+      'claude-sonnet-4-6',
+      'agent-1',
+      expect.objectContaining({ $ai_span_name: 'history-compression' }),
+    );
+  });
+
+  it('skips fallbackModelId if it matches a cheap model ID', async () => {
+    generateTextMock
+      .mockRejectedValueOnce(new Error('Gemini failed'))
+      .mockRejectedValueOnce(new Error('GPT failed'))
+      .mockRejectedValueOnce(new Error('Haiku failed'));
+
+    const mps = makeMockModelProviderService();
+    await expect(
+      generateSimpleCompressedHistory(
+        makeMessages(4),
+        mps,
+        'agent-1',
+        'claude-haiku-4-5' as any,
+      ),
+    ).rejects.toThrow('Haiku failed');
+    expect(mps.getModelWithOptions).toHaveBeenCalledTimes(3);
+  });
+
+  it('throws when fallback model also fails', async () => {
+    generateTextMock
+      .mockRejectedValueOnce(new Error('Gemini failed'))
+      .mockRejectedValueOnce(new Error('GPT failed'))
+      .mockRejectedValueOnce(new Error('Haiku failed'))
+      .mockRejectedValueOnce(new Error('Sonnet failed'));
+
+    const mps = makeMockModelProviderService();
+    await expect(
+      generateSimpleCompressedHistory(
+        makeMessages(4),
+        mps,
+        'agent-1',
+        'claude-sonnet-4-6' as any,
+      ),
+    ).rejects.toThrow('Sonnet failed');
+    expect(generateTextMock).toHaveBeenCalledTimes(4);
+  });
+
+  it('does not try fallbackModelId when a cheap model succeeds', async () => {
+    generateTextMock.mockResolvedValueOnce({
+      text: 'The user asked the assistant to help with a task.',
+    } as any);
+
+    const mps = makeMockModelProviderService();
+    const result = await generateSimpleCompressedHistory(
+      makeMessages(4),
+      mps,
+      'agent-1',
+      'claude-sonnet-4-6' as any,
+    );
+
+    expect(result).toBe('The user asked the assistant to help with a task.');
+    expect(generateTextMock).toHaveBeenCalledTimes(1);
+    expect(mps.getModelWithOptions).toHaveBeenCalledTimes(1);
+    expect(mps.getModelWithOptions).toHaveBeenCalledWith(
+      'gemini-3.1-flash-lite-preview',
+      'agent-1',
+      expect.any(Object),
+    );
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/apps/browser/src/backend/agents/shared/base-agent/history-compression/index.ts
+++ b/apps/browser/src/backend/agents/shared/base-agent/history-compression/index.ts
@@ -1,6 +1,7 @@
 import { generateText } from 'ai';
 import type { AgentMessage } from '@shared/karton-contracts/ui/agent';
 import type { ModelProviderService } from '@/agents/model-provider';
+import type { ModelId } from '@shared/available-models';
 
 // Import for local use + re-export so existing imports keep working.
 import {
@@ -41,10 +42,72 @@ const HISTORY_COMPRESSION_TIMEOUT_MS = 30_000;
 /** Minimum acceptable compression length; shorter results trigger a fallback. */
 const COMPRESSION_MIN_LENGTH = 30;
 
+/**
+ * Attempts a single compression call against the given model.
+ * Returns the compressed text on success, or throws on failure.
+ */
+const tryCompressWithModel = async (
+  modelId: string,
+  modelProviderService: ModelProviderService,
+  agentInstanceId: string,
+  compactHistory: string,
+  previousBriefingChars: number,
+): Promise<string> => {
+  const modelWithOptions = modelProviderService.getModelWithOptions(
+    modelId as ModelId,
+    `${agentInstanceId}`,
+    {
+      $ai_span_name: 'history-compression',
+      $ai_parent_id: `${agentInstanceId}`,
+    },
+  );
+
+  const abortController = new AbortController();
+  const timeout = setTimeout(
+    () => abortController.abort(),
+    HISTORY_COMPRESSION_TIMEOUT_MS,
+  );
+
+  try {
+    const compactionResult = await generateText({
+      model: modelWithOptions.model,
+      providerOptions: modelWithOptions.providerOptions,
+      headers: modelWithOptions.headers,
+      abortSignal: abortController.signal,
+      messages: [
+        {
+          role: 'system',
+          content: COMPRESSION_SYSTEM_PROMPT,
+        },
+        {
+          role: 'user',
+          content: buildCompressionUserMessage(
+            compactHistory,
+            previousBriefingChars,
+          ),
+        },
+      ],
+      temperature: 0.1,
+      maxOutputTokens: 20000,
+    }).then((result) => result.text.trim());
+
+    if (compactionResult.length < COMPRESSION_MIN_LENGTH) {
+      throw new Error(
+        `Compression too short (${compactionResult.length} chars)`,
+      );
+    }
+
+    return compactionResult;
+  } finally {
+    clearTimeout(timeout);
+  }
+};
+
 export const generateSimpleCompressedHistory = async (
   messages: AgentMessage[],
   modelProviderService: ModelProviderService,
   agentInstanceId: string,
+  fallbackModelId?: ModelId,
 ): Promise<string> => {
   const compactConvertedChatHistory =
     convertAgentMessagesToCompactMessageHistoryString(messages);
@@ -59,57 +122,37 @@ export const generateSimpleCompressedHistory = async (
 
   for (const modelId of HISTORY_COMPRESSION_MODELS) {
     try {
-      const modelWithOptions = modelProviderService.getModelWithOptions(
+      return await tryCompressWithModel(
         modelId,
-        `${agentInstanceId}`,
-        {
-          $ai_span_name: 'history-compression',
-          $ai_parent_id: `${agentInstanceId}`,
-        },
+        modelProviderService,
+        agentInstanceId,
+        compactConvertedChatHistory,
+        previousBriefingChars,
       );
-
-      const abortController = new AbortController();
-      const timeout = setTimeout(
-        () => abortController.abort(),
-        HISTORY_COMPRESSION_TIMEOUT_MS,
-      );
-
-      try {
-        const compactionResult = await generateText({
-          model: modelWithOptions.model,
-          providerOptions: modelWithOptions.providerOptions,
-          headers: modelWithOptions.headers,
-          abortSignal: abortController.signal,
-          messages: [
-            {
-              role: 'system',
-              content: COMPRESSION_SYSTEM_PROMPT,
-            },
-            {
-              role: 'user',
-              content: buildCompressionUserMessage(
-                compactConvertedChatHistory,
-                previousBriefingChars,
-              ),
-            },
-          ],
-          temperature: 0.1,
-          maxOutputTokens: 20000,
-        }).then((result) => result.text.trim());
-
-        if (compactionResult.length < COMPRESSION_MIN_LENGTH) {
-          throw new Error(
-            `Compression too short (${compactionResult.length} chars)`,
-          );
-        }
-
-        return compactionResult;
-      } finally {
-        clearTimeout(timeout);
-      }
     } catch (e) {
       lastError = e as Error;
       // Continue to the next fallback model
+    }
+  }
+
+  // Last resort: try the active chat model if it wasn't already attempted.
+  if (
+    fallbackModelId &&
+    !(HISTORY_COMPRESSION_MODELS as readonly string[]).includes(fallbackModelId)
+  ) {
+    console.warn(
+      `History compression: all preferred models failed, falling back to active model: ${fallbackModelId}`,
+    );
+    try {
+      return await tryCompressWithModel(
+        fallbackModelId,
+        modelProviderService,
+        agentInstanceId,
+        compactConvertedChatHistory,
+        previousBriefingChars,
+      );
+    } catch (e) {
+      lastError = e as Error;
     }
   }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Conversation history compression now respects the currently selected model for more accurate results.
  * Added a conditional fallback attempt when preferred compression attempts fail to improve reliability.

* **Tests**
  * Expanded test coverage for compression edge cases, fallback behavior, and retry handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->