### PR TITLE
feat(stagewise): enhance command timeout and idle management with rec…

### DIFF
--- a/apps/browser/src/backend/agents/shared/prompts/system/environment.md
+++ b/apps/browser/src/backend/agents/shared/prompts/system/environment.md
@@ -150,30 +150,30 @@ return `Saved as ${fileName}`;
 
 Persistent interactive PTY sessions. State (variables, cwd, aliases) persists across commands in a session.
 
-**Snapshot model.** The tool returns within **15 seconds max**. It does NOT block until a command finishes — you get a snapshot of what the command produced so far. The full session output is persisted to `shells/<session_id>.shell.log` and can be re-read any time.
+**Snapshot model.** The tool usually returns quickly with whatever the command produced so far. The full session output is persisted to `shells/<session_id>.shell.log` and can be re-read any time. Self-exiting long commands can opt into a longer wait with `wait_until: { exited: true }`.
 
-**Prefer no `wait_until`.** The defaults (10 s hard cap, 5 s idle after first output) handle almost everything correctly — plain commands, installs, builds, git, tests, and interactive prompts. Idle detection fires when output stops, which is exactly how an interactive prompt is detected. Only override when you have a specific reason.
+**Choose the smallest wait mode that fits.** For quick commands, omit `wait_until` (10 s hard cap, 5 s idle after first output). For long self-exiting commands — installs, builds, typechecks, tests, git operations expected to finish — use bare `wait_until: { exited: true }` (5 min hard cap, 15 s idle after first output). For dev servers, use `output_pattern` for the ready signal.
 
-**Common mistake:** Do NOT set `idle_ms: 0` defensively "to prevent premature exit." Idle detection is your primary signal that a command is waiting for input. Disabling it turns every interactive CLI into a long hang followed by `resolved_by: 'timeout'` — exactly the UX this tool is designed to prevent. The same applies to raising `timeout_ms` — longer waits do not help commands finish faster; they just block you.
+**Common mistake:** Do NOT set `idle_ms: 0` defensively "to prevent premature exit." Idle detection is your primary signal that a command is waiting for input or has gone quiet after producing useful output. Disabling it turns interactive CLIs into long hangs. The same applies to raising `timeout_ms` casually — longer waits do not make commands finish faster; they just block you.
 
 - **New session:** Omit `session_id`, set `cwd` (mount prefix). **Reuse:** pass the `session_id` from the result. `cwd` is ignored on reuse — the shell stays wherever `cd` left it.
 - **Reuse sessions.** Creating a session is expensive (shell init delay). Reuse an existing session (`session_id`) whenever one is available — active sessions are listed in `<shell-sessions>` in the env-snapshot. Only create a new session when no suitable one exists or when you need parallel execution (e.g. long-running dev server in one session, short commands in another).
 - **`command`:** Writes text + Enter to the shell.
 - **`wait_until`:** Optional; controls when the tool returns.
-  - `timeout_ms` — hard cap (max 60 s, default 15 s with `wait_until`, 10 s without). **Leave at default.** Raising this does not make commands finish sooner — follow-up calls are cheap and the full output is preserved in `shells/<session_id>.shell.log`.
-  - `output_pattern` — regex on output; resolves early when matched. Safe to use.
-  - `idle_ms` — silence threshold after the first output event. Default **5 s** (3 s with `exited: true`). **`0` disables idle — avoid.** Only correct when a command has proven long silent phases *during active work* (not while waiting for input), e.g. a dev server that pauses between log lines. For interactive prompts: rely on default idle — it's how you detect the prompt.
-  - `exited` — minor hint that the command is expected to end on its own. Lowers idle threshold from 5 s to 3 s. Does **not** imply other parameter overrides — bare `wait_until: { exited: true }` is complete on its own.
+  - `timeout_ms` — hard cap. Normal `wait_until` max is 60 s (default 15 s). With `exited: true`, max/default is 5 min. Without `wait_until`, default is 10 s. **Leave at default unless you know the command needs a different cap.**
+  - `output_pattern` — regex on output; resolves early when matched. Use for dev servers and watchers that do not exit on their own.
+  - `idle_ms` — silence threshold after the first output event. Default **5 s** (15 s with `exited: true`). **`0` disables idle — avoid.** Only correct when a command has proven long silent phases *during active work* (not while waiting for input), e.g. a dev server that pauses between log lines.
+  - `exited` — strong signal that the command is expected to terminate by itself. Use for long installs, builds, typechecks, tests, and git operations. Bare `wait_until: { exited: true }` is complete on its own.
 - **`resolved_by`** (returned) tells you *why* the tool returned:
   - `exit` — command finished. `exit_code` is set.
   - `pattern` — `output_pattern` matched. Command still running.
   - `idle` — no output for N ms. Usually waiting for input.
   - `timeout` — hard timeout. Command still running.
   - `abort` — cancelled. `session_exited` — shell itself died.
-- **Follow-up after `idle` / `pattern` / `timeout`** (command still running):
+- **Follow-up after `idle` / `pattern` / `timeout`** (command may still be running):
   - Send stdin to the same `session_id` (e.g. `y\r`, arrow keys) to answer prompts.
   - `read` `shells/<session_id>.shell.log` to see the latest output.
-  - Call with empty `command` and the `session_id` to poll for more output.
+  - Call with empty `command` and the `session_id` to poll for more output. Polls should usually omit `wait_until` or use a short timeout. Never set 60 s on polls.
   - `kill: true` to abort.
 - **`stdin`:** Write raw bytes to the PTY. Use for interactive input: control sequences, answering prompts, or interrupting processes. Requires `session_id`. Mutually exclusive with `command` and `kill`. Default timeout without `wait_until`: **5 s**. Common sequences:
   - `\x03` — Ctrl+C (interrupt running process)
@@ -187,22 +187,26 @@ Persistent interactive PTY sessions. State (variables, cwd, aliases) persists ac
 - OS/shell type in env snapshot. Prefer native tools for file ops; shell for dev scripts, git, installs.
 
 ```jsonc
-// Default case — most commands need no wait_until at all.
-{ "command": "pnpm install", "cwd": "w1" }
+// `explanation` is required on every call — keep it to ≤5 words.
+// Quick command — no wait_until needed.
+{ "explanation": "Check git status", "command": "git status", "cwd": "w1" }
+// Long self-exiting command — allow up to 5 min, return earlier on exit or 15s idle.
+{ "explanation": "Run typecheck", "command": "pnpm typecheck", "cwd": "w1", "wait_until": { "exited": true } }
 // Interactive CLI — defaults work. Idle fires at ~5s when the prompt appears.
 // resolved_by will be 'idle'; send stdin to answer.
-{ "command": "npx create-next-app test", "cwd": "w1" }
-{ "session_id": "abc123", "stdin": "\r" }
+{ "explanation": "Scaffold Next.js app", "command": "npx create-next-app test", "cwd": "w1" }
+{ "explanation": "Send Enter key", "session_id": "abc123", "stdin": "\r" }
 // Reuse an existing idle session for a quick command.
-{ "session_id": "f8a3b1c2", "command": "curl localhost:3000/health" }
+{ "explanation": "Check health endpoint", "session_id": "f8a3b1c2", "command": "curl localhost:3000/health" }
 // Poll an already-running command for more output without sending input.
-{ "session_id": "abc123", "command": "" }
+// Keep polls short; do not set a 60s timeout.
+{ "explanation": "Poll running command", "session_id": "abc123", "command": "" }
 // Interrupt a running process.
-{ "session_id": "abc123", "stdin": "\x03" }
+{ "explanation": "Interrupt process", "session_id": "abc123", "stdin": "\x03" }
 // Edge case: dev server with genuinely long silent startup phases.
 // output_pattern is the correctness signal; idle_ms=0 because the server
 // legitimately pauses between log lines during startup.
-{ "command": "pnpm dev", "cwd": "w1", "wait_until": { "output_pattern": "ready|listening", "timeout_ms": 30000, "idle_ms": 0 } }
+{ "explanation": "Start dev server", "command": "pnpm dev", "cwd": "w1", "wait_until": { "output_pattern": "ready|listening", "timeout_ms": 30000, "idle_ms": 0 } }
 ```
 
 ### 3. Browser Access (CDP)

--- a/apps/browser/src/backend/services/toolbox/services/shell/session-manager.test.ts
+++ b/apps/browser/src/backend/services/toolbox/services/shell/session-manager.test.ts
@@ -2,10 +2,29 @@ import { describe, it, expect, afterEach } from 'vitest';
 import os from 'node:os';
 import fs from 'node:fs';
 import path from 'node:path';
-import { applyHeadTailCap, stripAnsi, SessionManager } from './session-manager';
+import {
+  applyHeadTailCap,
+  stripAnsi,
+  SessionManager,
+  getCommandIdleMs,
+  getCommandTimeoutMs,
+} from './session-manager';
 import { detectShell } from './detect-shell';
 import { sanitizeEnv } from './sanitize-env';
-import { HEAD_LINES, MAX_SESSIONS_PER_AGENT, TAIL_LINES } from './types';
+import {
+  DEFAULT_EXITED_IDLE_MS,
+  DEFAULT_EXITED_WAIT_UNTIL_TIMEOUT_MS,
+  DEFAULT_IDLE_MS,
+  DEFAULT_TIMEOUT_NO_WAIT_UNTIL_MS,
+  DEFAULT_TIMEOUT_STDIN_MS,
+  DEFAULT_WAIT_UNTIL_TIMEOUT_MS,
+  HEAD_LINES,
+  MAX_EXITED_WAIT_UNTIL_TIMEOUT_MS,
+  MAX_SESSIONS_PER_AGENT,
+  MAX_WAIT_UNTIL_TIMEOUT_MS,
+  SHELL_RESPONSE_TAIL_MAX_CHARS,
+  TAIL_LINES,
+} from './types';
 import type { DetectedShell } from './types';
 
 // ─── Section A: applyHeadTailCap (pure) ──────────────────────────
@@ -92,7 +111,68 @@ describe('stripAnsi', () => {
   });
 });
 
-// ─── Section C: Integration tests (real PTY sessions) ────────────
+// ─── Section C: timeout/idle selection (pure) ────────────────────
+
+describe('command timeout/idle selection', () => {
+  it('uses quick timeout when waitUntil is omitted', () => {
+    expect(getCommandTimeoutMs({ command: 'echo hi' })).toBe(
+      DEFAULT_TIMEOUT_NO_WAIT_UNTIL_MS,
+    );
+  });
+
+  it('uses stdin timeout for raw input without waitUntil', () => {
+    expect(getCommandTimeoutMs({ command: '\r', rawInput: true })).toBe(
+      DEFAULT_TIMEOUT_STDIN_MS,
+    );
+  });
+
+  it('uses normal waitUntil default and cap without exited', () => {
+    expect(getCommandTimeoutMs({ command: 'sleep 1', waitUntil: {} })).toBe(
+      DEFAULT_WAIT_UNTIL_TIMEOUT_MS,
+    );
+    expect(
+      getCommandTimeoutMs({
+        command: 'sleep 1',
+        waitUntil: { timeoutMs: 300_000 },
+      }),
+    ).toBe(MAX_WAIT_UNTIL_TIMEOUT_MS);
+  });
+
+  it('uses extended default and cap with exited=true', () => {
+    expect(
+      getCommandTimeoutMs({
+        command: 'pnpm typecheck',
+        waitUntil: { exited: true },
+      }),
+    ).toBe(DEFAULT_EXITED_WAIT_UNTIL_TIMEOUT_MS);
+    expect(
+      getCommandTimeoutMs({
+        command: 'pnpm typecheck',
+        waitUntil: { exited: true, timeoutMs: 999_999 },
+      }),
+    ).toBe(MAX_EXITED_WAIT_UNTIL_TIMEOUT_MS);
+  });
+
+  it('uses 15s default idle with exited=true and preserves explicit idle', () => {
+    expect(getCommandIdleMs({ command: 'echo hi', waitUntil: {} })).toBe(
+      DEFAULT_IDLE_MS,
+    );
+    expect(
+      getCommandIdleMs({
+        command: 'pnpm typecheck',
+        waitUntil: { exited: true },
+      }),
+    ).toBe(DEFAULT_EXITED_IDLE_MS);
+    expect(
+      getCommandIdleMs({
+        command: 'pnpm typecheck',
+        waitUntil: { exited: true, idleMs: 0 },
+      }),
+    ).toBe(0);
+  });
+});
+
+// ─── Section D: Integration tests (real PTY sessions) ────────────
 
 const shell = detectShell();
 
@@ -373,6 +453,45 @@ describeIfShell('SessionManager (integration)', () => {
     expect(r.timedOut).toBe(false);
     // Should resolve well before the 10s timeout or 30s sleep
     expect(elapsed).toBeLessThan(8000);
+  });
+
+  // Dedicated because the basic-command and idle tests construct the
+  // SessionManager without a log directory, so `logger` is null and
+  // `getTail` returns ''. This test spins up a temporary logs directory
+  // specifically to exercise the tail path end-to-end.
+  it('populates recentOutput from the session log tail', async () => {
+    const logsDir = fs.mkdtempSync(path.join(cwd, 'sm-tail-'));
+    try {
+      sm = new SessionManager(
+        shell as DetectedShell,
+        () => logsDir,
+        TEST_DETECT_TIMEOUT_MS,
+      );
+      const sid = sm.createSession('agent-test', cwd, env);
+      await waitForReady(sm, sid);
+
+      // Mirror the known-good `matches outputPattern` test: keep the
+      // command alive with a sleep and resolve via pattern match. A bare
+      // `echo` can race the OSC 133 exit marker on slower CI runners,
+      // leaving the terminal buffer unstable when `serializeFrom` reads.
+      const r = await sm.executeCommand(sid, {
+        command: 'echo RECENT_TAIL_MARKER; sleep 30',
+        waitUntil: {
+          outputPattern: 'RECENT_TAIL_MARKER',
+          timeoutMs: 10000,
+        },
+      });
+
+      expect(r.output).toContain('RECENT_TAIL_MARKER');
+      expect(r.recentOutput).toContain('RECENT_TAIL_MARKER');
+      expect(r.recentOutput?.length ?? 0).toBeLessThanOrEqual(
+        SHELL_RESPONSE_TAIL_MAX_CHARS,
+      );
+    } finally {
+      sm?.killAll();
+      await new Promise((r) => setTimeout(r, 300));
+      fs.rmSync(logsDir, { recursive: true, force: true });
+    }
   });
 
   it('matches outputPattern against terminal buffer when logger exists', async () => {

--- a/apps/browser/src/backend/services/toolbox/services/shell/session-manager.ts
+++ b/apps/browser/src/backend/services/toolbox/services/shell/session-manager.ts
@@ -7,6 +7,7 @@ import { OscParser, wrapWithSentinel } from './osc-parser';
 import { SessionLogger } from './session-logger';
 import {
   DEFAULT_WAIT_UNTIL_TIMEOUT_MS,
+  DEFAULT_EXITED_WAIT_UNTIL_TIMEOUT_MS,
   DEFAULT_TIMEOUT_NO_WAIT_UNTIL_MS,
   DEFAULT_TIMEOUT_STDIN_MS,
   HEAD_LINES,
@@ -17,8 +18,10 @@ import {
   DEFAULT_TERMINAL_COLS,
   DEFAULT_TERMINAL_ROWS,
   DEFAULT_IDLE_MS,
-  AGGRESSIVE_IDLE_MS,
+  DEFAULT_EXITED_IDLE_MS,
   MAX_WAIT_UNTIL_TIMEOUT_MS,
+  MAX_EXITED_WAIT_UNTIL_TIMEOUT_MS,
+  SHELL_RESPONSE_TAIL_MAX_CHARS,
   type DetectedShell,
   type PtySession,
   type SessionCommandRequest,
@@ -27,6 +30,37 @@ import {
 
 /** Cap for rawOutput accumulator used only for pattern matching. */
 const MAX_RAW_OUTPUT_BYTES = 1_024 * 1_024;
+
+// ─── Command timeout/idle policy ────────────────────────────────
+// Exported so tests can exercise the selection logic as pure helpers.
+// Kept here (not inlined in `executeCommand`) so the policy is easy to
+// audit and to keep parity with the agent-facing schema describe text.
+
+export function getCommandIdleMs(request: SessionCommandRequest): number {
+  if (request.waitUntil?.idleMs !== undefined) return request.waitUntil.idleMs;
+  if (request.waitUntil?.exited) return DEFAULT_EXITED_IDLE_MS;
+  return DEFAULT_IDLE_MS;
+}
+
+export function getCommandTimeoutMs(request: SessionCommandRequest): number {
+  if (!request.waitUntil) {
+    return request.rawInput
+      ? DEFAULT_TIMEOUT_STDIN_MS
+      : DEFAULT_TIMEOUT_NO_WAIT_UNTIL_MS;
+  }
+
+  if (request.waitUntil.exited) {
+    return Math.min(
+      request.waitUntil.timeoutMs ?? DEFAULT_EXITED_WAIT_UNTIL_TIMEOUT_MS,
+      MAX_EXITED_WAIT_UNTIL_TIMEOUT_MS,
+    );
+  }
+
+  return Math.min(
+    request.waitUntil.timeoutMs ?? DEFAULT_WAIT_UNTIL_TIMEOUT_MS,
+    MAX_WAIT_UNTIL_TIMEOUT_MS,
+  );
+}
 
 // ─── ANSI stripping ──────────────────────────────────────────────
 // Strips ANSI/VT escape sequences from PTY output for clean text.
@@ -430,12 +464,7 @@ export class SessionManager {
 
     return new Promise<SessionCommandResult>((resolve) => {
       const mark = session.logger?.getMarkPosition() ?? 0;
-      const idleMs =
-        request.waitUntil?.idleMs !== undefined
-          ? request.waitUntil.idleMs
-          : request.waitUntil?.exited
-            ? AGGRESSIVE_IDLE_MS
-            : DEFAULT_IDLE_MS;
+      const idleMs = getCommandIdleMs(request);
       const pending: PendingCommand = {
         resolve,
         sessionId,
@@ -454,17 +483,10 @@ export class SessionManager {
       this.sessionCommandMap.set(sessionId, commandId);
 
       // Timeout handling
-      // If the model explicitly provided waitUntil, honour its timeoutMs (or the full default).
-      // If waitUntil was omitted entirely, use the shorter 20s default so dumb models
-      // that forget the param don't leave the tool hanging for 2 minutes.
-      const timeoutMs = request.waitUntil
-        ? Math.min(
-            request.waitUntil.timeoutMs ?? DEFAULT_WAIT_UNTIL_TIMEOUT_MS,
-            MAX_WAIT_UNTIL_TIMEOUT_MS,
-          )
-        : request.rawInput
-          ? DEFAULT_TIMEOUT_STDIN_MS
-          : DEFAULT_TIMEOUT_NO_WAIT_UNTIL_MS;
+      // Self-terminating commands (`exited: true`) get a longer ceiling;
+      // other shell calls keep the short snapshot cap so interactive hangs
+      // return quickly for follow-up/polling.
+      const timeoutMs = getCommandTimeoutMs(request);
       pending.timeoutHandle = setTimeout(() => {
         this.resolveCommandWithTimeout(commandId, 'timeout');
       }, timeoutMs);
@@ -653,6 +675,7 @@ export class SessionManager {
     pending.resolve({
       sessionId,
       output: finalOutput,
+      recentOutput: this.collectRecentOutput(sessionId),
       exitCode,
       sessionExited: session?.exited ?? true,
       timedOut: false,
@@ -677,6 +700,7 @@ export class SessionManager {
     pending.resolve({
       sessionId: pending.sessionId,
       output: finalOutput,
+      recentOutput: this.collectRecentOutput(pending.sessionId),
       exitCode,
       sessionExited: session?.exited ?? true,
       timedOut: false,
@@ -700,6 +724,7 @@ export class SessionManager {
     pending.resolve({
       sessionId: pending.sessionId,
       output: finalOutput,
+      recentOutput: this.collectRecentOutput(pending.sessionId),
       exitCode: null,
       sessionExited: session?.exited ?? true,
       timedOut: reason === 'timeout',
@@ -720,6 +745,7 @@ export class SessionManager {
     pending.resolve({
       sessionId: pending.sessionId,
       output: finalOutput,
+      recentOutput: this.collectRecentOutput(pending.sessionId),
       exitCode: null,
       sessionExited: session?.exited ?? true,
       timedOut: false,
@@ -739,6 +765,7 @@ export class SessionManager {
         pending.resolve({
           sessionId,
           output: this.collectOutput(pending) || reason,
+          recentOutput: this.collectRecentOutput(sessionId),
           exitCode: session?.exitCode ?? null,
           sessionExited: true,
           timedOut: false,
@@ -747,6 +774,11 @@ export class SessionManager {
       }
     }
     this.sessionCommandMap.delete(sessionId);
+  }
+
+  private collectRecentOutput(sessionId: string): string {
+    const session = this.sessions.get(sessionId);
+    return session?.logger?.getTail(SHELL_RESPONSE_TAIL_MAX_CHARS) ?? '';
   }
 
   private collectOutput(pending: PendingCommand): string {

--- a/apps/browser/src/backend/services/toolbox/services/shell/types.ts
+++ b/apps/browser/src/backend/services/toolbox/services/shell/types.ts
@@ -27,6 +27,20 @@ export interface DetectedShell {
 export const DEFAULT_WAIT_UNTIL_TIMEOUT_MS = 15_000;
 
 /**
+ * Default hard-timeout (ms) when the agent passes
+ * `waitUntil.exited: true`. This mode is for self-terminating commands
+ * such as typechecks, builds, installs, and tests. They may legitimately
+ * run longer than the normal snapshot cap, but still need a finite ceiling.
+ */
+export const DEFAULT_EXITED_WAIT_UNTIL_TIMEOUT_MS = 300_000;
+
+/**
+ * Hard-timeout ceiling (ms) for `waitUntil.exited: true` commands.
+ * Explicit timeout requests in exited mode are clamped to this value.
+ */
+export const MAX_EXITED_WAIT_UNTIL_TIMEOUT_MS = 300_000;
+
+/**
  * Hard-timeout (ms) used when the agent omits `waitUntil` entirely.
  * "Quick check" mode — must feel responsive.
  */
@@ -47,6 +61,13 @@ export const DEFAULT_TIMEOUT_STDIN_MS = 5_000;
 export const MAX_WAIT_UNTIL_TIMEOUT_MS = 60_000;
 
 /**
+ * Maximum characters included in `recentOutput` / `recent_output` shell
+ * responses. This gives the agent recent session context without making
+ * token cost depend on the full shell log size.
+ */
+export const SHELL_RESPONSE_TAIL_MAX_CHARS = 12_000;
+
+/**
  * Default idle threshold (ms). Once the command has produced any output,
  * N ms of silence resolves the tool call with `resolvedBy: 'idle'`.
  * 5s is long enough that continuously-emitting tools (pnpm install,
@@ -56,12 +77,12 @@ export const MAX_WAIT_UNTIL_TIMEOUT_MS = 60_000;
 export const DEFAULT_IDLE_MS = 5_000;
 
 /**
- * More aggressive idle threshold used when the agent passes
- * `waitUntil.exited: true`. The agent is explicitly signalling "I expect
- * this to end on its own" — if it hasn't produced output in 3s we can
- * safely assume it's stuck waiting for input or otherwise idle.
+ * Default idle threshold used when the agent passes
+ * `waitUntil.exited: true`. The command gets a longer hard cap to finish
+ * on its own, but 15s of silence after output still returns the snapshot
+ * promptly if the process stalls or waits for input.
  */
-export const AGGRESSIVE_IDLE_MS = 3_000;
+export const DEFAULT_EXITED_IDLE_MS = 15_000;
 
 /**
  * Why a command resolved. Used by the agent to decide follow-up actions:
@@ -152,7 +173,7 @@ export interface SessionCommandRequest {
     /**
      * Silence threshold (ms) after the first output event. `0` disables
      * idle detection entirely. Omit to use the default (see
-     * `DEFAULT_IDLE_MS` / `AGGRESSIVE_IDLE_MS`).
+     * `DEFAULT_IDLE_MS` / `DEFAULT_EXITED_IDLE_MS`).
      */
     idleMs?: number;
   };
@@ -162,6 +183,8 @@ export interface SessionCommandRequest {
 export interface SessionCommandResult {
   sessionId: string;
   output: string;
+  /** Character-capped tail of the full session log for recent context. */
+  recentOutput?: string;
   exitCode: number | null;
   sessionExited: boolean;
   timedOut: boolean;

--- a/apps/browser/src/backend/services/toolbox/tools/shell/execute-shell-command.ts
+++ b/apps/browser/src/backend/services/toolbox/tools/shell/execute-shell-command.ts
@@ -90,6 +90,24 @@ function expandCEscapes(s: string): string {
 
 type MountedPathsGetter = () => Map<string, string>;
 
+/**
+ * Returns `recent` only when it carries information not already present in
+ * `output`. Most short commands have `output` that already includes all
+ * session history the tail would add, so duplicating it in a dedicated
+ * field would double tokens for no gain. Longer-running sessions where the
+ * tail extends beyond the per-call snapshot remain intact.
+ */
+function pickRecentOutput(
+  output: string,
+  recent: string | undefined,
+): string | undefined {
+  if (!recent) return undefined;
+  const o = output.trimEnd();
+  const r = recent.trimEnd();
+  if (r.length === 0 || o === r || o.endsWith(r)) return undefined;
+  return recent;
+}
+
 function resolveCwd(
   mountPrefix: string | undefined,
   getMountedPaths: MountedPathsGetter,
@@ -136,6 +154,10 @@ export const executeShellCommand = (
       { toolCallId, abortSignal },
     ) => {
       try {
+        // Early-return branches below (stdin/kill validation errors) omit
+        // `recent_output` deliberately: those responses are synthetic
+        // tool-layer strings, not captured session output, so there is
+        // nothing meaningful to attach.
         // Stdin mode — write raw bytes, capture output
         if (params.stdin !== undefined) {
           if (params.command || params.kill) {
@@ -183,6 +205,7 @@ export const executeShellCommand = (
           return {
             session_id: result.sessionId,
             output: capped.result,
+            recent_output: pickRecentOutput(capped.result, result.recentOutput),
             exit_code: result.exitCode,
             session_exited: result.sessionExited,
             timed_out: result.timedOut,
@@ -235,9 +258,11 @@ export const executeShellCommand = (
           },
         );
 
+        const capped = capToolOutput(result.output);
         return {
           session_id: result.sessionId,
-          output: capToolOutput(result.output).result,
+          output: capped.result,
+          recent_output: pickRecentOutput(capped.result, result.recentOutput),
           exit_code: result.exitCode,
           session_exited: result.sessionExited,
           timed_out: result.timedOut,

--- a/apps/browser/src/shared/karton-contracts/ui/agent/tools/types.ts
+++ b/apps/browser/src/shared/karton-contracts/ui/agent/tools/types.ts
@@ -757,30 +757,51 @@ export const executeShellCommandToolInputSchema = z.object({
         .number()
         .int()
         .positive()
-        .max(60_000)
+        .max(300_000)
         .optional()
         .describe(
-          'Hard timeout in ms (max 60000, default 15000 with wait_until / 10000 without).',
+          'Hard timeout in ms. Shape: any positive integer up to 300000. Enforcement: backend clamps to 60000 without `exited: true`, 300000 with `exited: true`. Defaults: 10000 without wait_until, 15000 with wait_until (non-exited), 300000 with `exited: true`. Omit this field unless you specifically need to change the default.',
         ),
       exited: z
         .boolean()
         .optional()
         .describe(
-          'Hint that the command is expected to exit on its own. Lowers idle threshold from 5000ms to 3000ms.',
+          'Strong signal that the command will terminate on its own (builds, typechecks, tests, installs, git). Raises hard cap to 5 min (300000ms) and idle threshold to 15000ms. Use this for any long self-exiting command instead of a custom timeout_ms.',
         ),
       output_pattern: z
         .string()
         .optional()
-        .describe('Return early when stdout/stderr matches this regex.'),
+        .describe(
+          'Return early when stdout/stderr matches this regex. Use for dev servers and watchers that never exit.',
+        ),
       idle_ms: z
         .number()
         .int()
         .min(0)
-        .max(30_000)
+        .max(60_000)
         .optional()
         .describe(
-          'Silence threshold in ms after first output (0–30000, default 5000; 3000 with exited=true). 0 disables idle detection.',
+          'Silence threshold in ms after first output (max 60000). Defaults: 5000 normally, 15000 with `exited: true`. 0 disables idle detection — avoid unless the command has proven long silent phases during active work; prefer `output_pattern` instead.',
         ),
+    })
+    // Cross-field rule the `.max()` alone cannot express: `timeout_ms`
+    // above 60000 is only legal when `exited: true` is set. Without this
+    // refinement the backend would silently clamp such values, leading to
+    // confusing "why did my typecheck time out at 60s" reports. The schema
+    // rejects it up-front so the agent gets a clear, actionable error.
+    .superRefine((val, ctx) => {
+      if (
+        val.timeout_ms !== undefined &&
+        val.timeout_ms > 60_000 &&
+        !val.exited
+      ) {
+        ctx.addIssue({
+          code: 'custom',
+          path: ['timeout_ms'],
+          message:
+            'timeout_ms > 60000 requires `exited: true`. Either set `exited: true` for a long self-exiting command, or use a smaller timeout_ms.',
+        });
+      }
     })
     .optional()
     .describe('Controls when the tool returns.'),
@@ -789,6 +810,10 @@ export const executeShellCommandToolInputSchema = z.object({
 export const executeShellCommandToolOutputSchema = z.object({
   session_id: z.string().nullable(),
   output: z.string(),
+  recent_output: z
+    .string()
+    .optional()
+    .describe('Recent character-capped tail of the full session log.'),
   exit_code: z.number().nullable(),
   session_exited: z.boolean(),
   timed_out: z.boolean(),


### PR DESCRIPTION
…ent output tracking

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves shell session behavior with smarter timeout/idle defaults and better handling of long self-exiting commands. Adds `recent_output` so agents can read the latest session context without re-reading logs.

- New Features
  - `wait_until: { exited: true }` now gets a 5‑minute default/ceiling and a 15s idle threshold. Normal `wait_until` keeps a 15s default with a 60s cap; no `wait_until` stays quick (10s; stdin 5s).
  - Adds `recent_output` to tool responses, a 12k‑char tail from the session log; omitted when it duplicates `output`. Backend collects this from the logger and exposes it through the tool API.
  - Centralizes policy in `getCommandTimeoutMs`/`getCommandIdleMs`; updates schema to allow `timeout_ms` up to 300000 (clamped by mode) and `idle_ms` up to 60000, and rejects `timeout_ms > 60000` unless `exited: true`. Docs updated with clearer guidance and examples.

- Migration
  - For long self‑exiting commands (builds, installs, tests, typechecks, git), use `wait_until: { exited: true }`. For dev servers/watchers, use `output_pattern`. Keep polls short; never set 60s; avoid `idle_ms: 0`. Timeouts over 60s now require `exited: true`.
  - Note: the default idle with `exited: true` is now 15s (was 3s). Adjust only if you relied on the old threshold.

<sup>Written for commit f8e10ce21048224326d27a203a084a56557f02dc. Summary will update on new commits. <a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1005?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new recent_output field on shell command results to include a capped tail of session logs.

* **Improvements**
  * Revised wait modes and guidance for quick commands, long self-exiting tasks, and dev-server/watchers.
  * Adjusted timeout and idle defaults and raised allowable maximums for exited-mode commands.
  * Validation now surfaces errors when long timeouts are requested without the exited-mode flag.

* **Tests**
  * Added unit and end-to-end tests covering timeout/idle selection and recent_output population.

* **Documentation**
  * Updated Shell tool documentation and examples to reflect new semantics and required explanation field.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->