### PR TITLE
feat(stagewise): introduce tool approval modes (alwaysAllow and alwaysAsk)

### DIFF
--- a/apps/browser/.storybook/decorators/scenarios/shared-utilities.ts
+++ b/apps/browser/.storybook/decorators/scenarios/shared-utilities.ts
@@ -993,6 +993,7 @@ export function createAgentInstance(
       history: options?.initialHistory ?? [],
       queuedMessages: [],
       activeModelId: options?.activeModelId ?? 'claude-sonnet-4-6',
+      toolApprovalMode: 'alwaysAsk',
       inputState: options?.inputState ?? '',
       usedTokens: 0,
     },

--- a/apps/browser/src/backend/agents/shared/base-agent/base-agent.ts
+++ b/apps/browser/src/backend/agents/shared/base-agent/base-agent.ts
@@ -499,6 +499,11 @@ export abstract class BaseAgent<
       draft.queuedMessages = initialState?.queuedMessages ?? [];
       draft.activeModelId =
         initialState?.activeModelId ?? this.config.defaultModelId;
+      // `draft.toolApprovalMode` is always seeded by `defaultState` in
+      // AgentManager.createAgent before this constructor runs, so this
+      // fallback never yields undefined at runtime.
+      draft.toolApprovalMode =
+        initialState?.toolApprovalMode ?? draft.toolApprovalMode;
       draft.inputState = initialState?.inputState ?? draft.inputState;
       draft.usedTokens = initialState?.usedTokens ?? 0;
     });

--- a/apps/browser/src/backend/services/agent-manager/agent-manager.ts
+++ b/apps/browser/src/backend/services/agent-manager/agent-manager.ts
@@ -13,6 +13,10 @@ import type { Logger } from '../logger';
 import type { ToolboxService } from '../toolbox';
 import type { ModelProviderService } from '@/agents/model-provider';
 import type { ModelId } from '@shared/available-models';
+import {
+  toolApprovalModeSchema,
+  type ToolApprovalMode,
+} from '@shared/karton-contracts/ui/shared-types';
 import type { z } from 'zod';
 import { AgentPersistenceDB } from './persistence/db';
 import type { AgentState } from '@shared/karton-contracts/ui/agent';
@@ -233,6 +237,17 @@ export class AgentManagerService extends DisposableService {
           approved,
           reason,
         );
+      },
+    );
+    this.karton.registerServerProcedureHandler(
+      'agents.setToolApprovalMode',
+      async (
+        _callingClientId: string,
+        instanceId: string,
+        mode: ToolApprovalMode,
+      ) => {
+        const parsedMode = toolApprovalModeSchema.parse(mode);
+        await this.setToolApprovalMode(instanceId, parsedMode);
       },
     );
     this.karton.registerServerProcedureHandler(
@@ -555,6 +570,7 @@ export class AgentManagerService extends DisposableService {
       history: [],
       queuedMessages: [],
       activeModelId: 'claude-sonnet-4.6',
+      toolApprovalMode: 'alwaysAsk',
       inputState: initialInputState ?? '',
       usedTokens: 0,
     };
@@ -702,6 +718,7 @@ export class AgentManagerService extends DisposableService {
         history: agent.history,
         queuedMessages: agent.queuedMessages,
         activeModelId: resumedModelValid ? agent.activeModelId : undefined,
+        toolApprovalMode: agent.toolApprovalMode ?? 'alwaysAsk',
         inputState: agent.inputState,
         usedTokens: agent.usedTokens,
         isWorking: false,
@@ -760,6 +777,7 @@ export class AgentManagerService extends DisposableService {
         title: agentState.title,
         titleLockedByUser: agentState.titleLockedByUser,
         activeModelId: agentState.activeModelId,
+        toolApprovalMode: agentState.toolApprovalMode,
         createdAt: agentState.history[0].metadata?.createdAt ?? new Date(0), // Fallback should never be reached
         lastMessageAt:
           agentState.history[agentState.history.length - 1].metadata
@@ -922,6 +940,30 @@ export class AgentManagerService extends DisposableService {
       approved: approved,
       reason: reason,
     });
+  }
+
+  /**
+   * Update the per-agent tool approval policy. Persists immediately so the
+   * change survives agent resume. Safe to call on empty agents (no
+   * history) because it uses a narrow DB update that bypasses the full
+   * `persistAgentState` path.
+   */
+  public async setToolApprovalMode(instanceId: string, mode: ToolApprovalMode) {
+    const agent = this.activeAgents.get(instanceId);
+
+    if (!agent) {
+      throw new Error(`Agent with instance id ${instanceId} not found`);
+    }
+
+    const currentMode =
+      this.karton.state.agents.instances[instanceId]?.state.toolApprovalMode;
+    if (currentMode === mode) return;
+
+    this.karton.setState((draft) => {
+      draft.agents.instances[instanceId].state.toolApprovalMode = mode;
+    });
+
+    await this.agentPersistenceDB?.updateToolApprovalMode(instanceId, mode);
   }
 
   /**

--- a/apps/browser/src/backend/services/agent-manager/persistence/db.ts
+++ b/apps/browser/src/backend/services/agent-manager/persistence/db.ts
@@ -21,6 +21,7 @@ import {
   type AgentHistoryEntry,
   type AgentMessage,
 } from '@shared/karton-contracts/ui/agent';
+import type { ToolApprovalMode } from '@shared/karton-contracts/ui/shared-types';
 import { getAgentDbPath } from '@/utils/paths';
 
 export class AgentPersistenceDB {
@@ -385,6 +386,34 @@ export class AgentPersistenceDB {
     } catch (error) {
       this._logger.error(
         `[AgentPersistenceDB] Failed to update agent title: ${(error as Error).message}`,
+      );
+      throw error;
+    }
+  }
+
+  /**
+   * Updates just the tool approval mode of a persisted agent without
+   * going through the full `storeAgentInstance` path. Avoids touching
+   * history/message persistence, so it is safe to call on empty agents.
+   *
+   * @returns true if a row was updated, false if no agent with that id exists.
+   */
+  public async updateToolApprovalMode(
+    id: string,
+    mode: ToolApprovalMode,
+  ): Promise<boolean> {
+    this._logger.debug(
+      `[AgentPersistenceDB] Updating tool approval mode for agent: ${id}`,
+    );
+    try {
+      const result = await this._db
+        .update(schema.agentInstances)
+        .set({ toolApprovalMode: mode })
+        .where(eq(schema.agentInstances.id, id));
+      return (result as unknown as { rowsAffected: number }).rowsAffected > 0;
+    } catch (error) {
+      this._logger.error(
+        `[AgentPersistenceDB] Failed to update tool approval mode: ${(error as Error).message}`,
       );
       throw error;
     }

--- a/apps/browser/src/backend/services/agent-manager/persistence/migrations/index.ts
+++ b/apps/browser/src/backend/services/agent-manager/persistence/migrations/index.ts
@@ -6,6 +6,7 @@ import { up as v005Up } from './v005-backfill-file-attachment-filename';
 import { up as v006Up } from './v006-rename-readfile-to-read';
 import { up as v007Up } from './v007-normalize-history';
 import { up as v008Up } from './v008-add-title-locked-by-user';
+import { up as v009Up } from './v009-add-tool-approval-mode';
 
 const registry: MigrationScript[] = [
   { version: 2, name: 'add-mounted-workspaces', up: v002Up },
@@ -15,7 +16,8 @@ const registry: MigrationScript[] = [
   { version: 6, name: 'rename-file-tools', up: v006Up },
   { version: 7, name: 'normalize-history', up: v007Up },
   { version: 8, name: 'add-title-locked-by-user', up: v008Up },
+  { version: 9, name: 'add-tool-approval-mode', up: v009Up },
 ];
-const schemaVersion = 8;
+const schemaVersion = 9;
 
 export { registry, schemaVersion };

--- a/apps/browser/src/backend/services/agent-manager/persistence/migrations/v009-add-tool-approval-mode.ts
+++ b/apps/browser/src/backend/services/agent-manager/persistence/migrations/v009-add-tool-approval-mode.ts
@@ -1,0 +1,14 @@
+import { sql } from 'drizzle-orm';
+import type { MigrationScript } from '@/utils/migrate-database/types';
+
+/**
+ * v9 — add-tool-approval-mode
+ *
+ * Adds the `tool_approval_mode` column to `agentInstances`. Existing rows
+ * default to 'alwaysAsk' to preserve the safe, current behaviour.
+ */
+export const up: MigrationScript['up'] = async (db) => {
+  await db.run(
+    sql`ALTER TABLE agentInstances ADD COLUMN tool_approval_mode TEXT NOT NULL DEFAULT 'alwaysAsk'`,
+  );
+};

--- a/apps/browser/src/backend/services/agent-manager/persistence/schema.sql
+++ b/apps/browser/src/backend/services/agent-manager/persistence/schema.sql
@@ -1,4 +1,4 @@
--- VERSION: 8
+-- VERSION: 9
 
 CREATE TABLE IF NOT EXISTS meta(
   key LONGVARCHAR NOT NULL UNIQUE PRIMARY KEY,
@@ -19,7 +19,8 @@ CREATE TABLE IF NOT EXISTS agentInstances(
   queued_messages TEXT NOT NULL,
   input_state TEXT NOT NULL,
   used_tokens INTEGER NOT NULL,
-  mounted_workspaces TEXT
+  mounted_workspaces TEXT,
+  tool_approval_mode TEXT NOT NULL DEFAULT 'alwaysAsk'
 );
 
 CREATE INDEX IF NOT EXISTS agentInstances_created_at_index ON agentInstances(created_at);

--- a/apps/browser/src/backend/services/agent-manager/persistence/schema.ts
+++ b/apps/browser/src/backend/services/agent-manager/persistence/schema.ts
@@ -12,6 +12,10 @@ import type { ModelId } from '@shared/available-models';
 import { relations } from 'drizzle-orm';
 import type { AgentTypes } from '@shared/karton-contracts/ui/agent';
 import type { MountPermission } from '@shared/karton-contracts/ui/agent/metadata';
+import {
+  toolApprovalModeSchema,
+  type ToolApprovalMode,
+} from '@shared/karton-contracts/ui/shared-types';
 import superjson from 'superjson';
 
 const _sqliteBoolean = customType<{ data: boolean; driverData: number }>({
@@ -50,6 +54,25 @@ const modelId = customType<{ data: ModelId; driverData: string }>({
   },
   fromDriver(value) {
     return value as ModelId;
+  },
+});
+
+const toolApprovalMode = customType<{
+  data: ToolApprovalMode;
+  driverData: string;
+}>({
+  dataType() {
+    return 'text';
+  },
+  toDriver(value) {
+    return value;
+  },
+  fromDriver(value) {
+    // Fail-closed: any value that doesn't match the schema falls back to
+    // 'alwaysAsk' so a corrupted or unexpected DB entry cannot bypass tool
+    // approvals downstream.
+    const parsed = toolApprovalModeSchema.safeParse(value);
+    return parsed.success ? parsed.data : 'alwaysAsk';
   },
 });
 
@@ -93,6 +116,9 @@ export const agentInstances = sqliteTable(
       _sqliteJson('mounted_workspaces').$type<
         Array<{ path: string; permissions: MountPermission[] }>
       >(),
+    toolApprovalMode: toolApprovalMode('tool_approval_mode')
+      .notNull()
+      .$defaultFn(() => 'alwaysAsk'),
   },
   (table) => [
     primaryKey({ columns: [table.id] }),

--- a/apps/browser/src/backend/services/toolbox/index.ts
+++ b/apps/browser/src/backend/services/toolbox/index.ts
@@ -16,7 +16,10 @@ import {
   READ_ONLY_PERMISSIONS,
   type MountDescriptor,
 } from '../sandbox/ipc';
-import type { WorkspaceAgentSettings } from '@shared/karton-contracts/ui/shared-types';
+import type {
+  WorkspaceAgentSettings,
+  ToolApprovalMode,
+} from '@shared/karton-contracts/ui/shared-types';
 import type { Attachment } from '@shared/karton-contracts/ui/agent/metadata';
 import type { KartonService } from '@/services/karton';
 import type { GlobalConfigService } from '@/services/global-config';
@@ -927,6 +930,10 @@ export class ToolboxService extends DisposableService {
       this.mountManagerService?.getMountedLspServices(agentInstanceId);
     if (!mountedLspServices) return null;
 
+    const getToolApprovalMode = (): ToolApprovalMode =>
+      this.uiKarton.state.agents.instances[agentInstanceId]?.state
+        .toolApprovalMode ?? 'alwaysAsk';
+
     switch (tool) {
       case 'write':
         if (mountedRuntimes.size === 0) return null;
@@ -985,8 +992,11 @@ export class ToolboxService extends DisposableService {
         return askUserQuestionsTool(this.uiKarton, agentInstanceId);
       case 'executeShellCommand':
         if (!this.shellService?.isAvailable()) return null;
-        return executeShellCommandTool(this.shellService, agentInstanceId, () =>
-          this.getMountedPathsForAgent(agentInstanceId),
+        return executeShellCommandTool(
+          this.shellService,
+          agentInstanceId,
+          () => this.getMountedPathsForAgent(agentInstanceId),
+          getToolApprovalMode,
         );
       default:
         this.logger.error('[ToolboxService] Tool not found', { tool });

--- a/apps/browser/src/backend/services/toolbox/tools/shell/execute-shell-command.ts
+++ b/apps/browser/src/backend/services/toolbox/tools/shell/execute-shell-command.ts
@@ -7,6 +7,7 @@ import { capToolOutput } from '../../utils';
 import type { ShellService } from '@/services/toolbox/services/shell';
 import { homedir } from 'node:os';
 import { join, resolve, sep } from 'node:path';
+import type { ToolApprovalMode } from '@shared/karton-contracts/ui/shared-types';
 
 export const DESCRIPTION = `Execute a shell command in the user's system shell. Initial \`cwd\` MUST be a mount prefix from the environment snapshot (e.g. "wXXXX" or "wXXXX/apps/browser"), never ".".
 
@@ -143,12 +144,15 @@ export const executeShellCommand = (
   shellService: ShellService,
   agentInstanceId: string,
   getMountedPaths: MountedPathsGetter,
+  getToolApprovalMode: () => ToolApprovalMode,
 ) => {
   return tool({
     description: DESCRIPTION,
     inputSchema: executeShellCommandToolInputSchema,
     strict: false,
-    needsApproval: true,
+    needsApproval: async () => {
+      return getToolApprovalMode() === 'alwaysAsk';
+    },
     execute: async (
       params: ExecuteShellCommandToolInput,
       { toolCallId, abortSignal },

--- a/apps/browser/src/shared/karton-contracts/ui/agent/index.ts
+++ b/apps/browser/src/shared/karton-contracts/ui/agent/index.ts
@@ -1,5 +1,6 @@
 import type { ToolUIPart, UIDataTypes, UIMessage } from 'ai';
 import type { ModelId } from '@shared/available-models';
+import type { ToolApprovalMode } from '@shared/karton-contracts/ui/shared-types';
 import type { MountPermission, UserMessageMetadata } from './metadata';
 import type { UIAgentTools } from './tools/types';
 
@@ -47,6 +48,12 @@ export type AgentState = {
   history: AgentMessage[]; // The message history of the agent (visible to user)
   queuedMessages: (AgentMessage & { role: 'user' })[]; // Queued messages that have not yet been sent to the agent.
   activeModelId: ModelId; // The model ID that the agent last used
+  /**
+   * Per-agent tool-call approval policy. Controls whether tools with
+   * `needsApproval` require explicit user confirmation before execution.
+   * Defaults to 'alwaysAsk' for new agents (safe behaviour).
+   */
+  toolApprovalMode: ToolApprovalMode;
   inputState: string; // Serialized input state - may be simple text or some stringified object if our input field needs that.
   usedTokens: number;
   error?: AgentRuntimeError; // Current error state (not persisted, only available during runtime for UI display)

--- a/apps/browser/src/shared/karton-contracts/ui/index.ts
+++ b/apps/browser/src/shared/karton-contracts/ui/index.ts
@@ -29,6 +29,7 @@ import type {
   HostPermissionOverrides,
   WidgetId,
   DevToolbarOriginSettings,
+  ToolApprovalMode,
 } from './shared-types';
 import {
   defaultUserPreferences,
@@ -705,6 +706,10 @@ export type KartonContract = {
         approvalId: string,
         approved: boolean,
         reason?: string,
+      ) => Promise<void>;
+      setToolApprovalMode: (
+        instanceId: string,
+        mode: ToolApprovalMode,
       ) => Promise<void>;
       stop: (agentId: string) => Promise<void>;
       flushQueue: (agentId: string) => Promise<void>;

--- a/apps/browser/src/shared/karton-contracts/ui/shared-types.ts
+++ b/apps/browser/src/shared/karton-contracts/ui/shared-types.ts
@@ -365,6 +365,10 @@ export type WorkspaceAgentSettings = z.infer<
   typeof workspaceAgentSettingsSchema
 >;
 
+/** Controls whether tool calls (shell, sandbox) require user approval */
+export const toolApprovalModeSchema = z.enum(['alwaysAsk', 'alwaysAllow']);
+export type ToolApprovalMode = z.infer<typeof toolApprovalModeSchema>;
+
 /** Update channel for prerelease builds ('alpha' or 'beta') */
 export const updateChannelSchema = z.enum(['alpha', 'beta']);
 export type UpdateChannel = z.infer<typeof updateChannelSchema>;

--- a/apps/browser/src/ui/screens/main/sidebar/chat/_components/chat-input.tsx
+++ b/apps/browser/src/ui/screens/main/sidebar/chat/_components/chat-input.tsx
@@ -2,6 +2,7 @@ import { useEditor, EditorContent, type Content } from '@tiptap/react';
 import StarterKit from '@tiptap/starter-kit';
 import Placeholder from '@tiptap/extension-placeholder';
 import { ModelSelect } from './model-select';
+import { ToolApprovalSelect } from './tool-approval-select';
 import { WorkspaceSelect } from './workspace-select';
 import { ContextUsageRing } from './context-usage-ring';
 import { Button } from '@stagewise/stage-ui/components/button';
@@ -66,6 +67,10 @@ export interface ChatInputProps {
   // Workspace selector
   showWorkspaceSelect?: boolean;
   onWorkspaceChange?: () => void;
+
+  // Tool approval selector
+  showToolApprovalSelect?: boolean;
+  onToolApprovalChange?: () => void;
 
   // Context usage ring
   showContextUsageRing?: boolean;
@@ -137,6 +142,9 @@ export const ChatInput = memo(function ChatInput({
 
   showWorkspaceSelect = true,
   onWorkspaceChange,
+
+  showToolApprovalSelect = true,
+  onToolApprovalChange,
 
   showContextUsageRing = false,
   contextUsedPercentage = 0,
@@ -532,6 +540,8 @@ export const ChatInput = memo(function ChatInput({
   onModelChangeRef.current = onModelChange;
   const onWorkspaceChangeRef = useRef(onWorkspaceChange);
   onWorkspaceChangeRef.current = onWorkspaceChange;
+  const onToolApprovalChangeRef = useRef(onToolApprovalChange);
+  onToolApprovalChangeRef.current = onToolApprovalChange;
 
   const handleModelSelectChange = useCallback(() => {
     requestAnimationFrame(() => {
@@ -547,6 +557,15 @@ export const ChatInput = memo(function ChatInput({
       requestAnimationFrame(() => {
         editorRef.current?.commands.focus('end');
         onWorkspaceChangeRef.current?.();
+      });
+    });
+  }, []);
+
+  const handleToolApprovalChange = useCallback(() => {
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        editorRef.current?.commands.focus('end');
+        onToolApprovalChangeRef.current?.();
       });
     });
   }, []);
@@ -616,10 +635,11 @@ export const ChatInput = memo(function ChatInput({
       {!disabled &&
         (showWorkspaceSelect ||
           showModelSelect ||
+          showToolApprovalSelect ||
           (showContextUsageRing && contextUsedPercentage > 0)) && (
           <div
             className={cn(
-              'flex shrink-0 flex-row flex-wrap items-center justify-start gap-2 *:shrink-0',
+              'flex shrink-0 flex-row flex-wrap items-center justify-start gap-2 pr-2 *:shrink-0',
               !showWorkspaceSelect && 'pl-1',
             )}
           >
@@ -635,6 +655,22 @@ export const ChatInput = memo(function ChatInput({
                 usedKb={contextUsedKb}
                 maxKb={contextMaxKb}
               />
+            )}
+            {showToolApprovalSelect && (
+              <>
+                {/*
+                  Invisible flex spacer that eats remaining horizontal space on
+                  the line containing `ToolApprovalSelect`, pushing the select
+                  to the right edge. `!shrink` overrides the parent's
+                  `*:shrink-0` so the spacer can collapse to 0 when the row
+                  wraps — otherwise it would prevent natural wrap behavior and
+                  force `ToolApprovalSelect` onto its own line prematurely.
+                */}
+                <div className="!shrink min-w-0 grow" aria-hidden />
+                <ToolApprovalSelect
+                  onToolApprovalChange={handleToolApprovalChange}
+                />
+              </>
             )}
           </div>
         )}

--- a/apps/browser/src/ui/screens/main/sidebar/chat/_components/message-part-ui/tools/execute-shell-command.tsx
+++ b/apps/browser/src/ui/screens/main/sidebar/chat/_components/message-part-ui/tools/execute-shell-command.tsx
@@ -33,6 +33,9 @@ export const ExecuteShellCommandToolPart = ({
   const killShellSession = useKartonProcedure(
     (p) => p.toolbox.killShellSession,
   );
+  const setToolApprovalMode = useKartonProcedure(
+    (p) => p.agents.setToolApprovalMode,
+  );
 
   const finished = useMemo(
     () =>
@@ -131,6 +134,27 @@ export const ExecuteShellCommandToolPart = ({
       return;
     sendApproval(openAgentId, part.approval.id, false, 'User denied');
   }, [openAgentId, part.state, part.approval, sendApproval]);
+
+  const handleAlwaysAllow = useCallback(async () => {
+    if (
+      !openAgentId ||
+      part.state !== 'approval-requested' ||
+      !part.approval?.id
+    )
+      return;
+    try {
+      await setToolApprovalMode(openAgentId, 'alwaysAllow');
+    } catch (error) {
+      console.warn('[ExecuteShellCommand] Failed to set approval mode', error);
+    }
+    sendApproval(openAgentId, part.approval.id, true);
+  }, [
+    openAgentId,
+    part.state,
+    part.approval,
+    sendApproval,
+    setToolApprovalMode,
+  ]);
 
   const trigger = useMemo(() => {
     if (state === 'approval' || state === 'approval-responded') {
@@ -336,6 +360,31 @@ export const ExecuteShellCommandToolPart = ({
           >
             Skip
           </Button>
+          <Tooltip>
+            <TooltipTrigger delay={250}>
+              <Button
+                variant="ghost"
+                size="xs"
+                onClick={handleAlwaysAllow}
+                disabled={state === 'approval-responded'}
+                className="group/always-allow min-w-0"
+              >
+                <span className="shrink-0 whitespace-nowrap">Always allow</span>
+                <span className="min-w-0 truncate text-subtle-foreground group-hover/always-allow:text-muted-foreground group-focus-visible/always-allow:text-muted-foreground">
+                  (dangerous)
+                </span>
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="top" align="end">
+              <div className="flex max-w-64 flex-col gap-1 py-1">
+                <div className="font-medium">Skip future approvals</div>
+                <div className="text-muted-foreground">
+                  This agent will run every shell command without asking. Only
+                  enable this if you trust what this agent is about to do.
+                </div>
+              </div>
+            </TooltipContent>
+          </Tooltip>
           <Button
             variant="primary"
             size="xs"
@@ -350,7 +399,7 @@ export const ExecuteShellCommandToolPart = ({
         </div>
       );
     return undefined;
-  }, [state, handleApprove, handleDeny]);
+  }, [state, handleApprove, handleDeny, handleAlwaysAllow]);
 
   return (
     <ToolPartUI

--- a/apps/browser/src/ui/screens/main/sidebar/chat/_components/tool-approval-select.tsx
+++ b/apps/browser/src/ui/screens/main/sidebar/chat/_components/tool-approval-select.tsx
@@ -1,0 +1,246 @@
+import { Combobox as ComboboxBase } from '@base-ui/react/combobox';
+import {
+  Combobox,
+  ComboboxItem,
+  ComboboxItemIndicator,
+  ComboboxList,
+} from '@stagewise/stage-ui/components/combobox';
+import type { ToolApprovalMode } from '@shared/karton-contracts/ui/shared-types';
+import { IconChevronDownFill18 } from 'nucleo-ui-fill-18';
+import { IconTriangleWarningOutline18 } from 'nucleo-ui-outline-18';
+import { useKartonProcedure, useKartonState } from '@ui/hooks/use-karton';
+import { useOpenAgent } from '@ui/hooks/use-open-chat';
+import {
+  memo,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import { cn } from '@ui/utils';
+
+interface ToolApprovalOption {
+  value: ToolApprovalMode;
+  label: string;
+  title: string;
+  description: string;
+}
+
+const OPTIONS: ToolApprovalOption[] = [
+  {
+    value: 'alwaysAsk',
+    label: 'Always ask',
+    title: 'Ask before shell commands',
+    description:
+      'This agent will pause and ask for your approval before running any shell command.',
+  },
+  {
+    value: 'alwaysAllow',
+    label: 'Always allow',
+    title: 'Skip future approvals',
+    description:
+      'This agent will run every shell command without asking. Only enable this if you trust what this agent is about to do.',
+  },
+];
+
+interface ToolApprovalSelectProps {
+  onToolApprovalChange?: () => void;
+}
+
+export const ToolApprovalSelect = memo(function ToolApprovalSelect({
+  onToolApprovalChange,
+}: ToolApprovalSelectProps) {
+  const [openAgent] = useOpenAgent();
+  const currentMode = useKartonState((s) =>
+    openAgent
+      ? (s.agents.instances[openAgent]?.state.toolApprovalMode ?? 'alwaysAsk')
+      : null,
+  );
+  const setToolApprovalMode = useKartonProcedure(
+    (p) => p.agents.setToolApprovalMode,
+  );
+
+  const currentLabel = useMemo(() => {
+    if (!currentMode) return 'Always ask';
+    return OPTIONS.find((o) => o.value === currentMode)?.label ?? currentMode;
+  }, [currentMode]);
+
+  // Side-panel hover state
+  const containerRef = useRef<HTMLDivElement>(null);
+  const sidePanelRef = useRef<HTMLDivElement>(null);
+  const [hoveredOption, setHoveredOption] = useState<ToolApprovalOption | null>(
+    null,
+  );
+  const [itemCenterY, setItemCenterY] = useState(0);
+  const [sidePanelOffset, setSidePanelOffset] = useState(0);
+
+  useLayoutEffect(() => {
+    if (!hoveredOption || !sidePanelRef.current || !containerRef.current)
+      return;
+    const panelHeight = sidePanelRef.current.offsetHeight;
+    const containerHeight = containerRef.current.offsetHeight;
+
+    // Clamp both bounds to non-negative values so that when the panel is
+    // taller than the container we fall back to 0 (top-aligned) instead of
+    // pushing the panel to a negative `top`.
+    const maxOffset = Math.max(0, containerHeight - panelHeight);
+    const offset = Math.max(
+      0,
+      Math.min(itemCenterY - panelHeight / 2, maxOffset),
+    );
+
+    setSidePanelOffset(offset);
+  }, [hoveredOption, itemCenterY]);
+
+  const handleItemHover = useCallback(
+    (option: ToolApprovalOption, element: HTMLElement) => {
+      const container = containerRef.current;
+      if (!container) {
+        setHoveredOption(option);
+        return;
+      }
+
+      const containerRect = container.getBoundingClientRect();
+      const itemRect = element.getBoundingClientRect();
+      const centerY = itemRect.top + itemRect.height / 2 - containerRect.top;
+
+      setItemCenterY(centerY);
+      setHoveredOption(option);
+    },
+    [],
+  );
+
+  const handleValueChange = useCallback(
+    (value: string | null) => {
+      if (!openAgent || !value) return;
+      void setToolApprovalMode(openAgent, value as ToolApprovalMode).catch(
+        (error) => {
+          console.warn('[ToolApprovalSelect] Failed to set mode', error);
+        },
+      );
+      onToolApprovalChange?.();
+    },
+    [openAgent, setToolApprovalMode, onToolApprovalChange],
+  );
+
+  const handleOpenChange = useCallback((open: boolean) => {
+    if (!open) {
+      setHoveredOption(null);
+    }
+  }, []);
+
+  return (
+    <Combobox
+      value={currentMode}
+      onValueChange={handleValueChange}
+      onOpenChange={handleOpenChange}
+      filter={null}
+    >
+      <ComboboxBase.Trigger
+        className={cn(
+          'inline-flex min-w-0 max-w-full cursor-pointer items-center justify-between gap-1 rounded-lg p-0 font-normal text-xs shadow-none transition-colors',
+          'focus-visible:-outline-offset-2 focus-visible:outline-1 focus-visible:outline-muted-foreground/35',
+          'has-disabled:pointer-events-none has-disabled:opacity-50',
+          'bg-transparent text-muted-foreground hover:text-foreground data-popup-open:text-foreground',
+          'h-4 w-auto',
+        )}
+        disabled={!openAgent}
+      >
+        {currentMode === 'alwaysAllow' && (
+          <IconTriangleWarningOutline18 className="size-3 shrink-0" />
+        )}
+        <span className="truncate">{currentLabel}</span>
+        <ComboboxBase.Icon className="shrink-0">
+          <IconChevronDownFill18 className="size-3" />
+        </ComboboxBase.Icon>
+      </ComboboxBase.Trigger>
+
+      <ComboboxBase.Portal>
+        <ComboboxBase.Backdrop className="fixed inset-0 z-50" />
+        <ComboboxBase.Positioner
+          side="top"
+          sideOffset={4}
+          align="start"
+          className="z-50"
+        >
+          <div
+            ref={containerRef}
+            className="relative flex flex-row items-start gap-1"
+            onMouseLeave={() => setHoveredOption(null)}
+          >
+            <ComboboxBase.Popup
+              className={cn(
+                'flex max-w-72 origin-(--transform-origin) flex-col items-stretch gap-0.5 text-xs',
+                'rounded-lg border border-border-subtle bg-background p-1 shadow-lg',
+                'transition-[transform,scale,opacity] duration-150 ease-out',
+                'data-ending-style:scale-90 data-ending-style:opacity-0',
+                'data-starting-style:scale-90 data-starting-style:opacity-0',
+              )}
+            >
+              <ComboboxList>
+                {OPTIONS.map((option) => (
+                  <ToolApprovalItem
+                    key={option.value}
+                    option={option}
+                    onHighlight={handleItemHover}
+                  />
+                ))}
+              </ComboboxList>
+            </ComboboxBase.Popup>
+
+            {hoveredOption && (
+              <div
+                ref={sidePanelRef}
+                className={cn(
+                  'absolute left-full ml-1 flex w-72 flex-col gap-1 rounded-lg border border-derived bg-background p-2.5 text-foreground text-xs shadow-lg transition-[top] duration-100 ease-out',
+                  'fade-in-0 slide-in-from-left-1 animate-in duration-150',
+                )}
+                style={{ top: sidePanelOffset }}
+              >
+                <div className="font-semibold">{hoveredOption.title}</div>
+                <div className="text-muted-foreground">
+                  {hoveredOption.description}
+                </div>
+              </div>
+            )}
+          </div>
+        </ComboboxBase.Positioner>
+      </ComboboxBase.Portal>
+    </Combobox>
+  );
+});
+
+const ToolApprovalItem = memo(function ToolApprovalItem({
+  option,
+  onHighlight,
+}: {
+  option: ToolApprovalOption;
+  onHighlight: (option: ToolApprovalOption, element: HTMLElement) => void;
+}) {
+  const itemRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const el = itemRef.current;
+    if (!el) return;
+
+    const observer = new MutationObserver(() => {
+      if (el.hasAttribute('data-highlighted')) onHighlight(option, el);
+    });
+
+    observer.observe(el, {
+      attributes: true,
+      attributeFilter: ['data-highlighted'],
+    });
+
+    return () => observer.disconnect();
+  }, [option, onHighlight]);
+
+  return (
+    <ComboboxItem ref={itemRef} value={option.value} size="xs">
+      <ComboboxItemIndicator />
+      <span className="col-start-2 truncate">{option.label}</span>
+    </ComboboxItem>
+  );
+});


### PR DESCRIPTION
implements #941 


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds per-agent tool approval modes for shell commands: `alwaysAsk` (default) and `alwaysAllow`. The mode is persisted, applied at runtime, and can be changed from the chat input or directly in the shell approval prompt.

- **New Features**
  - Added `toolApprovalMode` to `AgentState` and persistence; defaults to `alwaysAsk`.
  - Introduced `agents.setToolApprovalMode` and a `ToolApprovalSelect` in the chat input to switch modes.
  - `executeShellCommand` now checks the current mode for `needsApproval`; added an “Always allow” action on approval prompts.

- **Migration**
  - Bumps DB schema to v9, adding `tool_approval_mode` to `agentInstances` with a default of `alwaysAsk` (auto-migrated).

<sup>Written for commit c1b8266bdcff858cf0bfe20b3a8259e8f63cf0e2. Summary will update on new commits. <a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1007?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-agent tool approval setting with "Always Ask" (default) and "Always Allow" options.
  * UI selector in chat input to configure an agent’s approval mode.
  * "Always Allow (dangerous)" quick action in shell-command approval prompts.
  * Tool execution now respects the agent’s approval mode.

* **Bug Fixes**
  * Approval mode persists and is correctly restored when agents are resumed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->