### PR TITLE
feat(stagewise): allow renaming agents

### DIFF
--- a/apps/browser/src/backend/agents/shared/base-agent/base-agent.ts
+++ b/apps/browser/src/backend/agents/shared/base-agent/base-agent.ts
@@ -491,6 +491,10 @@ export abstract class BaseAgent<
             hour12: true,
           },
         )}`;
+      // Preserve the user's manual-title lock across resumes. Without this
+      // hydration, updateTitle() would later see the flag as unset and
+      // auto-regenerate over a user-set title.
+      draft.titleLockedByUser = initialState?.titleLockedByUser;
       draft.history = initialState?.history ?? [];
       draft.queuedMessages = initialState?.queuedMessages ?? [];
       draft.activeModelId =
@@ -938,6 +942,17 @@ export abstract class BaseAgent<
     return;
   }
 
+  public async setTitle(newTitle: string): Promise<void> {
+    this.logger.debug(
+      `[BaseAgent:${this.instanceId}] User set title: ${newTitle}`,
+    );
+    this.state.set((draft) => {
+      draft.title = newTitle;
+      draft.titleLockedByUser = true;
+    });
+    await this.saveState();
+  }
+
   /**
    * =======================================================
    * EXTENDABLE METHODS (CONFIGURABLE BEHAVIOR BY THE INHERITING CLASS)
@@ -1344,6 +1359,11 @@ export abstract class BaseAgent<
         return;
       }
 
+      // Skip if the user has manually set a title
+      if (this.state.get().titleLockedByUser) {
+        return;
+      }
+
       // We only update whenever the last message is a user message (prevent repeated title updates when the assistant is running in loops)
       const lastMessage =
         this.state.get().history[this.state.get().history.length - 1];
@@ -1367,6 +1387,12 @@ export abstract class BaseAgent<
       );
 
       const newTitle = await this.generateTitle(this.state.get().history);
+
+      // Re-check: user may have manually set a title while generation was in-flight
+      if (this.state.get().titleLockedByUser) {
+        return;
+      }
+
       this.logger.debug(
         `[BaseAgent:${this.instanceId}] New title generated: ${newTitle}`,
       );

--- a/apps/browser/src/backend/services/agent-manager/agent-manager.ts
+++ b/apps/browser/src/backend/services/agent-manager/agent-manager.ts
@@ -30,6 +30,12 @@ import type { ProcessedImageCacheService } from '@/services/processed-image-cach
  */
 
 export class AgentManagerService extends DisposableService {
+  /** Server-side bounds for user-editable agent titles. Slightly more permissive
+   * than the UI's 2–80 range so minor client/server drift never silently drops
+   * a valid title. */
+  private static readonly TITLE_MIN_LENGTH = 1;
+  private static readonly TITLE_MAX_LENGTH = 200;
+
   private activeAgents = new Map<
     string,
     BaseAgent<any, any> | BaseAgent<never, any>
@@ -320,6 +326,42 @@ export class AgentManagerService extends DisposableService {
         modelId: ModelId,
       ) => {
         await this.updateActiveModelId(instanceId, modelId);
+      },
+    );
+    this.karton.registerServerProcedureHandler(
+      'agents.setTitle',
+      async (_callingClientId: string, instanceId: string, title: string) => {
+        const trimmed = title.trim();
+        if (
+          trimmed.length < AgentManagerService.TITLE_MIN_LENGTH ||
+          trimmed.length > AgentManagerService.TITLE_MAX_LENGTH
+        ) {
+          throw new Error(
+            `Invalid title length: ${trimmed.length} (must be ${AgentManagerService.TITLE_MIN_LENGTH}–${AgentManagerService.TITLE_MAX_LENGTH} chars)`,
+          );
+        }
+
+        // Active path: let the agent handle it so Karton state updates and
+        // titleLockedByUser is set via the normal state mutation.
+        const agent = this.activeAgents.get(instanceId);
+        if (agent) {
+          await agent.setTitle(trimmed);
+          return;
+        }
+
+        // Inactive path: update the persisted row directly — no hydration,
+        // no Karton fan-out; the UI's optimistic local update is authoritative
+        // until the next history refetch.
+        if (!this.agentPersistenceDB) {
+          throw new Error('Persistence layer unavailable');
+        }
+        const updated = await this.agentPersistenceDB.updateAgentTitle(
+          instanceId,
+          trimmed,
+        );
+        if (!updated) {
+          throw new Error(`Agent with instance id ${instanceId} not found`);
+        }
       },
     );
     this.karton.registerServerProcedureHandler(
@@ -620,6 +662,7 @@ export class AgentManagerService extends DisposableService {
       undefined,
       {
         title: agent.title,
+        titleLockedByUser: agent.titleLockedByUser ?? undefined,
         history: agent.history,
         queuedMessages: agent.queuedMessages,
         activeModelId: resumedModelValid ? agent.activeModelId : undefined,
@@ -679,6 +722,7 @@ export class AgentManagerService extends DisposableService {
         id: instanceId,
         type: agent.agentType,
         title: agentState.title,
+        titleLockedByUser: agentState.titleLockedByUser,
         activeModelId: agentState.activeModelId,
         createdAt: agentState.history[0].metadata?.createdAt ?? new Date(0), // Fallback should never be reached
         lastMessageAt:

--- a/apps/browser/src/backend/services/agent-manager/persistence/db.ts
+++ b/apps/browser/src/backend/services/agent-manager/persistence/db.ts
@@ -367,6 +367,30 @@ export class AgentPersistenceDB {
   }
 
   /**
+   * Updates just the title (and titleLockedByUser flag) of a persisted agent
+   * without rehydrating it into memory. Used for renaming inactive history
+   * agents — active ones go through BaseAgent.setTitle so Karton state and
+   * DB stay in sync via the normal saveState() path.
+   *
+   * @returns true if a row was updated, false if no agent with that id exists.
+   */
+  public async updateAgentTitle(id: string, title: string): Promise<boolean> {
+    this._logger.debug(`[AgentPersistenceDB] Updating title for agent: ${id}`);
+    try {
+      const result = await this._db
+        .update(schema.agentInstances)
+        .set({ title, titleLockedByUser: true })
+        .where(eq(schema.agentInstances.id, id));
+      return (result as unknown as { rowsAffected: number }).rowsAffected > 0;
+    } catch (error) {
+      this._logger.error(
+        `[AgentPersistenceDB] Failed to update agent title: ${(error as Error).message}`,
+      );
+      throw error;
+    }
+  }
+
+  /**
    * Deletes an agent instance from the persistence layer.
    *
    * @param id The id of the agent instance to delete

--- a/apps/browser/src/backend/services/agent-manager/persistence/migrations/index.ts
+++ b/apps/browser/src/backend/services/agent-manager/persistence/migrations/index.ts
@@ -5,6 +5,7 @@ import { up as v004Up } from './v004-rename-tool-suffixes';
 import { up as v005Up } from './v005-backfill-file-attachment-filename';
 import { up as v006Up } from './v006-rename-readfile-to-read';
 import { up as v007Up } from './v007-normalize-history';
+import { up as v008Up } from './v008-add-title-locked-by-user';
 
 const registry: MigrationScript[] = [
   { version: 2, name: 'add-mounted-workspaces', up: v002Up },
@@ -13,7 +14,8 @@ const registry: MigrationScript[] = [
   { version: 5, name: 'backfill-file-attachment-filename', up: v005Up },
   { version: 6, name: 'rename-file-tools', up: v006Up },
   { version: 7, name: 'normalize-history', up: v007Up },
+  { version: 8, name: 'add-title-locked-by-user', up: v008Up },
 ];
-const schemaVersion = 7;
+const schemaVersion = 8;
 
 export { registry, schemaVersion };

--- a/apps/browser/src/backend/services/agent-manager/persistence/migrations/v008-add-title-locked-by-user.ts
+++ b/apps/browser/src/backend/services/agent-manager/persistence/migrations/v008-add-title-locked-by-user.ts
@@ -1,0 +1,14 @@
+import { sql } from 'drizzle-orm';
+import type { MigrationScript } from '@/utils/migrate-database/types';
+
+/**
+ * v8 — add-title-locked-by-user
+ *
+ * Adds the `title_locked_by_user` column to `agentInstances`.
+ * When set to 1 (true), auto title-generation is skipped for the agent.
+ */
+export const up: MigrationScript['up'] = async (db) => {
+  await db.run(
+    sql`ALTER TABLE agentInstances ADD COLUMN title_locked_by_user INTEGER`,
+  );
+};

--- a/apps/browser/src/backend/services/agent-manager/persistence/schema.sql
+++ b/apps/browser/src/backend/services/agent-manager/persistence/schema.sql
@@ -1,4 +1,4 @@
--- VERSION: 7
+-- VERSION: 8
 
 CREATE TABLE IF NOT EXISTS meta(
   key LONGVARCHAR NOT NULL UNIQUE PRIMARY KEY,
@@ -14,6 +14,7 @@ CREATE TABLE IF NOT EXISTS agentInstances(
   last_message_at INTEGER NOT NULL,
   active_model_id TEXT NOT NULL,
   title TEXT NOT NULL,
+  title_locked_by_user INTEGER,
   history TEXT NOT NULL DEFAULT '{"json":[]}',  -- deprecated: kept for rollback safety
   queued_messages TEXT NOT NULL,
   input_state TEXT NOT NULL,

--- a/apps/browser/src/backend/services/agent-manager/persistence/schema.ts
+++ b/apps/browser/src/backend/services/agent-manager/persistence/schema.ts
@@ -78,6 +78,7 @@ export const agentInstances = sqliteTable(
     lastMessageAt: integer('last_message_at', { mode: 'timestamp' }).notNull(),
     activeModelId: modelId('active_model_id').notNull(),
     title: text('title').notNull(),
+    titleLockedByUser: _sqliteBoolean('title_locked_by_user'),
     /** @deprecated Kept for rollback safety. Read/write via agentMessages table instead. */
     history: _sqliteJson('history')
       .notNull()

--- a/apps/browser/src/shared/karton-contracts/ui/agent/index.ts
+++ b/apps/browser/src/shared/karton-contracts/ui/agent/index.ts
@@ -32,6 +32,7 @@ export type AgentRuntimeError =
 
 export type AgentState = {
   title: string; // The title of the agent - may not be necessary
+  titleLockedByUser?: boolean; // Whether the user manually set the title (prevents auto-regeneration)
   isWorking: boolean; // Whether the agent is currently working on a task or if it's idling (either finished or waiting for user input).
   history: AgentMessage[]; // The message history of the agent (visible to user)
   queuedMessages: (AgentMessage & { role: 'user' })[]; // Queued messages that have not yet been sent to the agent.

--- a/apps/browser/src/shared/karton-contracts/ui/index.ts
+++ b/apps/browser/src/shared/karton-contracts/ui/index.ts
@@ -726,6 +726,7 @@ export type KartonContract = {
       retryLastUserMessage: (agentId: string) => Promise<void>;
       markAsRead: (agentId: string) => Promise<void>;
       setActiveModelId: (agentId: string, modelId: ModelId) => Promise<void>;
+      setTitle: (agentId: string, title: string) => Promise<void>;
       storeAttachment: (
         agentId: string,
         originalFileName: string,

--- a/apps/browser/src/ui/screens/main/sidebar/active-agents/_components/agent-card.tsx
+++ b/apps/browser/src/ui/screens/main/sidebar/active-agents/_components/agent-card.tsx
@@ -1,4 +1,4 @@
-import { memo, useState } from 'react';
+import { memo, useCallback, useState } from 'react';
 import { cn } from '@ui/utils';
 import {
   Tooltip,
@@ -9,6 +9,7 @@ import { Button } from '@stagewise/stage-ui/components/button';
 import { IconTrash2Outline24 } from 'nucleo-core-outline-24';
 import { IconSleepingTimeOutline18 } from 'nucleo-ui-outline-18';
 import { DeleteConfirmPopover } from '../../_components/delete-confirm-popover';
+import { useInlineTitleEdit } from './use-inline-title-edit';
 import TimeAgo from 'javascript-time-ago';
 import en from 'javascript-time-ago/locale/en';
 
@@ -29,6 +30,7 @@ export interface AgentCardProps {
   onClick: (id: string) => void;
   onArchive: (id: string) => void;
   onDelete: (id: string) => void;
+  onRename: (id: string, newTitle: string) => void;
 }
 
 export function AgentCardSkeleton() {
@@ -55,16 +57,35 @@ export const AgentCard = memo(
     onClick,
     onArchive,
     onDelete,
+    onRename,
   }: AgentCardProps) {
     const subtitle = hasError ? 'Error' : activityText;
     const [deleteOpen, setDeleteOpen] = useState(false);
+
+    const handleCommitRename = useCallback(
+      (newTitle: string) => onRename(id, newTitle),
+      [id, onRename],
+    );
+    const {
+      isEditing,
+      titleRef,
+      displayTitle,
+      startEditing,
+      commitEdit,
+      cancelEdit,
+    } = useInlineTitleEdit({ title, onCommit: handleCommitRename });
 
     return (
       <div
         role="button"
         tabIndex={0}
         data-agent-id={id}
+        aria-keyshortcuts="F2"
         onClick={() => onClick(id)}
+        onDoubleClick={(e) => {
+          e.stopPropagation();
+          if (!isEditing) startEditing();
+        }}
         onKeyDown={(e) => {
           // Only handle keyboard interaction when the card itself is focused.
           // Otherwise, nested buttons (archive/delete) would also trigger this.
@@ -73,28 +94,76 @@ export const AgentCard = memo(
           if (e.key === 'Enter' || e.key === ' ') {
             e.preventDefault();
             onClick(id);
+          } else if (e.key === 'F2' && !isEditing) {
+            // F2 is the standard rename shortcut across Finder/Explorer/VS Code.
+            e.preventDefault();
+            startEditing();
           }
         }}
         className={cn(
-          'group/card relative flex min-w-0 shrink-0 cursor-pointer flex-col gap-0.5 rounded-md bg-surface-1 px-2 py-1.5 text-left transition-colors hover:bg-surface-2',
-          isActive && 'bg-surface-2 ring-2 ring-derived-subtle ring-inset',
+          'group/card relative flex min-w-0 shrink-0 flex-col gap-0.5 rounded-md bg-surface-1 px-2 py-1.5 text-left transition-colors hover:bg-surface-2',
+          isActive
+            ? 'cursor-default bg-surface-2 ring-2 ring-derived-subtle ring-inset'
+            : 'cursor-pointer',
           hasUnseen && 'animate-ring-pulse-primary',
         )}
       >
-        <Tooltip>
-          <TooltipTrigger delay={500}>
-            <button
-              type="button"
-              tabIndex={-1}
-              className="block w-full overflow-x-clip text-ellipsis whitespace-nowrap bg-transparent p-0 text-left font-medium text-foreground text-xs leading-normal outline-none"
+        {/* Title row */}
+        <div className="flex min-w-0 items-center gap-1">
+          {isEditing ? (
+            <span
+              ref={titleRef}
+              role="textbox"
+              contentEditable
+              suppressContentEditableWarning
+              className="block min-w-0 flex-1 cursor-text overflow-x-clip text-ellipsis whitespace-nowrap bg-transparent p-0 text-left font-medium text-foreground text-xs leading-normal outline-none"
+              onClick={(e) => e.stopPropagation()}
+              onPointerDown={(e) => e.stopPropagation()}
+              onKeyDown={(e) => {
+                e.stopPropagation();
+                if (e.key === 'Enter') {
+                  e.preventDefault();
+                  // Commit directly rather than via blur() for parity with
+                  // AgentsSelector — keeps both surfaces exiting edit mode
+                  // synchronously regardless of any surrounding focus trap.
+                  commitEdit();
+                } else if (e.key === 'Escape') {
+                  e.preventDefault();
+                  cancelEdit();
+                }
+              }}
+              onBlur={commitEdit}
+              onPaste={(e) => {
+                e.preventDefault();
+                const text = e.clipboardData.getData('text/plain');
+                document.execCommand('insertText', false, text);
+              }}
             >
-              {title}
-            </button>
-          </TooltipTrigger>
-          <TooltipContent side="bottom">
-            <span>{title}</span>
-          </TooltipContent>
-        </Tooltip>
+              {displayTitle}
+            </span>
+          ) : (
+            <Tooltip>
+              <TooltipTrigger delay={500}>
+                <button
+                  type="button"
+                  tabIndex={-1}
+                  className="block min-w-0 flex-1 cursor-pointer overflow-x-clip text-ellipsis whitespace-nowrap bg-transparent p-0 text-left font-medium text-foreground text-xs leading-normal outline-none"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    startEditing();
+                  }}
+                  onPointerDown={(e) => e.stopPropagation()}
+                >
+                  {displayTitle}
+                </button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom">
+                <span>{displayTitle}</span>
+              </TooltipContent>
+            </Tooltip>
+          )}
+        </div>
+
         <div className="flex w-full items-baseline gap-2">
           <span
             className={cn(
@@ -167,7 +236,7 @@ export const AgentCard = memo(
       </div>
     );
   },
-  // Skip onClick/onArchive/onDelete in comparison — their behavior is
+  // Skip onClick/onArchive/onDelete/onRename in comparison — their behavior is
   // stable (always call the same RPC with the card's `id`) but identity
   // changes every render due to upstream useKartonProcedure selectors.
   (prev, next) =>

--- a/apps/browser/src/ui/screens/main/sidebar/active-agents/_components/use-inline-title-edit.ts
+++ b/apps/browser/src/ui/screens/main/sidebar/active-agents/_components/use-inline-title-edit.ts
@@ -1,0 +1,135 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+export interface UseInlineTitleEditArgs {
+  /** Current title value (source of truth while not editing). */
+  title: string;
+  /** Called with the validated, trimmed new title when the user commits. */
+  onCommit: (newTitle: string) => void;
+}
+
+export interface UseInlineTitleEditReturn {
+  isEditing: boolean;
+  titleRef: React.RefObject<HTMLSpanElement | null>;
+  /**
+   * What consumers should render for the title. Equals `title` normally, or
+   * the optimistic pending value during the commit → Karton-echo window so
+   * the UI doesn't briefly flash back to the old title between the editable
+   * span unmounting and the parent's `title` prop catching up.
+   */
+  displayTitle: string;
+  startEditing: () => void;
+  commitEdit: () => void;
+  cancelEdit: () => void;
+}
+
+/**
+ * Shared logic for a click-to-edit inline title backed by a `contentEditable`
+ * `<span>`. Handles focus/select-all on entering edit mode, syncing the
+ * external `title` prop into the DOM while not editing, validation
+ * (2–80 chars, trimmed, must differ), and commit/cancel callbacks.
+ *
+ * Used by both the AgentCard and the AgentsSelector row.
+ */
+export function useInlineTitleEdit({
+  title,
+  onCommit,
+}: UseInlineTitleEditArgs): UseInlineTitleEditReturn {
+  const [isEditing, setIsEditing] = useState(false);
+  // Optimistic value shown between commit and the next `title` prop echo.
+  const [pendingTitle, setPendingTitle] = useState<string | null>(null);
+  const titleRef = useRef<HTMLSpanElement>(null);
+  // One-shot guard: both consumers wire Enter AND onBlur to commitEdit, and a
+  // programmatic commit on Enter triggers an implicit blur as the editable
+  // span unmounts. Without this flag the same rename would fire onCommit
+  // twice — two RPCs, two Karton fan-outs, two exception captures on failure.
+  const committedRef = useRef(false);
+
+  // Clear the pending title once the parent's authoritative title matches it
+  // (Karton state caught up). After this point `displayTitle` falls back to
+  // the prop naturally and we stop lying about the source of truth.
+  useEffect(() => {
+    if (pendingTitle !== null && title === pendingTitle) {
+      setPendingTitle(null);
+    }
+  }, [title, pendingTitle]);
+
+  // Safety net: if the RPC fails silently and `title` never echoes back,
+  // drop the optimistic value after 3s so the UI doesn't lie indefinitely.
+  useEffect(() => {
+    if (pendingTitle === null) return;
+    const t = setTimeout(() => setPendingTitle(null), 3000);
+    return () => clearTimeout(t);
+  }, [pendingTitle]);
+
+  const displayTitle = pendingTitle ?? title;
+
+  // When entering edit mode, focus the span and select all text.
+  //
+  // Defer to the next animation frame so we run AFTER any focus-restoration
+  // effects from parent focus-traps (e.g. base-ui Combobox keeps its Input
+  // focused by default; without the rAF we lose focus after one frame).
+  useEffect(() => {
+    if (!isEditing) return;
+    const raf = requestAnimationFrame(() => {
+      const el = titleRef.current;
+      if (!el) return;
+      el.focus();
+      const range = document.createRange();
+      range.selectNodeContents(el);
+      const sel = window.getSelection();
+      sel?.removeAllRanges();
+      sel?.addRange(range);
+    });
+    return () => cancelAnimationFrame(raf);
+  }, [isEditing]);
+
+  // Sync the displayed title into the DOM when not editing (e.g. backend
+  // auto-title, or the optimistic value after commit). Uses `displayTitle`
+  // so any future consumer that keeps the span mounted stays consistent
+  // with what we render.
+  useEffect(() => {
+    if (!isEditing && titleRef.current) {
+      titleRef.current.textContent = displayTitle;
+    }
+  }, [displayTitle, isEditing]);
+
+  const commitEdit = useCallback(() => {
+    if (!titleRef.current) return;
+    // Idempotent: subsequent calls in the same edit session are no-ops.
+    if (committedRef.current) return;
+    const newTitle = (titleRef.current.textContent ?? '').trim();
+    setIsEditing(false);
+
+    // Validate: 2–80 chars, and actually different
+    if (newTitle.length >= 2 && newTitle.length <= 80 && newTitle !== title) {
+      committedRef.current = true;
+      // Optimistically show the new title until the parent's prop catches up.
+      setPendingTitle(newTitle);
+      onCommit(newTitle);
+    } else {
+      titleRef.current.textContent = title;
+    }
+  }, [title, onCommit]);
+
+  const cancelEdit = useCallback(() => {
+    if (titleRef.current) {
+      titleRef.current.textContent = title;
+    }
+    committedRef.current = false;
+    setIsEditing(false);
+  }, [title]);
+
+  const startEditing = useCallback(() => {
+    committedRef.current = false;
+    setIsEditing(true);
+  }, []);
+
+  return {
+    isEditing,
+    titleRef,
+    displayTitle,
+    startEditing,
+    commitEdit,
+    cancelEdit,
+  };
+}

--- a/apps/browser/src/ui/screens/main/sidebar/active-agents/index.tsx
+++ b/apps/browser/src/ui/screens/main/sidebar/active-agents/index.tsx
@@ -121,6 +121,7 @@ export function ActiveAgentsGrid() {
   const resumeAgent = useKartonProcedure((p) => p.agents.resume);
   const archiveAgent = useKartonProcedure((p) => p.agents.archive);
   const deleteAgent = useKartonProcedure((p) => p.agents.delete);
+  const setAgentTitle = useKartonProcedure((p) => p.agents.setTitle);
 
   const [, emptyAgentIdRef] = useEmptyAgentId();
 
@@ -299,6 +300,13 @@ export function ActiveAgentsGrid() {
     [deleteAgent],
   );
 
+  const handleRename = useCallback(
+    (id: string, newTitle: string) => {
+      void setAgentTitle(id, newTitle);
+    },
+    [setAgentTitle],
+  );
+
   const scrollRef = useRef<OverlayScrollbarRef>(null);
 
   /** Scroll a card into the safe (non-masked) area of the scroll container.
@@ -392,6 +400,7 @@ export function ActiveAgentsGrid() {
               onClick={handleClick}
               onArchive={handleArchive}
               onDelete={handleDelete}
+              onRename={handleRename}
             />
           );
         })}

--- a/apps/browser/src/ui/screens/main/sidebar/top/_components/agents-selector.tsx
+++ b/apps/browser/src/ui/screens/main/sidebar/top/_components/agents-selector.tsx
@@ -19,8 +19,10 @@ import { Button } from '@stagewise/stage-ui/components/button';
 import { Switch } from '@stagewise/stage-ui/components/switch';
 import { IconHistoryFill18 } from 'nucleo-ui-fill-18';
 import { IconTrash2Outline24 } from 'nucleo-core-outline-24';
+import { IconPenOutline18 } from 'nucleo-ui-outline-18';
 import { cn } from '@ui/utils';
 import { DeleteConfirmPopover } from '../../_components/delete-confirm-popover';
+import { useInlineTitleEdit } from '../../active-agents/_components/use-inline-title-edit';
 import { useKartonProcedure, useKartonState } from '@ui/hooks/use-karton';
 import type React from 'react';
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
@@ -50,6 +52,7 @@ export interface AgentsSelectorProps {
   value: string | null;
   onValueChange: (id: string) => void;
   onDelete: (id: string) => void;
+  onRename: (id: string, newTitle: string) => void;
   onEndReached?: () => void;
 }
 
@@ -81,7 +84,234 @@ const minimalFormatter = buildFormatter({
 });
 
 // ============================================================================
-// Component
+// AgentListItem — one row
+// ============================================================================
+
+interface AgentListItemProps {
+  agent: AgentEntry;
+  isSelected: boolean;
+  isEditing: boolean;
+  pendingDeleteId: string | null;
+  onStartEdit: (id: string) => void;
+  onCancelEdit: () => void;
+  onCommitRename: (id: string, newTitle: string) => void;
+  onStartDelete: (id: string) => void;
+  onCancelDelete: () => void;
+  onConfirmDelete: (id: string) => void;
+}
+
+function AgentListItemImpl({
+  agent,
+  isSelected,
+  isEditing,
+  pendingDeleteId,
+  onStartEdit,
+  onCancelEdit,
+  onCommitRename,
+  onStartDelete,
+  onCancelDelete,
+  onConfirmDelete,
+}: AgentListItemProps) {
+  const hasUnseen = !isSelected && !!agent.unread;
+
+  const handleCommit = useCallback(
+    (newTitle: string) => onCommitRename(agent.id, newTitle),
+    [agent.id, onCommitRename],
+  );
+
+  const {
+    isEditing: editActive,
+    titleRef,
+    displayTitle,
+    startEditing,
+    commitEdit,
+    cancelEdit,
+  } = useInlineTitleEdit({ title: agent.title, onCommit: handleCommit });
+
+  // Keep local hook state in sync with the parent-driven `isEditing` flag.
+  // Parent owns the "only one row editing at a time" invariant.
+  //
+  // All callbacks come from useInlineTitleEdit (which useCallback-wraps them).
+  // `startEditing` is stable; `cancelEdit` re-creates when `title` changes,
+  // which is correct — if the prop title updates mid-edit, we want cancel
+  // to restore the fresh value, not a stale captured one.
+  useEffect(() => {
+    if (isEditing && !editActive) {
+      startEditing();
+    } else if (!isEditing && editActive) {
+      // Parent canceled (e.g. dropdown closed, another row started editing).
+      // Drop any pending changes silently.
+      cancelEdit();
+    }
+  }, [isEditing, editActive, startEditing, cancelEdit]);
+
+  return (
+    <ComboboxItem
+      key={agent.id}
+      value={agent.id}
+      size="xs"
+      className="grid-cols-[0.75rem_1fr_auto]"
+    >
+      <ComboboxItemIndicator />
+      <span className="col-start-2 flex w-full items-center gap-2">
+        {isEditing ? (
+          <span
+            ref={titleRef}
+            role="textbox"
+            contentEditable
+            suppressContentEditableWarning
+            className="min-w-0 flex-1 cursor-text truncate bg-transparent p-0 outline-none"
+            // Capture-phase stop on focus: base-ui's ComboboxPopup has an
+            // onFocus handler that redirects any focus landing inside the
+            // list back to its Input. Stopping propagation here prevents
+            // that handler from ever seeing the event.
+            onFocusCapture={(e) => e.stopPropagation()}
+            onPointerDown={(e) => e.stopPropagation()}
+            onMouseDown={(e) => e.stopPropagation()}
+            onClick={(e) => e.stopPropagation()}
+            onKeyDownCapture={(e) => {
+              // Capture-phase stop: base-ui's ComboboxList handler would
+              // otherwise steal Arrow/Enter/Escape.
+              e.stopPropagation();
+              if (e.key === 'Enter') {
+                e.preventDefault();
+                // Commit directly instead of going through blur() — base-ui's
+                // ComboboxPopup focus manager otherwise adds a perceptible
+                // handshake delay before onBlur fires.
+                commitEdit();
+                onCancelEdit();
+              } else if (e.key === 'Escape') {
+                e.preventDefault();
+                cancelEdit();
+                onCancelEdit();
+              }
+            }}
+            onKeyUpCapture={(e) => e.stopPropagation()}
+            onBlur={() => {
+              commitEdit();
+              onCancelEdit();
+            }}
+            onPaste={(e) => {
+              e.preventDefault();
+              const text = e.clipboardData.getData('text/plain');
+              document.execCommand('insertText', false, text);
+            }}
+          >
+            {displayTitle}
+          </span>
+        ) : (
+          <span
+            className={cn(
+              'truncate',
+              agent.isWorking && 'shimmer-text-primary',
+              hasUnseen && 'animate-text-pulse-warning',
+            )}
+          >
+            {displayTitle}
+          </span>
+        )}
+        {!isEditing && (
+          <span className="shrink-0 text-subtle-foreground text-xs">
+            <TimeAgo
+              date={agent.lastMessageAt}
+              formatter={minimalFormatter}
+              live={false}
+            />
+          </span>
+        )}
+      </span>
+      <div className="col-start-3 flex h-5 items-center gap-0.5">
+        {!isEditing && (
+          <button
+            type="button"
+            className="flex size-5 shrink-0 cursor-pointer items-center justify-center rounded-full text-muted-foreground opacity-0 transition-colors hover:text-foreground focus-visible:opacity-100 group-hover/item:opacity-100"
+            aria-label="Rename agent"
+            onPointerDown={(e) => {
+              // preventDefault prevents the button from stealing focus from
+              // the Combobox's virtual-focus Input. Without this, clicking the
+              // pencil triggers a focus change that base-ui then "restores",
+              // leaving us in a focus tug-of-war with the editable span.
+              e.preventDefault();
+              e.stopPropagation();
+            }}
+            onMouseDown={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+            }}
+            onClick={(e) => {
+              e.stopPropagation();
+              onStartEdit(agent.id);
+            }}
+          >
+            <IconPenOutline18 className="size-3" />
+          </button>
+        )}
+        <div className="relative">
+          {!isEditing && (
+            <button
+              type="button"
+              className="flex size-5 shrink-0 cursor-pointer items-center justify-center rounded-full text-muted-foreground opacity-0 transition-colors hover:text-foreground focus-visible:opacity-100 group-hover/item:opacity-100"
+              aria-label="Delete agent"
+              onPointerDown={(e) => e.stopPropagation()}
+              onMouseDown={(e) => e.stopPropagation()}
+              onClick={(e) => {
+                e.stopPropagation();
+                onStartDelete(agent.id);
+              }}
+            >
+              <IconTrash2Outline24 className="size-3" />
+            </button>
+          )}
+          {pendingDeleteId === agent.id && (
+            <DeleteConfirmPopover
+              open={true}
+              onOpenChange={(open) => {
+                if (!open) onCancelDelete();
+              }}
+              onConfirm={() => {
+                onConfirmDelete(agent.id);
+              }}
+            />
+          )}
+        </div>
+      </div>
+    </ComboboxItem>
+  );
+}
+
+// Custom comparator: the parent rebuilds `agent` objects on every render
+// (the `toEntry` helper in SidebarTopSection returns fresh objects), so the
+// default memo check sees a new reference for every sibling and re-renders
+// the entire list on any state change. That stampede delays the exit from
+// edit mode by hundreds of ms when there are many rows. Compare only the
+// primitive fields the row actually uses; also narrow `pendingDeleteId` to
+// the boolean "is this row's popover open?" so other rows' popover state
+// doesn't invalidate this row. Callback props are treated as stable — they
+// are all wrapped in useCallback at AgentsSelector scope and don't change
+// during a rename.
+const AgentListItem = memo(AgentListItemImpl, (prev, next) => {
+  const pa = prev.agent;
+  const na = next.agent;
+  if (
+    pa.id !== na.id ||
+    pa.title !== na.title ||
+    pa.messageCount !== na.messageCount ||
+    !!pa.isWorking !== !!na.isWorking ||
+    !!pa.unread !== !!na.unread ||
+    pa.lastMessageAt.getTime() !== na.lastMessageAt.getTime()
+  ) {
+    return false;
+  }
+  return (
+    prev.isSelected === next.isSelected &&
+    prev.isEditing === next.isEditing &&
+    // Narrow: we only rerender when THIS row's popover state changes.
+    (prev.pendingDeleteId === pa.id) === (next.pendingDeleteId === na.id)
+  );
+});
+
+// ============================================================================
+// AgentsSelector
 // ============================================================================
 
 /**
@@ -118,10 +348,12 @@ export const AgentsSelector = memo(
     value,
     onValueChange,
     onDelete,
+    onRename,
     onEndReached,
   }: AgentsSelectorProps) {
     const [inputValue, setInputValue] = useState('');
     const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null);
+    const [editingId, setEditingId] = useState<string | null>(null);
     const [isOpen, setIsOpen] = useState(false);
     const listRef = useRef<HTMLDivElement>(null);
     const sentinelRef = useRef<HTMLDivElement>(null);
@@ -161,25 +393,42 @@ export const AgentsSelector = memo(
 
     const handleValueChange = useCallback(
       (v: string | null) => {
-        if (v) onValueChange(v);
+        if (!v) return;
+        // Don't trigger navigation for the row currently being edited.
+        if (v === editingId) return;
+        onValueChange(v);
       },
-      [onValueChange],
+      [onValueChange, editingId],
     );
 
-    const handleDeleteClick = useCallback(
-      (e: React.MouseEvent<HTMLButtonElement>) => {
-        e.stopPropagation();
-        const agentId = e.currentTarget.dataset.agentId;
-        if (agentId) setPendingDeleteId(agentId);
+    const handleStartDelete = useCallback((id: string) => {
+      setPendingDeleteId(id);
+    }, []);
+    const handleCancelDelete = useCallback(() => {
+      setPendingDeleteId(null);
+    }, []);
+    const handleConfirmDelete = useCallback(
+      (id: string) => {
+        setPendingDeleteId(null);
+        onDelete(id);
       },
-      [],
+      [onDelete],
     );
+
+    const handleStartEdit = useCallback((id: string) => {
+      setEditingId(id);
+      setPendingDeleteId(null);
+    }, []);
+    const handleCancelEdit = useCallback(() => {
+      setEditingId(null);
+    }, []);
 
     const handleOpenChange = useCallback((open: boolean) => {
       setIsOpen(open);
       if (!open) {
         setInputValue('');
         setPendingDeleteId(null);
+        setEditingId(null);
       }
     }, []);
 
@@ -209,7 +458,7 @@ export const AgentsSelector = memo(
       >
         {/* Custom trigger: unstyled, using base-ui Trigger directly with render */}
         <ComboboxBase.Trigger
-          render={(props) => (
+          render={(props: React.HTMLAttributes<HTMLButtonElement>) => (
             <Tooltip>
               <TooltipTrigger>
                 <Button
@@ -247,61 +496,21 @@ export const AgentsSelector = memo(
                 {filteredGroups.map(({ label, agents }) => (
                   <ComboboxGroup key={label}>
                     <ComboboxGroupLabel>{label}</ComboboxGroupLabel>
-                    {agents.map((agent) => {
-                      const isSelected = agent.id === value;
-                      const hasUnseen = !isSelected && !!agent.unread;
-
-                      return (
-                        <ComboboxItem
-                          key={agent.id}
-                          value={agent.id}
-                          size="xs"
-                          className="grid-cols-[0.75rem_1fr_auto]"
-                        >
-                          <ComboboxItemIndicator />
-                          <span className="col-start-2 flex w-full items-center gap-2">
-                            <span
-                              className={cn(
-                                'truncate',
-                                agent.isWorking && 'shimmer-text-primary',
-                                hasUnseen && 'animate-text-pulse-warning',
-                              )}
-                            >
-                              {agent.title}
-                            </span>
-                            <span className="shrink-0 text-subtle-foreground text-xs">
-                              <TimeAgo
-                                date={agent.lastMessageAt}
-                                formatter={minimalFormatter}
-                                live={false}
-                              />
-                            </span>
-                          </span>
-                          <div className="relative col-start-3">
-                            <button
-                              type="button"
-                              className="flex size-5 shrink-0 cursor-pointer items-center justify-center rounded-full text-muted-foreground opacity-0 transition-colors hover:text-foreground focus-visible:opacity-100 group-hover/item:opacity-100"
-                              data-agent-id={agent.id}
-                              onClick={handleDeleteClick}
-                            >
-                              <IconTrash2Outline24 className="size-3" />
-                            </button>
-                            {pendingDeleteId === agent.id && (
-                              <DeleteConfirmPopover
-                                open={true}
-                                onOpenChange={(open) => {
-                                  if (!open) setPendingDeleteId(null);
-                                }}
-                                onConfirm={() => {
-                                  setPendingDeleteId(null);
-                                  onDelete(agent.id);
-                                }}
-                              />
-                            )}
-                          </div>
-                        </ComboboxItem>
-                      );
-                    })}
+                    {agents.map((agent) => (
+                      <AgentListItem
+                        key={agent.id}
+                        agent={agent}
+                        isSelected={agent.id === value}
+                        isEditing={editingId === agent.id}
+                        pendingDeleteId={pendingDeleteId}
+                        onStartEdit={handleStartEdit}
+                        onCancelEdit={handleCancelEdit}
+                        onCommitRename={onRename}
+                        onStartDelete={handleStartDelete}
+                        onCancelDelete={handleCancelDelete}
+                        onConfirmDelete={handleConfirmDelete}
+                      />
+                    ))}
                   </ComboboxGroup>
                 ))}
               </ComboboxList>
@@ -340,5 +549,6 @@ export const AgentsSelector = memo(
     prevProps.value === nextProps.value &&
     prevProps.onValueChange === nextProps.onValueChange &&
     prevProps.onDelete === nextProps.onDelete &&
+    prevProps.onRename === nextProps.onRename &&
     prevProps.onEndReached === nextProps.onEndReached,
 );

--- a/apps/browser/src/ui/screens/main/sidebar/top/index.tsx
+++ b/apps/browser/src/ui/screens/main/sidebar/top/index.tsx
@@ -112,6 +112,7 @@ export function SidebarTopSection({ isCollapsed }: { isCollapsed: boolean }) {
   const createAgent = useKartonProcedure((p) => p.agents.create);
   const resumeAgent = useKartonProcedure((p) => p.agents.resume);
   const deleteAgent = useKartonProcedure((p) => p.agents.delete);
+  const setAgentTitle = useKartonProcedure((p) => p.agents.setTitle);
   const getAgentsHistoryList = useKartonProcedure(
     (p) => p.agents.getAgentsHistoryList,
   );
@@ -326,6 +327,8 @@ export function SidebarTopSection({ isCollapsed }: { isCollapsed: boolean }) {
   // interaction), so refs avoid re-creating callbacks on every state change.
   const deleteAgentRef = useRef(deleteAgent);
   deleteAgentRef.current = deleteAgent;
+  const setAgentTitleRef = useRef(setAgentTitle);
+  setAgentTitleRef.current = setAgentTitle;
   const openAgentRef = useRef(openAgent);
   openAgentRef.current = openAgent;
   const openAgentModelIdRef = useRef(openAgentModelId);
@@ -371,6 +374,40 @@ export function SidebarTopSection({ isCollapsed }: { isCollapsed: boolean }) {
     });
     // Functional updater: always sees latest state, safe under rapid successive deletes.
     setAgentsList((prev) => prev.filter((agent) => agent.id !== id));
+  }, []);
+
+  const handleRenameAgent = useCallback((id: string, newTitle: string) => {
+    // Optimistic: update the local list immediately.
+    setAgentsList((prev) =>
+      prev.map((agent) =>
+        agent.id === id ? { ...agent, title: newTitle } : agent,
+      ),
+    );
+    void setAgentTitleRef.current(id, newTitle).catch((e) => {
+      console.error(e);
+      posthog.captureException(e instanceof Error ? e : new Error(String(e)), {
+        source: 'renderer',
+        operation: 'setAgentTitle',
+      });
+      // Recover: refetch the first page to pull fresh server state.
+      // Using a single-source-of-truth refetch (rather than a closure-captured
+      // prev-title rollback) also corrects any partial-success drift.
+      void getAgentsHistoryListRef
+        .current(0, PAGE_SIZE)
+        .then((fresh) => {
+          setAgentsList(fresh);
+          // Reset pagination state to match the refetched first page.
+          // Without this, a user who had already scrolled past page 0
+          // would keep the stale higher offset and subsequent
+          // loadMoreHistory() calls would skip items 200…stale-offset.
+          rawFetchedCountRef.current = fresh.length;
+          setHasMoreHistory(fresh.length >= PAGE_SIZE);
+          isLoadingMoreRef.current = false;
+        })
+        .catch(() => {
+          // Best-effort recovery; swallow secondary failure.
+        });
+    });
   }, []);
 
   // Helper to create a new chat and focus the input.
@@ -475,6 +512,7 @@ export function SidebarTopSection({ isCollapsed }: { isCollapsed: boolean }) {
               value={openAgent}
               onValueChange={handleAgentSelect}
               onDelete={handleDeleteAgent}
+              onRename={handleRenameAgent}
               onEndReached={loadMoreHistory}
             />
           )}


### PR DESCRIPTION
Closes #945 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Inline agent renaming: edit titles in the sidebar and agent cards (double‑click or F2), commit with Enter/blur, cancel with Escape; pasted content is plain text.
  * Title locking & persistence: trimmed/validated titles (2–80 chars) are locked from auto‑generation and preserved across restarts.
  * Backend rename API with optimistic UI updates and best‑effort recovery on failure.

* **Chores**
  * Database/schema migration to persist the title‑locked flag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->