### PR TITLE
fix(stagewise): implement gitignore-aware filtering and workspace root resolution for agent edits

### DIFF
--- a/apps/browser/src/backend/main.ts
+++ b/apps/browser/src/backend/main.ts
@@ -303,6 +303,14 @@ export async function main({ launchOptions: { verbose } }: MainParameters) {
     credentialsService,
   );
 
+  // Give DiffHistoryService a way to resolve workspace roots for the
+  // gitignore-aware filter in `registerAgentEdit`. Evaluated lazily per
+  // call, so the (still-async) MountManager initialization inside
+  // ToolboxService does not need to be awaited before wiring.
+  diffHistoryService.setMountPathsResolver(() =>
+    toolboxService.getAllMountedPaths(),
+  );
+
   // Push bundled skill definitions via the toolbox so it can
   // merge them with workspace/plugin skills on mount changes.
   // Display order for builtin slash commands (unlisted ones sort last).

--- a/apps/browser/src/backend/services/diff-history/index.test.ts
+++ b/apps/browser/src/backend/services/diff-history/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { DiffHistoryService } from '.';
+import { DiffHistoryService, categorizeFanoutPath } from '.';
 import { Logger } from '@/services/logger';
 import type { KartonService } from '@/services/karton';
 import type { TelemetryService } from '@/services/telemetry';
@@ -2992,5 +2992,751 @@ describe('DiffHistoryService (E2E)', () => {
       expect(remainingKeys.some((k) => k.startsWith('1::'))).toBe(true);
       expect(remainingKeys.some((k) => k.startsWith('2::'))).toBe(false);
     });
+  });
+
+  // ===========================================================================
+  // Defensive guards: gitignore filter + per-tool-call fan-out cap
+  // ===========================================================================
+
+  describe('gitignore filtering', () => {
+    it('drops edits under node_modules even without a resolved workspace', async () => {
+      service = await DiffHistoryService.create(
+        logger,
+        mockKarton,
+        mockTelemetry,
+      );
+
+      const filePath = path.join(
+        testFilesDir,
+        'node_modules',
+        'some-pkg',
+        'index.js',
+      );
+
+      await service.registerAgentEdit({
+        agentInstanceId: '1',
+        path: filePath,
+        toolCallId: 'nm-tool',
+        isExternal: false,
+        contentBefore: null,
+        contentAfter: 'module.exports = {}',
+      });
+
+      const toolboxState = mockKarton._getToolboxState('1');
+      // No op stored → no pending diff surfaces to the UI.
+      expect(toolboxState?.pendingFileDiffs).toHaveLength(0);
+    });
+
+    it('drops edits matching user .gitignore inside a mounted workspace', async () => {
+      service = await DiffHistoryService.create(
+        logger,
+        mockKarton,
+        mockTelemetry,
+      );
+
+      // Create a workspace with a .gitignore that blocks `custom-ignored/`.
+      const workspaceRoot = path.join(tempDir, 'ws-with-gitignore');
+      await fs.mkdir(workspaceRoot, { recursive: true });
+      await fs.writeFile(
+        path.join(workspaceRoot, '.gitignore'),
+        'custom-ignored/\n',
+        'utf8',
+      );
+      service.setMountPathsResolver(() => new Set([workspaceRoot]));
+
+      const ignoredPath = path.join(workspaceRoot, 'custom-ignored', 'x.ts');
+      const trackedPath = path.join(workspaceRoot, 'src', 'y.ts');
+
+      await service.registerAgentEdit({
+        agentInstanceId: '1',
+        path: ignoredPath,
+        toolCallId: 'gi-tool-ignored',
+        isExternal: false,
+        contentBefore: null,
+        contentAfter: 'ignored',
+      });
+      await service.registerAgentEdit({
+        agentInstanceId: '1',
+        path: trackedPath,
+        toolCallId: 'gi-tool-tracked',
+        isExternal: false,
+        contentBefore: null,
+        contentAfter: 'tracked',
+      });
+
+      const toolboxState = mockKarton._getToolboxState('1');
+      expect(toolboxState?.pendingFileDiffs).toHaveLength(1);
+      expect(toolboxState?.pendingFileDiffs[0].path).toBe(trackedPath);
+    });
+
+    it('drops edits when workspaceRoot hint is passed explicitly', async () => {
+      service = await DiffHistoryService.create(
+        logger,
+        mockKarton,
+        mockTelemetry,
+      );
+
+      const workspaceRoot = path.join(tempDir, 'ws-explicit-hint');
+      await fs.mkdir(workspaceRoot, { recursive: true });
+      await fs.writeFile(
+        path.join(workspaceRoot, '.gitignore'),
+        'secrets/\n',
+        'utf8',
+      );
+      // NOTE: no setMountPathsResolver — the hint on the edit itself is
+      // what unlocks the gitignore check.
+
+      const ignoredPath = path.join(workspaceRoot, 'secrets', 'api-key.ts');
+
+      await service.registerAgentEdit({
+        agentInstanceId: '1',
+        path: ignoredPath,
+        toolCallId: 'hint-tool',
+        workspaceRoot,
+        isExternal: false,
+        contentBefore: null,
+        contentAfter: 'SECRET',
+      });
+
+      expect(mockKarton._getToolboxState('1')?.pendingFileDiffs).toHaveLength(
+        0,
+      );
+    });
+
+    it('tracks edits to regular source files', async () => {
+      service = await DiffHistoryService.create(
+        logger,
+        mockKarton,
+        mockTelemetry,
+      );
+
+      const filePath = path.join(testFilesDir, 'src', 'app.ts');
+      await service.registerAgentEdit({
+        agentInstanceId: '1',
+        path: filePath,
+        toolCallId: 'src-tool',
+        isExternal: false,
+        contentBefore: null,
+        contentAfter: 'export const x = 1;',
+      });
+
+      expect(mockKarton._getToolboxState('1')?.pendingFileDiffs).toHaveLength(
+        1,
+      );
+    });
+
+    it('honors `.gitignore` negation when a workspace resolves', async () => {
+      // Locks in the ordering decision: once a workspace is resolved,
+      // its `.gitignore` (including negations like `!dir/keep.ts`) is
+      // authoritative and no further segment check runs.
+      service = await DiffHistoryService.create(
+        logger,
+        mockKarton,
+        mockTelemetry,
+      );
+
+      const workspaceRoot = path.join(tempDir, 'ws-gitignore-negation');
+      await fs.mkdir(workspaceRoot, { recursive: true });
+      // `custom-build/` is NOT in HARDCODED_DENY_SEGMENTS, so the phase-1
+      // segment matcher cannot short-circuit the decision — the test
+      // exercises exactly the phase-2 `.gitignore` path.
+      //
+      // NOTE: `ignore` follows Git's semantics: once a directory is
+      // ignored, files inside cannot be un-ignored. Use file-level
+      // patterns so the negation actually takes effect.
+      await fs.writeFile(
+        path.join(workspaceRoot, '.gitignore'),
+        'custom-build/**\n!custom-build/keep.ts\n',
+        'utf8',
+      );
+      service.setMountPathsResolver(() => new Set([workspaceRoot]));
+
+      const dropPath = path.join(workspaceRoot, 'custom-build', 'drop.ts');
+      const keepPath = path.join(workspaceRoot, 'custom-build', 'keep.ts');
+
+      await service.registerAgentEdit({
+        agentInstanceId: '1',
+        path: dropPath,
+        toolCallId: 'neg-drop',
+        isExternal: false,
+        contentBefore: null,
+        contentAfter: 'drop',
+      });
+      await service.registerAgentEdit({
+        agentInstanceId: '1',
+        path: keepPath,
+        toolCallId: 'neg-keep',
+        isExternal: false,
+        contentBefore: null,
+        contentAfter: 'keep',
+      });
+
+      const diffs = mockKarton._getToolboxState('1')?.pendingFileDiffs ?? [];
+      expect(diffs).toHaveLength(1);
+      expect(diffs[0].path).toBe(keepPath);
+    });
+
+    it('tracks edits under `.vscode/` when not ignored (segment denylist narrowing)', async () => {
+      // Regression guard: `.vscode` used to be in HARDCODED_DENY_SEGMENTS,
+      // which silently dropped legitimate agent edits to committed
+      // editor configs. The narrowed denylist must NOT match it.
+      service = await DiffHistoryService.create(
+        logger,
+        mockKarton,
+        mockTelemetry,
+      );
+
+      const workspaceRoot = path.join(tempDir, 'ws-vscode-committed');
+      await fs.mkdir(workspaceRoot, { recursive: true });
+      // Trivial `.gitignore` that does NOT ignore `.vscode`.
+      await fs.writeFile(
+        path.join(workspaceRoot, '.gitignore'),
+        '*.log\n',
+        'utf8',
+      );
+      service.setMountPathsResolver(() => new Set([workspaceRoot]));
+
+      const vscodePath = path.join(workspaceRoot, '.vscode', 'settings.json');
+
+      await service.registerAgentEdit({
+        agentInstanceId: '1',
+        path: vscodePath,
+        toolCallId: 'vscode-tool',
+        isExternal: false,
+        contentBefore: null,
+        contentAfter: '{}',
+      });
+
+      const diffs = mockKarton._getToolboxState('1')?.pendingFileDiffs ?? [];
+      expect(diffs).toHaveLength(1);
+      expect(diffs[0].path).toBe(vscodePath);
+    });
+
+    it('tracks edits under `dist/` when the project commits it via `.gitignore` negation', async () => {
+      // Regression guard for the PR review feedback that `dist`/`build`/
+      // `out` must NOT be in HARDCODED_DENY_SEGMENTS: projects that
+      // legitimately commit `dist/` (prebuilt assets, generated types,
+      // etc.) would otherwise lose diff history and `!dist/keep.ts`
+      // would be unrecoverable.
+      service = await DiffHistoryService.create(
+        logger,
+        mockKarton,
+        mockTelemetry,
+      );
+
+      const workspaceRoot = path.join(tempDir, 'ws-committed-dist');
+      await fs.mkdir(workspaceRoot, { recursive: true });
+      // `ignore` semantics: cannot un-ignore files inside an already
+      // ignored directory, so use the file-level `dist/**` form.
+      await fs.writeFile(
+        path.join(workspaceRoot, '.gitignore'),
+        'dist/**\n!dist/keep.ts\n',
+        'utf8',
+      );
+      service.setMountPathsResolver(() => new Set([workspaceRoot]));
+
+      const keepPath = path.join(workspaceRoot, 'dist', 'keep.ts');
+      const dropPath = path.join(workspaceRoot, 'dist', 'drop.ts');
+
+      await service.registerAgentEdit({
+        agentInstanceId: '1',
+        path: keepPath,
+        toolCallId: 'dist-keep',
+        isExternal: false,
+        contentBefore: null,
+        contentAfter: 'export const kept = true;',
+      });
+      await service.registerAgentEdit({
+        agentInstanceId: '1',
+        path: dropPath,
+        toolCallId: 'dist-drop',
+        isExternal: false,
+        contentBefore: null,
+        contentAfter: 'export const dropped = true;',
+      });
+
+      const diffs = mockKarton._getToolboxState('1')?.pendingFileDiffs ?? [];
+      expect(diffs).toHaveLength(1);
+      expect(diffs[0].path).toBe(keepPath);
+    });
+
+    it('honors nested `.gitignore` that adds rules beyond the root file', async () => {
+      // Regression guard for nested-gitignore support: a rule that
+      // lives only in `packages/foo/.gitignore` must apply to files
+      // under that package and ONLY that package.
+      service = await DiffHistoryService.create(
+        logger,
+        mockKarton,
+        mockTelemetry,
+      );
+
+      const workspaceRoot = path.join(tempDir, 'ws-nested-adds');
+      await fs.mkdir(path.join(workspaceRoot, 'packages', 'foo'), {
+        recursive: true,
+      });
+      // Root `.gitignore` intentionally empty (present so the
+      // matcher does not fall back to soft-defaults-only behavior).
+      await fs.writeFile(path.join(workspaceRoot, '.gitignore'), '', 'utf8');
+      await fs.writeFile(
+        path.join(workspaceRoot, 'packages', 'foo', '.gitignore'),
+        'custom-output/**\n',
+        'utf8',
+      );
+      service.setMountPathsResolver(() => new Set([workspaceRoot]));
+
+      const fooDrop = path.join(
+        workspaceRoot,
+        'packages',
+        'foo',
+        'custom-output',
+        'drop.ts',
+      );
+      const fooTrack = path.join(
+        workspaceRoot,
+        'packages',
+        'foo',
+        'src',
+        'app.ts',
+      );
+      const barTrack = path.join(
+        workspaceRoot,
+        'packages',
+        'bar',
+        'custom-output',
+        'also.ts',
+      );
+
+      for (const [p, id, content] of [
+        [fooDrop, 'nested-drop', 'drop'],
+        [fooTrack, 'nested-track', 'ok'],
+        [barTrack, 'sibling-track', 'ok'],
+      ] as const) {
+        await service.registerAgentEdit({
+          agentInstanceId: '1',
+          path: p,
+          toolCallId: id,
+          isExternal: false,
+          contentBefore: null,
+          contentAfter: content,
+        });
+      }
+
+      const diffs = mockKarton._getToolboxState('1')?.pendingFileDiffs ?? [];
+      const paths = diffs.map((d) => d.path).sort();
+      expect(paths).toEqual([barTrack, fooTrack].sort());
+    });
+
+    it('honors nested `.gitignore` negations against a shallow rule', async () => {
+      // Deeper `.gitignore` wins: a `!generated/keep.ts` in
+      // `src/.gitignore` overrides a `generated/**` rule from the
+      // root file, but only within `src/`.
+      service = await DiffHistoryService.create(
+        logger,
+        mockKarton,
+        mockTelemetry,
+      );
+
+      const workspaceRoot = path.join(tempDir, 'ws-nested-negate');
+      await fs.mkdir(path.join(workspaceRoot, 'src', 'generated'), {
+        recursive: true,
+      });
+      await fs.mkdir(path.join(workspaceRoot, 'other', 'generated'), {
+        recursive: true,
+      });
+      // Unanchored `**/generated/**` at root so the rule catches
+      // the `src/generated/...` subtree too (a bare `generated/**`
+      // would only match `/ws/generated/*`).
+      await fs.writeFile(
+        path.join(workspaceRoot, '.gitignore'),
+        '**/generated/**\n',
+        'utf8',
+      );
+      await fs.writeFile(
+        path.join(workspaceRoot, 'src', '.gitignore'),
+        '!generated/keep.ts\n',
+        'utf8',
+      );
+      service.setMountPathsResolver(() => new Set([workspaceRoot]));
+
+      const keep = path.join(workspaceRoot, 'src', 'generated', 'keep.ts');
+      const drop = path.join(workspaceRoot, 'src', 'generated', 'drop.ts');
+      const otherDrop = path.join(
+        workspaceRoot,
+        'other',
+        'generated',
+        'other.ts',
+      );
+
+      for (const [p, id, content] of [
+        [keep, 'neg-keep', 'keep'],
+        [drop, 'neg-drop', 'drop'],
+        [otherDrop, 'neg-other', 'drop'],
+      ] as const) {
+        await service.registerAgentEdit({
+          agentInstanceId: '1',
+          path: p,
+          toolCallId: id,
+          isExternal: false,
+          contentBefore: null,
+          contentAfter: content,
+        });
+      }
+
+      const diffs = mockKarton._getToolboxState('1')?.pendingFileDiffs ?? [];
+      expect(diffs.map((d) => d.path)).toEqual([keep]);
+    });
+
+    it('deeper layer with no opinion does not override shallow rule', async () => {
+      // Verdict-preservation check: a nested `.gitignore` that is
+      // silent on a file must NOT un-ignore it — the shallow rule
+      // from the root `.gitignore` still wins.
+      service = await DiffHistoryService.create(
+        logger,
+        mockKarton,
+        mockTelemetry,
+      );
+
+      const workspaceRoot = path.join(tempDir, 'ws-nested-silent');
+      await fs.mkdir(path.join(workspaceRoot, 'packages', 'foo'), {
+        recursive: true,
+      });
+      await fs.writeFile(
+        path.join(workspaceRoot, '.gitignore'),
+        '*.log\n',
+        'utf8',
+      );
+      // Nested file is non-empty but mentions unrelated patterns so
+      // we can assert `ig.test()` returns `no-opinion` for the file
+      // we care about.
+      await fs.writeFile(
+        path.join(workspaceRoot, 'packages', 'foo', '.gitignore'),
+        '# unrelated rules\nunused-pattern/**\n',
+        'utf8',
+      );
+      service.setMountPathsResolver(() => new Set([workspaceRoot]));
+
+      const logPath = path.join(workspaceRoot, 'packages', 'foo', 'out.log');
+
+      await service.registerAgentEdit({
+        agentInstanceId: '1',
+        path: logPath,
+        toolCallId: 'silent-layer',
+        isExternal: false,
+        contentBefore: null,
+        contentAfter: 'log',
+      });
+
+      expect(mockKarton._getToolboxState('1')?.pendingFileDiffs).toHaveLength(
+        0,
+      );
+    });
+
+    it('soft defaults still cover projects without any `.gitignore`', async () => {
+      // Without a root `.gitignore` the matcher synthesizes a
+      // soft-defaults-only shallowest layer so common build output
+      // is still dropped.
+      service = await DiffHistoryService.create(
+        logger,
+        mockKarton,
+        mockTelemetry,
+      );
+
+      const workspaceRoot = path.join(tempDir, 'ws-no-gitignore');
+      await fs.mkdir(workspaceRoot, { recursive: true });
+      service.setMountPathsResolver(() => new Set([workspaceRoot]));
+
+      const distPath = path.join(workspaceRoot, 'dist', 'bar.ts');
+      const srcPath = path.join(workspaceRoot, 'src', 'app.ts');
+
+      for (const [p, id] of [
+        [distPath, 'no-ig-dist'],
+        [srcPath, 'no-ig-src'],
+      ] as const) {
+        await service.registerAgentEdit({
+          agentInstanceId: '1',
+          path: p,
+          toolCallId: id,
+          isExternal: false,
+          contentBefore: null,
+          contentAfter: 'x',
+        });
+      }
+
+      const diffs = mockKarton._getToolboxState('1')?.pendingFileDiffs ?? [];
+      expect(diffs.map((d) => d.path)).toEqual([srcPath]);
+    });
+
+    it('nested `.gitignore` scoping is limited to its own subtree', async () => {
+      // A rule inside `packages/foo/.gitignore` must not leak to
+      // `packages/bar/`. This is the sibling-scoping invariant.
+      service = await DiffHistoryService.create(
+        logger,
+        mockKarton,
+        mockTelemetry,
+      );
+
+      const workspaceRoot = path.join(tempDir, 'ws-nested-scoping');
+      await fs.mkdir(path.join(workspaceRoot, 'packages', 'foo'), {
+        recursive: true,
+      });
+      await fs.mkdir(path.join(workspaceRoot, 'packages', 'bar'), {
+        recursive: true,
+      });
+      await fs.writeFile(
+        path.join(workspaceRoot, 'packages', 'foo', '.gitignore'),
+        'custom-output/**\n',
+        'utf8',
+      );
+      service.setMountPathsResolver(() => new Set([workspaceRoot]));
+
+      const fooPath = path.join(
+        workspaceRoot,
+        'packages',
+        'foo',
+        'custom-output',
+        'x.ts',
+      );
+      const barPath = path.join(
+        workspaceRoot,
+        'packages',
+        'bar',
+        'custom-output',
+        'x.ts',
+      );
+
+      for (const [p, id] of [
+        [fooPath, 'scope-foo'],
+        [barPath, 'scope-bar'],
+      ] as const) {
+        await service.registerAgentEdit({
+          agentInstanceId: '1',
+          path: p,
+          toolCallId: id,
+          isExternal: false,
+          contentBefore: null,
+          contentAfter: 'x',
+        });
+      }
+
+      const diffs = mockKarton._getToolboxState('1')?.pendingFileDiffs ?? [];
+      expect(diffs.map((d) => d.path)).toEqual([barPath]);
+    });
+  });
+
+  describe('per-tool-call fan-out cap', () => {
+    // Keep this in sync with MAX_EDITS_PER_TOOL_CALL inside the service.
+    const CAP = 50;
+
+    it('stores up to CAP edits for a single tool call and drops the rest', async () => {
+      service = await DiffHistoryService.create(
+        logger,
+        mockKarton,
+        mockTelemetry,
+      );
+
+      const toolCallId = 'fanout-tool-1';
+      // `Logger.warn` is a getter that returns a bound winston fn; spying
+      // directly on it replaces the getter and breaks other callers. Stub
+      // the underlying winston instance instead by overriding its `warn`.
+      const innerLogger = (logger as unknown as { logger: { warn: unknown } })
+        .logger;
+      const warnSpy = vi.fn();
+      const originalWarn = innerLogger.warn;
+      innerLogger.warn = warnSpy as unknown as typeof innerLogger.warn;
+
+      try {
+        // CAP edits — all stored.
+        for (let i = 0; i < CAP; i++) {
+          await service.registerAgentEdit({
+            agentInstanceId: '1',
+            path: path.join(testFilesDir, `fan-${i}.ts`),
+            toolCallId,
+            isExternal: false,
+            contentBefore: null,
+            contentAfter: `content ${i}`,
+          });
+        }
+        expect(mockKarton._getToolboxState('1')?.pendingFileDiffs).toHaveLength(
+          CAP,
+        );
+        expect(warnSpy).not.toHaveBeenCalled();
+        expect(
+          (mockTelemetry.capture as ReturnType<typeof vi.fn>).mock.calls.filter(
+            ([event]) => event === 'diff-history-fanout-cap-hit',
+          ),
+        ).toHaveLength(0);
+
+        // CAP+1 — dropped. One warning + one telemetry event.
+        await service.registerAgentEdit({
+          agentInstanceId: '1',
+          path: path.join(testFilesDir, `fan-${CAP}.ts`),
+          toolCallId,
+          isExternal: false,
+          contentBefore: null,
+          contentAfter: 'over-cap',
+        });
+        expect(mockKarton._getToolboxState('1')?.pendingFileDiffs).toHaveLength(
+          CAP,
+        );
+        expect(warnSpy).toHaveBeenCalledTimes(1);
+        const capHits = (
+          mockTelemetry.capture as ReturnType<typeof vi.fn>
+        ).mock.calls.filter(
+          ([event]) => event === 'diff-history-fanout-cap-hit',
+        );
+        expect(capHits).toHaveLength(1);
+        expect(capHits[0][1]).toMatchObject({
+          tool_call_id: toolCallId,
+          agent_instance_id: '1',
+          cap: CAP,
+          // First dropped path was `<testFilesDir>/fan-50.ts` which has
+          // no categorized segments and no leading-dot basename.
+          path_category: 'other',
+        });
+
+        // Further edits on the SAME tool-call — dropped silently (no duplicate
+        // warnings or telemetry).
+        for (let i = 0; i < 10; i++) {
+          await service.registerAgentEdit({
+            agentInstanceId: '1',
+            path: path.join(testFilesDir, `fan-extra-${i}.ts`),
+            toolCallId,
+            isExternal: false,
+            contentBefore: null,
+            contentAfter: `extra ${i}`,
+          });
+        }
+        expect(mockKarton._getToolboxState('1')?.pendingFileDiffs).toHaveLength(
+          CAP,
+        );
+        expect(warnSpy).toHaveBeenCalledTimes(1);
+        expect(
+          (mockTelemetry.capture as ReturnType<typeof vi.fn>).mock.calls.filter(
+            ([event]) => event === 'diff-history-fanout-cap-hit',
+          ),
+        ).toHaveLength(1);
+      } finally {
+        // Guarantee the patched warn is restored even if an assertion
+        // above throws; otherwise `afterEach` teardown log calls would
+        // be silently swallowed by the spy.
+        innerLogger.warn = originalWarn;
+      }
+    });
+
+    it('resets the counter per new tool call id', async () => {
+      service = await DiffHistoryService.create(
+        logger,
+        mockKarton,
+        mockTelemetry,
+      );
+
+      // First tool call hits the cap.
+      for (let i = 0; i < CAP + 5; i++) {
+        await service.registerAgentEdit({
+          agentInstanceId: '1',
+          path: path.join(testFilesDir, `call-a-${i}.ts`),
+          toolCallId: 'call-a',
+          isExternal: false,
+          contentBefore: null,
+          contentAfter: 'a',
+        });
+      }
+      const afterFirst =
+        mockKarton._getToolboxState('1')?.pendingFileDiffs.length ?? 0;
+      expect(afterFirst).toBe(CAP);
+
+      // New tool call id with one edit — it gets through.
+      await service.registerAgentEdit({
+        agentInstanceId: '1',
+        path: path.join(testFilesDir, 'call-b-0.ts'),
+        toolCallId: 'call-b',
+        isExternal: false,
+        contentBefore: null,
+        contentAfter: 'b',
+      });
+      expect(
+        mockKarton._getToolboxState('1')?.pendingFileDiffs.length ?? 0,
+      ).toBe(CAP + 1);
+    });
+
+    it('categorizes paths for telemetry without leaking raw values', () => {
+      // Telemetry privacy guard: the `diff-history-fanout-cap-hit`
+      // event must emit only a coarse category, never the raw path.
+      // Covers every branch of `categorizeFanoutPath` so a future
+      // rename / reorder cannot regress the payload shape.
+      const sep = path.sep;
+      expect(
+        categorizeFanoutPath(
+          ['', 'Users', 'alice', 'repo', 'node_modules', 'foo.js'].join(sep),
+        ),
+      ).toBe('node_modules');
+      // `node_modules` outranks `dotfile` for a `.bin`-style path.
+      expect(
+        categorizeFanoutPath(
+          ['', 'repo', 'node_modules', '.bin', 'tsc'].join(sep),
+        ),
+      ).toBe('node_modules');
+      expect(
+        categorizeFanoutPath(['', 'repo', 'dist', 'bundle.js'].join(sep)),
+      ).toBe('build-output');
+      expect(
+        categorizeFanoutPath(
+          ['', 'repo', '.next', 'static', 'index.js'].join(sep),
+        ),
+      ).toBe('build-output');
+      expect(
+        categorizeFanoutPath(['', 'repo', '.turbo', 'daemon.log'].join(sep)),
+      ).toBe('tooling-cache');
+      expect(
+        categorizeFanoutPath(['', 'repo', 'coverage', 'lcov.info'].join(sep)),
+      ).toBe('tooling-cache');
+      expect(categorizeFanoutPath(['', 'repo', '.gitignore'].join(sep))).toBe(
+        'dotfile',
+      );
+      expect(
+        categorizeFanoutPath(['', 'repo', 'src', 'app.ts'].join(sep)),
+      ).toBe('other');
+    });
+
+    it('caps the tracked-tool-call maps to prevent unbounded memory growth', async () => {
+      // Verifies the `MAX_TRACKED_TOOL_CALLS` reset kicks in when the
+      // counter map would otherwise grow indefinitely across a long
+      // session with thousands of short-lived tool calls.
+      service = await DiffHistoryService.create(
+        logger,
+        mockKarton,
+        mockTelemetry,
+      );
+
+      // Matches `DiffHistoryService.MAX_TRACKED_TOOL_CALLS` — keep in sync.
+      const MEMORY_CAP = 10_000;
+      const OVERFLOW = 5;
+
+      // Each iteration is a distinct tool call id with a single
+      // edit. That is enough to grow `_toolCallEditCounts` by one
+      // entry per iteration.
+      for (let i = 0; i < MEMORY_CAP + OVERFLOW; i++) {
+        await service.registerAgentEdit({
+          agentInstanceId: '1',
+          path: path.join(testFilesDir, `mem-cap-${i}.ts`),
+          toolCallId: `mem-tool-${i}`,
+          isExternal: false,
+          contentBefore: null,
+          contentAfter: 'x',
+        });
+      }
+
+      const counts = (
+        service as unknown as { _toolCallEditCounts: Map<string, number> }
+      )._toolCallEditCounts;
+      const warned = (
+        service as unknown as {
+          _toolCallTruncatedWarned: Set<string>;
+        }
+      )._toolCallTruncatedWarned;
+
+      expect(counts.size).toBeLessThanOrEqual(MEMORY_CAP);
+      expect(warned.size).toBeLessThanOrEqual(MEMORY_CAP);
+    }, 120_000); // Creating 10k edits is file-IO heavy; give the test extra room.
   });
 });

--- a/apps/browser/src/backend/services/diff-history/index.ts
+++ b/apps/browser/src/backend/services/diff-history/index.ts
@@ -12,6 +12,12 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import type { KartonService } from '@/services/karton';
 import {
+  HARDCODED_DENY_SEGMENTS,
+  loadWorkspaceIgnore,
+  type WorkspaceIgnoreMatcher,
+} from '@/utils/load-gitignore';
+import { pickOwningWorkspace } from '@/utils/workspace-resolution';
+import {
   getDiffHistoryDbPath,
   getDiffHistoryBlobsDir,
   getAgentAppsDir,
@@ -62,6 +68,13 @@ type AgentFileEdit = {
   agentInstanceId: string;
   path: string;
   toolCallId: string;
+  /**
+   * Absolute path of the mounted workspace that owns `path`, when the
+   * caller already knows it. Used as the fast-path for the gitignore
+   * check in `registerAgentEdit`. Optional — when omitted, the service
+   * walks up against its known mount set.
+   */
+  workspaceRoot?: string | null;
 } & (
   | {
       isExternal: false;
@@ -74,6 +87,64 @@ type AgentFileEdit = {
       tempPathToAfterContent: string | null;
     }
 );
+
+/**
+ * Coarse category of a filesystem path used as the telemetry-safe
+ * replacement for the raw `first_dropped_path` we used to ship in the
+ * `diff-history-fanout-cap-hit` event. Categories are intentionally
+ * chunky so the payload cannot leak usernames, repo names, or
+ * directory structure while still providing useful analytics signal
+ * (e.g. "90% of cap hits happen under node_modules").
+ */
+export type FanoutPathCategory =
+  | 'node_modules'
+  | 'build-output'
+  | 'tooling-cache'
+  | 'dotfile'
+  | 'other';
+
+const FANOUT_BUILD_OUTPUT_SEGMENTS: ReadonlySet<string> = new Set([
+  'dist',
+  'build',
+  'out',
+  '.output',
+  '.next',
+  '.nuxt',
+  '.svelte-kit',
+  '.astro',
+]);
+
+const FANOUT_TOOLING_CACHE_SEGMENTS: ReadonlySet<string> = new Set([
+  '.turbo',
+  '.cache',
+  '.parcel-cache',
+  '.vite',
+  '.angular',
+  '.gradle',
+  'coverage',
+]);
+
+/**
+ * Maps an absolute filesystem path to a coarse category for telemetry.
+ *
+ * Precedence is top-down: a match in a higher row wins even if lower
+ * rows would also match. `node_modules` deliberately outranks
+ * `dotfile` so that e.g. `node_modules/.bin/foo` still reports as
+ * `node_modules`.
+ *
+ * Never returns the path itself — that is the whole point.
+ */
+export function categorizeFanoutPath(filepath: string): FanoutPathCategory {
+  const segments = filepath.split(path.sep);
+  if (segments.includes('node_modules')) return 'node_modules';
+  for (const seg of segments) {
+    if (FANOUT_BUILD_OUTPUT_SEGMENTS.has(seg)) return 'build-output';
+    if (FANOUT_TOOLING_CACHE_SEGMENTS.has(seg)) return 'tooling-cache';
+  }
+  const basename = segments[segments.length - 1] ?? '';
+  if (basename.startsWith('.')) return 'dotfile';
+  return 'other';
+}
 
 export class DiffHistoryService extends DisposableService {
   private readonly logger: Logger;
@@ -146,6 +217,64 @@ export class DiffHistoryService extends DisposableService {
       editSummary: FileDiff[];
     }
   >();
+
+  /**
+   * Maximum number of file edits a single tool call may register in the
+   * ops table. Edits past this threshold are dropped on the floor — the
+   * tool's on-disk write has already succeeded; we just refuse to track
+   * it so a single rogue tool call cannot flood the diff store with
+   * thousands of entries.
+   *
+   * 50 is comfortably above any realistic hand-authored multi-file edit
+   * and well below the ~hundreds-of-files threshold at which the pending
+   * diff computation becomes UI-blocking.
+   */
+  private readonly MAX_EDITS_PER_TOOL_CALL = 50;
+
+  /**
+   * Memory-safety cap on `_toolCallEditCounts` / `_toolCallTruncatedWarned`
+   * size. These maps are keyed by `toolCallId` and have no natural
+   * expiry (a tool call completes in seconds but we never know when
+   * its last edit arrived). Rather than wire GC plumbing for what are
+   * tiny integer entries, we reset both maps when the count map
+   * crosses this threshold. Worst case: a previously-capped tool call
+   * could register 50 more edits after a reset — acceptable, and
+   * exceedingly unlikely in practice because tool calls are short-lived.
+   */
+  private static readonly MAX_TRACKED_TOOL_CALLS = 10_000;
+
+  /** Per-tool-call running count of registered edits. */
+  private _toolCallEditCounts = new Map<string, number>();
+
+  /**
+   * Tool-call IDs for which we have already emitted the one-shot
+   * "exceeded fan-out cap" warning. Prevents log/telemetry spam.
+   */
+  private _toolCallTruncatedWarned = new Set<string>();
+
+  /**
+   * Cache of `WorkspaceIgnoreMatcher` instances keyed by absolute
+   * workspace root. The matcher holds one `Ignore` instance per
+   * `.gitignore` file found under the workspace so the check honors
+   * git's nested-`.gitignore` semantics. Entries expire after
+   * `IGNORE_TTL_MS` so edits to any `.gitignore` in the tree are
+   * eventually picked up without the complexity of a dedicated
+   * per-file watcher.
+   */
+  private _ignoreCache = new Map<
+    string,
+    { matcher: WorkspaceIgnoreMatcher; expiresAt: number }
+  >();
+  private static readonly IGNORE_TTL_MS = 30_000;
+
+  /**
+   * Injected via `setMountPathsResolver` after construction (to avoid
+   * a circular dep with ToolboxService / MountManagerService at
+   * DiffHistoryService.create() time). Returns the current set of
+   * absolute workspace root paths. Used to resolve the owning workspace
+   * of a filepath when the caller did not provide it explicitly.
+   */
+  private _mountPathsResolver: (() => Set<string>) | null = null;
 
   private cacheKey(
     agentId: string,
@@ -247,6 +376,14 @@ export class DiffHistoryService extends DisposableService {
       })
       .on('change', async (path) => {
         if (this.filesIgnoredByWatcher.has(path)) return;
+        // NOTE: we deliberately do NOT re-run `shouldTrackFilepath`
+        // here. Every path in the watch set was approved by the
+        // gitignore guard at `registerAgentEdit` time, so a change
+        // to `.gitignore` after the fact (or a newly added nested
+        // mount) must not silently suppress the user-save op for a
+        // file that still has pending ops — doing so would leave
+        // a stale current snapshot that never self-heals and could
+        // clobber user changes on Accept.
         try {
           await storeFileAndAddOperation(path, {
             operation: 'edit',
@@ -262,6 +399,10 @@ export class DiffHistoryService extends DisposableService {
         await this.updateAgentsAffectedByFilepath(path);
       })
       .on('unlink', async (path) => {
+        // Same rationale as the `change` handler above: re-running
+        // the gitignore filter here would cause silent data loss
+        // for files that were legitimately tracked but later fell
+        // into an ignored path.
         if (this.filesIgnoredByWatcher.has(path)) return;
         await insertOperation(this.db, path, null, {
           operation: 'edit',
@@ -324,6 +465,117 @@ export class DiffHistoryService extends DisposableService {
   }
 
   /**
+   * Injects the resolver used to discover which absolute paths are
+   * currently mounted as agent workspaces. Called once from `main.ts`
+   * after both `DiffHistoryService` and `ToolboxService` (which owns
+   * the `MountManagerService`) have been constructed.
+   *
+   * Without a resolver the service still functions, but
+   * `shouldTrackFilepath` falls back to segment-only denylist matching
+   * for edits whose `workspaceRoot` was not explicitly passed in.
+   */
+  public setMountPathsResolver(fn: () => Set<string>): void {
+    this._mountPathsResolver = fn;
+  }
+
+  /**
+   * Longest-prefix match of `filepath` against the currently mounted
+   * workspace roots. Returns `null` when the resolver has not been
+   * wired, when no mount is registered, or when the path lies outside
+   * every mount. Longest match wins so nested mounts resolve to the
+   * innermost workspace (whose `.gitignore` is the relevant one).
+   */
+  private findWorkspaceRoot(filepath: string): string | null {
+    const mounts = this._mountPathsResolver?.();
+    if (!mounts || mounts.size === 0) return null;
+    // Single source of truth shared with `MountManagerService` so the
+    // two callers can't drift on path-boundary / longest-prefix /
+    // filesystem-root semantics.
+    return pickOwningWorkspace(filepath, mounts) ?? null;
+  }
+
+  /**
+   * TTL-cached `WorkspaceIgnoreMatcher` for a workspace root. The
+   * matcher scans every `.gitignore` file under the workspace once
+   * per TTL and answers git-accurate ignore queries for any file
+   * beneath the root. The cache TTL is low (30s) so `.gitignore`
+   * edits are eventually honored without the complexity of a
+   * dedicated watcher on every ignore file.
+   */
+  private async getCachedIgnore(
+    workspaceRoot: string,
+  ): Promise<WorkspaceIgnoreMatcher> {
+    const now = Date.now();
+    const hit = this._ignoreCache.get(workspaceRoot);
+    if (hit && hit.expiresAt > now) return hit.matcher;
+    const matcher = await loadWorkspaceIgnore(workspaceRoot);
+    this._ignoreCache.set(workspaceRoot, {
+      matcher,
+      expiresAt: now + DiffHistoryService.IGNORE_TTL_MS,
+    });
+    return matcher;
+  }
+
+  /**
+   * Decides whether a filepath should be tracked by diff-history.
+   *
+   * Three-phase check, cheapest-first:
+   *   1. Synchronous walk-up against `HARDCODED_DENY_SEGMENTS`. This
+   *      catches the pathological cases (`node_modules`, build dirs,
+   *      tooling caches) in microseconds with zero allocations, which
+   *      matters when a runaway tool fans out across thousands of
+   *      ignored paths. Segments in this list represent universally
+   *      non-committed output — no real project keeps them under
+   *      version control — so applying them unconditionally is safe.
+   *   2. Resolve the owning workspace (caller-provided hint, else
+   *      walk-up against the mounted set) and, if found, consult the
+   *      workspace's `.gitignore` (TTL-cached). When a workspace
+   *      resolves, its `.gitignore` is **authoritative**: negations
+   *      like `!dist/keep.ts` are honored and no further segment
+   *      check is applied after it.
+   *   3. Outside any mounted workspace with the segment check already
+   *      clean: allow the edit.
+   *
+   * Never throws — returns `true` on any unexpected error so we fail
+   * open (prefer tracking over silently dropping).
+   */
+  private async shouldTrackFilepath(
+    filepath: string,
+    workspaceRoot?: string | null,
+  ): Promise<boolean> {
+    try {
+      // Phase 1: synchronous segment denylist. Hot path for runaway
+      // node_modules fan-out; rejects in microseconds.
+      const segments = filepath.split(path.sep);
+      for (const seg of segments) {
+        if (HARDCODED_DENY_SEGMENTS.has(seg)) return false;
+      }
+
+      // Phase 2: authoritative per-workspace `.gitignore`, honoring
+      // nested `.gitignore` files at every level from the root down
+      // to the file's parent. The matcher internally walks layers
+      // and takes the deepest definitive verdict, so we do NOT fall
+      // through to any further segment check after this.
+      const root = workspaceRoot ?? this.findWorkspaceRoot(filepath);
+      if (root) {
+        const matcher = await this.getCachedIgnore(root);
+        return !matcher.ignores(filepath);
+      }
+
+      // Phase 3: no workspace found, segment check already passed.
+      return true;
+    } catch (error) {
+      // Never let an ignore-check failure block a real edit. Log and
+      // fall open so the edit is tracked as it would have been before.
+      this.logError(
+        `shouldTrackFilepath failed for ${filepath} — failing open`,
+        error,
+      );
+      return true;
+    }
+  }
+
+  /**
    * Registers an agent edit in the diff-db and updates the diff karton state.
    * **The caller is responsible for detecting binaries/ blobs and providing before/ after content accordingly.**
    * Binary content will be provided as temporary paths to files - the caller is responsible for cleaning up the temporary
@@ -338,10 +590,58 @@ export class DiffHistoryService extends DisposableService {
    * **For regular file edits:**
    * - set 'before*' to content and 'after*' to content
    *
+   * Two defensive guards apply before any DB write:
+   *   1. `shouldTrackFilepath` drops edits in gitignored / denylisted paths.
+   *   2. A per-`toolCallId` counter caps fan-out at `MAX_EDITS_PER_TOOL_CALL`.
+   * Both are silent no-ops from the caller's perspective — the tool's
+   * on-disk write has already succeeded; we just refuse to store
+   * untrackable / runaway entries in the ops table.
+   *
    * @param edit - The edit to register
    * @returns void
    */
   public async registerAgentEdit(edit: AgentFileEdit) {
+    // Guard 1: gitignore / hardcoded-denylist filter.
+    if (!(await this.shouldTrackFilepath(edit.path, edit.workspaceRoot))) {
+      this.logDebug(`Skipping ignored path: ${edit.path}`);
+      return;
+    }
+
+    // Guard 2: per-tool-call fan-out cap. Single runaway tool call can
+    // otherwise flood the ops table with thousands of entries.
+    const prev = this._toolCallEditCounts.get(edit.toolCallId) ?? 0;
+    // Memory-safety reset: if we are about to track a brand-new tool
+    // call and the map has grown past the hard cap, drop both maps.
+    // See `MAX_TRACKED_TOOL_CALLS` JSDoc for the trade-off.
+    if (
+      prev === 0 &&
+      this._toolCallEditCounts.size >= DiffHistoryService.MAX_TRACKED_TOOL_CALLS
+    ) {
+      this._toolCallEditCounts.clear();
+      this._toolCallTruncatedWarned.clear();
+    }
+    const next = prev + 1;
+    this._toolCallEditCounts.set(edit.toolCallId, next);
+    if (next > this.MAX_EDITS_PER_TOOL_CALL) {
+      if (!this._toolCallTruncatedWarned.has(edit.toolCallId)) {
+        this._toolCallTruncatedWarned.add(edit.toolCallId);
+        this.logger.warn(
+          `[DiffHistory] Tool call ${edit.toolCallId} exceeded fan-out cap ` +
+            `(${this.MAX_EDITS_PER_TOOL_CALL} edits). Further edits in ` +
+            `this call are dropped from diff history; on-disk writes are unaffected.`,
+        );
+        this.telemetryService.capture('diff-history-fanout-cap-hit', {
+          tool_call_id: edit.toolCallId,
+          agent_instance_id: edit.agentInstanceId,
+          // Intentionally NOT `edit.path` — raw paths leak usernames
+          // and repo names into analytics. See `FanoutPathCategory`.
+          path_category: categorizeFanoutPath(edit.path),
+          cap: this.MAX_EDITS_PER_TOOL_CALL,
+        });
+      }
+      return;
+    }
+
     // If path is null, it's a newly created blob
     const hasPendingEdits = edit.path
       ? await hasPendingEditsForFilepath(this.db, edit.path)
@@ -1320,6 +1620,10 @@ export class DiffHistoryService extends DisposableService {
     this.contributorStateCache.clear();
     this.oidContentCache.clear();
     this._agentDiffSnapshot.clear();
+    this._toolCallEditCounts.clear();
+    this._toolCallTruncatedWarned.clear();
+    this._ignoreCache.clear();
+    this._mountPathsResolver = null;
     this.uiKarton.removeServerProcedureHandler('toolbox.acceptHunks');
     this.uiKarton.removeServerProcedureHandler('toolbox.rejectHunks');
   }

--- a/apps/browser/src/backend/services/telemetry.ts
+++ b/apps/browser/src/backend/services/telemetry.ts
@@ -69,6 +69,22 @@ export type EventProperties = {
   // Edits
   'edits-accepted': { hunk_count: number };
   'edits-rejected': { hunk_count: number };
+  'diff-history-fanout-cap-hit': {
+    tool_call_id: string;
+    agent_instance_id: string;
+    /**
+     * Category bucket of the first dropped path. Derived from path
+     * segments — deliberately coarse so the telemetry event cannot
+     * leak usernames, repo names, or directory structure.
+     */
+    path_category:
+      | 'node_modules'
+      | 'build-output'
+      | 'tooling-cache'
+      | 'dotfile'
+      | 'other';
+    cap: number;
+  };
 
   // Suggestions
   'suggestion-clicked': {

--- a/apps/browser/src/backend/services/toolbox/index.ts
+++ b/apps/browser/src/backend/services/toolbox/index.ts
@@ -303,6 +303,16 @@ export class ToolboxService extends DisposableService {
     return path.join(getTempRoot(), 'agent-temp-files');
   }
 
+  /**
+   * Narrow accessor used by `DiffHistoryService` to resolve which
+   * filepaths belong to a mounted workspace (for the gitignore check).
+   * Returns an empty set before the mount manager has finished its
+   * async initialization — callers must tolerate that window.
+   */
+  public getAllMountedPaths(): Set<string> {
+    return this.mountManagerService?.getAllMountedPaths() ?? new Set();
+  }
+
   private constructor(
     logger: Logger,
     uiKarton: KartonService,
@@ -444,6 +454,11 @@ export class ToolboxService extends DisposableService {
             agentInstanceId,
             path: absolutePath,
             toolCallId,
+            workspaceRoot:
+              this.mountManagerService?.findWorkspaceForFile(
+                agentInstanceId,
+                absolutePath,
+              ) ?? null,
             ...editContent,
           });
 
@@ -535,6 +550,11 @@ export class ToolboxService extends DisposableService {
               agentInstanceId,
               path: absolutePath,
               toolCallId,
+              workspaceRoot:
+                this.mountManagerService?.findWorkspaceForFile(
+                  agentInstanceId,
+                  absolutePath,
+                ) ?? null,
               ...editContent,
             });
 
@@ -567,6 +587,13 @@ export class ToolboxService extends DisposableService {
 
         // Directory deletion — capture before-state for all files
         const filePaths = await this.collectAllFiles(absolutePath);
+
+        // All children share the same owning workspace — resolve once.
+        const dirWorkspaceRoot =
+          this.mountManagerService?.findWorkspaceForFile(
+            agentInstanceId,
+            absolutePath,
+          ) ?? null;
 
         // Capture before-state for each file and ignore them in watcher
         const beforeStates = new Map<
@@ -611,6 +638,7 @@ export class ToolboxService extends DisposableService {
               agentInstanceId,
               path: filePath,
               toolCallId,
+              workspaceRoot: dirWorkspaceRoot,
               ...editContent,
             });
 
@@ -759,6 +787,19 @@ export class ToolboxService extends DisposableService {
         // Execute the copy/move
         const result = await copyToolExecute(params, mountedRuntimes);
 
+        // All dest files share the dest workspace; all src files share the src
+        // workspace (src and dest may differ across a cross-workspace copy).
+        const destWorkspaceRoot =
+          this.mountManagerService?.findWorkspaceForFile(
+            agentInstanceId,
+            destAbsolute,
+          ) ?? null;
+        const srcWorkspaceRoot =
+          this.mountManagerService?.findWorkspaceForFile(
+            agentInstanceId,
+            srcAbsolute,
+          ) ?? null;
+
         // Register diff-history for destination files (created/overwritten)
         try {
           for (const destFile of destFilePaths) {
@@ -784,6 +825,7 @@ export class ToolboxService extends DisposableService {
               agentInstanceId,
               path: destFile,
               toolCallId,
+              workspaceRoot: destWorkspaceRoot,
               ...editContent,
             });
 
@@ -815,6 +857,7 @@ export class ToolboxService extends DisposableService {
                 agentInstanceId,
                 path: srcFile,
                 toolCallId,
+                workspaceRoot: srcWorkspaceRoot,
                 ...editContent,
               });
 

--- a/apps/browser/src/backend/services/toolbox/services/mount-manager/index.test.ts
+++ b/apps/browser/src/backend/services/toolbox/services/mount-manager/index.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest';
+import path from 'node:path';
+import { pickOwningWorkspace } from '.';
+
+// All tests use forward-slash paths joined via `path.join` so the
+// assertions are portable across platforms \u2014 `path.sep` is injected
+// implicitly into the candidate / input strings.
+const p = (...parts: string[]) => path.join(path.sep, ...parts);
+
+describe('pickOwningWorkspace', () => {
+  it('returns undefined when there are no candidates', () => {
+    expect(pickOwningWorkspace(p('Users', 'alice', 'foo.ts'), [])).toBe(
+      undefined,
+    );
+  });
+
+  it('returns undefined when no candidate contains the path', () => {
+    expect(
+      pickOwningWorkspace(p('Users', 'alice', 'bar', 'foo.ts'), [
+        p('Users', 'alice', 'baz'),
+      ]),
+    ).toBe(undefined);
+  });
+
+  it('returns the candidate when the path equals it exactly', () => {
+    const wsPath = p('Users', 'alice', 'repo');
+    expect(pickOwningWorkspace(wsPath, [wsPath])).toBe(wsPath);
+  });
+
+  it('returns the candidate when the path is a descendant', () => {
+    const wsPath = p('Users', 'alice', 'repo');
+    const filePath = p('Users', 'alice', 'repo', 'src', 'app.ts');
+    expect(pickOwningWorkspace(filePath, [wsPath])).toBe(wsPath);
+  });
+
+  it('does NOT match a sibling whose name shares the candidate prefix', () => {
+    // This is the bug the fix guards against: `/Users/alice/foo` must
+    // not match `/Users/alice/foo-other/app.ts` via naive `startsWith`.
+    const wsPath = p('Users', 'alice', 'foo');
+    const filePath = p('Users', 'alice', 'foo-other', 'app.ts');
+    expect(pickOwningWorkspace(filePath, [wsPath])).toBe(undefined);
+  });
+
+  it('picks the innermost mount when nested mounts both match', () => {
+    // Monorepo scenario: both the repo root and one of its packages
+    // are mounted as separate workspaces. A file inside the package
+    // must resolve to the package workspace so the package's own
+    // `.gitignore` / LSP is consulted.
+    const outer = p('Users', 'alice', 'monorepo');
+    const inner = p('Users', 'alice', 'monorepo', 'packages', 'app');
+    const filePath = p(
+      'Users',
+      'alice',
+      'monorepo',
+      'packages',
+      'app',
+      'src',
+      'index.ts',
+    );
+    expect(pickOwningWorkspace(filePath, [outer, inner])).toBe(inner);
+    // Iteration order must not matter \u2014 longest wins regardless.
+    expect(pickOwningWorkspace(filePath, [inner, outer])).toBe(inner);
+  });
+
+  it('picks the outer mount when only it matches (file outside inner)', () => {
+    const outer = p('Users', 'alice', 'monorepo');
+    const inner = p('Users', 'alice', 'monorepo', 'packages', 'app');
+    const filePath = p(
+      'Users',
+      'alice',
+      'monorepo',
+      'packages',
+      'other',
+      'src',
+      'index.ts',
+    );
+    expect(pickOwningWorkspace(filePath, [outer, inner])).toBe(outer);
+  });
+
+  it('matches descendants of a filesystem-root mount', () => {
+    // Regression guard: a root mount already ends with `path.sep`,
+    // so the naïve `root + path.sep` form yields `//` (POSIX) or
+    // `C:\\` (Windows) which no real path starts with. The helper
+    // must detect the existing trailing separator and reuse it.
+    const root = path.sep;
+    const filePath = path.join(path.sep, 'Users', 'alice', 'foo.ts');
+    expect(pickOwningWorkspace(filePath, [root])).toBe(root);
+  });
+
+  it('matches the exact root path against itself', () => {
+    // Exact-equality branch must fire for a root candidate too,
+    // independent of the descendant check.
+    const root = path.sep;
+    expect(pickOwningWorkspace(root, [root])).toBe(root);
+  });
+});

--- a/apps/browser/src/backend/services/toolbox/services/mount-manager/index.ts
+++ b/apps/browser/src/backend/services/toolbox/services/mount-manager/index.ts
@@ -3,6 +3,7 @@ import type { Logger } from '@/services/logger';
 import { ClientRuntimeNode } from '@stagewise/agent-runtime-node';
 import { LspService } from '../lsp';
 import path from 'node:path';
+import { pickOwningWorkspace } from '@/utils/workspace-resolution';
 import { createHash } from 'node:crypto';
 import chokidar, { type FSWatcher } from 'chokidar';
 import type { FilePickerService } from '@/services/file-picker';
@@ -38,6 +39,14 @@ function mountPrefixForPath(workspacePath: string): MountPrefix {
 
 export type MountedClientRuntimes = Map<MountPrefix, ClientRuntimeNode>;
 export type MountedLspServices = Map<MountPrefix, LspService>;
+
+// Re-export the canonical workspace resolver so the existing import
+// path `from '@/services/toolbox/services/mount-manager'` keeps
+// working for code that already uses it (including this file's own
+// tests). The single implementation lives in the shared utility at
+// `@/utils/workspace-resolution` so `DiffHistoryService` can use it
+// too without introducing a toolbox→diff-history import cycle.
+export { pickOwningWorkspace } from '@/utils/workspace-resolution';
 
 export class MountManagerService extends DisposableService {
   private readonly logger: Logger;
@@ -288,23 +297,8 @@ export class MountManagerService extends DisposableService {
     const mounts = this.agentMounts.get(agentInstanceId);
     if (!mounts || !mounts.has(mountPrefix)) return;
 
-    const workspacePath = this.workspacePathsPerMount.get(mountPrefix);
     mounts.delete(mountPrefix);
-
-    if (workspacePath) {
-      const stillInUse = [...this.agentMounts.values()].some((m) =>
-        m.has(mountPrefix),
-      );
-      if (!stillInUse) {
-        this.workspacePathsPerMount.delete(mountPrefix);
-        this.stopWorkspaceWatcher(workspacePath);
-        const lspService = this.lspServicesPerPath.get(workspacePath);
-        if (lspService) void lspService.teardown();
-        this.clientRuntimesPerPath.delete(workspacePath);
-        this.lspServicesPerPath.delete(workspacePath);
-        this.lspReady.delete(workspacePath);
-      }
-    }
+    this.releaseMountIfUnused(mountPrefix);
 
     this.uiKarton.setState((draft) => {
       draft.toolbox[agentInstanceId].workspace.mounts = draft.toolbox[
@@ -316,6 +310,36 @@ export class MountManagerService extends DisposableService {
     this.telemetryService.capture('workspace-unmounted', {
       agent_type: agentType,
     });
+  }
+
+  /**
+   * If `mountPrefix` is no longer referenced by any agent, tears down
+   * all resources keyed on its workspace path: watcher, LSP service,
+   * client runtime, and the `workspacePathsPerMount` entry itself.
+   *
+   * Central helper for both `handleUnmountWorkspace` (explicit unmount)
+   * and `clearAgentMounts` (agent teardown). Without this cleanup in
+   * `clearAgentMounts`, orphaned workspace paths would stick around in
+   * `workspacePathsPerMount` indefinitely, which (a) leaks watchers /
+   * LSP processes across the app session and (b) causes
+   * `getAllMountedPaths()` to return stale roots, making
+   * `DiffHistoryService.findWorkspaceRoot` pick the wrong workspace's
+   * `.gitignore` matcher for later edits.
+   */
+  private releaseMountIfUnused(mountPrefix: string): void {
+    const stillInUse = [...this.agentMounts.values()].some((m) =>
+      m.has(mountPrefix),
+    );
+    if (stillInUse) return;
+    const workspacePath = this.workspacePathsPerMount.get(mountPrefix);
+    if (!workspacePath) return;
+    this.workspacePathsPerMount.delete(mountPrefix);
+    this.stopWorkspaceWatcher(workspacePath);
+    const lspService = this.lspServicesPerPath.get(workspacePath);
+    if (lspService) void lspService.teardown();
+    this.clientRuntimesPerPath.delete(workspacePath);
+    this.lspServicesPerPath.delete(workspacePath);
+    this.lspReady.delete(workspacePath);
   }
 
   public getMountedPathsWithRuntimes(agentInstanceId: string): Array<{
@@ -348,11 +372,12 @@ export class MountManagerService extends DisposableService {
   ): string | undefined {
     const mounts = this.agentMounts.get(agentInstanceId);
     if (!mounts) return undefined;
+    const candidates: string[] = [];
     for (const prefix of mounts.keys()) {
       const wsPath = this.workspacePathsPerMount.get(prefix);
-      if (wsPath && filePath.startsWith(wsPath)) return wsPath;
+      if (wsPath) candidates.push(wsPath);
     }
-    return undefined;
+    return pickOwningWorkspace(filePath, candidates);
   }
 
   public getAllMountedPaths(): Set<string> {
@@ -384,7 +409,14 @@ export class MountManagerService extends DisposableService {
   }
 
   public clearAgentMounts(agentInstanceId: string): void {
+    const mounts = this.agentMounts.get(agentInstanceId);
     this.agentMounts.delete(agentInstanceId);
+    if (!mounts) return;
+    // Release every mount this agent was holding so orphaned
+    // workspace paths (and their watcher / LSP / runtime state) do
+    // not leak when an agent is torn down without going through
+    // `handleUnmountWorkspace` first. See `releaseMountIfUnused`.
+    for (const prefix of mounts.keys()) this.releaseMountIfUnused(prefix);
   }
 
   public setWorkspaceMdContent(

--- a/apps/browser/src/backend/services/toolbox/utils/sandbox-callbacks.ts
+++ b/apps/browser/src/backend/services/toolbox/utils/sandbox-callbacks.ts
@@ -31,12 +31,20 @@ export function createFileDiffHandler(
   ) => {
     deps.diffHistoryService.ignoreFileForWatcher(absolutePath);
 
+    // Resolve the owning workspace for the gitignore-aware filter in
+    // DiffHistoryService.registerAgentEdit. `findWorkspaceForFile`
+    // returns undefined when the path is outside any mount; map to
+    // null so the downstream walk-up fallback runs.
+    const workspaceRoot =
+      deps.mountManager.findWorkspaceForFile(agentId, absolutePath) ?? null;
+
     try {
       if (isExternal) {
         await deps.diffHistoryService.registerAgentEdit({
           agentInstanceId: agentId,
           path: absolutePath,
           toolCallId,
+          workspaceRoot,
           isExternal: true,
           tempPathToBeforeContent: null,
           tempPathToAfterContent: null,
@@ -77,6 +85,7 @@ export function createFileDiffHandler(
           agentInstanceId: agentId,
           path: absolutePath,
           toolCallId,
+          workspaceRoot,
           isExternal: false,
           contentBefore: before,
           contentAfter: after,

--- a/apps/browser/src/backend/utils/load-gitignore.ts
+++ b/apps/browser/src/backend/utils/load-gitignore.ts
@@ -1,29 +1,237 @@
-import { existsSync } from 'node:fs';
-import { readFile } from 'node:fs/promises';
-import { join } from 'node:path';
-import ignore from 'ignore';
+import { readFile, readdir } from 'node:fs/promises';
+import path from 'node:path';
+import ignore, { type Ignore } from 'ignore';
 
-export async function loadGitignore(
-  dir: string,
-): Promise<ReturnType<typeof ignore>> {
-  const ig = ignore();
-  const gitignorePath = join(dir, '.gitignore');
+/**
+ * Hardcoded path-segment denylist enforced unconditionally by
+ * `DiffHistoryService.shouldTrackFilepath` as a cheap synchronous
+ * pre-check BEFORE any `.gitignore` is consulted. Contains only
+ * exact path segments (no globs) so the matcher can be a trivial
+ * `segments.some(s => HARDCODED_DENY_SEGMENTS.has(s))`.
+ *
+ * **Scope is intentionally tiny:** because this check runs before
+ * `.gitignore`, any segment in here CANNOT be recovered via a user
+ * `!` negation rule. The list must therefore contain only segments
+ * that are **universally non-committed** — segments no real project
+ * legitimately keeps under version control.
+ *
+ * Only three categories qualify:
+ *   - `node_modules` — universally machine-generated; recreated by
+ *     the package manager on any fresh clone.
+ *   - `.git` — the VCS metadata directory; Git cannot function if
+ *     this is tracked as content.
+ *   - `.DS_Store` / `Thumbs.db` — OS filesystem junk that no one
+ *     commits on purpose.
+ *
+ * **Deliberately excluded** (handled by the soft defaults in the
+ * workspace ignore matcher below, overridable by the project's own
+ * `.gitignore`):
+ *   - Build output dirs (`dist`, `build`, `out`, `.output`, `.next`,
+ *     `.nuxt`, `.svelte-kit`, `.astro`) — some projects commit
+ *     generated code, prebuilt assets, or package `main` entry points.
+ *   - Tooling caches (`.turbo`, `.cache`, `.parcel-cache`, `.vite`,
+ *     `.angular`, `.gradle`) — usually ignored but not universally.
+ *   - Test / coverage (`coverage`) — occasionally committed.
+ *   - Editor / IDE / platform metadata (`.vscode`, `.idea`,
+ *     `.vercel`) — commonly committed.
+ *   - Lockfiles (`pnpm-lock.yaml`, `package-lock.json`, `yarn.lock`)
+ *     — small, meaningful, commonly reviewed.
+ */
+export const HARDCODED_DENY_SEGMENTS: ReadonlySet<string> = new Set([
+  // Package managers
+  'node_modules',
+  // VCS metadata
+  '.git',
+  // OS junk
+  '.DS_Store',
+  'Thumbs.db',
+]);
 
-  if (existsSync(gitignorePath)) {
-    const content = await readFile(gitignorePath, 'utf-8');
-    ig.add(content);
+/**
+ * Soft defaults seeded into the shallowest layer of every workspace
+ * ignore matcher.
+ *
+ * Pattern choice is deliberate on two axes:
+ *
+ * 1. **Unanchored prefix `**\/`**. A bare `dist/**` in the `ignore`
+ *    package anchors to the matcher's root, so
+ *    `packages/foo/dist/x.ts` would NOT match in a monorepo. The
+ *    `**\/dist/**` form matches at any depth \u2014 what a user
+ *    expects a soft default to do.
+ *
+ * 2. **File-level `/**` suffix** (rather than bare directory). Git's
+ *    semantics say once a **directory** is ignored, files inside
+ *    cannot be un-ignored \u2014 no later negation can recover them.
+ *    The file-level form ignores the contents without ignoring the
+ *    directory itself, so a project's `!dist/keep.ts` negation can
+ *    still un-ignore individual files.
+ *
+ * Editor / IDE / platform metadata (`.vscode`, `.idea`, `.vercel`)
+ * is deliberately NOT included \u2014 projects commonly commit those,
+ * and adding a soft default would force users to write explicit
+ * negations to recover them.
+ */
+const SOFT_DEFAULTS: readonly string[] = [
+  // Common build / framework output.
+  '**/dist/**',
+  '**/build/**',
+  '**/out/**',
+  '**/.output/**',
+  '**/.next/**',
+  '**/.nuxt/**',
+  '**/.svelte-kit/**',
+  '**/.astro/**',
+  // Tooling caches.
+  '**/.turbo/**',
+  '**/.cache/**',
+  '**/.parcel-cache/**',
+  '**/.vite/**',
+  '**/.angular/**',
+  '**/.gradle/**',
+  // Test / coverage.
+  '**/coverage/**',
+  // Log files.
+  '**/*.log',
+];
+
+/**
+ * Single `.gitignore` layer, scoped to the directory containing it.
+ * Patterns in `ig` are relative to `dir`, matching git's semantics
+ * (a pattern `foo` in `/pkg/.gitignore` matches `/pkg/foo`, not
+ * `/pkg/subpkg/foo-other`).
+ */
+interface GitignoreLayer {
+  readonly dir: string;
+  readonly ig: Ignore;
+}
+
+/**
+ * Multi-layer matcher that honors `.gitignore` files at every level
+ * from the workspace root down to each file's parent \u2014 matching
+ * git's actual resolution semantics rather than the simpler
+ * root-only approximation we had before.
+ */
+export interface WorkspaceIgnoreMatcher {
+  readonly root: string;
+  ignores(absoluteFilepath: string): boolean;
+}
+
+/**
+ * Recursively collects every `.gitignore` file under `workspaceRoot`,
+ * skipping directories whose basename is in `HARDCODED_DENY_SEGMENTS`
+ * so we do not wander into `node_modules` or `.git`.
+ *
+ * Each returned entry holds the directory that contains the file
+ * (which is what git uses as the pattern-anchor) plus the file's
+ * raw contents.
+ */
+async function findGitignoreFiles(
+  workspaceRoot: string,
+): Promise<Array<{ dir: string; content: string }>> {
+  const collected: Array<{ dir: string; content: string }> = [];
+  const stack: string[] = [workspaceRoot];
+  while (stack.length > 0) {
+    const dir = stack.pop()!;
+    let entries: Awaited<ReturnType<typeof readdir>>;
+    try {
+      entries = await readdir(dir, { withFileTypes: true });
+    } catch {
+      // Directory became inaccessible mid-walk \u2014 skip and keep
+      // discovering what we can. Never block an edit on this.
+      continue;
+    }
+    for (const entry of entries) {
+      if (entry.isDirectory()) {
+        if (HARDCODED_DENY_SEGMENTS.has(entry.name)) continue;
+        stack.push(path.join(dir, entry.name));
+      } else if (entry.isFile() && entry.name === '.gitignore') {
+        try {
+          const content = await readFile(path.join(dir, entry.name), 'utf-8');
+          collected.push({ dir, content });
+        } catch {
+          // Ignore read errors \u2014 treat as if the file didn't exist.
+        }
+      }
+    }
+  }
+  return collected;
+}
+
+/**
+ * Builds a `WorkspaceIgnoreMatcher` for the given workspace. The
+ * matcher holds one `Ignore` instance per `.gitignore` file found
+ * under the workspace, each scoped to the directory containing that
+ * file. Evaluation walks layers shallow-to-deep and takes the
+ * deepest layer that has a definitive opinion about the file \u2014
+ * matching git's precedence semantics including negations.
+ *
+ * The shallowest layer (at `workspaceRoot`) additionally carries
+ * the soft-default build-output / cache patterns so projects with
+ * no `.gitignore` still get sensible behavior.
+ */
+export async function loadWorkspaceIgnore(
+  workspaceRoot: string,
+): Promise<WorkspaceIgnoreMatcher> {
+  const files = await findGitignoreFiles(workspaceRoot);
+  // Shallowest first so layer walking is just left-to-right.
+  files.sort((a, b) => a.dir.length - b.dir.length);
+
+  const layers: GitignoreLayer[] = [];
+  // Ensure the shallowest layer exists and always carries soft
+  // defaults. If the workspace had its own root `.gitignore` it
+  // becomes this layer; otherwise we synthesize a defaults-only
+  // layer at the workspace root.
+  const hasRootLayer = files.length > 0 && files[0].dir === workspaceRoot;
+  if (hasRootLayer) {
+    const ig = ignore();
+    // Soft defaults added FIRST so the user's `.gitignore` content
+    // (including negations) added SECOND can override them.
+    ig.add(SOFT_DEFAULTS);
+    ig.add(files[0].content);
+    layers.push({ dir: workspaceRoot, ig });
+  } else {
+    layers.push({ dir: workspaceRoot, ig: ignore().add(SOFT_DEFAULTS) });
   }
 
-  // Always ignore node_modules and common non-source directories
-  ig.add([
-    'node_modules',
-    '.git',
-    'dist',
-    'build',
-    'coverage',
-    '.next',
-    '.nuxt',
-  ]);
+  // Deeper layers \u2014 each carries only its own `.gitignore`, no
+  // soft defaults (the shallowest layer already covers those for
+  // any descendant path).
+  for (let i = hasRootLayer ? 1 : 0; i < files.length; i++) {
+    const { dir, content } = files[i];
+    const ig = ignore();
+    ig.add(content);
+    layers.push({ dir, ig });
+  }
 
-  return ig;
+  return {
+    root: workspaceRoot,
+    ignores(absoluteFilepath: string): boolean {
+      let verdict: boolean | null = null;
+      for (const layer of layers) {
+        // A layer applies to `absoluteFilepath` only if the file is
+        // at or under the layer's directory. Path-boundary check
+        // (exact equality OR `dir + path.sep` prefix) avoids false
+        // positives from sibling names that share a prefix.
+        const isExactMatch = absoluteFilepath === layer.dir;
+        const isDescendant = absoluteFilepath.startsWith(
+          layer.dir.endsWith(path.sep) ? layer.dir : layer.dir + path.sep,
+        );
+        if (!isExactMatch && !isDescendant) continue;
+        const rel = path.relative(layer.dir, absoluteFilepath);
+        // Out-of-tree escape or the directory itself \u2014 ignore has
+        // nothing to test against.
+        if (rel === '' || rel.startsWith('..') || path.isAbsolute(rel))
+          continue;
+        // `ignore.test()` returns `{ignored, unignored}` so we can
+        // distinguish "this layer explicitly matched" from "no rule
+        // in this layer had anything to say." Only a definitive
+        // match updates the verdict; layers that shrug keep the
+        // prior answer.
+        const res = layer.ig.test(rel);
+        if (res.ignored) verdict = true;
+        else if (res.unignored) verdict = false;
+      }
+      return verdict ?? false;
+    },
+  };
 }

--- a/apps/browser/src/backend/utils/workspace-resolution.ts
+++ b/apps/browser/src/backend/utils/workspace-resolution.ts
@@ -1,0 +1,44 @@
+import path from 'node:path';
+
+/**
+ * Picks the workspace that owns `filePath` from a set of candidate
+ * workspace root paths.
+ *
+ * Two correctness properties to know about:
+ *
+ * 1. **Path-boundary match.** A bare `startsWith` would return true
+ *    for sibling paths whose name happens to prefix a candidate
+ *    (e.g. `/foo` vs `/foo-other/app.ts`). We require either exact
+ *    equality or a `path.sep` boundary after the candidate.
+ *
+ * 2. **Longest-prefix wins.** With nested mounts (e.g. a monorepo
+ *    root and one of its packages, both mounted), a file inside the
+ *    inner mount must resolve to the inner workspace \u2014 that is the
+ *    one whose `.gitignore` and LSP services are relevant for the
+ *    file. First-match iteration would otherwise return whichever
+ *    mount happens to be iterated first.
+ *
+ * Edge case: filesystem-root mounts (`/` on POSIX, `C:\` on Windows)
+ * already end with `path.sep`; appending another separator would
+ * produce `//` or `C:\\` which no real path starts with. Handled by
+ * reusing the existing trailing separator in that case.
+ *
+ * Assumes candidates are absolute paths. Mount roots stored by
+ * `MountManagerService.handleMountWorkspace` are normalized via
+ * `path.resolve(...)` so non-root candidates have any trailing
+ * separator already stripped; root candidates (`/`, `C:\`) keep theirs.
+ */
+export function pickOwningWorkspace(
+  filePath: string,
+  candidates: Iterable<string>,
+): string | undefined {
+  let best: string | undefined;
+  for (const wsPath of candidates) {
+    const rootWithSep = wsPath.endsWith(path.sep) ? wsPath : wsPath + path.sep;
+    const isExactMatch = filePath === wsPath;
+    const isDescendant = filePath.startsWith(rootWithSep);
+    if (!isExactMatch && !isDescendant) continue;
+    if (!best || wsPath.length > best.length) best = wsPath;
+  }
+  return best;
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workspace-aware .gitignore filtering for edit tracking, optional per-edit workspace context, and per-tool-call fan-out caps that emit a single coarse telemetry event when hit.
  * Toolbox: access to mounted-paths and improved owning-workspace selection for nested mounts and cross-workspace operations.

* **Tests**
  * Expanded tests covering gitignore semantics (negations, nesting, fallbacks), fan-out cap/telemetry behavior, and workspace-mount resolution edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->