### PR TITLE
fix(browser): make internal app frame resizable

### DIFF
--- a/apps/browser/src/ui/screens/main/sidebar/chat/_components/internal-app-frame.tsx
+++ b/apps/browser/src/ui/screens/main/sidebar/chat/_components/internal-app-frame.tsx
@@ -2,7 +2,7 @@ import { useKartonState, useKartonProcedure } from '@ui/hooks/use-karton';
 import { useOpenAgent } from '@ui/hooks/use-open-chat';
 import { Button } from '@stagewise/stage-ui/components/button';
 import { XIcon } from 'lucide-react';
-import { useRef, useEffect, useCallback } from 'react';
+import { useRef, useEffect, useCallback, useState } from 'react';
 
 let cachedVarNames: Set<string> | null = null;
 
@@ -34,9 +34,14 @@ function sendThemeToIframe(iframe: HTMLIFrameElement | null) {
   );
 }
 
+const MIN_HEIGHT = 100;
+
 export function InternalAppFrame() {
   const [openAgent] = useOpenAgent();
   const iframeRef = useRef<HTMLIFrameElement>(null);
+  const [userHeight, setUserHeight] = useState<number | null>(null);
+  const [isDragging, setIsDragging] = useState(false);
+  const dragRef = useRef<{ startY: number; startH: number } | null>(null);
 
   const dismissActiveApp = useKartonProcedure(
     (p) => p.toolbox.dismissActiveApp,
@@ -52,6 +57,41 @@ export function InternalAppFrame() {
     if (!openAgent) return null;
     return s.toolbox[openAgent]?.activeApp ?? null;
   });
+
+  // Reset user override when agent pushes a new height
+  const agentHeight = activeApp?.height ?? null;
+  useEffect(() => {
+    setUserHeight(null);
+  }, [agentHeight, activeApp?.appId]);
+
+  const handleResizePointerDown = useCallback((e: React.PointerEvent) => {
+    e.preventDefault();
+    const el = (e.target as HTMLElement).closest(
+      '[data-app-frame]',
+    ) as HTMLElement | null;
+    if (!el) return;
+    const startH = el.getBoundingClientRect().height;
+    dragRef.current = { startY: e.clientY, startH };
+    setIsDragging(true);
+
+    const onMove = (ev: PointerEvent) => {
+      if (!dragRef.current) return;
+      const maxH = window.innerHeight * 0.5;
+      const raw =
+        dragRef.current.startH - (ev.clientY - dragRef.current.startY);
+      setUserHeight(Math.round(Math.min(maxH, Math.max(MIN_HEIGHT, raw))));
+    };
+
+    const onUp = () => {
+      dragRef.current = null;
+      setIsDragging(false);
+      document.removeEventListener('pointermove', onMove);
+      document.removeEventListener('pointerup', onUp);
+    };
+
+    document.addEventListener('pointermove', onMove);
+    document.addEventListener('pointerup', onUp);
+  }, []);
 
   const pendingAppMessage = useKartonState((s) => {
     if (!openAgent) return null;
@@ -104,16 +144,26 @@ export function InternalAppFrame() {
     return () => mq.removeEventListener('change', handler);
   }, [activeApp]);
 
+  const effectiveHeight = userHeight ?? activeApp?.height ?? 300;
+
   if (!activeApp) return null;
 
   return (
     <div
+      data-app-frame
       className="scrollbar-subtle relative shrink-0 overflow-hidden rounded-md bg-background shadow-elevation-1 ring-1 ring-derived-strong dark:bg-surface-1"
       style={{
-        height: activeApp.height ?? 300,
+        height: effectiveHeight,
         maxHeight: '50vh',
       }}
     >
+      {/* Resize handle — top edge */}
+      <div
+        onPointerDown={handleResizePointerDown}
+        className="group absolute inset-x-0 top-0 z-10 flex h-1.5 cursor-ns-resize items-center justify-center"
+      >
+        <div className="h-0.5 w-6 rounded-full bg-muted-foreground/0 transition-colors group-hover:bg-muted-foreground/40" />
+      </div>
       <Button
         variant="ghost"
         size="icon-sm"
@@ -125,6 +175,7 @@ export function InternalAppFrame() {
       >
         <XIcon className="size-3.5" />
       </Button>
+      {isDragging && <div className="absolute inset-0 z-20" />}
       <iframe
         ref={iframeRef}
         src={activeApp.src}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive resize for the app frame: drag the top edge to adjust height with enforced minimum and maximum limits.
  * Visible top-edge resize handle and a dragging overlay provide clear feedback while resizing.
  * User-set height persists during use but automatically resets when the active app or its configured height changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->