### PR TITLE
fix(stagewise): fix-windows-shell-startup

### DIFF
--- a/apps/browser/src/backend/services/toolbox/services/shell/detect-shell.ts
+++ b/apps/browser/src/backend/services/toolbox/services/shell/detect-shell.ts
@@ -58,11 +58,14 @@ function whereLookup(binary: string): string | null {
 }
 
 function detectGitBashWindows(): string | null {
-  const commonPaths = [
-    'C:\\Program Files\\Git\\bin\\bash.exe',
-    'C:\\Program Files (x86)\\Git\\bin\\bash.exe',
-  ];
-  for (const p of commonPaths) {
+  const candidates: string[] = [];
+  const programFiles = process.env.ProgramFiles;
+  const programFilesX86 = process.env['ProgramFiles(x86)'];
+  if (programFiles)
+    candidates.push(path.join(programFiles, 'Git', 'bin', 'bash.exe'));
+  if (programFilesX86)
+    candidates.push(path.join(programFilesX86, 'Git', 'bin', 'bash.exe'));
+  for (const p of candidates) {
     if (fileExists(p)) return p;
   }
 

--- a/apps/browser/src/backend/services/toolbox/services/shell/index.ts
+++ b/apps/browser/src/backend/services/toolbox/services/shell/index.ts
@@ -142,7 +142,7 @@ export class ShellService extends DisposableService {
       };
     }
 
-    const env = sanitizeEnv(this.resolvedEnv);
+    const env = sanitizeEnv(this.resolvedEnv, this.shell.type);
 
     // Build a streaming callback targeting the current toolCallId
     const makeOnData = (targetToolCallId: string) => {

--- a/apps/browser/src/backend/services/toolbox/services/shell/normalize-windows-path.ts
+++ b/apps/browser/src/backend/services/toolbox/services/shell/normalize-windows-path.ts
@@ -1,0 +1,30 @@
+/**
+ * Normalize the Windows `Path` / `PATH` variable in-place.
+ *
+ * Windows env vars are case-insensitive, but Node preserves whatever casing
+ * the native env block has (usually mixed-case `Path`). MSYS2 / Git Bash
+ * reads only uppercase `PATH`. This helper:
+ *
+ * 1. If only `Path` exists → promotes it to `PATH`.
+ * 2. If both exist with different values → merges and deduplicates
+ *    (case-insensitive, semicolon-delimited).
+ * 3. Deletes the mixed-case `Path` key so downstream consumers see a single
+ *    canonical `PATH`.
+ */
+export function normalizeWindowsPath(env: Record<string, string>): void {
+  if (env.Path && !env.PATH) {
+    env.PATH = env.Path;
+  } else if (env.Path && env.PATH && env.Path !== env.PATH) {
+    const seen = new Set<string>();
+    env.PATH = `${env.PATH};${env.Path}`
+      .split(';')
+      .filter((p) => {
+        const k = p.toLowerCase();
+        if (!p || seen.has(k)) return false;
+        seen.add(k);
+        return true;
+      })
+      .join(';');
+  }
+  delete env.Path;
+}

--- a/apps/browser/src/backend/services/toolbox/services/shell/resolve-shell-env.ts
+++ b/apps/browser/src/backend/services/toolbox/services/shell/resolve-shell-env.ts
@@ -1,5 +1,6 @@
 import { spawn } from 'node:child_process';
 import { homedir, userInfo } from 'node:os';
+import { normalizeWindowsPath } from './normalize-windows-path';
 import type { DetectedShell } from './types';
 
 const DEFAULT_RESOLVE_TIMEOUT_MS = 10_000;
@@ -32,18 +33,124 @@ function parseEnv0(raw: string): Record<string, string> {
 }
 
 /**
- * Resolve the user's full shell environment by spawning a login shell
- * and capturing its environment via `env -0`.
+ * Parse `cmd.exe /d /c set` output into a key-value record.
+ * Each line is `KEY=VALUE`. Values may contain `=`; the first `=` is the split.
+ * Blank lines and malformed entries are skipped.
  *
- * Uses `env -0` (null-delimited output) instead of running the Electron
- * binary with `ELECTRON_RUN_AS_NODE=1`, because the `RunAsNode` fuse is
- * disabled in packaged builds.
+ * Limitation: `cmd.exe set` emits one logical entry per line with no
+ * continuation syntax. Values that contain embedded newlines (possible via
+ * `setx`, registry, or PowerShell) are truncated at the first `\n`. Rare in
+ * practice, but worth knowing when debugging missing env vars.
+ */
+function parseCmdSet(raw: string): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const rawLine of raw.split(/\r?\n/)) {
+    const line = rawLine.trimEnd();
+    if (!line) continue;
+    const eqIdx = line.indexOf('=');
+    if (eqIdx <= 0) continue;
+    const key = line.slice(0, eqIdx);
+    const value = line.slice(eqIdx + 1);
+    result[key] = value;
+  }
+  return result;
+}
+
+/**
+ * Resolve the real Windows user environment by spawning `cmd.exe /d /c set`.
+ *
+ * Why this is necessary: on Windows, Electron apps launched from shortcuts,
+ * auto-start, or npm scripts frequently inherit a stripped `process.env`
+ * (no PATH, no USERPROFILE, no LOCALAPPDATA). `child_process.spawn` on
+ * Windows forwards the parent's native env block at the Win32 level even
+ * when it looks empty in Node — but `node-pty` (ConPTY/winpty) does not.
+ * So we must explicitly resolve the real user env here and forward it.
+ *
+ * `cmd.exe` reads the session env from the Win32 env block, which includes
+ * the full user + system PATH via registry, regardless of what Node sees
+ * in `process.env`.
+ */
+async function resolveWindowsEnv(
+  timeoutMs: number,
+): Promise<Record<string, string> | null> {
+  return new Promise<Record<string, string> | null>((resolve) => {
+    const comspec = process.env.COMSPEC || 'cmd.exe';
+    // `/u` forces cmd's built-in output (here: `set`) to UTF-16LE, bypassing
+    // the active console code page entirely. Without it, Windows defaults to
+    // the system locale (CP1252 on Western installs, CP932 Japanese, CP936
+    // Chinese, CP949 Korean, CP1251 Russian, etc.), producing mojibake for
+    // non-ASCII env values like `C:\Users\François`. UTF-16LE is cmd's
+    // native internal encoding, so no re-encoding takes place — the most
+    // deterministic option for programmatic parsing.
+    const child = spawn(comspec, ['/u', '/d', '/c', 'set'], {
+      windowsHide: true,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      // Deliberately NOT passing `env` — we want cmd.exe to inherit the
+      // native Win32 env block, which carries the user+system PATH even
+      // if `process.env.PATH` is empty.
+    });
+
+    const timeout = setTimeout(() => {
+      try {
+        child.kill();
+      } catch {
+        // ignore
+      }
+      resolve(null);
+    }, timeoutMs);
+
+    const chunks: Buffer[] = [];
+    child.stdout?.on('data', (c: Buffer) => {
+      chunks.push(c);
+    });
+    child.on('error', () => {
+      clearTimeout(timeout);
+      resolve(null);
+    });
+    child.on('close', (code) => {
+      clearTimeout(timeout);
+      if (code !== 0 && code !== null) {
+        resolve(null);
+        return;
+      }
+      // Decode UTF-16LE output from `cmd.exe /u`. Strip a possible BOM
+      // (`0xFF 0xFE`); `cmd.exe` typically does not emit one on pipe output,
+      // but handle it defensively for robustness across Windows versions.
+      const buffer = Buffer.concat(chunks);
+      const startOffset =
+        buffer.length >= 2 && buffer[0] === 0xff && buffer[1] === 0xfe ? 2 : 0;
+      const raw = buffer.toString('utf16le', startOffset);
+      if (!raw.length) {
+        resolve(null);
+        return;
+      }
+      try {
+        const parsed = parseCmdSet(raw);
+        normalizeWindowsPath(parsed);
+        resolve(parsed);
+      } catch {
+        resolve(null);
+      }
+    });
+  });
+}
+
+/**
+ * Resolve the user's full shell environment by spawning a login shell
+ * and capturing its environment.
+ *
+ * On Windows, delegates to `cmd.exe /d /c set` to read the native Win32
+ * env block. On macOS/Linux, uses `env -0` (null-delimited output)
+ * instead of running the Electron binary with `ELECTRON_RUN_AS_NODE=1`,
+ * because the `RunAsNode` fuse is disabled in packaged builds.
  */
 export async function resolveShellEnv(
   shell: DetectedShell,
   timeoutMs = DEFAULT_RESOLVE_TIMEOUT_MS,
 ): Promise<Record<string, string> | null> {
-  if (process.platform === 'win32') return null;
+  if (process.platform === 'win32') {
+    return resolveWindowsEnv(timeoutMs);
+  }
 
   // `env -0` prints all environment variables null-delimited.
   // Supported natively on macOS (/usr/bin/env) and Linux (GNU coreutils).

--- a/apps/browser/src/backend/services/toolbox/services/shell/sanitize-env.test.ts
+++ b/apps/browser/src/backend/services/toolbox/services/shell/sanitize-env.test.ts
@@ -68,6 +68,43 @@ describe('sanitizeEnv', () => {
     expect(env.SOME_NORMAL_VAR).toBe('hello');
   });
 
+  describe('windows locale overrides', () => {
+    let originalPlatform: NodeJS.Platform;
+
+    beforeEach(() => {
+      originalPlatform = process.platform;
+      Object.defineProperty(process, 'platform', { value: 'win32' });
+      // Clear inherited host locale so the whitelist doesn't pass them
+      // through from process.env and mask the Windows-specific logic.
+      delete process.env.LC_ALL;
+      delete process.env.LC_CTYPE;
+      delete process.env.LANG;
+    });
+
+    afterEach(() => {
+      Object.defineProperty(process, 'platform', { value: originalPlatform });
+    });
+
+    it('applies C.UTF-8 locale for bash', () => {
+      const env = sanitizeEnv(undefined, 'bash');
+      expect(env.LC_ALL).toBe('C.UTF-8');
+      expect(env.LC_CTYPE).toBe('C.UTF-8');
+      expect(env.LANG).toBe('C.UTF-8');
+    });
+
+    it('skips C.UTF-8 locale for powershell', () => {
+      const env = sanitizeEnv(undefined, 'powershell');
+      expect(env.LC_ALL).toBeUndefined();
+      expect(env.LC_CTYPE).toBeUndefined();
+      expect(env.LANG).toBeUndefined();
+    });
+
+    it('applies C.UTF-8 locale when shell type is unknown (conservative default)', () => {
+      const env = sanitizeEnv();
+      expect(env.LC_ALL).toBe('C.UTF-8');
+    });
+  });
+
   it('uses resolvedEnv as base when provided', () => {
     process.env.FROM_PROCESS = 'process';
 

--- a/apps/browser/src/backend/services/toolbox/services/shell/sanitize-env.ts
+++ b/apps/browser/src/backend/services/toolbox/services/shell/sanitize-env.ts
@@ -1,3 +1,6 @@
+import { normalizeWindowsPath } from './normalize-windows-path';
+import type { ShellType } from './types';
+
 const WHITELIST = new Set([
   'PATH',
   'HOME',
@@ -21,6 +24,59 @@ const WHITELIST = new Set([
   'npm_config_registry',
 ]);
 
+/**
+ * Additional Windows-essential env vars that must pass through to child
+ * processes (especially PTY-spawned bash / pnpm / node). Without these,
+ * Git Bash / MSYS2 cannot bootstrap MSYSTEM paths, pnpm cannot locate its
+ * store (`%LOCALAPPDATA%\pnpm`), and tooling that shells out to Windows
+ * binaries fails with obscure errors.
+ */
+const WINDOWS_WHITELIST = new Set([
+  'SYSTEMROOT',
+  'WINDIR',
+  'USERPROFILE',
+  'HOMEDRIVE',
+  'HOMEPATH',
+  'LOCALAPPDATA',
+  'APPDATA',
+  'ALLUSERSPROFILE',
+  'PROGRAMDATA',
+  'PROGRAMFILES',
+  'PROGRAMFILES(X86)',
+  'PROGRAMW6432',
+  'PUBLIC',
+  'COMMONPROGRAMFILES',
+  'COMMONPROGRAMFILES(X86)',
+  'COMMONPROGRAMW6432',
+  'PATHEXT',
+  'COMSPEC',
+  'SYSTEMDRIVE',
+  'PROCESSOR_ARCHITECTURE',
+  'PROCESSOR_IDENTIFIER',
+  'PROCESSOR_LEVEL',
+  'PROCESSOR_REVISION',
+  'NUMBER_OF_PROCESSORS',
+  'OS',
+  'COMPUTERNAME',
+  'USERDOMAIN',
+  'USERDOMAIN_ROAMINGPROFILE',
+  'SESSIONNAME',
+  'LOGONSERVER',
+  'MSYSTEM',
+  'CHERE_INVOKING',
+  // Node / package manager related
+  'PNPM_HOME',
+  'NPM_CONFIG_PREFIX',
+  'NPM_CONFIG_CACHE',
+  'NODE_PATH',
+  'NVM_HOME',
+  'NVM_SYMLINK',
+  'FNM_DIR',
+  'FNM_MULTISHELL_PATH',
+  'FNM_NODE_DIST_MIRROR',
+  'FNM_VERSION_FILE_STRATEGY',
+]);
+
 const SENSITIVE_PATTERNS = [
   'SECRET',
   'TOKEN',
@@ -36,8 +92,18 @@ function isSensitive(key: string): boolean {
   return SENSITIVE_PATTERNS.some((p) => upper.includes(p));
 }
 
+function isWhitelisted(key: string): boolean {
+  if (WHITELIST.has(key)) return true;
+  if (process.platform === 'win32') {
+    const upper = key.toUpperCase();
+    if (WINDOWS_WHITELIST.has(upper)) return true;
+  }
+  return false;
+}
+
 export function sanitizeEnv(
   resolvedEnv?: Record<string, string> | null,
+  shellType?: ShellType,
 ): Record<string, string> {
   const env: Record<string, string> = {};
   const base: Record<string, string | undefined> =
@@ -48,15 +114,30 @@ export function sanitizeEnv(
 
     if (key.startsWith('ELECTRON_') || key.startsWith('ELECTRON ')) continue;
 
-    if (!WHITELIST.has(key) && isSensitive(key)) continue;
+    if (!isWhitelisted(key) && isSensitive(key)) continue;
 
     env[key] = value;
   }
 
   if (process.platform === 'win32') {
-    env.LC_ALL = 'C.UTF-8';
-    env.LC_CTYPE = 'C.UTF-8';
-    env.LANG = 'C.UTF-8';
+    // Ensure `PATH` is the authoritative variable (MSYS2 bash reads uppercase
+    // `PATH` only). `resolveWindowsEnv` already normalizes its output, so this
+    // call is usually a no-op — it's a defensive fallback for when
+    // `resolveWindowsEnv` returns `null` (timeout, spawn error) and the base
+    // env falls back to `process.env`, which may still contain mixed-case
+    // `Path`. Do not remove without adjusting the upstream path.
+    normalizeWindowsPath(env);
+
+    // Locale overrides target MSYS2 / Git Bash Unicode rendering. PowerShell
+    // ignores them itself but would pass them unchanged to spawned children
+    // (node, python, pnpm), silently altering their locale-dependent
+    // behavior. Skip them for PowerShell; apply for bash/zsh/sh or when the
+    // shell type is unknown (conservative default matching prior behavior).
+    if (shellType !== 'powershell') {
+      env.LC_ALL = 'C.UTF-8';
+      env.LC_CTYPE = 'C.UTF-8';
+      env.LANG = 'C.UTF-8';
+    }
   }
 
   env.STAGEWISE_SHELL = '1';

--- a/apps/browser/src/backend/services/toolbox/services/shell/session-manager.ts
+++ b/apps/browser/src/backend/services/toolbox/services/shell/session-manager.ts
@@ -1,6 +1,7 @@
 import * as pty from 'node-pty';
 import { randomUUID } from 'node:crypto';
 import fs from 'node:fs';
+import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { OscParser, wrapWithSentinel } from './osc-parser';
 import { SessionLogger } from './session-logger';
@@ -818,12 +819,17 @@ export class SessionManager {
       // Write to a temp file and dot-source it. This avoids ZLE echoing
       // the entire script char-by-char (which can exceed the detection
       // timeout with rich prompt frameworks like starship/p10k).
-      const tempPath = `/tmp/sw-${session.id}.sh`;
+      const nativeTempPath = path.join(tmpdir(), `sw-${session.id}.sh`);
       try {
-        fs.writeFileSync(tempPath, script, { mode: 0o600 });
-        session.initScriptPath = tempPath;
+        fs.writeFileSync(nativeTempPath, script, { mode: 0o600 });
+        session.initScriptPath = nativeTempPath;
         // Dot-source is POSIX (cannot be aliased). Cleanup handled by deactivateSession.
-        session.pty.write(`. ${tempPath}\r`);
+        // Single-quote to survive paths containing spaces (e.g. Windows
+        // usernames with spaces → `/c/Users/Some Name/...`). Node's
+        // `os.tmpdir()` output never contains single quotes, so wrapping is
+        // safe without additional escaping.
+        const shellPath = toMsysPath(nativeTempPath);
+        session.pty.write(`. '${shellPath}'\r`);
       } catch {
         // Temp file write failed — fall back to eval through the line editor.
         session.pty.write(`eval $'${escapeForShell(script)}'\r`);
@@ -841,6 +847,9 @@ export class SessionManager {
   private getSpawnArgs(): string[] {
     if (this.shell.type === 'powershell') {
       return ['-NoExit', '-Command', POWERSHELL_INTEGRATION];
+    }
+    if (process.platform === 'win32' && this.shell.type === 'bash') {
+      return ['--login', '-i'];
     }
     return [];
   }
@@ -866,4 +875,19 @@ function escapeForShell(s: string): string {
   // must be escaped; \n becomes a real newline inside $'...'.
   // Dollar signs and backticks are literal in $'...' — no escaping needed.
   return s.replace(/\\/g, '\\\\').replace(/'/g, "\\'").replace(/\n/g, '\\n');
+}
+
+/**
+ * Convert a native Windows path to an MSYS/Git Bash compatible path.
+ * e.g. `C:\Users\X\AppData\Local\Temp` → `/c/Users/X/AppData/Local/Temp`
+ *
+ * On non-Windows platforms, returns the path unchanged.
+ */
+function toMsysPath(nativePath: string): string {
+  if (process.platform !== 'win32') return nativePath;
+  const match = nativePath.match(/^([A-Za-z]):[/\\](.*)/);
+  if (!match) return nativePath;
+  const driveLetter = match[1].toLowerCase();
+  const rest = match[2].replace(/\\/g, '/');
+  return `/${driveLetter}/${rest}`;
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Windows now resolves shell environment variables (including PATH merge/deduplication and UTF-16 handling) for sessions, improving reliability.
  * Environment sanitization is OS-aware: preserves important Windows variables and applies locale defaults (C.UTF-8) except when using PowerShell.
  * Bash on Windows is started as a login/interactive shell and sources init scripts from the OS temp directory for more robust startup.

* **Tests**
  * Added Windows-focused tests for sanitizeEnv locale and shell-specific behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->