### PR TITLE
fix(stagewise): instruct agents to reuse open shell sessions

### DIFF
--- a/apps/browser/src/backend/agents/shared/prompts/system/environment.md
+++ b/apps/browser/src/backend/agents/shared/prompts/system/environment.md
@@ -151,6 +151,7 @@ return `Saved as ${fileName}`;
 Persistent interactive PTY sessions. State (variables, cwd, aliases) persists across commands in a session.
 
 - **New session:** Omit `session_id`, set `cwd` (mount prefix). **Reuse:** pass the `session_id` from the result. `cwd` is ignored on reuse — the shell stays wherever `cd` left it.
+- **Reuse sessions.** Creating a session is expensive (shell init delay). Reuse an existing session (`session_id`) whenever one is available — active sessions are listed in `<shell-sessions>` in the env-snapshot. Only create a new session when no suitable one exists or when you need parallel execution (e.g. long-running dev server in one session, short commands in another).
 - **`command`:** Writes text + Enter to the shell. Registers output capture — the tool waits and returns output.
 - **`wait_until`:** Controls when the tool returns. `timeout_ms` = time cap, `output_pattern` = regex match on output, `exited` = wait for process exit. Omitting `wait_until` defaults to **20 s**. When `wait_until` is provided without an explicit `timeout_ms`, the cap is **120 s**.
 - **Timeout ≠ error.** `timed_out: true` returns partial output; session stays alive. Reuse `session_id` to continue.
@@ -167,9 +168,10 @@ Persistent interactive PTY sessions. State (variables, cwd, aliases) persists ac
 - OS/shell type in env snapshot. Prefer native tools for file ops; shell for dev scripts, git, installs.
 
 ```jsonc
-// Start dev server (long-running), then health-check in a new session
+// Start a long-running dev server (new session — needs its own PTY)
 { "command": "pnpm dev", "cwd": "w1", "wait_until": { "output_pattern": "ready|listening", "timeout_ms": 30000 } }
-{ "command": "curl localhost:3000/health", "cwd": "w1" }
+// Reuse an existing idle session for a quick command (don't create a new one)
+{ "session_id": "f8a3b1c2", "command": "curl localhost:3000/health" }
 // Interrupt a running dev server
 { "session_id": "abc12345", "stdin": "\x03" }
 // Answer "yes" to an interactive prompt

--- a/apps/browser/src/backend/agents/shared/prompts/utils/environment-renderer.ts
+++ b/apps/browser/src/backend/agents/shared/prompts/utils/environment-renderer.ts
@@ -62,6 +62,30 @@ export function renderFullEnvironmentContext(
     );
   }
 
+  // Active shell sessions
+  const activeSessions = snapshot.shells.sessions.filter((s) => !s.exited);
+  if (activeSessions.length > 0) {
+    const sessionTags = activeSessions.map((s) => {
+      // Reverse-resolve absolute cwd to mount prefix (longest match wins)
+      let cwd = s.cwd;
+      let bestLen = 0;
+      for (const m of workspace.mounts) {
+        if (
+          (s.cwd === m.path || s.cwd.startsWith(`${m.path}/`)) &&
+          m.path.length > bestLen
+        ) {
+          bestLen = m.path.length;
+          const relative = s.cwd.slice(m.path.length);
+          cwd = relative ? `${m.prefix}${relative}` : m.prefix;
+        }
+      }
+      return `  <session id="${esc(s.id)}" cwd="${esc(cwd)}" />`;
+    });
+    sections.push(
+      `<shell-sessions>\n${sessionTags.join('\n')}\n</shell-sessions>`,
+    );
+  }
+
   // Available skills
   const { enabledSkills } = snapshot;
   if (enabledSkills.paths.length > 0) {

--- a/apps/browser/src/backend/services/toolbox/tools/shell/execute-shell-command.ts
+++ b/apps/browser/src/backend/services/toolbox/tools/shell/execute-shell-command.ts
@@ -6,6 +6,7 @@ import { tool } from 'ai';
 import { capToolOutput } from '../../utils';
 import type { ShellService } from '@/services/toolbox/services/shell';
 import { homedir } from 'node:os';
+import { join, resolve, sep } from 'node:path';
 
 export const DESCRIPTION = `Execute a shell command in the user's system shell. You **MUST** define a symlinked path (NOT "."!) as initial cwd for the command to run in.`;
 
@@ -51,12 +52,25 @@ function resolveCwd(
   const mounts = getMountedPaths();
 
   if (mountPrefix) {
-    const resolved = mounts.get(mountPrefix);
-    if (resolved) return resolved;
+    // Split "weba9/apps/browser" into prefix "weba9" + rest "apps/browser"
+    const slashIdx = mountPrefix.indexOf('/');
+    const prefix =
+      slashIdx === -1 ? mountPrefix : mountPrefix.slice(0, slashIdx);
+    const rest = slashIdx === -1 ? '' : mountPrefix.slice(slashIdx + 1);
+
+    const mountRoot = mounts.get(prefix);
+    if (mountRoot) {
+      if (!rest) return mountRoot;
+      const full = resolve(join(mountRoot, rest));
+      // Prevent traversal outside the mount root
+      if (full === mountRoot || full.startsWith(`${mountRoot}${sep}`))
+        return full;
+      return mountRoot;
+    }
   }
 
-  for (const [prefix, path] of mounts) {
-    if (prefix !== 'att') return path;
+  for (const [prefix, fsPath] of mounts) {
+    if (prefix !== 'att') return fsPath;
   }
 
   return homedir();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Environment view now lists active shell sessions with IDs and their working directories.

* **Bug Fixes**
  * Working directories are constrained to their mount root to prevent path escaping.
  * Nested mount-prefixes in shell commands are resolved more accurately to target the intended workspace path.

* **Documentation**
  * Guidance updated to recommend reusing existing terminal sessions; examples show session reuse.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->