### PR TITLE
style(stagewise): use more obvious icons for devtools and settings

### DIFF
--- a/apps/browser/src/ui/screens/main/content/_components/dev-toolbar/widgets/chrome-devtools.tsx
+++ b/apps/browser/src/ui/screens/main/content/_components/dev-toolbar/widgets/chrome-devtools.tsx
@@ -2,7 +2,7 @@ import { useKartonProcedure } from '@ui/hooks/use-karton';
 // import { IconGoogleChrome } from 'nucleo-social-media';
 import { ToggleButton } from '../primitives';
 import type { WidgetProps } from './types';
-import { IconWrenchScrewdriverFillDuo18 } from 'nucleo-ui-fill-duo-18';
+import { IconSquareCodeFillDuo18 } from 'nucleo-ui-fill-duo-18';
 
 export function ChromeDevToolsWidget({ tab, sortableProps }: WidgetProps) {
   const { isDragging, dragHandleProps } = sortableProps;
@@ -13,7 +13,7 @@ export function ChromeDevToolsWidget({ tab, sortableProps }: WidgetProps) {
   return (
     <ToggleButton
       ariaLabel="Show Chrome DevTools"
-      icon={<IconWrenchScrewdriverFillDuo18 className="size-5" />}
+      icon={<IconSquareCodeFillDuo18 className="size-5" />}
       onClick={() => toggleChromeDevTools(tab.id)}
       active={tab.devTools.chromeOpen}
       dragHandleProps={dragHandleProps}

--- a/apps/browser/src/ui/screens/main/sidebar/top/index.tsx
+++ b/apps/browser/src/ui/screens/main/sidebar/top/index.tsx
@@ -1,6 +1,6 @@
 import posthog from 'posthog-js';
 import { cn } from '@ui/utils';
-import { IconDotsFill18, IconPlusFill18 } from 'nucleo-ui-fill-18';
+import { IconPlusFill18 } from 'nucleo-ui-fill-18';
 import { IconGear2Outline24 } from 'nucleo-core-outline-24';
 import { IconSidebarLeftHideOutline18 } from 'nucleo-ui-outline-18';
 import {
@@ -9,13 +9,11 @@ import {
   TooltipTrigger,
 } from '@stagewise/stage-ui/components/tooltip';
 import { Button } from '@stagewise/stage-ui/components/button';
-import { Select, type SelectItem } from '@stagewise/stage-ui/components/select';
 import {
   useComparingSelector,
   useKartonProcedure,
   useKartonState,
 } from '@ui/hooks/use-karton';
-import type React from 'react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useHotKeyListener } from '@ui/hooks/use-hotkey-listener';
 import { HotkeyActions } from '@shared/hotkeys';
@@ -30,40 +28,6 @@ import {
 import { EMPTY_MOUNTS } from '@shared/karton-contracts/ui';
 import { useEmptyAgentId } from '@ui/hooks/use-empty-agent';
 import { AgentsSelector, type AgentGroup } from './_components/agents-selector';
-
-// Static menu items — no component state captured, safe at module scope.
-const menuItems: SelectItem[] = [
-  {
-    value: 'settings',
-    label: (
-      <span className="flex items-center gap-1.5">
-        <IconGear2Outline24 className="size-3.5 text-muted-foreground" />
-        <span>Settings</span>
-      </span>
-    ),
-  },
-];
-
-// Static trigger renderer — takes triggerProps as argument, captures nothing.
-const menuTrigger = (
-  triggerProps: React.ComponentPropsWithoutRef<'button'>,
-) => (
-  <Tooltip>
-    <TooltipTrigger>
-      <Button
-        {...triggerProps}
-        variant="ghost"
-        size="icon-xs"
-        className="app-no-drag shrink-0"
-      >
-        <IconDotsFill18 className="size-4" />
-      </Button>
-    </TooltipTrigger>
-    <TooltipContent side="bottom">
-      <span>More options</span>
-    </TooltipContent>
-  </Tooltip>
-);
 
 /** Shape returned by the activeAgentsList selector. */
 type ActiveAgentSummary = {
@@ -467,13 +431,9 @@ export function SidebarTopSection({ isCollapsed }: { isCollapsed: boolean }) {
     [setOpenAgent],
   );
 
-  // Handle menu selection
-  const handleMenuSelect = useCallback(
-    (value: string | null) => {
-      if (value === 'settings') createTab(SETTINGS_PAGE_URL, true);
-    },
-    [createTab],
-  );
+  const handleOpenSettings = useCallback(() => {
+    createTab(SETTINGS_PAGE_URL, true);
+  }, [createTab]);
 
   return (
     <div
@@ -516,17 +476,21 @@ export function SidebarTopSection({ isCollapsed }: { isCollapsed: boolean }) {
               onEndReached={loadMoreHistory}
             />
           )}
-          <Select
-            items={menuItems}
-            value={null}
-            onValueChange={handleMenuSelect}
-            side="bottom"
-            sideOffset={8}
-            popupClassName="max-w-64"
-            size="xs"
-            showItemIndicator={false}
-            customTrigger={menuTrigger}
-          />
+          <Tooltip>
+            <TooltipTrigger>
+              <Button
+                variant="ghost"
+                size="icon-xs"
+                className="app-no-drag shrink-0"
+                onClick={handleOpenSettings}
+              >
+                <IconGear2Outline24 className="size-4" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">
+              <span>Settings</span>
+            </TooltipContent>
+          </Tooltip>
           <div className="mx-0.5 h-3.5 w-px shrink-0 bg-border-subtle" />
           <Tooltip>
             <TooltipTrigger>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -493,7 +493,7 @@ importers:
         specifier: ^1.3.0
         version: 1.3.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       nucleo-ui-fill-duo-18:
-        specifier: ^1.4.0
+        specifier: ^1.3.2
         version: 1.4.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       nucleo-ui-outline-18:
         specifier: ^1.3.2
@@ -680,7 +680,7 @@ importers:
         specifier: ^1.3.0
         version: 1.3.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       nucleo-ui-fill-duo-18:
-        specifier: ^1.4.0
+        specifier: ^1.3.2
         version: 1.4.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       nucleo-ui-outline-18:
         specifier: ^1.3.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -493,8 +493,8 @@ importers:
         specifier: ^1.3.0
         version: 1.3.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       nucleo-ui-fill-duo-18:
-        specifier: ^1.3.2
-        version: 1.3.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        specifier: ^1.4.0
+        version: 1.4.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       nucleo-ui-outline-18:
         specifier: ^1.3.2
         version: 1.3.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -680,8 +680,8 @@ importers:
         specifier: ^1.3.0
         version: 1.3.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       nucleo-ui-fill-duo-18:
-        specifier: ^1.3.2
-        version: 1.3.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        specifier: ^1.4.0
+        version: 1.4.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       nucleo-ui-outline-18:
         specifier: ^1.3.2
         version: 1.3.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -8505,8 +8505,8 @@ packages:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
 
-  nucleo-ui-fill-duo-18@1.3.2:
-    resolution: {integrity: sha512-PW4XPQutbcfKXHDPt3WhsBi7s/08SqrVxoWrwJ2jK0j1kuhYAfw/TyfioNt+f1UYIfLqTmzZIaAnyWBSxosicg==}
+  nucleo-ui-fill-duo-18@1.4.0:
+    resolution: {integrity: sha512-iTkAV2XIYzjiWaE+mg71xwmDgH7/bMYLceMuNcSOzn/SMRt0FoI7Te2e98xlG5p4g21tbxjslmXPu3aH6Phenw==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
@@ -19600,7 +19600,7 @@ snapshots:
       react-dom: 19.2.3(react@19.2.3)
       tslib: 2.8.1
 
-  nucleo-ui-fill-duo-18@1.3.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  nucleo-ui-fill-duo-18@1.4.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use clearer icons for DevTools and Settings, and replace the overflow menu with a dedicated Settings button for faster access.

- **Refactors**
  - Dev toolbar: replaced wrench/screwdriver with a code-square icon for the Chrome DevTools toggle.
  - Sidebar: removed the kebab menu; added a gear Settings button with tooltip that opens the Settings tab directly.

- **Dependencies**
  - Fixed lockfile; bumped `nucleo-ui-fill-duo-18` to 1.4.0 for new icons.

<sup>Written for commit 8020f6f631436563baef1b3a4075bd48c42370f6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Replaced the sidebar dropdown with a dedicated Settings button that opens Settings in a new tab.

* **Style**
  * Updated the developer toolbar icon for a refreshed appearance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->