### PR TITLE
feat(stagewise): add agent-preview panels to agent-cards

### DIFF
--- a/apps/browser/src/ui/screens/main/sidebar/active-agents/_components/agent-card-with-preview.tsx
+++ b/apps/browser/src/ui/screens/main/sidebar/active-agents/_components/agent-card-with-preview.tsx
@@ -1,0 +1,335 @@
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from 'react';
+import { createPortal } from 'react-dom';
+import { useKartonProcedure } from '@ui/hooks/use-karton';
+import { AgentCard, type AgentCardProps } from './agent-card';
+import {
+  AgentPreviewPanel,
+  prefetchAgentPreview,
+  type CachedPreview,
+} from '@ui/screens/main/sidebar/top/_components/agent-preview-panel';
+
+const SHOW_DELAY_MS = 500;
+const EXIT_DURATION_MS = 150;
+const MARGIN = 4;
+
+interface AgentCardWithPreviewProps extends AgentCardProps {
+  cache: Map<string, CachedPreview>;
+}
+
+/**
+ * Hover-preview wrapper for `AgentCard`. Shows `AgentPreviewPanel` next to the
+ * card after a delay, portaled to `document.body` to escape any ancestor
+ * clipping. Purely informational — closes instantly on `mouseleave` /
+ * `mousedown` (no gap-traversal timer needed).
+ *
+ * To eliminate visual jitter, the wrapper:
+ *  1. Pre-warms the shared cache during the hover delay, so the panel mounts
+ *     with content (no skeleton → content height swap).
+ *  2. Uses `useLayoutEffect` to measure the panel synchronously before the
+ *     first paint, and keeps the portal `visibility: hidden` until measured,
+ *     so the panel never appears at a stale-position first frame.
+ */
+export function AgentCardWithPreview({
+  cache,
+  ...cardProps
+}: AgentCardWithPreviewProps) {
+  const cardRef = useRef<HTMLDivElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
+  const showTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const exitTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Monotonically incrementing hover-session counter. Used to discard a
+  // late-resolving prefetch that belonged to a hover session the user has
+  // already abandoned (moved to another card / clicked / left), and to
+  // cancel a queued exit-unmount when a new hover arrives mid-fade-out.
+  const hoverSessionRef = useRef(0);
+
+  // Karton procedures are not referentially stable across state updates
+  // (see `AgentPreviewPanel`). Mirror them into refs so `handleMouseEnter`'s
+  // `useCallback` identity does not flip on every message/status change.
+  // This matters because `AgentCard`'s memo comparator compares
+  // `onMouseEnter` identity — an unstable handler would force every card to
+  // re-render on every Karton state update, defeating the memo entirely.
+  const getStoredInstance = useKartonProcedure(
+    (p) => p.agents.getStoredInstance,
+  );
+  const getTouchedFiles = useKartonProcedure((p) => p.agents.getTouchedFiles);
+  const getStoredInstanceRef = useRef(getStoredInstance);
+  getStoredInstanceRef.current = getStoredInstance;
+  const getTouchedFilesRef = useRef(getTouchedFiles);
+  getTouchedFilesRef.current = getTouchedFiles;
+
+  const [isOpen, setIsOpen] = useState(false);
+  // Mirror `isOpen` into a ref so event handlers (`close`, `handleMouseEnter`)
+  // can read the *committed* open-state regardless of React closure snapshots.
+  // Used by `handleMouseEnter`'s re-hover branch to detect "portal currently
+  // mounted" (both fully-open and fading-out count).
+  const isOpenRef = useRef(isOpen);
+  isOpenRef.current = isOpen;
+  // Synchronous open-intent flag. Set `true` the instant we call
+  // `setIsOpen(true)` (before React commits) and `false` the instant `close`
+  // runs. Distinct from `isOpenRef` because it reflects *intent*, not
+  // committed state.
+  //
+  // Why both are needed: when the timer callback calls `setIsOpen(true)` and
+  // the user's `mouseleave` arrives before React commits, `close` reading
+  // only `isOpenRef` would see `false` and take the early-return path —
+  // leaving the pending open queued, which then mounts the panel even
+  // though the hover has ended. Checking the intent ref instead lets
+  // `close` run the full fade-out path: the portal mounts invisible
+  // (`isExiting=true`) and unmounts after the transition, with no visible
+  // flash.
+  const openIntentRef = useRef(false);
+  const [isMeasured, setIsMeasured] = useState(false);
+  // When true the portal remains mounted but the panel is transitioning
+  // opacity → 0 so the user sees a fade-out. Unmount happens after the
+  // transition completes.
+  const [isExiting, setIsExiting] = useState(false);
+  const [pos, setPos] = useState<{ top: number; left: number }>({
+    top: 0,
+    left: 0,
+  });
+
+  const cancelShowTimer = useCallback(() => {
+    if (showTimerRef.current !== null) {
+      clearTimeout(showTimerRef.current);
+      showTimerRef.current = null;
+    }
+  }, []);
+
+  const cancelExitTimer = useCallback(() => {
+    if (exitTimerRef.current !== null) {
+      clearTimeout(exitTimerRef.current);
+      exitTimerRef.current = null;
+    }
+  }, []);
+
+  const close = useCallback(() => {
+    cancelShowTimer();
+    // Bump the session so an in-flight prefetch cannot re-open the panel
+    // after the user moved away.
+    hoverSessionRef.current++;
+    // Snapshot + clear intent atomically. A racing `setIsOpen(true)` that
+    // was queued but not yet committed still counts as "panel about to
+    // mount" — we must run the full fade-out path so the portal unmounts
+    // cleanly rather than staying stuck open.
+    const hadIntent = openIntentRef.current;
+    openIntentRef.current = false;
+
+    // If neither currently rendered nor about-to-render, nothing to fade.
+    if (!isOpenRef.current && !hadIntent) {
+      setIsMeasured(false);
+      setIsExiting(false);
+      return;
+    }
+
+    // Start fade-out transition, then unmount after it completes. A
+    // mid-fade re-hover calls `cancelExitTimer` in `handleMouseEnter`,
+    // which prevents this callback from ever firing — no session check
+    // needed here.
+    setIsExiting(true);
+    cancelExitTimer();
+    exitTimerRef.current = setTimeout(() => {
+      exitTimerRef.current = null;
+      setIsOpen(false);
+      setIsMeasured(false);
+      setIsExiting(false);
+    }, EXIT_DURATION_MS);
+  }, [cancelShowTimer, cancelExitTimer]);
+
+  /** Compute final position using the currently-rendered panel height. Only
+   *  safe to call *after* the portal has mounted (panelRef.current is set).
+   */
+  const computePosition = useCallback(() => {
+    const card = cardRef.current;
+    const panel = panelRef.current;
+    if (!card || !panel) return;
+
+    const cardRect = card.getBoundingClientRect();
+    // Measure the rendered panel (includes padding + border from
+    // `PreviewCard`'s wrapper, not just the inner `w-56` content) so the
+    // viewport-edge flip/clamp math matches what the user actually sees.
+    const panelW = panel.offsetWidth;
+    const panelH = panel.offsetHeight;
+    const viewportW = window.innerWidth;
+    const viewportH = window.innerHeight;
+
+    const rightAnchor = cardRect.right + MARGIN;
+    const placeLeft = rightAnchor + panelW > viewportW;
+    const left = placeLeft
+      ? Math.max(MARGIN, cardRect.left - panelW - MARGIN)
+      : rightAnchor;
+
+    const idealTop = cardRect.top + cardRect.height / 2 - panelH / 2;
+    const top = Math.max(
+      MARGIN,
+      Math.min(idealTop, viewportH - panelH - MARGIN),
+    );
+
+    setPos({ top, left });
+  }, []);
+
+  const handleMouseEnter = useCallback(() => {
+    cancelShowTimer();
+    cancelExitTimer();
+    const session = ++hoverSessionRef.current;
+
+    // If the panel is still mounted (fade-out in progress or already open),
+    // cancel the exit and show immediately instead of re-running the full
+    // 500ms intent delay. Feels snappy when the user moves away briefly
+    // and comes back. `cancelExitTimer` above already prevented the pending
+    // unmount; just flip `isExiting` back off so the opacity/transform
+    // transition reverses.
+    if (isOpenRef.current) {
+      setIsExiting(false);
+      return;
+    }
+    // Start prefetch immediately so it runs in parallel with the 500ms
+    // intent delay. By the time the timer fires the RPC is typically
+    // already resolved and the cache is warm — the panel then mounts with
+    // content on the very first frame, no skeleton flash.
+    // `isLiveAgent=true`: every card in `ActiveAgentsGrid` is sourced from
+    // `s.agents.instances`, so it is by construction a live (in-memory)
+    // agent — regardless of whether it's the currently-focused card
+    // (`cardProps.isActive`, which is pure visual state). Passing the
+    // visual flag here would cause prefetch to cache `{ data: null }` for
+    // non-focused live agents whose stored row hasn't been flushed yet,
+    // pinning their preview blank for the grid lifetime.
+    const prefetchPromise = prefetchAgentPreview(
+      cardProps.id,
+      cache,
+      getStoredInstanceRef.current,
+      getTouchedFilesRef.current,
+      true,
+    );
+    showTimerRef.current = setTimeout(async () => {
+      showTimerRef.current = null;
+      // Await to guarantee the cache is warm before mounting the portal,
+      // even if the RPC is slower than the delay. On warm cache this is a
+      // no-op (early return inside `prefetchAgentPreview`).
+      const prefetched = await prefetchPromise;
+      // Abort if the user moved away / a newer hover superseded this one.
+      if (hoverSessionRef.current !== session) return;
+      // Skip opening the portal when there is nothing to render:
+      //   - `prefetched === null` — cache could not be warmed (stored-fetch
+      //     rejected, or active agent not yet persisted). Next hover retries.
+      //   - `prefetched.data === null` — confirmed-empty history agent; the
+      //     panel would render nothing anyway, so suppressing the portal
+      //     avoids an empty-div flash.
+      // Without this guard we'd break the "pre-warm before first paint"
+      // contract: the portal would mount cold, show the skeleton, then
+      // resolve to nothing.
+      if (!prefetched?.data) return;
+      // Mark intent synchronously *before* queueing the state update. If a
+      // `mouseleave` lands between here and React's commit, `close` will
+      // observe the intent and trigger a fade-out that mounts the portal
+      // invisible instead of leaving it stuck open.
+      openIntentRef.current = true;
+      setIsOpen(true);
+    }, SHOW_DELAY_MS);
+    // Dep-array intentionally omits `getStoredInstance` / `getTouchedFiles`
+    // — they're read via refs above, so reference changes should not
+    // re-create the callback. See the comment where the refs are set up.
+  }, [cancelShowTimer, cancelExitTimer, cardProps.id, cache]);
+
+  // Measure-then-show: runs synchronously before paint so the panel never
+  // renders at a stale position.
+  useLayoutEffect(() => {
+    if (!isOpen) return;
+    computePosition();
+    setIsMeasured(true);
+  }, [isOpen, computePosition]);
+
+  // While open, reposition on panel height changes (late fetch resolution,
+  // content swap), list scroll, and window resize.
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const onScroll = () => computePosition();
+    const onResize = () => computePosition();
+    window.addEventListener('scroll', onScroll, {
+      capture: true,
+      passive: true,
+    });
+    window.addEventListener('resize', onResize, { passive: true });
+
+    let ro: ResizeObserver | null = null;
+    const panel = panelRef.current;
+    if (panel) {
+      ro = new ResizeObserver(() => computePosition());
+      ro.observe(panel);
+    }
+
+    return () => {
+      window.removeEventListener('scroll', onScroll, { capture: true });
+      window.removeEventListener('resize', onResize);
+      ro?.disconnect();
+    };
+  }, [isOpen, computePosition]);
+
+  // Cancel any pending timers on unmount.
+  useEffect(
+    () => () => {
+      cancelShowTimer();
+      cancelExitTimer();
+    },
+    [cancelShowTimer, cancelExitTimer],
+  );
+
+  return (
+    <>
+      <AgentCard
+        {...cardProps}
+        ref={cardRef}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={close}
+        onMouseDown={close}
+      />
+      {isOpen &&
+        createPortal(
+          <div
+            ref={panelRef}
+            // `pointer-events: none` so the cursor passes through the panel
+            // back to the card beneath — avoids flicker on the narrow gap
+            // and keeps the panel purely informational.
+            //
+            // Opacity + translateX transition, gated on `isMeasured`, gives
+            // us both the jitter-prevention (no paint at panelH=0 position)
+            // and a smooth fade-in-from-left on entry. The `PreviewCard`'s
+            // own `animate-in` classes still run underneath, but invisibly
+            // during the opacity=0 window — the user sees the combined
+            // effect as a single smooth reveal.
+            style={{
+              position: 'fixed',
+              top: pos.top,
+              left: pos.left,
+              pointerEvents: 'none',
+              opacity: isMeasured && !isExiting ? 1 : 0,
+              transform:
+                isMeasured && !isExiting ? 'translateX(0)' : 'translateX(-4px)',
+              transition: `opacity ${EXIT_DURATION_MS}ms ease-out, transform ${EXIT_DURATION_MS}ms ease-out`,
+              zIndex: 50,
+            }}
+          >
+            <AgentPreviewPanel
+              key={cardProps.id}
+              agentId={cardProps.id}
+              // Always `true` in this surface — see the prefetch call above
+              // for the rationale. `cardProps.isActive` here would make the
+              // panel skip the Karton live-overlay (title / messageCount /
+              // workspaces) for non-focused live cards, rendering stale
+              // persisted values instead.
+              isActive={true}
+              cache={cache}
+            />
+          </div>,
+          document.body,
+        )}
+    </>
+  );
+}

--- a/apps/browser/src/ui/screens/main/sidebar/active-agents/_components/agent-card.tsx
+++ b/apps/browser/src/ui/screens/main/sidebar/active-agents/_components/agent-card.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useState } from 'react';
+import { forwardRef, memo, useCallback, useState } from 'react';
 import { cn } from '@ui/utils';
 import {
   Tooltip,
@@ -31,6 +31,12 @@ export interface AgentCardProps {
   onArchive: (id: string) => void;
   onDelete: (id: string) => void;
   onRename: (id: string, newTitle: string) => void;
+  /** Optional hover/pointer callbacks — used by `AgentCardWithPreview` to
+   *  drive the hover-preview without introducing a wrapping element that
+   *  would disrupt the parent grid layout. */
+  onMouseEnter?: () => void;
+  onMouseLeave?: () => void;
+  onMouseDown?: () => void;
 }
 
 export function AgentCardSkeleton() {
@@ -43,22 +49,28 @@ export function AgentCardSkeleton() {
 }
 
 export const AgentCard = memo(
-  function AgentCard({
-    id,
-    title,
-    isActive,
-    isWorking,
-    isWaitingForUser,
-    hasError,
-    hasUnseen,
-    activityText,
-    activityIsUserInput,
-    lastMessageAt,
-    onClick,
-    onArchive,
-    onDelete,
-    onRename,
-  }: AgentCardProps) {
+  forwardRef<HTMLDivElement, AgentCardProps>(function AgentCard(
+    {
+      id,
+      title,
+      isActive,
+      isWorking,
+      isWaitingForUser,
+      hasError,
+      hasUnseen,
+      activityText,
+      activityIsUserInput,
+      lastMessageAt,
+      onClick,
+      onArchive,
+      onDelete,
+      onRename,
+      onMouseEnter,
+      onMouseLeave,
+      onMouseDown,
+    },
+    ref,
+  ) {
     const subtitle = hasError ? 'Error' : activityText;
     const [deleteOpen, setDeleteOpen] = useState(false);
 
@@ -77,11 +89,15 @@ export const AgentCard = memo(
 
     return (
       <div
+        ref={ref}
         role="button"
         tabIndex={0}
         data-agent-id={id}
         aria-keyshortcuts="F2"
         onClick={() => onClick(id)}
+        onMouseEnter={onMouseEnter}
+        onMouseLeave={onMouseLeave}
+        onMouseDown={onMouseDown}
         onDoubleClick={(e) => {
           if (!isActive) return;
           e.stopPropagation();
@@ -144,29 +160,22 @@ export const AgentCard = memo(
               {displayTitle}
             </span>
           ) : (
-            <Tooltip>
-              <TooltipTrigger delay={500}>
-                <button
-                  type="button"
-                  tabIndex={-1}
-                  className="block min-w-0 max-w-full cursor-pointer overflow-x-clip text-ellipsis whitespace-nowrap bg-transparent p-0 text-left font-medium text-foreground text-xs leading-normal outline-none"
-                  onClick={(e) => {
-                    if (!isActive) return;
-                    e.stopPropagation();
-                    startEditing();
-                  }}
-                  onPointerDown={(e) => {
-                    if (!isActive) return;
-                    e.stopPropagation();
-                  }}
-                >
-                  {displayTitle}
-                </button>
-              </TooltipTrigger>
-              <TooltipContent side="bottom">
-                <span>{displayTitle}</span>
-              </TooltipContent>
-            </Tooltip>
+            <button
+              type="button"
+              tabIndex={-1}
+              className="block min-w-0 max-w-full cursor-pointer overflow-x-clip text-ellipsis whitespace-nowrap bg-transparent p-0 text-left font-medium text-foreground text-xs leading-normal outline-none"
+              onClick={(e) => {
+                if (!isActive) return;
+                e.stopPropagation();
+                startEditing();
+              }}
+              onPointerDown={(e) => {
+                if (!isActive) return;
+                e.stopPropagation();
+              }}
+            >
+              {displayTitle}
+            </button>
           )}
         </div>
 
@@ -241,10 +250,19 @@ export const AgentCard = memo(
         </div>
       </div>
     );
-  },
-  // Skip onClick/onArchive/onDelete/onRename in comparison — their behavior is
-  // stable (always call the same RPC with the card's `id`) but identity
-  // changes every render due to upstream useKartonProcedure selectors.
+  }),
+  // Skip `onClick` / `onArchive` / `onDelete` / `onRename` in comparison —
+  // their behavior is stable (always call the same RPC with the card's
+  // `id`) but identity changes every render due to upstream
+  // `useKartonProcedure` selectors.
+  //
+  // Hover handlers (`onMouseEnter` / `onMouseLeave` / `onMouseDown`) ARE
+  // compared strictly: `AgentCardWithPreview` wraps them in `useCallback`
+  // with stable deps and mirrors any closed-over state through a ref, so
+  // their identity is stable across renders in the common case. Including
+  // them here gives us a correctness safety net — if a future change makes
+  // a handler legitimately change identity (e.g. a new dep is added), the
+  // DOM binding updates instead of silently using a stale reference.
   (prev, next) =>
     prev.id === next.id &&
     prev.title === next.title &&
@@ -255,5 +273,8 @@ export const AgentCard = memo(
     prev.hasUnseen === next.hasUnseen &&
     prev.activityText === next.activityText &&
     prev.activityIsUserInput === next.activityIsUserInput &&
-    prev.lastMessageAt === next.lastMessageAt,
+    prev.lastMessageAt === next.lastMessageAt &&
+    prev.onMouseEnter === next.onMouseEnter &&
+    prev.onMouseLeave === next.onMouseLeave &&
+    prev.onMouseDown === next.onMouseDown,
 );

--- a/apps/browser/src/ui/screens/main/sidebar/active-agents/index.tsx
+++ b/apps/browser/src/ui/screens/main/sidebar/active-agents/index.tsx
@@ -15,7 +15,9 @@ import {
 import { IconPlusFill18 } from 'nucleo-ui-fill-18';
 import { extractTipTapText, firstWords } from '@ui/utils/text-utils';
 import { useEmptyAgentId } from '@ui/hooks/use-empty-agent';
-import { AgentCard, AgentCardSkeleton } from './_components/agent-card';
+import { AgentCardSkeleton } from './_components/agent-card';
+import { AgentCardWithPreview } from './_components/agent-card-with-preview';
+import type { CachedPreview } from '@ui/screens/main/sidebar/top/_components/agent-preview-panel';
 import { getToolActivityLabel } from './_utils/tool-label';
 
 type ActiveAgentCardData = {
@@ -124,6 +126,12 @@ export function ActiveAgentsGrid() {
   const setAgentTitle = useKartonProcedure((p) => p.agents.setTitle);
 
   const [, emptyAgentIdRef] = useEmptyAgentId();
+
+  // Per-surface preview cache. Survives the ActiveAgents mount lifetime so
+  // re-hovering the same card is instant. Not shared with the selector's
+  // cache on purpose — the selector clears on dropdown close and we don't
+  // want that side-effect to hit cards.
+  const previewCacheRef = useRef<Map<string, CachedPreview>>(new Map());
 
   const openAgentModelId = useKartonState((s) =>
     openAgent
@@ -385,7 +393,7 @@ export function ActiveAgentsGrid() {
           const hasUnseen = !isOpen && agent.unread;
 
           return (
-            <AgentCard
+            <AgentCardWithPreview
               key={agent.id}
               id={agent.id}
               title={agent.title}
@@ -401,6 +409,7 @@ export function ActiveAgentsGrid() {
               onArchive={handleArchive}
               onDelete={handleDelete}
               onRename={handleRename}
+              cache={previewCacheRef.current}
             />
           );
         })}

--- a/apps/browser/src/ui/screens/main/sidebar/top/_components/agent-preview-panel.tsx
+++ b/apps/browser/src/ui/screens/main/sidebar/top/_components/agent-preview-panel.tsx
@@ -6,6 +6,7 @@ import {
 } from '@ui/hooks/use-karton';
 import { cn } from '@ui/utils';
 import { getBaseName, getParentPath } from '@shared/path-utils';
+import type { StoredAgentPreview } from '@shared/karton-contracts/ui/agent';
 import { FileIcon } from '@ui/components/file-icon';
 import { OverlayScrollbar } from '@stagewise/stage-ui/components/overlay-scrollbar';
 import { useScrollFadeMask } from '@ui/hooks/use-scroll-fade-mask';
@@ -39,6 +40,79 @@ export type CachedPreview = {
   data: PreviewData | null;
   fetchedAt: number;
 };
+
+type GetStoredInstance = (
+  agentId: string,
+) => Promise<StoredAgentPreview | null | undefined>;
+type GetTouchedFiles = (agentId: string) => Promise<string[]>;
+
+/** Map a resolved `getStoredInstance` row + touched files into `PreviewData`.
+ *  Factored out so the hover-preview wrapper can pre-warm the cache without
+ *  duplicating the shape logic. */
+function shapeStoredInstance(
+  stored: StoredAgentPreview,
+): Omit<PreviewData, 'touchedFiles'> {
+  return {
+    title: stored.title,
+    messageCount: stored.messageCount,
+    createdAt: stored.createdAt,
+    lastMessageAt: stored.lastMessageAt,
+    workspaces: (stored.mountedWorkspaces ?? []).map((w) => ({
+      path: w.path,
+      isGitRepo: w.isGitRepo,
+      gitBranch: w.gitBranch,
+    })),
+  };
+}
+
+/** Fetch `{stored, touchedFiles}` into the shared cache if not already
+ *  present. Returns the cache entry (existing or newly written). Callers can
+ *  use this to avoid rendering the preview until data is ready — e.g. the
+ *  hover-preview wrapper uses the hover delay to pre-warm the cache, so the
+ *  panel mounts with content and no skeleton-to-content jitter. */
+export async function prefetchAgentPreview(
+  agentId: string,
+  cache: Map<string, CachedPreview>,
+  getStoredInstance: GetStoredInstance,
+  getTouchedFiles: GetTouchedFiles,
+  isActive: boolean,
+): Promise<CachedPreview | null> {
+  const existing = cache.get(agentId);
+  if (existing) return existing;
+
+  const [storedResult, filesResult] = await Promise.allSettled([
+    getStoredInstance(agentId),
+    getTouchedFiles(agentId),
+  ]);
+
+  if (storedResult.status === 'rejected') {
+    // Do not cache on stored-fetch failure; the panel's own fetch can retry.
+    return null;
+  }
+
+  const stored = storedResult.value;
+  if (!stored) {
+    // Mirror the guard in `AgentPreviewPanel`'s own fetch path: only cache
+    // the empty result for inactive (history) agents. Active agents may
+    // simply not have been flushed to disk yet; caching `null` here would
+    // permanently suppress the preview for the rest of the session even
+    // after the agent produces messages and gets persisted.
+    if (!isActive) {
+      const entry: CachedPreview = { data: null, fetchedAt: Date.now() };
+      cache.set(agentId, entry);
+      return entry;
+    }
+    return null;
+  }
+
+  const files = filesResult.status === 'fulfilled' ? filesResult.value : [];
+  const entry: CachedPreview = {
+    data: { ...shapeStoredInstance(stored), touchedFiles: files },
+    fetchedAt: Date.now(),
+  };
+  cache.set(agentId, entry);
+  return entry;
+}
 
 /** Live overlay fields read from Karton state for active agents. These drift
  * over the agent's lifetime and should override the (potentially stale) cached
@@ -191,15 +265,7 @@ export const AgentPreviewPanel = memo(function AgentPreviewPanel({
       const files = filesResult.status === 'fulfilled' ? filesResult.value : [];
 
       const data: PreviewData = {
-        title: stored.title,
-        messageCount: stored.messageCount,
-        createdAt: stored.createdAt,
-        lastMessageAt: stored.lastMessageAt,
-        workspaces: (stored.mountedWorkspaces ?? []).map((w) => ({
-          path: w.path,
-          isGitRepo: w.isGitRepo,
-          gitBranch: w.gitBranch,
-        })),
+        ...shapeStoredInstance(stored),
         touchedFiles: files,
       };
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hover-activated preview panel for agent cards with immediate prefetching, delayed show/exit, and graceful fade transitions.
  * Shared per-view preview cache so repeated hovers load faster.
  * Card title now behaves as a plain button to start inline editing.

* **Bug Fixes**
  * Robust hover/session handling to prevent stale or late previews and inconsistent portal states.
* **Stability**
  * Improved positioning and resize/scroll handling to avoid visual jumps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds hover preview panels to agent cards in the Active Agents grid so you can see key details without clicking. Panels prefetch and measure for a jitter-free open, and close immediately on mouse leave or mousedown.

- **New Features**
  - Added `AgentCardWithPreview` that shows a non-interactive preview after ~500ms hover; portaled to `document.body`, cancels fade-out on quick re-hover, and fades out on close.
  - Introduced `prefetchAgentPreview` with a per-surface cache in the grid; warms during the hover delay, skips empty/failed results, and never caches empty data for active agents.
  - Measured before first paint, flips/clamps to the viewport, and repositions on scroll/resize/content changes.

- **Refactors**
  - Updated `AgentCard` to `forwardRef`, added optional `onMouseEnter`/`onMouseLeave`/`onMouseDown`, and removed the title tooltip to avoid hover conflicts; title button still starts inline rename.
  - Extracted a shared preview-shaping helper used by the panel and prefetch; tightened the memo comparator to include the hover handlers.

<sup>Written for commit 06c6e3acc102f6520ecace78cc8ffba4847ecbe5. Summary will update on new commits. <a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/990?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

