### PR TITLE
feat(stagewise): implement fast-path cache probing to optimize file r…

### DIFF
--- a/apps/browser/src/backend/agents/shared/base-agent/file-read-transformer/index.ts
+++ b/apps/browser/src/backend/agents/shared/base-agent/file-read-transformer/index.ts
@@ -388,6 +388,52 @@ export async function fileReadTransformer(
     );
   }
 
+  // Fast-path: probe cache with the expected hash before touching disk.
+  // When the file hasn't changed on disk, `currentHash === expectedHash`
+  // and the downstream cache lookup will hit under the same key we can
+  // build right now from `expectedHash` alone. Probing upfront lets us
+  // skip `fs.stat`, `blobReader`, and `hashBuffer` entirely on hits.
+  //
+  // Directory detection without stat: we can't reliably know if the path
+  // is a directory. Dirs typically have no extension, so
+  // `nodePath.extname()` returns ''. Any key mismatch misses the fast
+  // path and falls through to the existing slow-path.
+  //
+  // Preview-promotion: if the caller requests `{preview: true}` but a
+  // prior slow-path run wrote the cache under a promoted (full-read)
+  // key, the fast-path probe misses and we fall through. The slow path
+  // then rediscovers the promoted entry. One-time cost per file; not
+  // worth an extra probe here.
+  const fastPathNameForExt = originalFileName ?? mountedPath;
+  const fastPathExt = nodePath.extname(fastPathNameForExt).toLowerCase();
+  const fastPathSuffix = buildReadParamsSuffix(
+    effectiveReadParams,
+    maxReadChars,
+    maxPreviewLines,
+  );
+  const fastPathKey = FileReadCacheService.buildCacheKey(
+    expectedHash,
+    fastPathExt,
+    fastPathSuffix,
+  );
+  try {
+    const fastCached = await cache.get(fastPathKey);
+    if (fastCached) {
+      const fastDeserialized = deserializeTransformResult(fastCached.content);
+      if (fastDeserialized) {
+        logger.debug(
+          `[fileReadTransformer] Fast-path cache hit for ${mountedPath}`,
+        );
+        return wrapResult(mountedPath, fastDeserialized, effectiveReadParams);
+      }
+    }
+  } catch (e: unknown) {
+    logger.warn(
+      `[fileReadTransformer] Fast-path cache probe failed for ${mountedPath}, falling through`,
+      e,
+    );
+  }
+
   let stat: Awaited<ReturnType<typeof fs.stat>>;
   try {
     stat = await fs.stat(absolutePath);


### PR DESCRIPTION
…ead performance

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a fast-path cache probe to `fileReadTransformer` to skip disk I/O when there’s a cache hit, improving read performance. Falls back to the slow path on miss or errors with no behavior change.

- **Performance**
  - Probe cache upfront using `expectedHash` and read params; on hit, bypass `fs.stat`, blob read, and hashing.
  - Misses or probe errors fall through to the existing path, including preview/full-read promotion and directory cases.

<sup>Written for commit 4e1460480c173134bd3d5a658b3ad231d2c88583. Summary will update on new commits. <a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1008?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented caching optimization for file reading operations to enhance performance. Previously read files are now retrieved from cache, eliminating unnecessary disk access and reducing latency on repeated operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->