### PR TITLE
feat(stagewise): add AST-previews to file-read-pipeline for files w/ …

### DIFF
--- a/apps/browser/forge.config.mts
+++ b/apps/browser/forge.config.mts
@@ -49,6 +49,8 @@ const nativeDependencies = [
   'node-pty',
   '@xterm/headless',
   'semver',
+  'web-tree-sitter',
+  '@vscode/tree-sitter-wasm',
 ];
 
 const copyNativeDependencies = (
@@ -293,7 +295,7 @@ const config: ForgeConfig = {
   buildIdentifier: buildConstants.__APP_RELEASE_CHANNEL__,
   packagerConfig: {
     asar: {
-      unpack: '**/{sharp,@img,node-pty}/**',
+      unpack: '**/{sharp,@img,node-pty,web-tree-sitter,@vscode}/**',
     },
     extraResource: [
       './bundled',

--- a/apps/browser/package.json
+++ b/apps/browser/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@bokuweb/zstd-wasm": "^0.0.27",
     "@libsql/client": "^0.15.15",
+    "@vscode/tree-sitter-wasm": "^0.3.0",
     "@paralleldrive/cuid2": "^3.3.0",
     "@streamdown/math": "^1.0.2",
     "@tiptap/extension-mention": "^3.20.0",
@@ -49,6 +50,7 @@
     "react-virtuoso": "^4.18.1",
     "sharp": "^0.34.5",
     "tiptap-markdown": "^0.9.0",
+    "web-tree-sitter": "^0.26.6",
     "yauzl": "^3.2.0"
   },
   "devDependencies": {

--- a/apps/browser/src/backend/agents/shared/base-agent/file-read-transformer/ast/index.ts
+++ b/apps/browser/src/backend/agents/shared/base-agent/file-read-transformer/ast/index.ts
@@ -1,0 +1,47 @@
+/**
+ * AST index module — Node entry point.
+ *
+ * Provides `getFileSymbols()`, the single public API for parsing source
+ * code and extracting top-level symbols. Internally wires up the
+ * Node-native parser, grammar loader, and symbol extractor.
+ */
+
+import type { ParsedFileSymbols } from '@shared/ast/types';
+import { getLanguageForExt } from '@shared/ast/language-map';
+import { initParser, loadGrammar } from './parser';
+import { extractSymbols } from './symbol-extractor';
+
+export type { ParsedFileSymbols } from '@shared/ast/types';
+export { SymbolKind, type SymbolInfo } from '@shared/ast/types';
+export { getLanguageForExt } from '@shared/ast/language-map';
+
+/**
+ * Parse source code and extract top-level symbols.
+ *
+ * @param sourceText — UTF-8 source code string (NOT a URL or file path).
+ * @param ext — File extension without leading dot (e.g. `'ts'`, `'py'`, `'go'`).
+ * @returns Parsed symbols, or `null` if the extension has no grammar.
+ */
+export async function getFileSymbols(
+  sourceText: string,
+  ext: string,
+): Promise<ParsedFileSymbols | null> {
+  const lang = getLanguageForExt(ext);
+  if (!lang) return null;
+
+  const parser = await initParser();
+  let tree: ReturnType<typeof parser.parse> | null = null;
+
+  try {
+    const language = await loadGrammar(lang.grammarFile);
+    parser.setLanguage(language);
+    tree = parser.parse(sourceText);
+    if (!tree) return null;
+
+    const symbols = extractSymbols(tree.rootNode, lang.grammarFile, sourceText);
+    return { language: lang.label, symbols };
+  } finally {
+    tree?.delete();
+    parser.delete();
+  }
+}

--- a/apps/browser/src/backend/agents/shared/base-agent/file-read-transformer/ast/parser.ts
+++ b/apps/browser/src/backend/agents/shared/base-agent/file-read-transformer/ast/parser.ts
@@ -1,0 +1,90 @@
+/**
+ * Node-native Tree-sitter WASM parser.
+ *
+ * Replaces the browser-specific parser from the stash (which used Vite
+ * `?url` imports and `fetch()`) with `createRequire` + `fs.readFile`
+ * for locating and loading WASM binaries in the Electron main process.
+ *
+ * - `initParser()` — lazy-initialises the WASM runtime and returns a
+ *   fresh `Parser` instance. Callers must call `parser.delete()` when
+ *   done.
+ * - `loadGrammar()` — loads (and caches) a language grammar by its
+ *   `.wasm` filename from `@vscode/tree-sitter-wasm`.
+ */
+
+import fs from 'node:fs/promises';
+import { createRequire } from 'node:module';
+
+// web-tree-sitter uses named exports (no default).
+// `Parser.init()` is static, `Language.load()` is static,
+// and `new Parser()` constructs a parser instance.
+import { Parser, Language } from 'web-tree-sitter';
+
+const require = createRequire(import.meta.url);
+
+// ---------------------------------------------------------------------------
+// Singleton init
+// ---------------------------------------------------------------------------
+
+let initPromise: Promise<void> | null = null;
+
+function resolveWasmPath(pkg: string, subpath: string): string {
+  return require.resolve(`${pkg}/${subpath}`);
+}
+
+/**
+ * Initialise the Tree-sitter WASM runtime (once) and return a new
+ * `Parser` instance. Each caller gets its own parser so concurrent
+ * parses don't interfere. The caller is responsible for calling
+ * `parser.delete()` after use.
+ */
+export async function initParser(): Promise<Parser> {
+  if (!initPromise) {
+    const wasmPath = resolveWasmPath('web-tree-sitter', 'web-tree-sitter.wasm');
+    initPromise = Parser.init({
+      locateFile: () => wasmPath,
+    }).catch((err) => {
+      initPromise = null;
+      throw err;
+    });
+  }
+  await initPromise;
+  return new Parser();
+}
+
+// ---------------------------------------------------------------------------
+// Grammar cache
+// ---------------------------------------------------------------------------
+
+const grammarCache = new Map<string, Promise<Language>>();
+
+/**
+ * Load a Tree-sitter language grammar by its `.wasm` filename
+ * (e.g. `"tree-sitter-typescript.wasm"`).
+ *
+ * Grammars are cached after first load — the WASM binary is read from
+ * disk via `@vscode/tree-sitter-wasm` and compiled once. Concurrent
+ * first-loads of the same grammar share a single in-flight promise.
+ */
+export async function loadGrammar(grammarFile: string): Promise<Language> {
+  const cached = grammarCache.get(grammarFile);
+  if (cached) return cached;
+
+  const promise = (async () => {
+    const wasmPath = resolveWasmPath(
+      '@vscode/tree-sitter-wasm',
+      `wasm/${grammarFile}`,
+    );
+    const bytes = new Uint8Array(await fs.readFile(wasmPath));
+    return Language.load(bytes);
+  })();
+
+  grammarCache.set(grammarFile, promise);
+
+  // If loading fails, evict from cache so future attempts retry.
+  promise.catch(() => {
+    grammarCache.delete(grammarFile);
+  });
+
+  return promise;
+}

--- a/apps/browser/src/backend/agents/shared/base-agent/file-read-transformer/ast/symbol-extractor.ts
+++ b/apps/browser/src/backend/agents/shared/base-agent/file-read-transformer/ast/symbol-extractor.ts
@@ -1,0 +1,792 @@
+import type { Node } from 'web-tree-sitter';
+import { SymbolKind, type SymbolInfo } from '@shared/ast/types';
+
+type Extractor = (root: Node, source: string) => SymbolInfo[];
+
+function nameOf(node: Node, field: string): string {
+  return node.childForFieldName(field)?.text ?? '<anonymous>';
+}
+
+function isExported(node: Node): boolean {
+  const parent = node.parent;
+  return parent?.type === 'export_statement';
+}
+
+// ---------------------------------------------------------------------------
+// Signature extraction
+// ---------------------------------------------------------------------------
+
+const SIGNATURE_MAX_LENGTH = 120;
+
+interface SignatureOpts {
+  maxLength?: number;
+  stripTrailing?: string;
+}
+
+/**
+ * Extract the source signature of a declaration node.
+ *
+ * Strategy: slice source text from node start to body start (the `{…}` or
+ * `:` block).  When no body child exists, fall back to the first line of the
+ * node's source range.
+ */
+function extractSignature(
+  node: Node,
+  sourceText: string,
+  opts?: SignatureOpts,
+): string {
+  const maxLen = opts?.maxLength ?? SIGNATURE_MAX_LENGTH;
+
+  let raw: string;
+  const body = node.childForFieldName('body');
+  if (body) {
+    raw = sourceText.substring(node.startIndex, body.startIndex);
+  } else {
+    raw = sourceText.substring(node.startIndex, node.endIndex).split('\n')[0];
+  }
+
+  // Collapse newlines + surrounding whitespace into single space.
+  raw = raw.replace(/\s*\n\s*/g, ' ').trim();
+
+  // Strip trailing characters (e.g. ":" for Python).
+  if (opts?.stripTrailing && raw.endsWith(opts.stripTrailing)) {
+    raw = raw.slice(0, -opts.stripTrailing.length).trimEnd();
+  }
+
+  if (raw.length > maxLen) {
+    raw = `${raw.slice(0, maxLen - 1)}…`;
+  }
+
+  return raw;
+}
+
+/** Prefix `export ` when the TS/JS node sits inside an `export_statement`. */
+function tsSignature(node: Node, source: string): string {
+  const sig = extractSignature(node, source);
+  return isExported(node) ? `export ${sig}` : sig;
+}
+
+function extractTsSymbols(root: Node, source: string): SymbolInfo[] {
+  const symbols: SymbolInfo[] = [];
+
+  function visitTopLevel(node: Node) {
+    switch (node.type) {
+      case 'function_declaration':
+        symbols.push({
+          name: nameOf(node, 'name'),
+          kind: SymbolKind.Function,
+          exported: isExported(node),
+          line: node.startPosition.row,
+          signature: tsSignature(node, source),
+        });
+        break;
+
+      case 'class_declaration': {
+        const children = extractClassMembers(node, source);
+        symbols.push({
+          name: nameOf(node, 'name'),
+          kind: SymbolKind.Class,
+          exported: isExported(node),
+          line: node.startPosition.row,
+          signature: tsSignature(node, source),
+          children: children.length ? children : undefined,
+        });
+        break;
+      }
+
+      case 'abstract_class_declaration': {
+        const children = extractClassMembers(node, source);
+        symbols.push({
+          name: nameOf(node, 'name'),
+          kind: SymbolKind.Class,
+          exported: isExported(node),
+          line: node.startPosition.row,
+          signature: tsSignature(node, source),
+          children: children.length ? children : undefined,
+        });
+        break;
+      }
+
+      case 'interface_declaration':
+        symbols.push({
+          name: nameOf(node, 'name'),
+          kind: SymbolKind.Interface,
+          exported: isExported(node),
+          line: node.startPosition.row,
+          signature: tsSignature(node, source),
+        });
+        break;
+
+      case 'type_alias_declaration':
+        symbols.push({
+          name: nameOf(node, 'name'),
+          kind: SymbolKind.Type,
+          exported: isExported(node),
+          line: node.startPosition.row,
+          signature: tsSignature(node, source),
+        });
+        break;
+
+      case 'enum_declaration':
+        symbols.push({
+          name: nameOf(node, 'name'),
+          kind: SymbolKind.Enum,
+          exported: isExported(node),
+          line: node.startPosition.row,
+          signature: tsSignature(node, source),
+        });
+        break;
+
+      case 'lexical_declaration': {
+        for (const decl of node.namedChildren) {
+          if (decl.type === 'variable_declarator') {
+            // Slice up to the initializer (value) if present.
+            const value = decl.childForFieldName('value');
+            let sig: string;
+            if (value) {
+              sig = source
+                .substring(decl.startIndex, value.startIndex)
+                .replace(/\s*\n\s*/g, ' ')
+                .trim()
+                .replace(/\s*=\s*$/, '');
+            } else {
+              sig = source
+                .substring(decl.startIndex, decl.endIndex)
+                .split('\n')[0]
+                .trim();
+            }
+            // Prepend const/let from the parent lexical_declaration.
+            const keyword = node.children[0]?.text ?? 'const';
+            const exportPrefix = isExported(node) ? 'export ' : '';
+            symbols.push({
+              name: nameOf(decl, 'name'),
+              kind: SymbolKind.Variable,
+              exported: isExported(node),
+              line: decl.startPosition.row,
+              signature: `${exportPrefix}${keyword} ${sig}`,
+            });
+          }
+        }
+        break;
+      }
+
+      case 'export_statement': {
+        const child = node.namedChildren[0];
+        if (child) visitTopLevel(child);
+        break;
+      }
+    }
+  }
+
+  for (const child of root.namedChildren) {
+    visitTopLevel(child);
+  }
+  return symbols;
+}
+
+function extractClassMembers(classNode: Node, source: string): SymbolInfo[] {
+  const members: SymbolInfo[] = [];
+  const body = classNode.childForFieldName('body');
+  if (!body) return members;
+
+  for (const member of body.namedChildren) {
+    switch (member.type) {
+      case 'method_definition':
+        members.push({
+          name: nameOf(member, 'name'),
+          kind: SymbolKind.Method,
+          exported: false,
+          line: member.startPosition.row,
+          signature: extractSignature(member, source),
+        });
+        break;
+      case 'public_field_definition':
+      case 'property_definition':
+        members.push({
+          name: nameOf(member, 'name'),
+          kind: SymbolKind.Property,
+          exported: false,
+          line: member.startPosition.row,
+          signature: extractSignature(member, source),
+        });
+        break;
+    }
+  }
+  return members;
+}
+
+function extractPySymbols(root: Node, source: string): SymbolInfo[] {
+  const symbols: SymbolInfo[] = [];
+
+  for (const child of root.namedChildren) {
+    switch (child.type) {
+      case 'function_definition':
+        symbols.push({
+          name: nameOf(child, 'name'),
+          kind: SymbolKind.Function,
+          exported: true,
+          line: child.startPosition.row,
+          signature: extractSignature(child, source, { stripTrailing: ':' }),
+        });
+        break;
+
+      case 'class_definition': {
+        const methods: SymbolInfo[] = [];
+        const body = child.childForFieldName('body');
+        if (body) {
+          for (const m of body.namedChildren) {
+            let fn = m;
+            if (fn.type === 'decorated_definition') {
+              const inner = fn.namedChildren.find(
+                (c) => c.type === 'function_definition',
+              );
+              if (!inner) continue;
+              fn = inner;
+            }
+            if (fn.type === 'function_definition') {
+              methods.push({
+                name: nameOf(fn, 'name'),
+                kind: SymbolKind.Method,
+                exported: false,
+                line: fn.startPosition.row,
+                signature: extractSignature(fn, source, { stripTrailing: ':' }),
+              });
+            }
+          }
+        }
+        symbols.push({
+          name: nameOf(child, 'name'),
+          kind: SymbolKind.Class,
+          exported: true,
+          line: child.startPosition.row,
+          signature: extractSignature(child, source, { stripTrailing: ':' }),
+          children: methods.length ? methods : undefined,
+        });
+        break;
+      }
+
+      case 'decorated_definition': {
+        const inner = child.namedChildren.find(
+          (c) =>
+            c.type === 'function_definition' || c.type === 'class_definition',
+        );
+        if (inner) {
+          const temp = extractPySymbols(fakeRoot([inner]), source);
+          for (const s of temp) symbols.push(s);
+        }
+        break;
+      }
+    }
+  }
+  return symbols;
+}
+
+function extractGoSymbols(root: Node, source: string): SymbolInfo[] {
+  const symbols: SymbolInfo[] = [];
+
+  for (const child of root.namedChildren) {
+    switch (child.type) {
+      case 'function_declaration':
+        symbols.push({
+          name: nameOf(child, 'name'),
+          kind: SymbolKind.Function,
+          exported: isGoExported(nameOf(child, 'name')),
+          line: child.startPosition.row,
+          signature: extractSignature(child, source),
+        });
+        break;
+
+      case 'method_declaration':
+        symbols.push({
+          name: nameOf(child, 'name'),
+          kind: SymbolKind.Method,
+          exported: isGoExported(nameOf(child, 'name')),
+          line: child.startPosition.row,
+          signature: extractSignature(child, source),
+        });
+        break;
+
+      case 'type_declaration': {
+        for (const spec of child.namedChildren) {
+          if (spec.type === 'type_spec') {
+            const typeName = nameOf(spec, 'name');
+            const typeValue = spec.childForFieldName('type');
+            const kind =
+              typeValue?.type === 'interface_type'
+                ? SymbolKind.Interface
+                : SymbolKind.Type;
+            symbols.push({
+              name: typeName,
+              kind,
+              exported: isGoExported(typeName),
+              line: spec.startPosition.row,
+              signature: extractSignature(spec, source),
+            });
+          }
+        }
+        break;
+      }
+    }
+  }
+  return symbols;
+}
+
+function isGoExported(name: string): boolean {
+  if (name.length === 0) return false;
+  const ch = name[0];
+  // Only Unicode uppercase *letters* make a Go name exported.
+  // Reject `_`, digits, and other non-letter characters where
+  // toUpperCase() === toLowerCase().
+  return ch !== ch.toLowerCase() && ch === ch.toUpperCase();
+}
+
+function extractRsSymbols(root: Node, source: string): SymbolInfo[] {
+  const symbols: SymbolInfo[] = [];
+
+  for (const child of root.namedChildren) {
+    switch (child.type) {
+      case 'function_item':
+        symbols.push({
+          name: nameOf(child, 'name'),
+          kind: SymbolKind.Function,
+          exported: hasRsPub(child),
+          line: child.startPosition.row,
+          signature: extractSignature(child, source),
+        });
+        break;
+
+      case 'struct_item':
+        symbols.push({
+          name: nameOf(child, 'name'),
+          kind: SymbolKind.Class,
+          exported: hasRsPub(child),
+          line: child.startPosition.row,
+          signature: extractSignature(child, source),
+        });
+        break;
+
+      case 'enum_item':
+        symbols.push({
+          name: nameOf(child, 'name'),
+          kind: SymbolKind.Enum,
+          exported: hasRsPub(child),
+          line: child.startPosition.row,
+          signature: extractSignature(child, source),
+        });
+        break;
+
+      case 'trait_item':
+        symbols.push({
+          name: nameOf(child, 'name'),
+          kind: SymbolKind.Interface,
+          exported: hasRsPub(child),
+          line: child.startPosition.row,
+          signature: extractSignature(child, source),
+        });
+        break;
+
+      case 'impl_item': {
+        const typeName = child.childForFieldName('type')?.text ?? '<impl>';
+        const methods: SymbolInfo[] = [];
+        const body = child.childForFieldName('body');
+        if (body) {
+          for (const m of body.namedChildren) {
+            if (m.type === 'function_item') {
+              methods.push({
+                name: nameOf(m, 'name'),
+                kind: SymbolKind.Method,
+                exported: hasRsPub(m),
+                line: m.startPosition.row,
+                signature: extractSignature(m, source),
+              });
+            }
+          }
+        }
+        symbols.push({
+          name: typeName,
+          kind: SymbolKind.Class,
+          exported: false,
+          line: child.startPosition.row,
+          signature: extractSignature(child, source),
+          children: methods.length ? methods : undefined,
+        });
+        break;
+      }
+    }
+  }
+  return symbols;
+}
+
+function hasRsPub(node: Node): boolean {
+  for (const child of node.children) {
+    if (child.type === 'visibility_modifier') return true;
+  }
+  return false;
+}
+
+function extractJavaSymbols(root: Node, source: string): SymbolInfo[] {
+  const symbols: SymbolInfo[] = [];
+
+  for (const child of root.namedChildren) {
+    if (child.type === 'class_declaration') {
+      const methods: SymbolInfo[] = [];
+      const body = child.childForFieldName('body');
+      if (body) {
+        for (const m of body.namedChildren) {
+          if (m.type === 'method_declaration') {
+            methods.push({
+              name: nameOf(m, 'name'),
+              kind: SymbolKind.Method,
+              exported: hasJavaModifier(m, 'public'),
+              line: m.startPosition.row,
+              signature: extractSignature(m, source),
+            });
+          }
+        }
+      }
+      symbols.push({
+        name: nameOf(child, 'name'),
+        kind: SymbolKind.Class,
+        exported: hasJavaModifier(child, 'public'),
+        line: child.startPosition.row,
+        signature: extractSignature(child, source),
+        children: methods.length ? methods : undefined,
+      });
+    } else if (child.type === 'interface_declaration') {
+      symbols.push({
+        name: nameOf(child, 'name'),
+        kind: SymbolKind.Interface,
+        exported: hasJavaModifier(child, 'public'),
+        line: child.startPosition.row,
+        signature: extractSignature(child, source),
+      });
+    } else if (child.type === 'enum_declaration') {
+      symbols.push({
+        name: nameOf(child, 'name'),
+        kind: SymbolKind.Enum,
+        exported: hasJavaModifier(child, 'public'),
+        line: child.startPosition.row,
+        signature: extractSignature(child, source),
+      });
+    }
+  }
+  return symbols;
+}
+
+function hasJavaModifier(node: Node, modifier: string): boolean {
+  for (const child of node.children) {
+    if (child.type === 'modifiers') {
+      return child.text.includes(modifier);
+    }
+  }
+  return false;
+}
+
+function extractCssSymbols(root: Node, _source: string): SymbolInfo[] {
+  const symbols: SymbolInfo[] = [];
+
+  for (const child of root.namedChildren) {
+    if (child.type === 'rule_set') {
+      const selectors = child.childForFieldName('selectors');
+      const name = selectors?.text ?? '<rule>';
+      symbols.push({
+        name,
+        kind: SymbolKind.CssSelector,
+        exported: false,
+        line: child.startPosition.row,
+        signature: name,
+      });
+    }
+  }
+  return symbols;
+}
+
+function extractBashSymbols(root: Node, source: string): SymbolInfo[] {
+  const symbols: SymbolInfo[] = [];
+
+  for (const child of root.namedChildren) {
+    if (child.type === 'function_definition') {
+      symbols.push({
+        name: nameOf(child, 'name'),
+        kind: SymbolKind.Function,
+        exported: false,
+        line: child.startPosition.row,
+        signature: extractSignature(child, source),
+      });
+    }
+  }
+  return symbols;
+}
+
+// ── C++ / C ────────────────────────────────────────────────────
+
+function extractCppSymbols(root: Node, source: string): SymbolInfo[] {
+  const symbols: SymbolInfo[] = [];
+
+  for (const child of root.namedChildren) {
+    switch (child.type) {
+      case 'function_definition':
+      case 'declaration': {
+        const declarator = child.childForFieldName('declarator');
+        const isFuncDecl = declarator?.type === 'function_declarator';
+        const isPtrToFunc =
+          declarator?.type === 'pointer_declarator' &&
+          declarator.childForFieldName('declarator')?.type ===
+            'function_declarator';
+        if (isFuncDecl || isPtrToFunc) {
+          const name =
+            declarator.childForFieldName('declarator')?.text ?? declarator.text;
+          symbols.push({
+            name,
+            kind: SymbolKind.Function,
+            exported: false,
+            line: child.startPosition.row,
+            signature: extractSignature(child, source),
+          });
+        }
+        break;
+      }
+      case 'class_specifier':
+      case 'struct_specifier': {
+        symbols.push({
+          name: nameOf(child, 'name'),
+          kind: SymbolKind.Class,
+          exported: false,
+          line: child.startPosition.row,
+          signature: extractSignature(child, source),
+        });
+        break;
+      }
+      case 'enum_specifier': {
+        symbols.push({
+          name: nameOf(child, 'name'),
+          kind: SymbolKind.Enum,
+          exported: false,
+          line: child.startPosition.row,
+          signature: extractSignature(child, source),
+        });
+        break;
+      }
+      case 'namespace_definition': {
+        symbols.push({
+          name: nameOf(child, 'name'),
+          kind: SymbolKind.Type,
+          exported: false,
+          line: child.startPosition.row,
+          signature: extractSignature(child, source),
+        });
+        break;
+      }
+    }
+  }
+  return symbols;
+}
+
+function extractRubySymbols(root: Node, source: string): SymbolInfo[] {
+  const symbols: SymbolInfo[] = [];
+
+  for (const child of root.namedChildren) {
+    switch (child.type) {
+      case 'method':
+        symbols.push({
+          name: nameOf(child, 'name'),
+          kind: SymbolKind.Function,
+          exported: true,
+          line: child.startPosition.row,
+          signature: extractSignature(child, source),
+        });
+        break;
+      case 'class': {
+        const methods: SymbolInfo[] = [];
+        const body = child.childForFieldName('body');
+        if (body) {
+          for (const m of body.namedChildren) {
+            if (m.type === 'method') {
+              methods.push({
+                name: nameOf(m, 'name'),
+                kind: SymbolKind.Method,
+                exported: true,
+                line: m.startPosition.row,
+                signature: extractSignature(m, source),
+              });
+            }
+          }
+        }
+        symbols.push({
+          name: nameOf(child, 'name'),
+          kind: SymbolKind.Class,
+          exported: true,
+          line: child.startPosition.row,
+          signature: extractSignature(child, source),
+          children: methods.length ? methods : undefined,
+        });
+        break;
+      }
+      case 'module':
+        symbols.push({
+          name: nameOf(child, 'name'),
+          kind: SymbolKind.Type,
+          exported: true,
+          line: child.startPosition.row,
+          signature: extractSignature(child, source),
+        });
+        break;
+    }
+  }
+  return symbols;
+}
+
+// ── PHP ────────────────────────────────────────────────────────────
+
+function extractPhpSymbols(root: Node, source: string): SymbolInfo[] {
+  const symbols: SymbolInfo[] = [];
+
+  function visit(node: Node) {
+    for (const child of node.namedChildren) {
+      switch (child.type) {
+        case 'function_definition':
+          symbols.push({
+            name: nameOf(child, 'name'),
+            kind: SymbolKind.Function,
+            exported: true,
+            line: child.startPosition.row,
+            signature: extractSignature(child, source),
+          });
+          break;
+        case 'class_declaration':
+          symbols.push({
+            name: nameOf(child, 'name'),
+            kind: SymbolKind.Class,
+            exported: true,
+            line: child.startPosition.row,
+            signature: extractSignature(child, source),
+          });
+          break;
+        case 'interface_declaration':
+          symbols.push({
+            name: nameOf(child, 'name'),
+            kind: SymbolKind.Interface,
+            exported: true,
+            line: child.startPosition.row,
+            signature: extractSignature(child, source),
+          });
+          break;
+        case 'program':
+          visit(child);
+          break;
+      }
+    }
+  }
+
+  visit(root);
+  return symbols;
+}
+
+/**
+ * C# uses `modifier` (singular) per child node, unlike Java's
+ * `modifiers` (plural) wrapper. Check each direct child for a
+ * matching modifier keyword.
+ */
+function hasCsharpModifier(node: Node, modifier: string): boolean {
+  for (const child of node.children) {
+    if (child.type === 'modifier' && child.text.includes(modifier)) return true;
+  }
+  return false;
+}
+
+function extractCsharpSymbols(root: Node, source: string): SymbolInfo[] {
+  const symbols: SymbolInfo[] = [];
+
+  function visit(node: Node) {
+    for (const child of node.namedChildren) {
+      switch (child.type) {
+        case 'class_declaration': {
+          const methods: SymbolInfo[] = [];
+          const body = child.childForFieldName('body');
+          if (body) {
+            for (const m of body.namedChildren) {
+              if (m.type === 'method_declaration') {
+                methods.push({
+                  name: nameOf(m, 'name'),
+                  kind: SymbolKind.Method,
+                  exported: hasCsharpModifier(m, 'public'),
+                  line: m.startPosition.row,
+                  signature: extractSignature(m, source),
+                });
+              }
+            }
+          }
+          symbols.push({
+            name: nameOf(child, 'name'),
+            kind: SymbolKind.Class,
+            exported: hasCsharpModifier(child, 'public'),
+            line: child.startPosition.row,
+            signature: extractSignature(child, source),
+            children: methods.length ? methods : undefined,
+          });
+          break;
+        }
+        case 'interface_declaration':
+          symbols.push({
+            name: nameOf(child, 'name'),
+            kind: SymbolKind.Interface,
+            exported: hasCsharpModifier(child, 'public'),
+            line: child.startPosition.row,
+            signature: extractSignature(child, source),
+          });
+          break;
+        case 'enum_declaration':
+          symbols.push({
+            name: nameOf(child, 'name'),
+            kind: SymbolKind.Enum,
+            exported: hasCsharpModifier(child, 'public'),
+            line: child.startPosition.row,
+            signature: extractSignature(child, source),
+          });
+          break;
+        case 'namespace_declaration':
+          visit(child);
+          break;
+      }
+    }
+  }
+
+  visit(root);
+  return symbols;
+}
+
+const EXTRACTORS: Record<string, Extractor> = {
+  'tree-sitter-typescript.wasm': extractTsSymbols,
+  'tree-sitter-tsx.wasm': extractTsSymbols,
+  'tree-sitter-javascript.wasm': extractTsSymbols,
+  'tree-sitter-python.wasm': extractPySymbols,
+  'tree-sitter-go.wasm': extractGoSymbols,
+  'tree-sitter-rust.wasm': extractRsSymbols,
+  'tree-sitter-java.wasm': extractJavaSymbols,
+  'tree-sitter-css.wasm': extractCssSymbols,
+  'tree-sitter-bash.wasm': extractBashSymbols,
+  'tree-sitter-ruby.wasm': extractRubySymbols,
+  'tree-sitter-php.wasm': extractPhpSymbols,
+  'tree-sitter-c-sharp.wasm': extractCsharpSymbols,
+  'tree-sitter-cpp.wasm': extractCppSymbols,
+};
+
+export function extractSymbols(
+  rootNode: Node,
+  grammarFile: string,
+  sourceText: string,
+): SymbolInfo[] {
+  const extractor = EXTRACTORS[grammarFile];
+  if (!extractor) return [];
+  return extractor(rootNode, sourceText);
+}
+
+/**
+ * Create a minimal wrapper that looks like a root node
+ * so we can pass a subset of children to an extractor.
+ */
+function fakeRoot(children: Node[]): Node {
+  return {
+    namedChildren: children,
+  } as unknown as Node;
+}

--- a/apps/browser/src/backend/agents/shared/base-agent/file-read-transformer/content-limits.test.ts
+++ b/apps/browser/src/backend/agents/shared/base-agent/file-read-transformer/content-limits.test.ts
@@ -351,7 +351,9 @@ describe('content limits – preview mode', () => {
   it('preview respects maxPreviewLines', async () => {
     setMaxPreviewLines(5);
 
-    const content = generateLines(50);
+    // Generate 200 lines so the file exceeds the preview-promotion
+    // line threshold (150) and stays in preview mode.
+    const content = generateLines(200);
     const filePath = path.join(ctx.workDir, 'file.ts');
     await nodeFs.writeFile(filePath, content);
     const hash = sha256(content);
@@ -365,7 +367,7 @@ describe('content limits – preview mode', () => {
     expect(text).toContain('1|line 0001');
     expect(text).toContain('5|line 0005');
     expect(text).not.toContain('6|line 0006');
-    expect(text).toContain('45 more lines');
+    expect(text).toContain('195 more lines');
   });
 });
 
@@ -559,9 +561,11 @@ describe('content limits – per-request options override globals', () => {
 
   it('maxPreviewLines on options overrides global setter', async () => {
     // Set global preview limit high so it would NOT truncate.
-    setMaxPreviewLines(200);
+    setMaxPreviewLines(500);
 
-    const content = generateLines(50);
+    // Generate 200 lines so the file exceeds the preview-promotion
+    // line threshold (150) and stays in preview mode.
+    const content = generateLines(200);
     const filePath = path.join(ctx.workDir, 'per-req-preview.ts');
     await nodeFs.writeFile(filePath, content);
     const hash = sha256(content);
@@ -581,7 +585,7 @@ describe('content limits – per-request options override globals', () => {
     expect(text).toContain('1|line 0001');
     expect(text).toContain('7|line 0007');
     expect(text).not.toContain('8|line 0008');
-    expect(text).toContain('43 more lines');
+    expect(text).toContain('193 more lines');
   });
 
   it('per-request maxReadChars affects line-range reads', async () => {

--- a/apps/browser/src/backend/agents/shared/base-agent/file-read-transformer/file-read-transformer.test.ts
+++ b/apps/browser/src/backend/agents/shared/base-agent/file-read-transformer/file-read-transformer.test.ts
@@ -178,7 +178,10 @@ describe('fileReadTransformer – XML wrapping', () => {
   });
 
   it('uses <preview> instead of <content> in preview mode', async () => {
-    const content = 'line 1\nline 2\nline 3\n';
+    // Generate 200 lines of content to exceed the preview-promotion
+    // line threshold (150) so the file stays in preview mode instead
+    // of being promoted to a full read.
+    const content = `${Array.from({ length: 200 }, (_, i) => `line ${i + 1}`).join('\n')}\n`;
     const filePath = path.join(ctx.workDir, 'prev.ts');
     await nodeFs.writeFile(filePath, content);
     const hash = sha256(content);

--- a/apps/browser/src/backend/agents/shared/base-agent/file-read-transformer/index.ts
+++ b/apps/browser/src/backend/agents/shared/base-agent/file-read-transformer/index.ts
@@ -36,11 +36,26 @@ import {
   baseMetadata,
   getMaxReadChars,
   getMaxPreviewLines,
+  isBinaryBuffer,
 } from './format-utils';
 
 /** Default content limits used when callers don't supply explicit values. */
 const DEFAULT_MAX_READ_CHARS = 500 * 80;
 const DEFAULT_MAX_PREVIEW_LINES = 30;
+
+/**
+ * Maximum file size (bytes) for which a preview request is promoted
+ * to a full-content read. Files below this threshold are small enough
+ * that the preview would save negligible tokens while costing an
+ * extra tool-call round-trip when the agent re-reads.
+ */
+export const PREVIEW_PROMOTION_MAX_BYTES = 6 * 1024;
+
+/**
+ * Maximum line count for preview → full-read promotion. Both byte
+ * and line thresholds must hold for promotion to fire.
+ */
+export const PREVIEW_PROMOTION_MAX_LINES = 150;
 import type {
   FileTransformResult,
   FileTransformer,
@@ -61,7 +76,9 @@ import {
   archiveTransformer,
   rawImageTransformer,
   diskImageTransformer,
+  sourceCodeTransformer,
 } from './transformers/index';
+import { LANGUAGE_MAP } from '@shared/ast/language-map';
 
 // ---------------------------------------------------------------------------
 // Extension → transformer lookup table
@@ -122,6 +139,19 @@ const TRANSFORMER_BY_EXT: Record<string, FileTransformer> = {
   '.img': diskImageTransformer,
   '.dmg': diskImageTransformer,
 };
+
+// Source-code files — AST-based preview with symbol outline.
+// Registered dynamically from the language map so adding a new grammar
+// only requires updating `language-map.ts`.
+for (const [ext, grammar] of Object.entries(LANGUAGE_MAP)) {
+  if (grammar !== null) {
+    const dotExt = `.${ext}`;
+    // Don't override existing transformers (e.g. images, markdown, svg).
+    if (!TRANSFORMER_BY_EXT[dotExt]) {
+      TRANSFORMER_BY_EXT[dotExt] = sourceCodeTransformer;
+    }
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Known-binary extensions — never sent to the model
@@ -343,7 +373,10 @@ export async function fileReadTransformer(
 
   // Normalise readParams — strip undefined values so an empty object
   // and a missing value produce the same cache key.
-  const effectiveReadParams: ReadParams = readParams ?? {};
+  // Declared `let` because the preview-promotion block below may
+  // reassign it when a small file's preview request is promoted to a
+  // full-content read.
+  let effectiveReadParams: ReadParams = readParams ?? {};
 
   // ── 1. Resolve to absolute path + stat ──────────────────────────────
   const absolutePath = resolveMountedPath(mountedPath, agentId, mountPaths);
@@ -394,6 +427,38 @@ export async function fileReadTransformer(
       );
     }
     currentHash = hashBuffer(buf);
+  }
+
+  // ── 2b. Preview promotion ───────────────────────────────
+  // Small text files in preview mode are promoted to full reads.
+  // This saves a tool-call round-trip (the agent almost always
+  // re-reads after a preview) and aligns the cache key with later
+  // full-read requests for the same file.
+  //
+  // Gates:
+  //   - must be in preview mode
+  //   - must not be a directory (different transformer path)
+  //   - must not be a binary buffer (let the binary guard handle it)
+  //   - must fit within PREVIEW_PROMOTION_MAX_BYTES
+  //   - must fit within PREVIEW_PROMOTION_MAX_LINES
+  if (
+    effectiveReadParams.preview &&
+    !isDirectory &&
+    buf.length <= PREVIEW_PROMOTION_MAX_BYTES &&
+    !isBinaryBuffer(buf)
+  ) {
+    const lineCount = buf.toString('utf-8').split('\n').length;
+    if (lineCount <= PREVIEW_PROMOTION_MAX_LINES) {
+      logger.debug(
+        `[fileReadTransformer] Promoting preview → full read for ${mountedPath} ` +
+          `(size=${buf.length}B, lines=${lineCount})`,
+      );
+      // Strip `preview` but preserve any other flags (e.g. startLine/
+      // endLine — though those shouldn't appear alongside preview in
+      // practice; defensive).
+      const { preview: _preview, ...rest } = effectiveReadParams;
+      effectiveReadParams = rest;
+    }
   }
 
   // ── 3. Build cache key ─────────────────────────────────────────────
@@ -553,6 +618,7 @@ async function runTransformer(
   }
 
   transformer ??= TRANSFORMER_BY_EXT[ext] ?? textTransformer;
+
   return transformer(buf, mountedPath, stats, ctx, originalFileName);
 }
 
@@ -737,6 +803,9 @@ function buildReadParamsSuffix(
   if (params.startPage !== undefined) parts.push(`sp=${params.startPage}`);
   if (params.endPage !== undefined) parts.push(`ep=${params.endPage}`);
   if (params.preview) parts.push('pv=1');
+  // Version tag — bump when preview output format changes
+  // (e.g. AST outline replaces line-based preview for source files).
+  if (params.preview) parts.push('pvv=7');
   if (params.depth !== undefined) parts.push(`d=${params.depth}`);
 
   // Include the runtime content-limit settings so that changing them

--- a/apps/browser/src/backend/agents/shared/base-agent/file-read-transformer/preview-promotion.test.ts
+++ b/apps/browser/src/backend/agents/shared/base-agent/file-read-transformer/preview-promotion.test.ts
@@ -1,0 +1,357 @@
+/**
+ * Tests for the preview-promotion feature in fileReadTransformer.
+ *
+ * When a preview request targets a small text file, the pipeline
+ * promotes it to a full-content read. This saves a tool-call round-trip
+ * and aligns the cache key with subsequent full reads.
+ *
+ * Gates:
+ *   - must be in preview mode
+ *   - must not be a directory
+ *   - must not be a binary buffer
+ *   - file size <= PREVIEW_PROMOTION_MAX_BYTES (6 KB)
+ *   - line count <= PREVIEW_PROMOTION_MAX_LINES (150)
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import os from 'node:os';
+import path from 'node:path';
+import nodeFs from 'node:fs/promises';
+import { randomUUID, createHash } from 'node:crypto';
+import { FileReadCacheService } from '@/services/file-read-cache';
+import {
+  fileReadTransformer,
+  type FileReadTransformerOptions,
+  PREVIEW_PROMOTION_MAX_BYTES,
+  PREVIEW_PROMOTION_MAX_LINES,
+} from './index';
+
+// ---------------------------------------------------------------------------
+// Stubs
+// ---------------------------------------------------------------------------
+
+const noopLogger = {
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  log: () => {},
+  verboseMode: false,
+} as any;
+
+// ---------------------------------------------------------------------------
+// Test scaffolding (mirrors file-read-transformer.test.ts)
+// ---------------------------------------------------------------------------
+
+const testRoot = path.join(os.tmpdir(), 'frt-promotion-tests');
+
+interface TestContext {
+  cache: FileReadCacheService;
+  workDir: string;
+  mountPrefix: string;
+  mountPaths: Map<string, string>;
+  agentId: string;
+}
+
+async function setup(): Promise<TestContext> {
+  const id = randomUUID().slice(0, 8);
+  const workDir = path.join(testRoot, id);
+  await nodeFs.mkdir(workDir, { recursive: true });
+
+  const mountPrefix = `w${id.slice(0, 3)}`;
+
+  const cache = await FileReadCacheService.createWithUrl(
+    `file:${path.join(testRoot, `${id}.sqlite`)}`,
+    noopLogger,
+  );
+
+  return {
+    cache,
+    workDir,
+    mountPrefix,
+    mountPaths: new Map([[mountPrefix, workDir]]),
+    agentId: `agent-${id}`,
+  };
+}
+
+async function teardown(ctx: TestContext): Promise<void> {
+  await ctx.cache.teardown();
+}
+
+function sha256(content: string | Buffer): string {
+  return createHash('sha256')
+    .update(typeof content === 'string' ? Buffer.from(content) : content)
+    .digest('hex');
+}
+
+function makeBlobReader(
+  mountPaths: Map<string, string>,
+): (agentId: string, mountedPath: string) => Promise<Buffer> {
+  return async (_agentId: string, mountedPath: string) => {
+    const slashIdx = mountedPath.indexOf('/');
+    if (slashIdx <= 0) throw new Error(`Invalid path: ${mountedPath}`);
+    const prefix = mountedPath.slice(0, slashIdx);
+    const relative = mountedPath.slice(slashIdx + 1);
+    const root = mountPaths.get(prefix);
+    if (!root) throw new Error(`Unknown mount: ${prefix}`);
+    return nodeFs.readFile(path.join(root, relative));
+  };
+}
+
+function makeOpts(
+  ctx: TestContext,
+  mountedPath: string,
+  expectedHash: string,
+  readParams?: FileReadTransformerOptions['readParams'],
+): FileReadTransformerOptions {
+  return {
+    mountedPath,
+    expectedHash,
+    blobReader: makeBlobReader(ctx.mountPaths),
+    cache: ctx.cache,
+    logger: noopLogger,
+    agentId: ctx.agentId,
+    mountPaths: ctx.mountPaths,
+    readParams,
+  };
+}
+
+function allText(parts: any[]): string {
+  return parts
+    .filter((p: any) => p.type === 'text')
+    .map((p: any) => p.text)
+    .join('');
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('fileReadTransformer – preview promotion', () => {
+  let ctx: TestContext;
+  beforeEach(async () => {
+    ctx = await setup();
+  });
+  afterEach(async () => {
+    await teardown(ctx);
+  });
+
+  // -------------------------------------------------------------------------
+  // Promotion cases (small file → full read)
+  // -------------------------------------------------------------------------
+
+  it('promotes small text file preview to full content', async () => {
+    const content = `${Array.from({ length: 20 }, (_, i) => `line ${i + 1}`).join('\n')}\n`;
+    const filePath = path.join(ctx.workDir, 'small.txt');
+    await nodeFs.writeFile(filePath, content);
+    const hash = sha256(content);
+
+    const result = await fileReadTransformer(
+      makeOpts(ctx, `${ctx.mountPrefix}/small.txt`, hash, { preview: true }),
+    );
+
+    const text = allText(result.parts);
+
+    // Promoted → <content>, not <preview>
+    expect(text).toContain('<content>');
+    expect(text).toContain('</content>');
+    expect(text).not.toContain('<preview>');
+
+    // Full content delivered: all 20 lines present
+    expect(text).toContain('1|line 1');
+    expect(text).toContain('20|line 20');
+
+    // No "more lines" truncation indicator
+    expect(text).not.toMatch(/more lines/);
+  });
+
+  it('promotes small markdown file preview to full content', async () => {
+    const content =
+      '# Title\n\n' +
+      Array.from({ length: 30 }, (_, i) => `Paragraph ${i + 1}.`).join('\n') +
+      '\n';
+    const filePath = path.join(ctx.workDir, 'doc.md');
+    await nodeFs.writeFile(filePath, content);
+    const hash = sha256(content);
+
+    const result = await fileReadTransformer(
+      makeOpts(ctx, `${ctx.mountPrefix}/doc.md`, hash, { preview: true }),
+    );
+
+    const text = allText(result.parts);
+
+    // Promoted → <content>, no heading outline
+    expect(text).toContain('<content>');
+    expect(text).not.toContain('<preview>');
+    expect(text).not.toContain('<headings>');
+
+    // Full content: all paragraphs present
+    expect(text).toContain('Paragraph 1.');
+    expect(text).toContain('Paragraph 30.');
+  });
+
+  it('promotes small source-code file preview — no AST outline emitted', async () => {
+    const content =
+      `import { foo } from './foo';\n\n` +
+      `export function greet(name: string): string {\n` +
+      `  return \`Hello, \${name}!\`;\n` +
+      `}\n\n` +
+      `export class AppRouter {\n` +
+      `  handle(path: string): void {}\n` +
+      `}\n`;
+    const filePath = path.join(ctx.workDir, 'app.ts');
+    await nodeFs.writeFile(filePath, content);
+    const hash = sha256(content);
+
+    const result = await fileReadTransformer(
+      makeOpts(ctx, `${ctx.mountPrefix}/app.ts`, hash, { preview: true }),
+    );
+
+    const text = allText(result.parts);
+
+    // Promoted → full content, no AST outline
+    expect(text).toContain('<content>');
+    expect(text).not.toContain('<outline>');
+    expect(text).not.toContain('<preview>');
+    expect(text).not.toContain('source-outline');
+
+    // Full content delivered
+    expect(text).toContain("import { foo } from './foo';");
+    expect(text).toContain('export function greet');
+    expect(text).toContain('export class AppRouter');
+  });
+
+  // -------------------------------------------------------------------------
+  // Non-promotion cases (must still produce a preview)
+  // -------------------------------------------------------------------------
+
+  it('does NOT promote a file exceeding the line threshold', async () => {
+    // 300 lines > 150-line threshold
+    const content = `${Array.from({ length: 300 }, (_, i) => `line ${i + 1}`).join('\n')}\n`;
+    const filePath = path.join(ctx.workDir, 'big.txt');
+    await nodeFs.writeFile(filePath, content);
+    const hash = sha256(content);
+
+    const result = await fileReadTransformer(
+      makeOpts(ctx, `${ctx.mountPrefix}/big.txt`, hash, { preview: true }),
+    );
+
+    const text = allText(result.parts);
+
+    // Still in preview mode
+    expect(text).toContain('<preview>');
+    expect(text).not.toContain('<content>');
+
+    // Truncation indicator present
+    expect(text).toMatch(/more lines/);
+  });
+
+  it('does NOT promote a file exceeding the byte threshold', async () => {
+    // 20 lines but each very long → exceeds 6 KB byte threshold
+    const longLine = 'x'.repeat(500);
+    const content = `${Array.from({ length: 20 }, () => longLine).join('\n')}\n`;
+    const filePath = path.join(ctx.workDir, 'long-lines.txt');
+    await nodeFs.writeFile(filePath, content);
+    const hash = sha256(content);
+
+    expect(content.length).toBeGreaterThan(PREVIEW_PROMOTION_MAX_BYTES);
+
+    const result = await fileReadTransformer(
+      makeOpts(ctx, `${ctx.mountPrefix}/long-lines.txt`, hash, {
+        preview: true,
+      }),
+    );
+
+    const text = allText(result.parts);
+
+    // Still in preview mode — byte check blocked promotion
+    expect(text).toContain('<preview>');
+    expect(text).not.toContain('<content>');
+  });
+
+  it('does NOT promote a binary buffer with source-code extension', async () => {
+    // 1 KB binary buffer with a .ts extension
+    const bytes = Buffer.from(Array.from({ length: 1024 }, (_, i) => i % 256));
+    // Force a null byte pattern that triggers isBinaryBuffer
+    bytes[10] = 0x00;
+    bytes[20] = 0x00;
+    bytes[30] = 0x00;
+
+    const filePath = path.join(ctx.workDir, 'blob.ts');
+    await nodeFs.writeFile(filePath, bytes);
+    const hash = sha256(bytes);
+
+    const result = await fileReadTransformer(
+      makeOpts(ctx, `${ctx.mountPrefix}/blob.ts`, hash, { preview: true }),
+    );
+
+    const text = allText(result.parts);
+
+    // Binary guard kicks in — message from textTransformer
+    expect(text).toContain('Binary file');
+    expect(text).toContain('sandbox');
+    expect(text).not.toContain('<content>');
+  });
+
+  it('does NOT promote a line-range read (no preview flag)', async () => {
+    const content = `${Array.from({ length: 20 }, (_, i) => `line ${i + 1}`).join('\n')}\n`;
+    const filePath = path.join(ctx.workDir, 'range.txt');
+    await nodeFs.writeFile(filePath, content);
+    const hash = sha256(content);
+
+    const result = await fileReadTransformer(
+      makeOpts(ctx, `${ctx.mountPrefix}/range.txt`, hash, {
+        startLine: 5,
+        endLine: 10,
+      }),
+    );
+
+    const text = allText(result.parts);
+
+    // Line-range read — not a preview, so promotion doesn't apply.
+    // Content is sliced to lines 5-10.
+    expect(text).toContain('<content>');
+    expect(text).toContain('5|line 5');
+    expect(text).toContain('10|line 10');
+    expect(text).not.toMatch(/^1\|/m);
+  });
+
+  // -------------------------------------------------------------------------
+  // Threshold sanity checks
+  // -------------------------------------------------------------------------
+
+  it('exports sensible threshold constants', () => {
+    // Sanity: constants match plan-approved values.
+    expect(PREVIEW_PROMOTION_MAX_BYTES).toBe(6 * 1024);
+    expect(PREVIEW_PROMOTION_MAX_LINES).toBe(150);
+  });
+
+  // -------------------------------------------------------------------------
+  // Cache-key alignment: promoted preview + later full read share a key
+  // -------------------------------------------------------------------------
+
+  it('promoted preview shares cache key with subsequent full read', async () => {
+    const content = `${Array.from({ length: 25 }, (_, i) => `line ${i + 1}`).join('\n')}\n`;
+    const filePath = path.join(ctx.workDir, 'shared.txt');
+    await nodeFs.writeFile(filePath, content);
+    const hash = sha256(content);
+
+    // First: promoted preview request
+    const r1 = await fileReadTransformer(
+      makeOpts(ctx, `${ctx.mountPrefix}/shared.txt`, hash, { preview: true }),
+    );
+
+    // Second: explicit full read
+    const r2 = await fileReadTransformer(
+      makeOpts(ctx, `${ctx.mountPrefix}/shared.txt`, hash, {}),
+    );
+
+    const t1 = allText(r1.parts);
+    const t2 = allText(r2.parts);
+
+    // Both should be identical full-content reads (same cache key).
+    expect(t1).toBe(t2);
+    expect(t1).toContain('<content>');
+    expect(t1).not.toContain('<preview>');
+  });
+});

--- a/apps/browser/src/backend/agents/shared/base-agent/file-read-transformer/transformers/index.ts
+++ b/apps/browser/src/backend/agents/shared/base-agent/file-read-transformer/transformers/index.ts
@@ -12,3 +12,4 @@ export { pdfTransformer } from './pdf';
 export { archiveTransformer } from './archive';
 export { rawImageTransformer } from './raw-image';
 export { diskImageTransformer } from './disk-image';
+export { sourceCodeTransformer } from './source-code';

--- a/apps/browser/src/backend/agents/shared/base-agent/file-read-transformer/transformers/source-code.test.ts
+++ b/apps/browser/src/backend/agents/shared/base-agent/file-read-transformer/transformers/source-code.test.ts
@@ -1,0 +1,456 @@
+/**
+ * Tests for the source-code transformer.
+ *
+ * Covers AST-based preview, line-based fallback, full/range reads,
+ * and binary delegation. Requires `web-tree-sitter` and
+ * `@vscode/tree-sitter-wasm` to be installed for the AST-specific
+ * tests; those are skipped if WASM loading fails at suite startup.
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import type { TransformerContext, ReadParams } from '../types';
+import { sourceCodeTransformer } from './source-code';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const noopLogger = {
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  log: () => {},
+  verboseMode: false,
+} as any;
+
+function makeCtx(readParams: ReadParams = {}): TransformerContext {
+  return {
+    agentId: 'test-agent',
+    mountPaths: new Map(),
+    cache: {} as any,
+    logger: noopLogger,
+    readParams,
+    maxReadChars: 500 * 80,
+    maxPreviewLines: 30,
+  };
+}
+
+function makeStats(buf: Buffer) {
+  return {
+    size: buf.length,
+    mtime: new Date('2025-01-01T00:00:00Z'),
+    isDirectory: false,
+  };
+}
+
+function allText(parts: any[]): string {
+  return parts
+    .filter((p: any) => p.type === 'text')
+    .map((p: any) => p.text)
+    .join('');
+}
+
+// ---------------------------------------------------------------------------
+// Sample source code
+// ---------------------------------------------------------------------------
+
+// Filler to push fixture past the preview-promotion line threshold
+// (150 lines). Without this, small fixtures get promoted to full
+// reads and preview-specific assertions fail.
+const TS_FILLER = Array.from(
+  { length: 160 },
+  (_, i) => `// filler comment line ${i + 1}`,
+).join('\n');
+
+const TS_SOURCE = `import { foo } from './foo';
+
+export function greet(name: string): string {
+  return \`Hello, \${name}!\`;
+}
+
+export class AppRouter {
+  private routes: Map<string, Function>;
+
+  constructor() {
+    this.routes = new Map();
+  }
+
+  handle(path: string): void {
+    // handle route
+  }
+
+  use(middleware: Function): void {
+    // use middleware
+  }
+}
+
+export interface AppConfig {
+  port: number;
+  host: string;
+}
+
+export type Route = {
+  path: string;
+  handler: Function;
+};
+
+const INTERNAL_CONSTANT = 42;
+
+enum Status {
+  Active,
+  Inactive,
+}
+
+${TS_FILLER}
+`;
+
+const PY_FILLER = Array.from(
+  { length: 160 },
+  (_, i) => `# filler comment line ${i + 1}`,
+).join('\n');
+
+const PY_SOURCE = `import os
+from typing import Optional
+
+def greet(name: str) -> str:
+    return f"Hello, {name}!"
+
+class AppRouter:
+    def __init__(self):
+        self.routes = {}
+
+    def handle(self, path: str) -> None:
+        pass
+
+    def use(self, middleware) -> None:
+        pass
+
+class Config:
+    port: int = 8080
+
+${PY_FILLER}
+`;
+
+// ---------------------------------------------------------------------------
+// Tests: AST-based preview
+// ---------------------------------------------------------------------------
+
+describe('sourceCodeTransformer', () => {
+  // -------------------------------------------------------------------
+  // One-time WASM environment probe.
+  // Confirms that web-tree-sitter initialises and produces an AST
+  // outline. When the probe fails (missing WASM, CI sandbox, etc.),
+  // all AST-specific tests are skipped — visibly, via ctx.skip().
+  // When the probe passes, every subsequent test hard-asserts on
+  // outline output so regressions are never silently green.
+  // -------------------------------------------------------------------
+  let astAvailable = false;
+
+  beforeAll(async () => {
+    try {
+      const buf = Buffer.from(TS_SOURCE);
+      const ctx = makeCtx({ preview: true });
+      const result = await sourceCodeTransformer(
+        buf,
+        'test/probe.ts',
+        makeStats(buf),
+        ctx,
+      );
+      astAvailable = allText(result.parts).includes('<outline>');
+    } catch {
+      astAvailable = false;
+    }
+    if (!astAvailable) {
+      console.warn(
+        'AST tests will be skipped — web-tree-sitter WASM not available in test env',
+      );
+    }
+  });
+
+  describe('preview mode — AST outline', () => {
+    it('produces AST outline for TypeScript', async (ctx) => {
+      if (!astAvailable) ctx.skip();
+
+      const buf = Buffer.from(TS_SOURCE);
+      const mCtx = makeCtx({ preview: true });
+      const result = await sourceCodeTransformer(
+        buf,
+        'test/app.ts',
+        makeStats(buf),
+        mCtx,
+      );
+      const text = allText(result.parts);
+
+      expect(text).toContain('<outline>');
+      expect(text).toContain('</outline>');
+
+      // Should contain key symbols with signatures
+      expect(text).toContain('function greet(name: string): string');
+      expect(text).toContain('class AppRouter');
+      expect(text).toContain('interface AppConfig');
+      expect(text).toContain('type Route');
+
+      // Signatures preserve the source-level export keyword
+      expect(text).toContain('export function greet');
+      expect(text).toContain('export class AppRouter');
+
+      // Should contain class member signatures (no "method" kind prefix)
+      expect(text).toContain('handle(path: string): void');
+      expect(text).toContain('use(middleware: Function): void');
+
+      // Should NOT contain line-numbered content (outline-only)
+      expect(text).not.toMatch(/^1\|/m);
+
+      // Metadata should indicate source-outline format
+      expect(result.metadata.format).toBe('source-outline');
+      expect(result.metadata.language).toBe('typescript');
+      expect(result.metadata.preview).toBe('true');
+
+      // Should report effective read params
+      expect(result.effectiveReadParams?.preview).toBe(true);
+    });
+
+    it('produces AST outline for Python', async (ctx) => {
+      if (!astAvailable) ctx.skip();
+
+      const buf = Buffer.from(PY_SOURCE);
+      const mCtx = makeCtx({ preview: true });
+      const result = await sourceCodeTransformer(
+        buf,
+        'test/app.py',
+        makeStats(buf),
+        mCtx,
+      );
+      const text = allText(result.parts);
+
+      expect(text).toContain('<outline>');
+
+      // Should contain signatures (Python: stripped trailing ':')
+      expect(text).toContain('def greet(name: str) -> str');
+      expect(text).toContain('class AppRouter');
+      expect(text).toContain('class Config');
+
+      // Class method signatures
+      expect(text).toContain('def __init__(self)');
+      expect(text).toContain('def handle(self, path: str) -> None');
+
+      expect(result.metadata.language).toBe('python');
+      expect(result.metadata.format).toBe('source-outline');
+    });
+
+    it('falls back to line-based preview on unsupported extension', async () => {
+      const htmlSource = '<html><head><title>Hello</title></head></html>\n';
+      const buf = Buffer.from(htmlSource);
+      const ctx = makeCtx({ preview: true });
+
+      // .html has no grammar → should fall through to line-based preview
+      const result = await sourceCodeTransformer(
+        buf,
+        'test/index.html',
+        makeStats(buf),
+        ctx,
+      );
+
+      const text = allText(result.parts);
+
+      // Should NOT contain an outline (no grammar for HTML)
+      expect(text).not.toContain('<outline>');
+
+      // Should contain line-numbered content
+      expect(text).toMatch(/1\|/);
+
+      expect(result.metadata.preview).toBe('true');
+      // Should not have source-outline format
+      expect(result.metadata.format).toBeUndefined();
+    });
+
+    it('falls back to line-based preview on parse failure', async () => {
+      // A buffer that decodes as UTF-8 but is nonsensical for TS parsing.
+      // Tree-sitter should still parse it (it's very tolerant), but
+      // we test with an empty file which yields zero symbols.
+      const buf = Buffer.from('');
+      const ctx = makeCtx({ preview: true });
+
+      const result = await sourceCodeTransformer(
+        buf,
+        'test/empty.ts',
+        makeStats(buf),
+        ctx,
+      );
+
+      const text = allText(result.parts);
+
+      // Empty file → zero symbols → should fall through to line-based
+      expect(text).not.toContain('<outline>');
+      expect(result.metadata.preview).toBe('true');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Outline truncation — depth pruning
+  // -------------------------------------------------------------------------
+
+  describe('outline truncation', () => {
+    it('prunes deeper members before dropping top-level symbols', async (ctx) => {
+      if (!astAvailable) ctx.skip();
+
+      const buf = Buffer.from(TS_SOURCE);
+      // Use a tight budget: enough for top-level symbols (~250 chars)
+      // but not the class members (~165 chars extra). This forces
+      // depth pruning while keeping all 6 top-level symbols.
+      const mCtx = makeCtx({ preview: true });
+      mCtx.maxReadChars = 300;
+
+      const result = await sourceCodeTransformer(
+        buf,
+        'test/app.ts',
+        makeStats(buf),
+        mCtx,
+      );
+      const text = allText(result.parts);
+
+      expect(text).toContain('<outline>');
+
+      // Top-level symbols should still be present
+      expect(text).toContain('function greet');
+      expect(text).toContain('class AppRouter');
+      expect(text).toContain('interface AppConfig');
+      expect(text).toContain('type Route');
+
+      // Truncation notice should be present
+      expect(text).toContain('outline truncated');
+    });
+
+    it('shows hard-cutoff notice when top-level alone exceeds budget', async (ctx) => {
+      if (!astAvailable) ctx.skip();
+
+      const buf = Buffer.from(TS_SOURCE);
+      // Extremely tiny budget — can't even fit all top-level symbols.
+      const mCtx = makeCtx({ preview: true });
+      mCtx.maxReadChars = 150;
+
+      const result = await sourceCodeTransformer(
+        buf,
+        'test/app.ts',
+        makeStats(buf),
+        mCtx,
+      );
+      const text = allText(result.parts);
+
+      expect(text).toContain('<outline>');
+
+      // Should show hard-cutoff notice
+      expect(text).toContain('more top-level symbols not shown');
+    });
+
+    it('produces identical output when everything fits', async (ctx) => {
+      if (!astAvailable) ctx.skip();
+
+      const buf = Buffer.from(TS_SOURCE);
+      // Very generous budget — nothing should be pruned.
+      const mCtx = makeCtx({ preview: true });
+      mCtx.maxReadChars = 100_000;
+
+      const result = await sourceCodeTransformer(
+        buf,
+        'test/app.ts',
+        makeStats(buf),
+        mCtx,
+      );
+      const text = allText(result.parts);
+
+      expect(text).toContain('<outline>');
+
+      // No truncation notices
+      expect(text).not.toContain('outline truncated');
+      expect(text).not.toContain('not shown');
+
+      // All symbols present including children
+      expect(text).toContain('function greet');
+      expect(text).toContain('class AppRouter');
+      expect(text).toContain('handle(path: string)');
+      expect(text).toContain('use(middleware: Function)');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Non-preview reads
+  // -------------------------------------------------------------------------
+
+  describe('non-preview reads', () => {
+    it('full read returns line-numbered text', async () => {
+      const buf = Buffer.from(TS_SOURCE);
+      const ctx = makeCtx(); // no preview
+
+      const result = await sourceCodeTransformer(
+        buf,
+        'test/app.ts',
+        makeStats(buf),
+        ctx,
+      );
+
+      const text = allText(result.parts);
+
+      // Should have line numbers
+      expect(text).toMatch(/^1\|/);
+      expect(text).toContain("import { foo } from './foo';");
+
+      // Should NOT have outline
+      expect(text).not.toContain('<outline>');
+
+      expect(result.metadata.language).toBe('typescript');
+      expect(result.metadata.lines).toBeDefined();
+    });
+
+    it('line-range read returns sliced content', async () => {
+      const buf = Buffer.from(TS_SOURCE);
+      const ctx = makeCtx({ startLine: 3, endLine: 5 });
+
+      const result = await sourceCodeTransformer(
+        buf,
+        'test/app.ts',
+        makeStats(buf),
+        ctx,
+      );
+
+      const text = allText(result.parts);
+
+      // Should start at line 3
+      expect(text).toMatch(/^3\|/);
+
+      // Should NOT contain line 1 content
+      expect(text).not.toContain('1|import');
+
+      expect(result.effectiveReadParams?.startLine).toBe(3);
+      expect(result.effectiveReadParams?.endLine).toBe(5);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Binary guard
+  // -------------------------------------------------------------------------
+
+  describe('binary guard', () => {
+    it('delegates binary buffer to text transformer', async () => {
+      // Create a buffer with null bytes (binary indicator)
+      const binaryBuf = Buffer.from([
+        0x00, 0x01, 0x02, 0x03, 0xff, 0xfe, 0x00, 0x00,
+      ]);
+      const ctx = makeCtx({ preview: true });
+
+      const result = await sourceCodeTransformer(
+        binaryBuf,
+        'test/app.ts',
+        makeStats(binaryBuf),
+        ctx,
+      );
+
+      const text = allText(result.parts);
+
+      // Should get the binary file message from text transformer
+      expect(text).toContain('Binary file');
+      expect(text).toContain('sandbox');
+    });
+  });
+});

--- a/apps/browser/src/backend/agents/shared/base-agent/file-read-transformer/transformers/source-code.ts
+++ b/apps/browser/src/backend/agents/shared/base-agent/file-read-transformer/transformers/source-code.ts
@@ -1,0 +1,246 @@
+/**
+ * Source-code transformer.
+ *
+ * Handles source files for which a Tree-sitter grammar is available
+ * (TypeScript, Python, Go, Rust, Java, C/C++, Ruby, PHP, C#, CSS,
+ * Shell/Bash, etc.).
+ *
+ * Behaviour:
+ *   - `preview: true` → AST-based symbol outline (`<outline>…</outline>`).
+ *     Falls back to line-based preview when parsing fails or yields
+ *     zero symbols.
+ *   - `startLine` / `endLine` → line-range slice via `truncateTextContent`.
+ *   - Full read (no params) → full text via `truncateTextContent`.
+ *
+ * Binary files are delegated to `textTransformer`.
+ */
+
+import nodePath from 'node:path';
+import type {
+  FileTransformer,
+  FileTransformResult,
+  ReadParams,
+} from '../types';
+import {
+  baseMetadata,
+  inferLanguage,
+  prefixLineNumbers,
+  isBinaryBuffer,
+  truncateTextContent,
+} from '../format-utils';
+import { getFileSymbols, type SymbolInfo } from '../ast';
+
+// ---------------------------------------------------------------------------
+// Outline formatting
+// ---------------------------------------------------------------------------
+
+/**
+ * Tagged outline entry produced during the full render pass.
+ */
+interface OutlineEntry {
+  text: string;
+  depth: number;
+  /** Character cost including the trailing newline. */
+  cost: number;
+}
+
+/**
+ * Render a `SymbolInfo[]` tree as a compact outline string.
+ *
+ * Strategy: render the complete tree first, then prune the deepest
+ * nesting levels until the output fits within `maxChars`. This
+ * guarantees all top-level symbols remain visible before any nested
+ * detail, giving the model a broad file map rather than a deep dump
+ * of only the first symbol.
+ *
+ * When pruning occurs a truncation notice is appended so the model
+ * knows the outline is incomplete.
+ */
+function formatSymbolOutline(symbols: SymbolInfo[], maxChars: number): string {
+  if (symbols.length === 0) return '';
+
+  // ── 1. Full depth-first render (no budget check) ──────────────────
+  const entries: OutlineEntry[] = [];
+  let maxDepthSeen = 0;
+
+  function renderSymbol(sym: SymbolInfo, depth: number): void {
+    const indent = '  '.repeat(depth);
+
+    const display = sym.signature || `${sym.kind} ${sym.name}`;
+
+    const text = `${indent}${display} (line ${sym.line + 1})`;
+    entries.push({ text, depth, cost: text.length + 1 });
+    if (depth > maxDepthSeen) maxDepthSeen = depth;
+
+    if (sym.children) {
+      for (const child of sym.children) {
+        renderSymbol(child, depth + 1);
+      }
+    }
+  }
+
+  for (const sym of symbols) {
+    renderSymbol(sym, 1);
+  }
+
+  // ── 2. Prune deepest levels until budget fits ─────────────────────
+  let kept = entries;
+  let totalCost = kept.reduce((sum, e) => sum + e.cost, 0);
+  let depthPruned = false;
+
+  while (totalCost > maxChars && maxDepthSeen > 1) {
+    kept = kept.filter((e) => e.depth < maxDepthSeen);
+    totalCost = kept.reduce((sum, e) => sum + e.cost, 0);
+    maxDepthSeen--;
+    depthPruned = true;
+  }
+
+  // ── 3. Hard cutoff if depth-1-only still overflows ────────────────
+  let hardCutoffCount = 0;
+  if (totalCost > maxChars && kept.length > 1) {
+    let budget = maxChars;
+    let cutIdx = kept.length;
+    for (let i = 0; i < kept.length; i++) {
+      budget -= kept[i].cost;
+      if (budget < 0) {
+        cutIdx = i;
+        break;
+      }
+    }
+    hardCutoffCount = kept.length - cutIdx;
+    kept = kept.slice(0, cutIdx);
+  }
+
+  // ── 4. Build outline string with truncation notice ────────────────
+  const body = kept.map((e) => e.text).join('\n');
+  const notices: string[] = [];
+
+  if (depthPruned) {
+    notices.push(
+      '  … (outline truncated — deeper members omitted to fit budget)',
+    );
+  }
+  if (hardCutoffCount > 0) {
+    notices.push(`  … (${hardCutoffCount} more top-level symbols not shown)`);
+  }
+
+  const suffix = notices.length > 0 ? `\n${notices.join('\n')}` : '';
+  return `<outline>\n${body}${suffix}\n</outline>`;
+}
+
+// ---------------------------------------------------------------------------
+// Line-based preview fallback (mirrors textTransformer preview logic)
+// ---------------------------------------------------------------------------
+
+function lineBasedPreview(
+  allLines: readonly string[],
+  totalLines: number,
+  maxPreviewLines: number,
+): { output: string; effectiveReadParams: ReadParams } {
+  const previewEnd = Math.min(maxPreviewLines, totalLines);
+  const slice = allLines.slice(0, previewEnd);
+  let numbered = prefixLineNumbers(slice.join('\n'), 1);
+
+  if (totalLines > previewEnd) {
+    numbered += `\n… (${totalLines - previewEnd} more lines)`;
+  }
+
+  return {
+    output: numbered,
+    effectiveReadParams: {
+      preview: true,
+      startLine: 1,
+      endLine: previewEnd,
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Main transformer
+// ---------------------------------------------------------------------------
+
+export const sourceCodeTransformer: FileTransformer = async (
+  buf,
+  mountedPath,
+  stats,
+  ctx,
+  originalFileName,
+): Promise<FileTransformResult> => {
+  // Guard: if the buffer is actually binary despite the source extension,
+  // fall back to the text transformer which handles binary gracefully.
+  if (isBinaryBuffer(buf)) {
+    const { textTransformer } = await import('./text');
+    return textTransformer(buf, mountedPath, stats, ctx, originalFileName);
+  }
+
+  const metadata = baseMetadata(stats.size, stats.mtime);
+
+  const nameForExt = originalFileName ?? mountedPath;
+  const ext = nodePath.extname(nameForExt).toLowerCase();
+
+  const text = buf.toString('utf-8');
+  const allLines = text.split('\n');
+  const totalLines = allLines.length;
+
+  const language = inferLanguage(ext);
+  if (language) metadata.language = language;
+  metadata.lines = String(totalLines);
+  metadata.chars = String(text.length);
+
+  const { preview } = ctx.readParams;
+
+  // ── Preview mode — AST-based symbol outline ──────────────────────
+  if (preview) {
+    metadata.preview = 'true';
+
+    try {
+      // Strip leading dot for the AST module (expects 'ts', not '.ts').
+      const extNoDot = ext.startsWith('.') ? ext.slice(1) : ext;
+      const parsed = await getFileSymbols(text, extNoDot);
+
+      if (parsed && parsed.symbols.length > 0) {
+        metadata.format = 'source-outline';
+
+        const outline = formatSymbolOutline(parsed.symbols, ctx.maxReadChars);
+
+        const effectiveReadParams: ReadParams = {
+          preview: true,
+        };
+
+        return {
+          metadata,
+          parts: [{ type: 'text', text: outline }],
+          effectiveReadParams,
+        };
+      }
+    } catch {
+      // AST parsing failed — fall through to line-based preview.
+    }
+
+    // Fallback: line-based preview (same as textTransformer).
+    const { output, effectiveReadParams } = lineBasedPreview(
+      allLines,
+      totalLines,
+      ctx.maxPreviewLines,
+    );
+
+    return {
+      metadata,
+      parts: [{ type: 'text', text: output }],
+      effectiveReadParams,
+    };
+  }
+
+  // ── Line-range and full content (via shared helper) ────────────────
+  const { output, effectiveReadParams } = truncateTextContent(
+    allLines,
+    ctx.readParams,
+    ctx.maxReadChars,
+  );
+
+  return {
+    metadata,
+    parts: [{ type: 'text', text: output }],
+    effectiveReadParams,
+  };
+};

--- a/apps/browser/src/backend/services/toolbox/tools/file-modification/read.ts
+++ b/apps/browser/src/backend/services/toolbox/tools/file-modification/read.ts
@@ -11,7 +11,11 @@ import { resolveMountedRelativePath } from '../../utils/path-mounting';
 
 export const DESCRIPTION = `Read metadata and contents of a file. Equals \`cat\` / \`echo\` in bash. For directories, use \`ls\` instead.
 If the file is not in context after the tool call, this **ALWAYS** implies that the file has **NOT** changed since the last read that is already in your context!
-Large files are truncated to a dynamic token budget. To read a large file efficiently, issue multiple parallel read calls with non-overlapping \`start_line\`/\`end_line\` ranges.`;
+Large files are truncated to a dynamic token budget. To read a large file efficiently, issue multiple parallel read calls with non-overlapping \`start_line\`/\`end_line\` ranges.
+
+The \`preview\` parameter controls the output format:
+- **\`preview: true\`** — Returns a structural outline instead of raw content. For source code files (ts, tsx, js, jsx, py, go, rs, java, c, cpp, cs, rb, php, sh, css), produces an AST-based symbol outline listing functions, classes, interfaces, types, and exports with their signatures and line numbers. For markdown files, produces a heading outline. For other text files, returns a short line-head summary. Small files (≤150 lines / ≤6 KB) are auto-promoted to full content regardless.
+- **\`preview: false\` (default)** — Returns the full file content, line-numbered and truncated to budget.`;
 
 /**
  * Read tool

--- a/apps/browser/src/shared/ast/language-map.ts
+++ b/apps/browser/src/shared/ast/language-map.ts
@@ -1,0 +1,62 @@
+export interface LanguageGrammar {
+  grammarFile: string;
+  label: string;
+}
+
+export const LANGUAGE_MAP: Record<string, LanguageGrammar | null> = {
+  ts: { grammarFile: 'tree-sitter-typescript.wasm', label: 'TypeScript' },
+  tsx: { grammarFile: 'tree-sitter-tsx.wasm', label: 'TypeScript React' },
+  js: {
+    grammarFile: 'tree-sitter-javascript.wasm',
+    label: 'JavaScript',
+  },
+  jsx: {
+    grammarFile: 'tree-sitter-javascript.wasm',
+    label: 'JavaScript React',
+  },
+  mjs: {
+    grammarFile: 'tree-sitter-javascript.wasm',
+    label: 'JavaScript',
+  },
+  cjs: {
+    grammarFile: 'tree-sitter-javascript.wasm',
+    label: 'JavaScript',
+  },
+  py: { grammarFile: 'tree-sitter-python.wasm', label: 'Python' },
+  go: { grammarFile: 'tree-sitter-go.wasm', label: 'Go' },
+  rs: { grammarFile: 'tree-sitter-rust.wasm', label: 'Rust' },
+  java: { grammarFile: 'tree-sitter-java.wasm', label: 'Java' },
+  css: { grammarFile: 'tree-sitter-css.wasm', label: 'CSS' },
+  scss: null,
+  less: null,
+  sh: { grammarFile: 'tree-sitter-bash.wasm', label: 'Shell' },
+  bash: { grammarFile: 'tree-sitter-bash.wasm', label: 'Bash' },
+  zsh: { grammarFile: 'tree-sitter-bash.wasm', label: 'Zsh' },
+  rb: { grammarFile: 'tree-sitter-ruby.wasm', label: 'Ruby' },
+  php: { grammarFile: 'tree-sitter-php.wasm', label: 'PHP' },
+  cs: { grammarFile: 'tree-sitter-c-sharp.wasm', label: 'C#' },
+  cpp: { grammarFile: 'tree-sitter-cpp.wasm', label: 'C++' },
+  c: { grammarFile: 'tree-sitter-cpp.wasm', label: 'C' },
+  h: { grammarFile: 'tree-sitter-cpp.wasm', label: 'C Header' },
+  hpp: { grammarFile: 'tree-sitter-cpp.wasm', label: 'C++ Header' },
+  // No grammar available in @vscode/tree-sitter-wasm
+  html: null,
+  xml: null,
+  svg: null,
+  json: null,
+  yaml: null,
+  yml: null,
+  toml: null,
+  md: null,
+  mdx: null,
+  sql: null,
+  kt: null,
+  scala: null,
+  swift: null,
+  vue: null,
+  svelte: null,
+};
+
+export function getLanguageForExt(ext: string): LanguageGrammar | null {
+  return LANGUAGE_MAP[ext] ?? null;
+}

--- a/apps/browser/src/shared/ast/types.ts
+++ b/apps/browser/src/shared/ast/types.ts
@@ -1,0 +1,26 @@
+export enum SymbolKind {
+  Function = 'function',
+  Class = 'class',
+  Interface = 'interface',
+  Type = 'type',
+  Enum = 'enum',
+  Variable = 'variable',
+  Method = 'method',
+  Property = 'property',
+  CssSelector = 'css-selector',
+}
+
+export interface SymbolInfo {
+  name: string;
+  kind: SymbolKind;
+  exported: boolean;
+  line: number;
+  /** Source signature (text before body), e.g. "function greet(name: string): string". */
+  signature?: string;
+  children?: SymbolInfo[];
+}
+
+export interface ParsedFileSymbols {
+  language: string;
+  symbols: SymbolInfo[];
+}

--- a/apps/browser/src/shared/karton-contracts/ui/agent/tools/types.ts
+++ b/apps/browser/src/shared/karton-contracts/ui/agent/tools/types.ts
@@ -80,7 +80,7 @@ export const readToolInputSchema = z.object({
     .default(false)
     .optional()
     .describe(
-      'Only request a short preview of the file structure and heavily truncated content instead of full content.',
+      'Only request a short preview of the file structure and heavily truncated content instead of full content. For source code, returns an AST symbol outline (functions, classes, signatures, line numbers). For markdown, returns a heading outline. Small files are auto-promoted to full content.',
     ),
 });
 

--- a/apps/browser/vite.backend.config.ts
+++ b/apps/browser/vite.backend.config.ts
@@ -14,7 +14,14 @@ export default defineConfig({
       fileName: 'main',
     },
     rollupOptions: {
-      external: ['@libsql/client', 'sharp', 'node-pty', '@xterm/headless'],
+      external: [
+        '@libsql/client',
+        'sharp',
+        'node-pty',
+        '@xterm/headless',
+        'web-tree-sitter',
+        '@vscode/tree-sitter-wasm',
+      ],
     },
   },
   resolve: {

--- a/apps/browser/vitest.config.ts
+++ b/apps/browser/vitest.config.ts
@@ -2,6 +2,11 @@ import { defineConfig } from 'vitest/config';
 import path from 'node:path';
 
 export default defineConfig({
+  ssr: {
+    // web-tree-sitter ships WASM and uses CJS patterns — let Node
+    // resolve it natively instead of Vite trying to transform it.
+    external: ['web-tree-sitter'],
+  },
   test: {
     globals: true,
     environment: 'node',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -179,6 +179,9 @@ importers:
       '@tiptap/markdown':
         specifier: ^3.20.0
         version: 3.20.0(@tiptap/core@3.20.0(@tiptap/pm@3.20.0))(@tiptap/pm@3.20.0)
+      '@vscode/tree-sitter-wasm':
+        specifier: ^0.3.0
+        version: 0.3.1
       '@xterm/headless':
         specifier: ^6.0.0
         version: 6.0.0
@@ -224,6 +227,9 @@ importers:
       tiptap-markdown:
         specifier: ^0.9.0
         version: 0.9.0(@tiptap/core@3.20.0(@tiptap/pm@3.20.0))
+      web-tree-sitter:
+        specifier: ^0.26.6
+        version: 0.26.8
       yauzl:
         specifier: ^3.2.0
         version: 3.2.0
@@ -4631,6 +4637,9 @@ packages:
 
   '@vscode/sudo-prompt@9.3.1':
     resolution: {integrity: sha512-9ORTwwS74VaTn38tNbQhsA5U44zkJfcb0BdTSyyG6frP4e8KMtHuTXYmwefe5dpL8XB1aGSIVTaLjD3BbWb5iA==}
+
+  '@vscode/tree-sitter-wasm@0.3.1':
+    resolution: {integrity: sha512-RJFoomET6FajjG511fmQxeBQfU6M24a0aFZPqpid+ttIxanWf1VGytBG0UmsGjt07qmIPJS8U31D+aecuCucsQ==}
 
   '@vueless/storybook-dark-mode@10.0.4':
     resolution: {integrity: sha512-0sNP9i7OkjVx+0JqKipd3rlaulv0bxcZFZ7OQL5+8Z2VXrQQR+jLBclRoLlZCoRA/wnNZA/gjia8dI8aqiF+DA==}
@@ -10744,6 +10753,9 @@ packages:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
 
+  web-tree-sitter@0.26.8:
+    resolution: {integrity: sha512-4sUwi7ZyOrIk5KLgYLkc2A/F0LFMQnBhfb+2Cdl7ik4ePJ6JD+fk4ofI2sA5eGawBKBaK4Vntt7Ww5KcEsay4A==}
+
   web-vitals@4.2.4:
     resolution: {integrity: sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw==}
 
@@ -14977,6 +14989,8 @@ snapshots:
       tinyrainbow: 2.0.0
 
   '@vscode/sudo-prompt@9.3.1': {}
+
+  '@vscode/tree-sitter-wasm@0.3.1': {}
 
   '@vueless/storybook-dark-mode@10.0.4(storybook@10.1.11(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.7.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@6.0.6))':
     dependencies:
@@ -22275,6 +22289,8 @@ snapshots:
   web-namespaces@2.0.1: {}
 
   web-streams-polyfill@3.3.3: {}
+
+  web-tree-sitter@0.26.8: {}
 
   web-vitals@4.2.4: {}
 


### PR DESCRIPTION
…src code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AST-based source-code outline previews with symbol extraction, signatures, hierarchical members, and language detection; preview falls back to line-based summaries for unsupported inputs.
  * New source-code transformer with preview/full-read promotion and binary-safe handling; preview promotion thresholds added (6KB / 150 lines).

* **Tests**
  * Extensive tests for symbol extraction, outline generation, preview-promotion, truncation, fallbacks and binary handling.

* **Chores**
  * Bundling/packaging updated to include Tree-sitter WASM runtimes and unpack them at runtime.
  * Read-tool docs and preview schema descriptions updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->