### PR TITLE
fix(stagewise): add file system documentation to workspace-md-agent

### DIFF
--- a/apps/browser/src/backend/agents/shared/prompts/fragments/filesystem.md
+++ b/apps/browser/src/backend/agents/shared/prompts/fragments/filesystem.md
@@ -1,0 +1,16 @@
+# File System
+
+You have access to a single mounted workspace directory via tools.
+
+All file paths use a **mount prefix** — a short symlink of the form `w{4_CHAR_ID}/` that maps to the workspace's absolute path on disk. Tools only accept mount-prefixed paths; never use absolute paths.
+
+Example: if the workspace is mounted as `w6053/`, then:
+- Read a file: `w6053/src/index.ts`
+- Write a file: `w6053/.stagewise/WORKSPACE.md`
+- Glob pattern: `w6053/**/*.json`
+
+Discover the mount prefix from:
+1. Existing `<file path="wXXXX/...">` tags in the conversation
+2. Tool responses (glob, read) which return mount-prefixed paths
+
+All tools — `read`, `write`, `multiEdit`, `glob`, `grepSearch` — require the mount prefix on every path argument.

--- a/apps/browser/src/backend/agents/workspace-md/system-prompt.md
+++ b/apps/browser/src/backend/agents/workspace-md/system-prompt.md
@@ -1,6 +1,6 @@
 # Workspace →  Synthesis Agent
 
-You must create or update a single file: ``.
+You must create or update a single file: `{mountPrefix}/.stagewise/WORKSPACE.md` (where `{mountPrefix}` is the workspace mount prefix described in the File System section above).
 
 Purpose:
 Produce an ultra-dense, ambiguity-free workspace briefing optimized for LLM consumption.
@@ -26,7 +26,7 @@ Do not include commentary outside the file.
 
 # Non-Negotiable Rules
 
-1. Use fully-qualified workspace-relative paths only.
+1. Use workspace-relative paths (without mount prefix) inside the WORKSPACE.md content. Use mount-prefixed paths in all tool calls.
 2. Never describe a system without naming its owning package.
 3. No emojis or decorative formatting.
 4. No large prose paragraphs.
@@ -259,7 +259,7 @@ Do not exceed 4 columns.
 
 # Output
 
-- You MUST write a `` file to finish your work.
-- After writing the `` file, you MUST call the `finish` tool.
+- You MUST write `{mountPrefix}/.stagewise/WORKSPACE.md` using the `write` tool with the mount-prefixed path.
+- After writing the file, you MUST call the `finish` tool.
 - Do NOT use any other mechanism to indicate completion.
 - Output only the file content.

--- a/apps/browser/src/backend/agents/workspace-md/workspace-md.ts
+++ b/apps/browser/src/backend/agents/workspace-md/workspace-md.ts
@@ -2,6 +2,7 @@ import { BaseAgent, type BaseAgentConfig } from '../shared/base-agent';
 import { AgentTypes } from '@shared/karton-contracts/ui/agent';
 import type { StagewiseToolSet } from '@shared/karton-contracts/ui/agent/tools/types';
 import { z } from 'zod';
+import filesystemPrimer from '../shared/prompts/fragments/filesystem.md?raw';
 import systemPrompt from './system-prompt.md?raw';
 
 const finishToolOutputSchema = z.object({
@@ -46,7 +47,7 @@ export class WorkspaceMdAgent extends BaseAgent<
   } satisfies BaseAgentConfig<typeof finishToolOutputSchema>;
 
   protected getSystemPrompt = async (): Promise<string> => {
-    return systemPrompt;
+    return `${filesystemPrimer}\n\n${systemPrompt}`;
   };
 
   protected async onCreated(): Promise<void> {
@@ -71,6 +72,16 @@ export class WorkspaceMdAgent extends BaseAgent<
       await this.toolbox.handleMountWorkspace(this.instanceId, path);
     }
 
+    // Resolve the mount prefix for the workspace we just mounted
+    const mounts = this.toolbox.getMountedPathsForAgent(this.instanceId);
+    let resolvedPrefix = '';
+    for (const [prefix, mountedPath] of mounts) {
+      if (mountedPath === workspacePath) {
+        resolvedPrefix = prefix;
+        break;
+      }
+    }
+
     const workspaceMdEntries = await this.toolbox.getWorkspaceMd(
       this.instanceId,
     );
@@ -89,7 +100,9 @@ export class WorkspaceMdAgent extends BaseAgent<
         {
           type: 'text',
           text: `
-${reason ? `Update the file \`.stagewise/WORKSPACE.md\`. You need to update because of the following reason: ${reason}` : 'Generate a new file `.stagewise/WORKSPACE.md` after analyzing the project.'}
+Your workspace is mounted at prefix \`${resolvedPrefix}\`. Use \`${resolvedPrefix}/\` for all tool calls.
+
+${reason ? `Update the file \`${resolvedPrefix}/.stagewise/WORKSPACE.md\`. You need to update because of the following reason: ${reason}` : `Generate a new file \`${resolvedPrefix}/.stagewise/WORKSPACE.md\` after analyzing the project.`}
 
 ${workspaceMdParts}`.trim(),
         },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Agents now require and enforce mount-prefixed paths for all workspace file operations, ensuring consistent read/write/glob/grep behavior.

* **Documentation**
  * Clarified workspace file handling: explicit mount-prefixed tool-call paths, workspace-relative content inside generated files, and a concrete default output location for workspace metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->