### PR TITLE
feat(stagewise): add support for DeepSeek and Z.ai providers

### DIFF
--- a/apps/browser/src/backend/agents/model-provider.ts
+++ b/apps/browser/src/backend/agents/model-provider.ts
@@ -158,7 +158,9 @@ export class ModelProviderService {
       endpointId === 'openai' ||
       endpointId === 'google' ||
       endpointId === 'moonshotai' ||
-      endpointId === 'alibaba'
+      endpointId === 'alibaba' ||
+      endpointId === 'deepseek' ||
+      endpointId === 'z-ai'
     ) {
       const { apiKey, baseURL } = this.resolveProviderEndpoint(endpointId);
       const apiSpecMap: Record<ModelProvider, ApiSpec> = {
@@ -167,6 +169,8 @@ export class ModelProviderService {
         google: 'google',
         moonshotai: 'openai-chat-completions',
         alibaba: 'openai-chat-completions',
+        deepseek: 'openai-chat-completions',
+        'z-ai': 'openai-chat-completions',
       };
       return { apiKey, baseURL, apiSpec: apiSpecMap[endpointId] };
     }
@@ -422,7 +426,9 @@ export class ModelProviderService {
         });
         return {
           model: this.telemetryService.withTracing(
-            p(modelId as any),
+            // Moonshot's native API speaks Chat Completions, not Responses.
+            // `createOpenAI()(id)` defaults to Responses — must use `.chat()`.
+            p.chat(modelId as any),
             posthogConfig,
           ),
           headers,
@@ -440,7 +446,44 @@ export class ModelProviderService {
         });
         return {
           model: this.telemetryService.withTracing(
-            p(modelId as any),
+            // Alibaba's DashScope speaks Chat Completions — use `.chat()`.
+            p.chat(modelId as any),
+            posthogConfig,
+          ),
+          headers,
+          providerOptions: providerOptions as Parameters<
+            typeof streamText
+          >[0]['providerOptions'],
+          contextWindowSize,
+        };
+      }
+      case 'deepseek': {
+        const p = createOpenAI({
+          apiKey,
+          baseURL: baseURL ?? 'https://api.deepseek.com/v1',
+        });
+        return {
+          model: this.telemetryService.withTracing(
+            // DeepSeek's native API speaks Chat Completions — use `.chat()`.
+            p.chat(modelId as any),
+            posthogConfig,
+          ),
+          headers,
+          providerOptions: providerOptions as Parameters<
+            typeof streamText
+          >[0]['providerOptions'],
+          contextWindowSize,
+        };
+      }
+      case 'z-ai': {
+        const p = createOpenAI({
+          apiKey,
+          baseURL: baseURL ?? 'https://api.z.ai/api/paas/v4',
+        });
+        return {
+          model: this.telemetryService.withTracing(
+            // Z.AI's OpenAI-compatible endpoint speaks Chat Completions.
+            p.chat(modelId as any),
             posthogConfig,
           ),
           headers,

--- a/apps/browser/src/backend/services/preferences.ts
+++ b/apps/browser/src/backend/services/preferences.ts
@@ -132,6 +132,8 @@ export class PreferencesService extends DisposableService {
       'google',
       'moonshotai',
       'alibaba',
+      'deepseek',
+      'z-ai',
     ] as const;
     let needsSave = false;
 

--- a/apps/browser/src/backend/utils/validate-api-keys.ts
+++ b/apps/browser/src/backend/utils/validate-api-keys.ts
@@ -8,7 +8,9 @@ export type ApiKeyProvider =
   | 'openai'
   | 'google'
   | 'moonshotai'
-  | 'alibaba';
+  | 'alibaba'
+  | 'deepseek'
+  | 'z-ai';
 
 export type ApiKeyValidationResult =
   | null
@@ -34,17 +36,32 @@ const providerConfigs: Record<
   openai: (apiKey, baseURL) => createOpenAI({ apiKey, baseURL })('gpt-5-nano'),
   google: (apiKey, baseURL) =>
     createGoogleGenerativeAI({ apiKey, baseURL })('gemini-2.5-flash-lite'),
+  // OpenAI-compatible providers below must use `.chat(...)` rather than the
+  // default `(id)` shorthand: `createOpenAI()(id)` targets the Responses API
+  // (only OpenAI itself implements it), whereas these upstreams speak Chat
+  // Completions. Without `.chat(...)`, the probe hits a non-existent endpoint
+  // and valid keys get rejected.
   moonshotai: (apiKey, baseURL) =>
     createOpenAI({
       apiKey,
       baseURL: baseURL ?? 'https://api.moonshot.ai/v1',
-    })('kimi-k2.6'),
+    }).chat('kimi-k2.6'),
   alibaba: (apiKey, baseURL) =>
     createOpenAI({
       apiKey,
       baseURL:
         baseURL ?? 'https://dashscope-intl.aliyuncs.com/compatible-mode/v1',
-    })('qwen-turbo'),
+    }).chat('qwen-turbo'),
+  deepseek: (apiKey, baseURL) =>
+    createOpenAI({
+      apiKey,
+      baseURL: baseURL ?? 'https://api.deepseek.com/v1',
+    }).chat('deepseek-v4-flash'),
+  'z-ai': (apiKey, baseURL) =>
+    createOpenAI({
+      apiKey,
+      baseURL: baseURL ?? 'https://api.z.ai/api/paas/v4',
+    }).chat('glm-4.5-flash'),
 };
 
 /**
@@ -64,6 +81,8 @@ export async function validateApiKeys(
     google: null,
     moonshotai: null,
     alibaba: null,
+    deepseek: null,
+    'z-ai': null,
   };
 
   const promises: Promise<void>[] = [];

--- a/apps/browser/src/pages/routes/_internal-app/agent-settings.models-providers.tsx
+++ b/apps/browser/src/pages/routes/_internal-app/agent-settings.models-providers.tsx
@@ -76,6 +76,8 @@ const PROVIDERS: ModelProvider[] = [
   'google',
   'moonshotai',
   'alibaba',
+  'deepseek',
+  'z-ai',
 ];
 
 function ProviderConfigCard({ provider }: { provider: ModelProvider }) {
@@ -325,11 +327,29 @@ function ProviderConfigCard({ provider }: { provider: ModelProvider }) {
 }
 
 function ModelProvidersSection() {
+  const [showAll, setShowAll] = useState(false);
+  const primary = PROVIDERS.slice(0, 3);
+  const secondary = PROVIDERS.slice(3);
   return (
     <div className="space-y-3">
-      {PROVIDERS.map((provider) => (
+      {primary.map((provider) => (
         <ProviderConfigCard key={provider} provider={provider} />
       ))}
+      {showAll &&
+        secondary.map((provider) => (
+          <ProviderConfigCard key={provider} provider={provider} />
+        ))}
+      {secondary.length > 0 && (
+        <div className="flex justify-end">
+          <Button
+            variant="ghost"
+            size="xs"
+            onClick={() => setShowAll((v) => !v)}
+          >
+            {showAll ? 'Show less' : `Show ${secondary.length} more providers`}
+          </Button>
+        </div>
+      )}
     </div>
   );
 }
@@ -446,6 +466,8 @@ function CustomModelDialog({
       { value: 'google', label: 'Google', group: 'Built-in' },
       { value: 'moonshotai', label: 'Moonshot AI', group: 'Built-in' },
       { value: 'alibaba', label: 'Alibaba Cloud', group: 'Built-in' },
+      { value: 'deepseek', label: 'DeepSeek', group: 'Built-in' },
+      { value: 'z-ai', label: 'Z.ai', group: 'Built-in' },
     ];
     const custom = customEndpoints.map((ep) => ({
       value: ep.id,
@@ -911,6 +933,8 @@ function CustomModelsSection() {
       if (endpointId === 'google') return 'Google';
       if (endpointId === 'moonshotai') return 'Moonshot AI';
       if (endpointId === 'alibaba') return 'Alibaba Cloud';
+      if (endpointId === 'deepseek') return 'DeepSeek';
+      if (endpointId === 'z-ai') return 'Z.ai';
       return (
         customEndpoints.find((ep) => ep.id === endpointId)?.name ?? 'Unknown'
       );

--- a/apps/browser/src/shared/available-models.ts
+++ b/apps/browser/src/shared/available-models.ts
@@ -782,6 +782,179 @@ export const availableModels = [
       toolCalling: true,
     },
   },
+  {
+    officialProvider: 'deepseek',
+    modelId: 'deepseek-v4-pro',
+    modelDisplayName: 'DeepSeek V4 Pro',
+    modelDescription:
+      "DeepSeek's flagship 1.6T-parameter Mixture-of-Experts model with 49B activated. Strong reasoning and coding at a low price point.",
+    modelContext: '1M context',
+    modelContextRaw: 1_048_576,
+    headers: {},
+    providerOptions: {
+      stagewise: {
+        reasoning: { enabled: true, effort: 'medium' },
+        // Skip OpenRouter upstreams that don't accept `tools`/`tool_choice`
+        // (SiliconFlow, GMICloud). Without this, requests silently route to
+        // endpoints that reject tool definitions.
+        provider: { require_parameters: true },
+      },
+    },
+    thinkingEnabled: true,
+    pricing: {
+      inputPerMillion: 0.435,
+      outputPerMillion: 0.87,
+      relativeMultiplier: 0.22,
+    },
+    capabilities: {
+      inputModalities: {
+        text: true,
+        audio: false,
+        image: false,
+        video: false,
+        file: false,
+      },
+      outputModalities: {
+        text: true,
+        audio: false,
+        image: false,
+        video: false,
+        file: false,
+      },
+      toolCalling: true,
+    },
+  },
+  {
+    officialProvider: 'deepseek',
+    modelId: 'deepseek-v4-flash',
+    modelDisplayName: 'DeepSeek V4 Flash',
+    modelDescription:
+      "DeepSeek's efficiency-optimized 284B-parameter MoE with 13B activated. Fast and cheap for high-volume workflows.",
+    modelContext: '1M context',
+    modelContextRaw: 1_048_576,
+    headers: {},
+    providerOptions: {
+      stagewise: {
+        reasoning: { enabled: true, effort: 'medium' },
+        // Defensive: all current V4 Flash upstreams support tools, but this
+        // guards against future upstream additions that don't.
+        provider: { require_parameters: true },
+      },
+    },
+    thinkingEnabled: true,
+    pricing: {
+      inputPerMillion: 0.14,
+      outputPerMillion: 0.28,
+      relativeMultiplier: 0.07,
+    },
+    capabilities: {
+      inputModalities: {
+        text: true,
+        audio: false,
+        image: false,
+        video: false,
+        file: false,
+      },
+      outputModalities: {
+        text: true,
+        audio: false,
+        image: false,
+        video: false,
+        file: false,
+      },
+      toolCalling: true,
+    },
+  },
+  {
+    officialProvider: 'z-ai',
+    modelId: 'glm-5.1',
+    modelDisplayName: 'GLM 5.1',
+    modelDescription:
+      "Z.ai's newest flagship. Major leap in long-horizon coding and agentic workflows.",
+    modelContext: '200k context',
+    modelContextRaw: 202_752,
+    headers: {},
+    providerOptions: {
+      stagewise: {
+        reasoning: { enabled: true, effort: 'medium' },
+        // Only ~6 of 15 GLM 5.1 upstreams support tools. Filter to those.
+        provider: { require_parameters: true },
+      },
+    },
+    thinkingEnabled: true,
+    pricing: {
+      inputPerMillion: 1.4,
+      outputPerMillion: 4.4,
+      relativeMultiplier: 0.97,
+    },
+    capabilities: {
+      inputModalities: {
+        text: true,
+        audio: false,
+        image: false,
+        video: false,
+        file: false,
+      },
+      outputModalities: {
+        text: true,
+        audio: false,
+        image: false,
+        video: false,
+        file: false,
+      },
+      toolCalling: true,
+    },
+  },
+  {
+    officialProvider: 'z-ai',
+    modelId: 'glm-5v-turbo',
+    modelDisplayName: 'GLM 5V-Turbo',
+    modelDescription:
+      "Z.ai's native multimodal agent model. Handles image, video, and text input for vision-based coding and agent tasks.",
+    modelContext: '200k context',
+    modelContextRaw: 202_752,
+    headers: {},
+    providerOptions: {
+      stagewise: {
+        reasoning: { enabled: true, effort: 'medium' },
+        // Only Z.AI serves GLM 5V-Turbo today. No-op for now, but guards
+        // against future upstream additions that lack tool support.
+        provider: { require_parameters: true },
+      },
+    },
+    thinkingEnabled: true,
+    pricing: {
+      inputPerMillion: 1.2,
+      outputPerMillion: 4.0,
+      relativeMultiplier: 0.87,
+    },
+    capabilities: {
+      inputModalities: {
+        text: true,
+        audio: false,
+        image: true,
+        video: true,
+        file: false,
+      },
+      outputModalities: {
+        text: true,
+        audio: false,
+        image: false,
+        video: false,
+        file: false,
+      },
+      // Reused from Google's constraint set as a sane multimodal default
+      // for image + video limits. Z.AI upstream limits may differ; refine
+      // if we observe rejections on larger inline payloads.
+      // `file` is omitted so the constraints stay consistent with
+      // `inputModalities.file = false` (no PDF ingestion).
+      inputConstraints: {
+        ...GOOGLE_INPUT_CONSTRAINTS,
+        file: undefined,
+      },
+      toolCalling: true,
+    },
+  },
 ] as const satisfies ModelSettings[];
 
 export type BuiltInModelId = (typeof availableModels)[number]['modelId'];
@@ -830,7 +1003,11 @@ export function findModelsAcceptingMime(
   return availableModels
     .filter((m) => {
       if (m.modelId === excludeModelId) return false;
-      const c = m.capabilities.inputConstraints;
+      // `inputConstraints` is optional on the zod schema (text-only
+      // models omit it). The `as const satisfies` narrowing removes the
+      // key from the union for those entries — cast to the schema shape.
+      const c = (m.capabilities as { inputConstraints?: InputConstraints })
+        .inputConstraints;
       if (!c) return false;
       for (const constraint of [c.image, c.file, c.video, c.audio])
         if (constraint?.mimeTypes.includes(lowerMime)) return true;

--- a/apps/browser/src/shared/karton-contracts/ui/index.ts
+++ b/apps/browser/src/shared/karton-contracts/ui/index.ts
@@ -807,12 +807,16 @@ export type KartonContract = {
         google?: string;
         moonshotai?: string;
         alibaba?: string;
+        deepseek?: string;
+        'z-ai'?: string;
       }) => Promise<{
         anthropic: ApiKeyValidationResult;
         openai: ApiKeyValidationResult;
         google: ApiKeyValidationResult;
         moonshotai: ApiKeyValidationResult;
         alibaba: ApiKeyValidationResult;
+        deepseek: ApiKeyValidationResult;
+        'z-ai': ApiKeyValidationResult;
       }>;
     };
     userExperience: {

--- a/apps/browser/src/shared/karton-contracts/ui/shared-types.ts
+++ b/apps/browser/src/shared/karton-contracts/ui/shared-types.ts
@@ -15,6 +15,8 @@ export const modelProviderSchema = z.enum([
   'google',
   'moonshotai',
   'alibaba',
+  'deepseek',
+  'z-ai',
 ]);
 export type ModelProvider = z.infer<typeof modelProviderSchema>;
 
@@ -46,6 +48,8 @@ export const providerConfigsSchema = z.object({
   google: providerConfigSchema.default({ mode: 'stagewise' }),
   moonshotai: providerConfigSchema.default({ mode: 'stagewise' }),
   alibaba: providerConfigSchema.default({ mode: 'stagewise' }),
+  deepseek: providerConfigSchema.default({ mode: 'stagewise' }),
+  'z-ai': providerConfigSchema.default({ mode: 'stagewise' }),
 });
 export type ProviderConfigs = z.infer<typeof providerConfigsSchema>;
 
@@ -193,6 +197,8 @@ export const PROVIDER_OFFICIAL_URLS: Record<ModelProvider, string> = {
   google: 'https://generativelanguage.googleapis.com/v1beta',
   moonshotai: 'https://api.moonshot.ai/v1',
   alibaba: 'https://dashscope-intl.aliyuncs.com/compatible-mode/v1',
+  deepseek: 'https://api.deepseek.com/v1',
+  'z-ai': 'https://api.z.ai/api/paas/v4',
 };
 
 /** Display info for each provider (for UI) */
@@ -220,6 +226,14 @@ export const PROVIDER_DISPLAY_INFO: Record<
     name: 'Alibaba Cloud',
     description: 'Qwen models',
   },
+  deepseek: {
+    name: 'DeepSeek',
+    description: 'DeepSeek V-series models',
+  },
+  'z-ai': {
+    name: 'Z.ai',
+    description: 'GLM models',
+  },
 };
 
 export type StagewiseProviderOptions = {
@@ -229,6 +243,25 @@ export type StagewiseProviderOptions = {
   };
   cache_control?: {
     type: 'ephemeral' | 'persistent';
+  };
+  /**
+   * OpenRouter provider routing preferences (forwarded verbatim).
+   * See https://openrouter.ai/docs/provider-routing.
+   *
+   * Note: the ai-proxy's `applyStickyRouting` overlays its own `order`
+   * and `allow_fallbacks: false` when the model's prefix is listed in
+   * `BYOK_ORDER`. Existing keys set here are preserved via spread, but
+   * `order` / `allow_fallbacks` will be overwritten by the platform.
+   * `require_parameters` typically becomes redundant once the platform
+   * pins routing to a single BYOK upstream.
+   */
+  provider?: {
+    /** Only route to endpoints that support every parameter in the request (e.g. tools). */
+    require_parameters?: boolean;
+    /** Restrict routing to an allow-list of upstream providers (lower-case slugs). */
+    only?: string[];
+    /** Preferred ordering of upstream providers. */
+    order?: string[];
   };
 };
 
@@ -411,6 +444,8 @@ export const userPreferencesSchema = z.object({
     google: { mode: 'stagewise' },
     moonshotai: { mode: 'stagewise' },
     alibaba: { mode: 'stagewise' },
+    deepseek: { mode: 'stagewise' },
+    'z-ai': { mode: 'stagewise' },
   }),
   /** User-defined API endpoints */
   customEndpoints: z.array(customEndpointSchema).default([]),
@@ -503,6 +538,8 @@ export const defaultUserPreferences: UserPreferences = {
     google: { mode: 'stagewise' },
     moonshotai: { mode: 'stagewise' },
     alibaba: { mode: 'stagewise' },
+    deepseek: { mode: 'stagewise' },
+    'z-ai': { mode: 'stagewise' },
   },
   customEndpoints: [],
   customModels: [],

--- a/apps/browser/src/ui/screens/onboarding/steps/02-auth.tsx
+++ b/apps/browser/src/ui/screens/onboarding/steps/02-auth.tsx
@@ -18,7 +18,14 @@ import type { TelemetryLevel } from '@shared/karton-contracts/ui/shared-types';
 
 type AuthMode = 'stagewise' | 'api-keys';
 type AuthPhase = 'form-input' | 'waiting-for-otp' | 'authentication-validated';
-type ProviderKey = 'anthropic' | 'openai' | 'google' | 'moonshotai' | 'alibaba';
+type ProviderKey =
+  | 'anthropic'
+  | 'openai'
+  | 'google'
+  | 'moonshotai'
+  | 'alibaba'
+  | 'deepseek'
+  | 'z-ai';
 type FieldErrors = Record<ProviderKey, string | null>;
 
 export function StepAuth({
@@ -75,12 +82,17 @@ export function StepAuth({
   const [apiKey3, setApiKey3] = useState('');
   const [apiKey4, setApiKey4] = useState('');
   const [apiKey5, setApiKey5] = useState('');
+  const [apiKey6, setApiKey6] = useState('');
+  const [apiKey7, setApiKey7] = useState('');
+  const [showMoreProviders, setShowMoreProviders] = useState(false);
   const emptyErrors: FieldErrors = {
     anthropic: null,
     openai: null,
     google: null,
     moonshotai: null,
     alibaba: null,
+    deepseek: null,
+    'z-ai': null,
   };
   const [fieldErrors, setFieldErrors] = useState<FieldErrors>(emptyErrors);
 
@@ -124,7 +136,15 @@ export function StepAuth({
     }
   }, [mode]);
 
-  const hasAnyKey = !!(apiKey1 || apiKey2 || apiKey3 || apiKey4 || apiKey5);
+  const hasAnyKey = !!(
+    apiKey1 ||
+    apiKey2 ||
+    apiKey3 ||
+    apiKey4 ||
+    apiKey5 ||
+    apiKey6 ||
+    apiKey7
+  );
   const isValid = phase === 'authentication-validated';
 
   const handleSubmitApiKeys = useCallback(() => {
@@ -137,6 +157,8 @@ export function StepAuth({
       google: apiKey3,
       moonshotai: apiKey4,
       alibaba: apiKey5,
+      deepseek: apiKey6,
+      'z-ai': apiKey7,
     })
       .then(async (results) => {
         const next: FieldErrors = { ...emptyErrors };
@@ -145,6 +167,18 @@ export function StepAuth({
           next[key] = r && !r.success ? r.error : null;
         }
         setFieldErrors(next);
+        // Auto-expand the secondary section if any hidden provider errored,
+        // otherwise the error message is rendered into an unmounted field
+        // and the user gets no feedback.
+        const secondaryKeys: ProviderKey[] = [
+          'moonshotai',
+          'alibaba',
+          'deepseek',
+          'z-ai',
+        ];
+        if (secondaryKeys.some((k) => next[k] !== null)) {
+          setShowMoreProviders(true);
+        }
         if (Object.values(next).every((v) => v === null)) {
           const keysToSave = (
             [
@@ -153,6 +187,8 @@ export function StepAuth({
               ['google', apiKey3],
               ['moonshotai', apiKey4],
               ['alibaba', apiKey5],
+              ['deepseek', apiKey6],
+              ['z-ai', apiKey7],
             ] as [ProviderKey, string][]
           ).filter(([, v]) => !!v);
           for (const [provider, key] of keysToSave) {
@@ -177,6 +213,8 @@ export function StepAuth({
     apiKey3,
     apiKey4,
     apiKey5,
+    apiKey6,
+    apiKey7,
     validateApiKeys,
     setProviderApiKey,
     preferencesUpdate,
@@ -518,69 +556,146 @@ export function StepAuth({
               />
             )}
           </div>
-          <div className="flex flex-col gap-1">
-            <label
-              htmlFor="api-key-4"
-              className="text-muted-foreground text-xs"
+          {showMoreProviders && (
+            <>
+              <div className="flex flex-col gap-1">
+                <label
+                  htmlFor="api-key-4"
+                  className="text-muted-foreground text-xs"
+                >
+                  Moonshot AI
+                </label>
+                <Input
+                  id="api-key-4"
+                  placeholder="sk-..."
+                  size="sm"
+                  className="app-no-drag"
+                  value={apiKey4}
+                  aria-invalid={!!fieldErrors.moonshotai}
+                  aria-describedby={
+                    fieldErrors.moonshotai ? 'api-key-4-error' : undefined
+                  }
+                  onValueChange={(v) => {
+                    setApiKey4(v);
+                    setFieldErrors((prev) => ({ ...prev, moonshotai: null }));
+                  }}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') handleSubmitApiKeys();
+                  }}
+                />
+                {fieldErrors.moonshotai && (
+                  <TruncatedErrorText
+                    id="api-key-4-error"
+                    text={fieldErrors.moonshotai}
+                  />
+                )}
+              </div>
+              <div className="flex flex-col gap-1">
+                <label
+                  htmlFor="api-key-5"
+                  className="text-muted-foreground text-xs"
+                >
+                  Alibaba Cloud
+                </label>
+                <Input
+                  id="api-key-5"
+                  placeholder="sk-..."
+                  size="sm"
+                  className="app-no-drag"
+                  value={apiKey5}
+                  aria-invalid={!!fieldErrors.alibaba}
+                  aria-describedby={
+                    fieldErrors.alibaba ? 'api-key-5-error' : undefined
+                  }
+                  onValueChange={(v) => {
+                    setApiKey5(v);
+                    setFieldErrors((prev) => ({ ...prev, alibaba: null }));
+                  }}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') handleSubmitApiKeys();
+                  }}
+                />
+                {fieldErrors.alibaba && (
+                  <TruncatedErrorText
+                    id="api-key-5-error"
+                    text={fieldErrors.alibaba}
+                  />
+                )}
+              </div>
+              <div className="flex flex-col gap-1">
+                <label
+                  htmlFor="api-key-6"
+                  className="text-muted-foreground text-xs"
+                >
+                  DeepSeek
+                </label>
+                <Input
+                  id="api-key-6"
+                  placeholder="sk-..."
+                  size="sm"
+                  className="app-no-drag"
+                  value={apiKey6}
+                  aria-invalid={!!fieldErrors.deepseek}
+                  aria-describedby={
+                    fieldErrors.deepseek ? 'api-key-6-error' : undefined
+                  }
+                  onValueChange={(v) => {
+                    setApiKey6(v);
+                    setFieldErrors((prev) => ({ ...prev, deepseek: null }));
+                  }}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') handleSubmitApiKeys();
+                  }}
+                />
+                {fieldErrors.deepseek && (
+                  <TruncatedErrorText
+                    id="api-key-6-error"
+                    text={fieldErrors.deepseek}
+                  />
+                )}
+              </div>
+              <div className="flex flex-col gap-1">
+                <label
+                  htmlFor="api-key-7"
+                  className="text-muted-foreground text-xs"
+                >
+                  Z.ai
+                </label>
+                <Input
+                  id="api-key-7"
+                  placeholder="sk-..."
+                  size="sm"
+                  className="app-no-drag"
+                  value={apiKey7}
+                  aria-invalid={!!fieldErrors['z-ai']}
+                  aria-describedby={
+                    fieldErrors['z-ai'] ? 'api-key-7-error' : undefined
+                  }
+                  onValueChange={(v) => {
+                    setApiKey7(v);
+                    setFieldErrors((prev) => ({ ...prev, 'z-ai': null }));
+                  }}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') handleSubmitApiKeys();
+                  }}
+                />
+                {fieldErrors['z-ai'] && (
+                  <TruncatedErrorText
+                    id="api-key-7-error"
+                    text={fieldErrors['z-ai']}
+                  />
+                )}
+              </div>
+            </>
+          )}
+          <div className="flex justify-end">
+            <Button
+              variant="ghost"
+              size="xs"
+              onClick={() => setShowMoreProviders((v) => !v)}
             >
-              Moonshot AI
-            </label>
-            <Input
-              id="api-key-4"
-              placeholder="sk-..."
-              size="sm"
-              className="app-no-drag"
-              value={apiKey4}
-              aria-invalid={!!fieldErrors.moonshotai}
-              aria-describedby={
-                fieldErrors.moonshotai ? 'api-key-4-error' : undefined
-              }
-              onValueChange={(v) => {
-                setApiKey4(v);
-                setFieldErrors((prev) => ({ ...prev, moonshotai: null }));
-              }}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter') handleSubmitApiKeys();
-              }}
-            />
-            {fieldErrors.moonshotai && (
-              <TruncatedErrorText
-                id="api-key-4-error"
-                text={fieldErrors.moonshotai}
-              />
-            )}
-          </div>
-          <div className="flex flex-col gap-1">
-            <label
-              htmlFor="api-key-5"
-              className="text-muted-foreground text-xs"
-            >
-              Alibaba Cloud
-            </label>
-            <Input
-              id="api-key-5"
-              placeholder="sk-..."
-              size="sm"
-              className="app-no-drag"
-              value={apiKey5}
-              aria-invalid={!!fieldErrors.alibaba}
-              aria-describedby={
-                fieldErrors.alibaba ? 'api-key-5-error' : undefined
-              }
-              onValueChange={(v) => {
-                setApiKey5(v);
-                setFieldErrors((prev) => ({ ...prev, alibaba: null }));
-              }}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter') handleSubmitApiKeys();
-              }}
-            />
-            {fieldErrors.alibaba && (
-              <TruncatedErrorText
-                id="api-key-5-error"
-                text={fieldErrors.alibaba}
-              />
-            )}
+              {showMoreProviders ? 'Show less' : 'Show 4 more providers'}
+            </Button>
           </div>
         </div>
       )}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds native support for `deepseek` and `z-ai` via OpenAI‑compatible Chat Completions, with built‑in presets for DeepSeek V4 Pro/Flash and GLM 5.1/5V‑Turbo. Updates onboarding/settings, API key validation, schemas, and routing for correct tool support and multimodal limits.

- **New Features**
  - Providers: `deepseek` (https://api.deepseek.com/v1) and `z-ai` (https://api.z.ai/api/paas/v4) integrated into model resolution and telemetry.
  - Built‑in models: DeepSeek V4 Pro, DeepSeek V4 Flash, GLM 5.1, GLM 5V‑Turbo (vision + tool‑calling; input constraints added).
  - UI: onboarding and provider settings show top 3 providers with a “Show more providers” toggle; fields accept `deepseek` and `z-ai` keys.
  - Defaults: preferences schema, official URLs, display info, and migrations include `deepseek` and `z-ai`; model routing uses `require_parameters` to avoid upstreams missing tool support.

- **Bug Fixes**
  - Force Chat Completions (`.chat(...)`) for Moonshot, Alibaba, DeepSeek, and Z.ai in routing and API‑key validation to avoid Responses API rejections.
  - Model search: handle text‑only models without `inputConstraints`; add image/video limits for GLM 5V‑Turbo.
  - Onboarding: auto‑expand hidden provider section when a validation error occurs so messages are visible.

<sup>Written for commit 1b1939303bd761d916ef1015e7c5cf8560272bb5. Summary will update on new commits. <a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/998?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added DeepSeek and Z.AI as selectable providers and new models (DeepSeek v4 pro/flash, GLM-5.1, GLM-5v-turbo).
  * Onboarding and agent settings let you add/configure DeepSeek and Z.AI API keys; provider defaults included and additional providers hidden behind a "show more" toggle.

* **Improvements**
  * Model catalog updated with capabilities, tool-calling and multimodal flags; provider routing options exposed.
  * Preferences migration and API-key validation extended to handle DeepSeek and Z.AI.

* **Bug Fixes**
  * More robust MIME-type detection when finding compatible models.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->