### PR TITLE
fix(stagewise): prevent editing agent title when agent is inactive

### DIFF
--- a/apps/browser/src/ui/screens/main/sidebar/active-agents/_components/agent-card.tsx
+++ b/apps/browser/src/ui/screens/main/sidebar/active-agents/_components/agent-card.tsx
@@ -83,6 +83,7 @@ export const AgentCard = memo(
         aria-keyshortcuts="F2"
         onClick={() => onClick(id)}
         onDoubleClick={(e) => {
+          if (!isActive) return;
           e.stopPropagation();
           if (!isEditing) startEditing();
         }}
@@ -94,8 +95,9 @@ export const AgentCard = memo(
           if (e.key === 'Enter' || e.key === ' ') {
             e.preventDefault();
             onClick(id);
-          } else if (e.key === 'F2' && !isEditing) {
+          } else if (e.key === 'F2' && !isEditing && isActive) {
             // F2 is the standard rename shortcut across Finder/Explorer/VS Code.
+            // Only allow rename on the active agent — consistent with click/double-click.
             e.preventDefault();
             startEditing();
           }
@@ -149,10 +151,14 @@ export const AgentCard = memo(
                   tabIndex={-1}
                   className="block min-w-0 max-w-full cursor-pointer overflow-x-clip text-ellipsis whitespace-nowrap bg-transparent p-0 text-left font-medium text-foreground text-xs leading-normal outline-none"
                   onClick={(e) => {
+                    if (!isActive) return;
                     e.stopPropagation();
                     startEditing();
                   }}
-                  onPointerDown={(e) => e.stopPropagation()}
+                  onPointerDown={(e) => {
+                    if (!isActive) return;
+                    e.stopPropagation();
+                  }}
                 >
                   {displayTitle}
                 </button>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable title editing for inactive agents in the Active Agents sidebar to prevent accidental changes. Blocks edit mode on double‑click, title click/pointer down, and the F2 rename shortcut when the agent is inactive.

<sup>Written for commit 067ab9484f5049f7b92ca93846de5aaf4ac9b875. Summary will update on new commits. <a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/995?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where rename/edit mode could be triggered on inactive agent cards via double-click, title button, or the F2 shortcut. Edit entry and event suppression now only occur for the active agent, preventing unintended edits and unwanted event propagation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->