### PR TITLE
feat(stagewise): add PendingApprovalBanner component to handle tool approval requests

### DIFF
--- a/apps/browser/src/ui/screens/main/sidebar/chat/_components/index.tsx
+++ b/apps/browser/src/ui/screens/main/sidebar/chat/_components/index.tsx
@@ -12,6 +12,7 @@ import { ChatPanelFooter } from './panel-footer';
 import { InternalAppFrame } from './internal-app-frame';
 import { UsageWarningBadge } from './usage-warning-badge';
 import { NotificationBanners } from './notification-banners';
+import { PendingApprovalBanner } from './pending-approval-banner';
 import { useKartonState } from '@ui/hooks/use-karton';
 import { cn } from '@ui/utils';
 import { useOpenAgent, OpenAgentContext } from '@ui/hooks/use-open-chat';
@@ -159,6 +160,7 @@ export function ChatPanel() {
         >
           <InternalAppFrame />
           <NotificationBanners />
+          <PendingApprovalBanner />
           <UsageWarningBadge />
         </div>
         <ChatPanelFooter key={openAgent} />

--- a/apps/browser/src/ui/screens/main/sidebar/chat/_components/pending-approval-banner.tsx
+++ b/apps/browser/src/ui/screens/main/sidebar/chat/_components/pending-approval-banner.tsx
@@ -71,15 +71,19 @@ export function PendingApprovalBanner() {
   );
 
   const handleRespond = useCallback(
-    (approvalId: string, approved: boolean) => {
+    async (approvalId: string, approved: boolean) => {
       if (!openAgentId || respondingIds.includes(approvalId)) return;
       setRespondingIds((prev) => [...prev, approvalId]);
-      sendApproval(
-        openAgentId,
-        approvalId,
-        approved,
-        approved ? undefined : 'User denied',
-      );
+      try {
+        await sendApproval(
+          openAgentId,
+          approvalId,
+          approved,
+          approved ? undefined : 'User denied',
+        );
+      } catch {
+        setRespondingIds((prev) => prev.filter((id) => id !== approvalId));
+      }
     },
     [openAgentId, sendApproval, respondingIds],
   );

--- a/apps/browser/src/ui/screens/main/sidebar/chat/_components/pending-approval-banner.tsx
+++ b/apps/browser/src/ui/screens/main/sidebar/chat/_components/pending-approval-banner.tsx
@@ -1,0 +1,135 @@
+import { useCallback, useState } from 'react';
+import { useKartonState, useKartonProcedure } from '@ui/hooks/use-karton';
+import { useComparingSelector } from '@stagewise/karton/react/client';
+import { useOpenAgent } from '@ui/hooks/use-open-chat';
+import { Button } from '@stagewise/stage-ui/components/button';
+import {
+  IconTerminalOutline18,
+  IconLoader6Outline18,
+} from 'nucleo-ui-outline-18';
+import type { AgentToolUIPart } from '@shared/karton-contracts/ui/agent';
+
+type PendingApproval = {
+  approvalId: string;
+  label: string;
+};
+
+const EMPTY: PendingApproval[] = [];
+
+function sameApprovals(a: PendingApproval[], b: PendingApproval[]): boolean {
+  if (a === b) return true;
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (a[i]!.approvalId !== b[i]!.approvalId || a[i]!.label !== b[i]!.label)
+      return false;
+  }
+  return true;
+}
+
+export function PendingApprovalBanner() {
+  const [openAgentId] = useOpenAgent();
+  const sendApproval = useKartonProcedure(
+    (p) => p.agents.sendToolApprovalResponse,
+  );
+  const [respondingIds, setRespondingIds] = useState<string[]>([]);
+
+  const pendingApprovals = useKartonState(
+    useComparingSelector((s): PendingApproval[] => {
+      if (!openAgentId) return EMPTY;
+      const history = s.agents.instances[openAgentId]?.state.history;
+      if (!history?.length) return EMPTY;
+
+      for (let i = history.length - 1; i >= 0; i--) {
+        const msg = history[i]!;
+        if (msg.role !== 'assistant') continue;
+
+        const result: PendingApproval[] = [];
+        for (const part of msg.parts) {
+          if (
+            part.type !== 'tool-executeShellCommand' ||
+            part.state !== 'approval-requested'
+          )
+            continue;
+          const shellPart = part as Extract<
+            AgentToolUIPart,
+            { type: 'tool-executeShellCommand' }
+          >;
+          if (!shellPart.approval?.id) continue;
+          const input = shellPart.input as {
+            explanation?: string;
+            command?: string;
+          } | null;
+          result.push({
+            approvalId: shellPart.approval.id,
+            label: input?.explanation || input?.command || 'Run command',
+          });
+        }
+        return result.length > 0 ? result : EMPTY;
+      }
+      return EMPTY;
+    }, sameApprovals),
+  );
+
+  const handleRespond = useCallback(
+    (approvalId: string, approved: boolean) => {
+      if (!openAgentId || respondingIds.includes(approvalId)) return;
+      setRespondingIds((prev) => [...prev, approvalId]);
+      sendApproval(
+        openAgentId,
+        approvalId,
+        approved,
+        approved ? undefined : 'User denied',
+      );
+    },
+    [openAgentId, sendApproval, respondingIds],
+  );
+
+  if (pendingApprovals.length === 0) return null;
+
+  return (
+    <div className="flex flex-col gap-2">
+      {pendingApprovals.map((approval) => {
+        const isResponding = respondingIds.includes(approval.approvalId);
+        return (
+          <div
+            key={approval.approvalId}
+            className="flex shrink-0 flex-col gap-1.5 rounded-md bg-background p-2.5 shadow-elevation-1 ring-1 ring-derived-strong dark:bg-surface-1"
+          >
+            <div className="flex flex-row items-start gap-2">
+              <IconTerminalOutline18 className="mt-0.5 size-3.5 shrink-0 text-warning-foreground" />
+              <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+                <p className="font-medium text-warning-foreground text-xs">
+                  Approval needed
+                </p>
+                <p className="truncate text-muted-foreground text-xs">
+                  {approval.label}
+                </p>
+              </div>
+            </div>
+            <div className="flex flex-row-reverse items-center gap-2">
+              <Button
+                variant="primary"
+                size="xs"
+                onClick={() => handleRespond(approval.approvalId, true)}
+                disabled={isResponding}
+              >
+                {isResponding && (
+                  <IconLoader6Outline18 className="size-3 shrink-0 animate-spin" />
+                )}
+                Allow
+              </Button>
+              <Button
+                variant="ghost"
+                size="xs"
+                onClick={() => handleRespond(approval.approvalId, false)}
+                disabled={isResponding}
+              >
+                Skip
+              </Button>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}


### PR DESCRIPTION
Problem
When an agent triggers a shell command requiring user approval, subsequent tool calls in the same turn push the inline Allow/Skip buttons out of view. The user has no indication that anything is waiting — they have to scroll up and discover the request themselves.

Solution
Adds a PendingApprovalBanner that appears in the sticky footer area (above the chat input) whenever a tool-executeShellCommand part is in approval-requested state. The banner shows an "Approval needed" header, the command explanation, and Allow/Skip buttons — so the user can respond without scrolling at all.

The banner disappears automatically once the approval is resolved, and uses useComparingSelector to avoid re-renders during streaming when the approval state hasn't changed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new UI that inspects agent message history and triggers `sendToolApprovalResponse`; bugs here could hide approvals or send the wrong approvalId, but changes are limited to the chat sidebar UI.
> 
> **Overview**
> Adds a new `PendingApprovalBanner` shown in the chat panel’s sticky footer area to surface pending `tool-executeShellCommand` approvals without requiring users to scroll.
> 
> The banner scans the most recent assistant message for parts in `approval-requested` state, displays the command/explanation, and provides **Allow/Skip** actions that call `sendToolApprovalResponse` while locally disabling buttons during submission (with `useComparingSelector` to reduce re-renders during streaming).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e917fae639a99d402fb4c7829c31f08f094e076. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a pending approval banner in the chat footer so users can allow or skip shell command requests without scrolling. Improves visibility when multiple tool calls happen in one turn.

- **New Features**
  - Added PendingApprovalBanner in the sticky footer showing “Approval needed,” the command/explanation, and Allow/Skip actions.
  - Appears when a `tool-executeShellCommand` part is `approval-requested` and hides after a response.
  - Uses useComparingSelector to avoid extra re-renders during streaming, disables actions with a spinner while sending, and awaits the approval response to keep state in sync.

<sup>Written for commit 13da865d1f5a612d489147708d11f5cc0579a814. Summary will update on new commits. <a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/996?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a pending approval banner in the chat sidebar that surfaces pending tool-command approval requests from recent assistant activity. Each request appears as a card with "Allow" and "Skip" actions; buttons show loading/disabled states while a response is processed. If there are no pending requests the banner is hidden. Error handling restores button availability on failure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->