### PR TITLE
feat(update-server): add public URL configuration and nupkg proxy end…

### DIFF
--- a/apps/update-server/src/config.ts
+++ b/apps/update-server/src/config.ts
@@ -5,7 +5,28 @@ export const config = {
   githubRepo: process.env.APP_GITHUB_REPO || 'stagewise',
   githubToken: process.env.GITHUB_TOKEN || undefined,
   refreshIntervalMs: 15 * 60 * 1000, // 15 minutes
+  // Public-facing base URL of this update server (e.g. https://update.stagewise.io).
+  // Used when building self-referential proxy URLs inside Squirrel.Windows
+  // RELEASES manifests. REQUIRED in production (enforced at startup); in
+  // non-production environments we fall back to the request-derived origin.
+  publicUrl: process.env.PUBLIC_URL || undefined,
+  isProduction: process.env.NODE_ENV === 'production',
 };
+
+/**
+ * Validate runtime configuration. Called at startup so misconfigured
+ * deployments fail fast (health check fails → Railway rolls back) instead
+ * of serving broken RELEASES manifests to users.
+ */
+export function validateConfig(): void {
+  if (config.isProduction && !config.publicUrl) {
+    throw new Error(
+      'FATAL: PUBLIC_URL must be set in production. ' +
+        'This is required to build self-referential URLs in Squirrel.Windows ' +
+        'RELEASES manifests. Example: PUBLIC_URL=https://dl.stagewise.io',
+    );
+  }
+}
 
 export type Channel = 'release' | 'beta' | 'alpha';
 export type Platform = 'macos' | 'win' | 'linux';

--- a/apps/update-server/src/index.ts
+++ b/apps/update-server/src/index.ts
@@ -1,5 +1,5 @@
 import express from 'express';
-import { config } from './config.js';
+import { config, validateConfig } from './config.js';
 import { getReleases, startRefreshInterval } from './github.js';
 import routes from './routes.js';
 
@@ -14,6 +14,14 @@ app.get('/health', (_req, res) => {
 app.use('/', routes);
 
 async function start() {
+  // Fail fast on missing required configuration (e.g. PUBLIC_URL in prod).
+  try {
+    validateConfig();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : error);
+    process.exit(1);
+  }
+
   // Initial fetch of releases
   console.log('Fetching initial releases...');
   try {

--- a/apps/update-server/src/releases.ts
+++ b/apps/update-server/src/releases.ts
@@ -146,6 +146,7 @@ export async function findMacOSDownloadAsset(
 export async function findWindowsUpdateAsset(
   channel: Channel,
   arch: string,
+  baseUrl: string,
   currentVersion?: string,
 ): Promise<{ release: Release; releasesContent: string } | null> {
   const releases = await getReleases();
@@ -182,8 +183,14 @@ export async function findWindowsUpdateAsset(
       if (!response.ok) continue;
 
       const content = await response.text();
-      // Transform relative file paths to full URLs
-      const transformed = transformReleasesContent(content, release);
+      // Transform relative file paths to proxy URLs with arch-free filenames
+      const transformed = transformReleasesContent(
+        content,
+        release,
+        baseUrl,
+        channel,
+        arch,
+      );
 
       return { release, releasesContent: transformed };
     } catch {
@@ -194,9 +201,33 @@ export async function findWindowsUpdateAsset(
   return null;
 }
 
-function transformReleasesContent(content: string, release: Release): string {
+/**
+ * Rewrites a Squirrel.Windows RELEASES manifest so that each nupkg entry
+ * points at the update server's own proxy endpoint with an arch-free filename.
+ *
+ * Background: the build pipeline renames nupkg files to
+ * `{appName}-{version}-{arch}-full.nupkg` so that the same release can host
+ * multiple architectures on GitHub. Squirrel.Windows, however, parses the
+ * nupkg filename as `{id}-{version}-full.nupkg` and feeds the extracted
+ * version into `System.Version.Parse`. An embedded `-{arch}` segment (e.g.
+ * `-x64`) breaks that parser ("'63-x64' is not a valid version string").
+ *
+ * Fix: the URL surfaced to Squirrel ends with the CLEAN filename
+ * (no `-{arch}`). When Squirrel requests that URL, our proxy endpoint
+ * re-adds the arch suffix and 302-redirects to the real GitHub asset.
+ * The payload bytes and SHA1 are unchanged.
+ */
+function transformReleasesContent(
+  content: string,
+  release: Release,
+  baseUrl: string,
+  channel: string,
+  arch: string,
+): string {
   const lines = content.trim().split('\n');
   const transformed: string[] = [];
+
+  const archFullSuffix = `-${arch}-full.nupkg`;
 
   for (const line of lines) {
     const parts = line.trim().split(/\s+/);
@@ -206,17 +237,72 @@ function transformReleasesContent(content: string, release: Release): string {
     const fileName = parts[1];
     const size = parts[2] || '0';
 
-    // Find the matching asset to get the full URL
+    // Find the matching asset to confirm it exists on the release
     const asset = release.assets.find((a) => a.name === fileName);
-    if (asset) {
-      transformed.push(`${hash} ${asset.browser_download_url} ${size}`);
-    } else {
+    if (!asset) {
       // Keep original if asset not found
       transformed.push(line);
+      continue;
     }
+
+    // Only full-packages are renamed by the build pipeline and thus only
+    // full-packages need to go through the filename-rewriting proxy.
+    // Delta packages (`*-delta.nupkg`) never receive an arch suffix and
+    // are served directly from GitHub to avoid an unnecessary hop — the
+    // proxy route also rejects anything not ending in `-full.nupkg`.
+    if (!fileName.endsWith(archFullSuffix)) {
+      transformed.push(`${hash} ${asset.browser_download_url} ${size}`);
+      continue;
+    }
+
+    // Strip the arch suffix from the filename we hand to Squirrel.
+    // The proxy endpoint will add it back before redirecting.
+    const cleanFileName = `${fileName.slice(
+      0,
+      -archFullSuffix.length,
+    )}-full.nupkg`;
+
+    const trimmedBase = baseUrl.replace(/\/+$/, '');
+    const proxyUrl = `${trimmedBase}/update/${encodeURIComponent(
+      config.appName,
+    )}/${encodeURIComponent(channel)}/win/${encodeURIComponent(
+      arch,
+    )}/nupkg/${encodeURIComponent(cleanFileName)}`;
+
+    transformed.push(`${hash} ${proxyUrl} ${size}`);
   }
 
   return transformed.join('\n');
+}
+
+/**
+ * Resolve the actual GitHub-hosted nupkg asset for a given arch-free
+ * filename by re-inserting the arch suffix. Used by the nupkg proxy route.
+ */
+export async function findNupkgAsset(
+  channel: Channel,
+  arch: string,
+  cleanFileName: string,
+): Promise<AssetMatch | null> {
+  if (!cleanFileName.endsWith('-full.nupkg')) return null;
+
+  const archAssetName = `${cleanFileName.slice(
+    0,
+    -'-full.nupkg'.length,
+  )}-${arch}-full.nupkg`;
+
+  const releases = await getReleases();
+
+  for (const release of releases) {
+    if (!matchesChannel(release.parsedVersion, channel)) continue;
+
+    const asset = release.assets.find((a) => a.name === archAssetName);
+    if (asset) {
+      return { release, asset };
+    }
+  }
+
+  return null;
 }
 
 export async function findWindowsDownloadAsset(

--- a/apps/update-server/src/routes.ts
+++ b/apps/update-server/src/routes.ts
@@ -7,7 +7,46 @@ import {
   findWindowsUpdateAsset,
   findWindowsDownloadAsset,
   findLinuxDownloadAsset,
+  findNupkgAsset,
 } from './releases.js';
+
+/**
+ * Determine the public-facing base URL of this update server.
+ *
+ * In production PUBLIC_URL MUST be set — enforced at startup by
+ * `validateConfig()`, so this function cannot be reached in production
+ * without it. We never trust proxy-forwarded headers
+ * (X-Forwarded-Host / X-Forwarded-Proto) for URL construction, because
+ * those can be spoofed by any HTTP client when the app is not configured
+ * with an explicit `trust proxy` chain. A spoofed host would end up
+ * embedded in RELEASES manifests and could poison shared caches or
+ * redirect Squirrel clients at attacker-controlled hosts.
+ *
+ * When PUBLIC_URL is not configured (dev only) we fall back to Express's
+ * own `req.protocol` / `req.get('host')`, which already respect the app's
+ * `trust proxy` setting when one is configured.
+ */
+function resolveBaseUrl(req: Request): string {
+  if (config.publicUrl) return config.publicUrl;
+
+  // Defense-in-depth: even though validateConfig() refuses to start a
+  // production server without PUBLIC_URL, double-check here so an
+  // accidental mutation of isProduction (tests, etc.) can't leak
+  // request-derived URLs into RELEASES manifests.
+  if (config.isProduction) {
+    throw new Error(
+      'resolveBaseUrl: PUBLIC_URL is required in production but was not configured',
+    );
+  }
+
+  const host = req.get('host');
+  if (!host) {
+    throw new Error(
+      'resolveBaseUrl: cannot determine base URL — PUBLIC_URL is not configured and the request has no Host header',
+    );
+  }
+  return `${req.protocol}://${host}`;
+}
 
 const router = Router();
 
@@ -83,7 +122,13 @@ router.get(
     }
 
     try {
-      const match = await findWindowsUpdateAsset(channel, arch, version);
+      const baseUrl = resolveBaseUrl(req);
+      const match = await findWindowsUpdateAsset(
+        channel,
+        arch,
+        baseUrl,
+        version,
+      );
 
       if (!match) {
         res.setHeader('Content-Type', 'text/plain');
@@ -95,6 +140,50 @@ router.get(
       res.send(match.releasesContent);
     } catch (error) {
       console.error('Error in Windows update endpoint:', error);
+      res.status(500).send('Internal server error');
+    }
+  },
+);
+
+// Windows nupkg proxy endpoint
+// Squirrel.Windows parses the nupkg filename it sees in RELEASES as
+// `{id}-{version}-full.nupkg` and feeds the version into System.Version,
+// which rejects strings containing an arch suffix (e.g. `-x64`). The
+// /RELEASES endpoint therefore rewrites each nupkg URL to point here with
+// the arch suffix stripped from the filename. This proxy restores the
+// arch suffix and 302-redirects to the actual GitHub asset.
+// GET /update/:appName/:channel/win/:arch/nupkg/:filename
+router.get(
+  '/update/:appName/:channel/win/:arch/nupkg/:filename',
+  async (req: Request, res: Response) => {
+    const { appName, channel, arch, filename } = req.params;
+
+    if (appName !== config.appName) {
+      res.status(404).send('App not found');
+      return;
+    }
+
+    if (!isValidChannel(channel)) {
+      res.status(400).send('Invalid channel');
+      return;
+    }
+
+    if (!filename.endsWith('-full.nupkg')) {
+      res.status(400).send('Invalid nupkg filename');
+      return;
+    }
+
+    try {
+      const match = await findNupkgAsset(channel, arch, filename);
+
+      if (!match) {
+        res.status(404).send('nupkg not found');
+        return;
+      }
+
+      res.redirect(302, match.asset.browser_download_url);
+    } catch (error) {
+      console.error('Error in Windows nupkg proxy endpoint:', error);
       res.status(500).send('Internal server error');
     }
   },


### PR DESCRIPTION
…point for Windows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Windows nupkg proxy endpoint to download package files via the update server
  * Public URL setting to explicitly set the server base URL

* **Improvements**
  * Windows update manifests now emit update-server proxy URLs instead of direct asset links
  * Improved base-URL resolution and manifest URL generation for served updates
  * Startup now validates PUBLIC_URL in production and will fail to start if missing
<!-- end of auto-generated comment: release notes by coderabbit.ai -->