### PR TITLE
fix(stagewise): normalize agent-intances-db (separate messages)

### DIFF
--- a/apps/browser/src/backend/agents/shared/base-agent/base-agent.ts
+++ b/apps/browser/src/backend/agents/shared/base-agent/base-agent.ts
@@ -327,7 +327,7 @@ export abstract class BaseAgent<
   private readonly state: {
     get: () => AgentState;
     set: (recipe: (draft: AgentState) => void) => void;
-    persist: () => Promise<void>;
+    persist: (dirtyMessageIndices?: number[]) => Promise<void>;
   };
 
   /**
@@ -430,7 +430,7 @@ export abstract class BaseAgent<
     state: {
       get: () => AgentState;
       set: (recipe: (draft: AgentState) => void) => void;
-      persist: () => Promise<void>;
+      persist: (dirtyMessageIndices?: number[]) => Promise<void>;
     },
     toolbox: ToolboxService,
     telemetryService: TelemetryService,
@@ -1830,7 +1830,10 @@ export abstract class BaseAgent<
         );
       });
 
-      await this.saveState();
+      const boundarySeq = this.state
+        .get()
+        .history.findIndex((m) => m.id === boundaryMessageId);
+      await this.saveState(boundarySeq >= 0 ? [boundarySeq] : undefined);
     } catch (e) {
       // Fail silently — compression is best-effort. The agent continues
       // without compression until the context window is exhausted, at which
@@ -1848,10 +1851,10 @@ export abstract class BaseAgent<
   /**
    * Updates the persisted state of the agent
    */
-  private async saveState(): Promise<void> {
+  private async saveState(dirtyMessageIndices?: number[]): Promise<void> {
     if (!this.config.persistent) return;
 
-    await this.state.persist();
+    await this.state.persist(dirtyMessageIndices);
   }
 
   /**

--- a/apps/browser/src/backend/services/agent-manager/agent-manager.ts
+++ b/apps/browser/src/backend/services/agent-manager/agent-manager.ts
@@ -511,7 +511,8 @@ export class AgentManagerService extends DisposableService {
             draft.agents.instances[agentInstanceId].type = type;
           });
         },
-        persist: () => this.persistAgentState(agentInstanceId),
+        persist: (dirtyMessageIndices?: number[]) =>
+          this.persistAgentState(agentInstanceId, dirtyMessageIndices),
       },
       this.toolbox,
       this.telemetryService,
@@ -653,7 +654,10 @@ export class AgentManagerService extends DisposableService {
     return createdAgent;
   }
 
-  private async persistAgentState(instanceId: string) {
+  private async persistAgentState(
+    instanceId: string,
+    dirtyMessageIndices?: number[],
+  ) {
     // Store agent state into DB.
     const agent = this.activeAgents.get(instanceId);
 
@@ -670,21 +674,24 @@ export class AgentManagerService extends DisposableService {
     const mountedWorkspaces =
       this.toolbox.getWorkspaceSnapshotForPersistence(instanceId);
 
-    await this.agentPersistenceDB?.storeAgentInstance({
-      id: instanceId,
-      type: agent.agentType,
-      title: agentState.title,
-      history: agentState.history,
-      activeModelId: agentState.activeModelId,
-      createdAt: agentState.history[0].metadata?.createdAt ?? new Date(0), // Fallback should never be reached
-      lastMessageAt:
-        agentState.history[agentState.history.length - 1].metadata?.createdAt ??
-        new Date(), // Fallback should never be reached
-      queuedMessages: agentState.queuedMessages,
-      inputState: agentState.inputState,
-      usedTokens: agentState.usedTokens,
-      mountedWorkspaces,
-    });
+    await this.agentPersistenceDB?.storeAgentInstance(
+      {
+        id: instanceId,
+        type: agent.agentType,
+        title: agentState.title,
+        activeModelId: agentState.activeModelId,
+        createdAt: agentState.history[0].metadata?.createdAt ?? new Date(0), // Fallback should never be reached
+        lastMessageAt:
+          agentState.history[agentState.history.length - 1].metadata
+            ?.createdAt ?? new Date(), // Fallback should never be reached
+        queuedMessages: agentState.queuedMessages,
+        inputState: agentState.inputState,
+        usedTokens: agentState.usedTokens,
+        mountedWorkspaces,
+      },
+      agentState.history,
+      dirtyMessageIndices,
+    );
   }
 
   /**

--- a/apps/browser/src/backend/services/agent-manager/persistence/db.ts
+++ b/apps/browser/src/backend/services/agent-manager/persistence/db.ts
@@ -1,6 +1,15 @@
 import { drizzle } from 'drizzle-orm/libsql/driver';
 import * as schema from './schema';
-import { and, notInArray, ilike, desc, isNull, eq, sql } from 'drizzle-orm';
+import {
+  and,
+  notInArray,
+  ilike,
+  desc,
+  isNull,
+  eq,
+  sql,
+  gte,
+} from 'drizzle-orm';
 import type { LibSQLDatabase } from 'drizzle-orm/libsql';
 import { createClient, type Client } from '@libsql/client';
 import { migrateDatabase } from '@/utils/migrate-database';
@@ -10,6 +19,7 @@ import type { Logger } from '@/services/logger';
 import {
   AgentTypes,
   type AgentHistoryEntry,
+  type AgentMessage,
 } from '@shared/karton-contracts/ui/agent';
 import { getAgentDbPath } from '@/utils/paths';
 
@@ -17,6 +27,7 @@ export class AgentPersistenceDB {
   private _dbDriver: Client;
   private _db: LibSQLDatabase<typeof schema>;
   private _logger: Logger;
+  private _lastPersistedIds = new Map<string, string[]>();
 
   private constructor(logger: Logger) {
     const dbPath = getAgentDbPath();
@@ -82,7 +93,7 @@ export class AgentPersistenceDB {
         title: schema.agentInstances.title,
         createdAt: schema.agentInstances.createdAt,
         lastMessageAt: schema.agentInstances.lastMessageAt,
-        messageCount: sql<number>`json_array_length(${schema.agentInstances.history})`,
+        messageCount: sql<number>`(SELECT COUNT(*) FROM agentMessages WHERE agent_instance_id = ${schema.agentInstances.id})`,
         parentAgentInstanceId: schema.agentInstances.parentAgentInstanceId,
       })
       .from(schema.agentInstances)
@@ -118,46 +129,183 @@ export class AgentPersistenceDB {
     id: string,
   ): Promise<schema.StoredAgentInstance | null> {
     this._logger.debug(`[AgentPersistenceDB] Fetching agent instance: ${id}`);
-    const results = await this._db
-      .selectDistinct()
-      .from(schema.agentInstances)
-      .where(eq(schema.agentInstances.id, id))
-      .limit(1)
-      .catch((error) => {
-        this._logger.error(
-          `[AgentPersistenceDB] Failed to fetch agent instance: ${error}`,
-        );
-        return null;
-      });
+    try {
+      const results = await this._db
+        .selectDistinct()
+        .from(schema.agentInstances)
+        .where(eq(schema.agentInstances.id, id))
+        .limit(1);
 
-    return results?.[0] ?? null;
+      const row = results?.[0] ?? null;
+      if (!row) return null;
+
+      // Reconstruct history from normalised message rows
+      const messageRows = await this._db
+        .select()
+        .from(schema.agentMessages)
+        .where(eq(schema.agentMessages.agentInstanceId, id))
+        .orderBy(schema.agentMessages.seq);
+
+      const history: AgentMessage[] = messageRows.map((r) => ({
+        id: r.messageId,
+        role: r.role as AgentMessage['role'],
+        parts: r.parts as AgentMessage['parts'],
+        metadata: r.metadata as AgentMessage['metadata'],
+      }));
+
+      // Initialise dirty-tracking baseline
+      this._lastPersistedIds.set(
+        id,
+        messageRows.map((r) => r.messageId),
+      );
+
+      return { ...row, history };
+    } catch (error) {
+      this._logger.error(
+        `[AgentPersistenceDB] Failed to fetch agent instance: ${error}`,
+      );
+      return null;
+    }
   }
 
   /**
    * Stores or updates an agent instance in the persistence layer.
+   * History is persisted incrementally into the `agentMessages` table —
+   * only changed / new messages are written.
    *
-   * @param agentInstance The agent instance to store
+   * @param agentInstance Scalar agent metadata (without history)
+   * @param history       Current in-memory message history
    */
   public async storeAgentInstance(
-    agentInstance: schema.NewStoredAgentInstance,
+    agentInstance: Omit<schema.NewStoredAgentInstance, 'history'>,
+    history: AgentMessage[],
+    dirtyMessageIndices?: number[],
   ): Promise<void> {
-    this._logger.debug(
-      `[AgentPersistenceDB] Storing agent instance: ${agentInstance.id}`,
-    );
-    await this._db
-      .insert(schema.agentInstances)
-      .values(agentInstance)
-      .onConflictDoUpdate({
-        target: schema.agentInstances.id,
-        set: {
-          ...agentInstance,
-        },
-      })
-      .catch((error) => {
-        this._logger.error(
-          `[AgentPersistenceDB] Failed to store agent instance: ${error.message}, ${error.stack}`,
-        );
+    const id = agentInstance.id;
+    this._logger.debug(`[AgentPersistenceDB] Storing agent instance: ${id}`);
+
+    // Compute divergence point outside the transaction (pure, no I/O)
+    const lastIds = this._lastPersistedIds.get(id) ?? [];
+    const divergePoint = this._findDivergencePoint(history, lastIds);
+
+    try {
+      await this._db.transaction(async (tx) => {
+        // 1. Upsert scalar metadata (legacy history column gets $defaultFn → [])
+        await tx
+          .insert(schema.agentInstances)
+          .values(agentInstance as schema.NewStoredAgentInstance)
+          .onConflictDoUpdate({
+            target: schema.agentInstances.id,
+            set: {
+              ...agentInstance,
+            },
+          });
+
+        // 2. Incremental message persistence via divergence detection
+
+        // Delete divergent / truncated messages
+        if (divergePoint < lastIds.length) {
+          await tx
+            .delete(schema.agentMessages)
+            .where(
+              and(
+                eq(schema.agentMessages.agentInstanceId, id),
+                gte(schema.agentMessages.seq, divergePoint),
+              ),
+            );
+        }
+
+        // Insert new / replacement messages from the divergence point
+        if (divergePoint < history.length) {
+          const newMsgs = history.slice(divergePoint);
+          await tx.insert(schema.agentMessages).values(
+            newMsgs.map((msg, i) => ({
+              agentInstanceId: id,
+              seq: divergePoint + i,
+              messageId: msg.id,
+              role: msg.role,
+              parts: msg.parts as unknown[],
+              metadata: (msg.metadata ?? null) as unknown,
+            })),
+          );
+        } else if (history.length > 0) {
+          // No structural change — update the last message in case of
+          // in-place mutations (streaming content, attachment draining)
+          const lastMsg = history[history.length - 1];
+          await tx
+            .update(schema.agentMessages)
+            .set({
+              messageId: lastMsg.id,
+              role: lastMsg.role,
+              parts: lastMsg.parts as unknown[],
+              metadata: (lastMsg.metadata ?? null) as unknown,
+            })
+            .where(
+              and(
+                eq(schema.agentMessages.agentInstanceId, id),
+                eq(schema.agentMessages.seq, history.length - 1),
+              ),
+            );
+        }
+
+        // 3. Targeted updates for in-place mutations on non-tail messages
+        //    (e.g. history compression writing compressedHistory metadata)
+        if (dirtyMessageIndices && dirtyMessageIndices.length > 0) {
+          for (const idx of dirtyMessageIndices) {
+            // Skip out-of-bounds or indices already written by divergence path
+            if (idx < 0 || idx >= history.length || idx >= divergePoint)
+              continue;
+            const msg = history[idx];
+            await tx
+              .update(schema.agentMessages)
+              .set({
+                messageId: msg.id,
+                role: msg.role,
+                parts: msg.parts as unknown[],
+                metadata: (msg.metadata ?? null) as unknown,
+              })
+              .where(
+                and(
+                  eq(schema.agentMessages.agentInstanceId, id),
+                  eq(schema.agentMessages.seq, idx),
+                ),
+              );
+          }
+        }
       });
+
+      // Update dirty-tracking state only after successful commit
+      this._lastPersistedIds.set(
+        id,
+        history.map((m) => m.id),
+      );
+    } catch (error) {
+      this._logger.error(
+        `[AgentPersistenceDB] Failed to store agent instance: ${(error as Error).message}, ${(error as Error).stack}`,
+      );
+    }
+  }
+
+  /**
+   * Finds the first index where the current history diverges from the
+   * last-persisted message IDs.  Optimises for the common case (pure
+   * append) with a single comparison at the tail of the shared range.
+   */
+  private _findDivergencePoint(
+    history: AgentMessage[],
+    lastIds: string[],
+  ): number {
+    const minLen = Math.min(history.length, lastIds.length);
+    if (minLen === 0) return 0;
+    // Fast path: if the last shared position matches, no undo occurred
+    if (history[minLen - 1].id === lastIds[minLen - 1]) {
+      return minLen;
+    }
+    // Slow path: linear scan for the divergence point
+    for (let i = 0; i < minLen; i++) {
+      if (history[i].id !== lastIds[i]) return i;
+    }
+    return minLen;
   }
 
   /**
@@ -225,7 +373,7 @@ export class AgentPersistenceDB {
    */
   public async deleteAgentInstance(id: string): Promise<void> {
     this._logger.debug(`[AgentPersistenceDB] Deleting agent instance: ${id}`);
-    // We should also delete all persisted child agents as well (do it recursively to catch all agents)
+    // Recursively delete all persisted child agents
     const childAgentInstanceIds = await this._db
       .select({ id: schema.agentInstances.id })
       .from(schema.agentInstances)
@@ -233,6 +381,16 @@ export class AgentPersistenceDB {
     for (const childAgentInstanceId of childAgentInstanceIds) {
       await this.deleteAgentInstance(childAgentInstanceId.id);
     }
+
+    // Delete associated messages first
+    await this._db
+      .delete(schema.agentMessages)
+      .where(eq(schema.agentMessages.agentInstanceId, id))
+      .catch((error) => {
+        this._logger.error(
+          `[AgentPersistenceDB] Failed to delete agent messages: ${error}`,
+        );
+      });
 
     await this._db
       .delete(schema.agentInstances)
@@ -242,5 +400,8 @@ export class AgentPersistenceDB {
           `[AgentPersistenceDB] Failed to delete agent instance: ${error}`,
         );
       });
+
+    // Clean up dirty-tracking state
+    this._lastPersistedIds.delete(id);
   }
 }

--- a/apps/browser/src/backend/services/agent-manager/persistence/migrations/index.ts
+++ b/apps/browser/src/backend/services/agent-manager/persistence/migrations/index.ts
@@ -4,6 +4,7 @@ import { up as v003Up } from './v003-unify-tab-ids';
 import { up as v004Up } from './v004-rename-tool-suffixes';
 import { up as v005Up } from './v005-backfill-file-attachment-filename';
 import { up as v006Up } from './v006-rename-readfile-to-read';
+import { up as v007Up } from './v007-normalize-history';
 
 const registry: MigrationScript[] = [
   { version: 2, name: 'add-mounted-workspaces', up: v002Up },
@@ -11,7 +12,8 @@ const registry: MigrationScript[] = [
   { version: 4, name: 'rename-tool-suffixes', up: v004Up },
   { version: 5, name: 'backfill-file-attachment-filename', up: v005Up },
   { version: 6, name: 'rename-file-tools', up: v006Up },
+  { version: 7, name: 'normalize-history', up: v007Up },
 ];
-const schemaVersion = 6;
+const schemaVersion = 7;
 
 export { registry, schemaVersion };

--- a/apps/browser/src/backend/services/agent-manager/persistence/migrations/v007-normalize-history.ts
+++ b/apps/browser/src/backend/services/agent-manager/persistence/migrations/v007-normalize-history.ts
@@ -1,0 +1,76 @@
+import { sql } from 'drizzle-orm';
+import type { MigrationScript } from '@/utils/migrate-database/types';
+import superjson from 'superjson';
+
+/**
+ * v7 — normalize-history
+ *
+ * Extracts persisted AgentMessage history blobs from the monolithic
+ * `agentInstances.history` column into individual rows in the new
+ * `agentMessages` table. The original `history` column is left intact
+ * as a rollback safety net — a future v008 migration will clear it
+ * once the normalised path is proven in production.
+ */
+export const up: MigrationScript['up'] = async (db) => {
+  // 1. Create the agentMessages table
+  await db.run(sql`
+    CREATE TABLE IF NOT EXISTS agentMessages (
+      agent_instance_id TEXT NOT NULL,
+      seq INTEGER NOT NULL,
+      message_id TEXT NOT NULL,
+      role TEXT NOT NULL,
+      parts TEXT NOT NULL,
+      metadata TEXT,
+      PRIMARY KEY (agent_instance_id, seq)
+    )
+  `);
+
+  await db.run(sql`
+    CREATE INDEX IF NOT EXISTS agent_messages_agent_id_index
+    ON agentMessages(agent_instance_id)
+  `);
+
+  // 2. Extract history blobs into individual message rows
+  const rows = await db.all<{
+    id: string;
+    history: string;
+  }>(sql`SELECT id, history FROM agentInstances`);
+
+  for (const row of rows) {
+    try {
+      if (!row.history) continue;
+
+      const history = superjson.parse<unknown[]>(row.history);
+      if (!Array.isArray(history) || history.length === 0) continue;
+
+      for (let i = 0; i < history.length; i++) {
+        const msg = history[i];
+        if (!msg || typeof msg !== 'object') continue;
+
+        const m = msg as Record<string, unknown>;
+        if (typeof m.id !== 'string' || typeof m.role !== 'string') {
+          console.warn(
+            `[migration:normalize-history] Skipping invalid message at index ${i} in agent ${row.id}`,
+          );
+          continue;
+        }
+
+        const partsStr =
+          m.parts != null ? superjson.stringify(m.parts) : '{"json":[]}';
+        const metaStr =
+          m.metadata != null ? superjson.stringify(m.metadata) : null;
+
+        await db.run(
+          sql`INSERT INTO agentMessages (agent_instance_id, seq, message_id, role, parts, metadata)
+              VALUES (${row.id}, ${i}, ${m.id as string}, ${m.role as string}, ${partsStr}, ${metaStr})`,
+        );
+      }
+    } catch (err) {
+      console.warn(
+        `[migration:normalize-history] Skipping row ${row.id}: ${err}`,
+      );
+    }
+  }
+
+  // history column is intentionally left intact for rollback safety.
+};

--- a/apps/browser/src/backend/services/agent-manager/persistence/schema.sql
+++ b/apps/browser/src/backend/services/agent-manager/persistence/schema.sql
@@ -1,4 +1,4 @@
--- VERSION: 3
+-- VERSION: 7
 
 CREATE TABLE IF NOT EXISTS meta(
   key LONGVARCHAR NOT NULL UNIQUE PRIMARY KEY,
@@ -14,7 +14,7 @@ CREATE TABLE IF NOT EXISTS agentInstances(
   last_message_at INTEGER NOT NULL,
   active_model_id TEXT NOT NULL,
   title TEXT NOT NULL,
-  history TEXT NOT NULL,
+  history TEXT NOT NULL DEFAULT '{"json":[]}',  -- deprecated: kept for rollback safety
   queued_messages TEXT NOT NULL,
   input_state TEXT NOT NULL,
   used_tokens INTEGER NOT NULL,
@@ -23,3 +23,15 @@ CREATE TABLE IF NOT EXISTS agentInstances(
 
 CREATE INDEX IF NOT EXISTS agentInstances_created_at_index ON agentInstances(created_at);
 CREATE INDEX IF NOT EXISTS agentInstances_last_message_at_index ON agentInstances(last_message_at);
+
+CREATE TABLE IF NOT EXISTS agentMessages(
+  agent_instance_id TEXT NOT NULL,
+  seq INTEGER NOT NULL,
+  message_id TEXT NOT NULL,
+  role TEXT NOT NULL,
+  parts TEXT NOT NULL,
+  metadata TEXT,
+  PRIMARY KEY (agent_instance_id, seq)
+);
+
+CREATE INDEX IF NOT EXISTS agent_messages_agent_id_index ON agentMessages(agent_instance_id);

--- a/apps/browser/src/backend/services/agent-manager/persistence/schema.ts
+++ b/apps/browser/src/backend/services/agent-manager/persistence/schema.ts
@@ -78,7 +78,11 @@ export const agentInstances = sqliteTable(
     lastMessageAt: integer('last_message_at', { mode: 'timestamp' }).notNull(),
     activeModelId: modelId('active_model_id').notNull(),
     title: text('title').notNull(),
-    history: _sqliteJson('history').notNull().$type<AgentMessage[]>(),
+    /** @deprecated Kept for rollback safety. Read/write via agentMessages table instead. */
+    history: _sqliteJson('history')
+      .notNull()
+      .$type<AgentMessage[]>()
+      .$defaultFn(() => [] as AgentMessage[]),
     queuedMessages: _sqliteJson('queued_messages')
       .notNull()
       .$type<(AgentMessage & { role: 'user' })[]>(),
@@ -96,6 +100,29 @@ export const agentInstances = sqliteTable(
   ],
 );
 
+export const agentMessages = sqliteTable(
+  'agentMessages',
+  {
+    agentInstanceId: text('agent_instance_id').notNull(),
+    seq: integer('seq').notNull(),
+    messageId: text('message_id').notNull(),
+    role: text('role').notNull(),
+    parts: _sqliteJson('parts').notNull().$type<unknown[]>(),
+    metadata: _sqliteJson('metadata').$type<unknown>(),
+  },
+  (table) => [
+    primaryKey({ columns: [table.agentInstanceId, table.seq] }),
+    index('agent_messages_agent_id_index').on(table.agentInstanceId),
+  ],
+);
+
+const _agentMessageRelations = relations(agentMessages, ({ one }) => ({
+  agentInstance: one(agentInstances, {
+    fields: [agentMessages.agentInstanceId],
+    references: [agentInstances.id],
+  }),
+}));
+
 const _agentInstanceRelations = relations(agentInstances, ({ one, many }) => ({
   parentAgentInstance: one(agentInstances, {
     fields: [agentInstances.parentAgentInstanceId],
@@ -104,6 +131,7 @@ const _agentInstanceRelations = relations(agentInstances, ({ one, many }) => ({
   childAgentInstances: many(agentInstances, {
     relationName: 'childAgentInstances',
   }),
+  messages: many(agentMessages),
 }));
 
 export type NewStoredAgentInstance = typeof agentInstances.$inferInsert;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Agent state persistence now saves only changed messages, reducing disk I/O and speeding up saves.
  * Message storage normalized for more efficient reads, edits, and truncation.

* **Chores / Migration**
  * Added a migration to move history into per-message storage and bumped the on-disk schema for compatibility and performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->