### PR TITLE
Telemetry refactor

### DIFF
--- a/apps/browser/src/backend/agents/shared/base-agent/base-agent.ts
+++ b/apps/browser/src/backend/agents/shared/base-agent/base-agent.ts
@@ -555,11 +555,23 @@ export abstract class BaseAgent<
 
     // If the agent is running, we queue the message
     if (this.state.get().isWorking) {
+      let queuedModelId = 'unknown';
+      let queueLengthAfter = 0;
+
       this.state.set((draft) => {
         draft.queuedMessages.push(msg);
+        queuedModelId = draft.activeModelId ?? 'unknown';
+        queueLengthAfter = draft.queuedMessages.length;
       });
 
       this.logger.debug(`[BaseAgent:${this.instanceId}] Queued message`);
+
+      this.telemetryService.capture('agent-message-queued', {
+        agent_type: this.agentType,
+        agent_instance_id: this.instanceId,
+        model_id: queuedModelId,
+        queue_length_after: queueLengthAfter,
+      });
 
       return message.id;
     }
@@ -708,11 +720,15 @@ export abstract class BaseAgent<
       }
     }
     if (approved) {
-      this.telemetryService.capture('tool-approved', { tool_name: toolName });
+      this.telemetryService.capture('tool-approved', {
+        tool_name: toolName,
+        agent_instance_id: this.instanceId,
+      });
     } else {
       this.telemetryService.capture('tool-denied', {
         tool_name: toolName,
         reason,
+        agent_instance_id: this.instanceId,
       });
     }
 
@@ -757,6 +773,8 @@ export abstract class BaseAgent<
    * @note DO NOT OVERRIDE
    */
   public async flushQueue(): Promise<void> {
+    const flushedCount = this.state.get().queuedMessages.length;
+
     await this.internalStop('user-flushed-queue');
 
     // Send all queued messages into the chat
@@ -764,6 +782,14 @@ export abstract class BaseAgent<
       draft.history.push(...draft.queuedMessages);
       draft.queuedMessages = [];
     });
+
+    if (flushedCount > 0) {
+      this.telemetryService.capture('agent-queue-flushed', {
+        agent_type: this.agentType,
+        agent_instance_id: this.instanceId,
+        flushed_message_count: flushedCount,
+      });
+    }
 
     this.runStep();
 
@@ -2143,6 +2169,7 @@ export abstract class BaseAgent<
 
     this.telemetryService.capture('agent-step-completed', {
       agent_type: this.agentType,
+      agent_instance_id: this.instanceId,
       model_id: this.state.get().activeModelId,
       provider_mode: this._stepProviderMode,
       input_tokens: result.usage.inputTokens ?? 0,
@@ -3072,6 +3099,7 @@ export abstract class BaseAgent<
         this.telemetryService.capture('tool-call-executed', {
           tool_name: part.toolName,
           agent_type: this.agentType,
+          agent_instance_id: this.instanceId,
           model_id: modelId,
           success: true,
           input_keys: inputKeys,
@@ -3082,6 +3110,7 @@ export abstract class BaseAgent<
         this.telemetryService.capture('tool-call-executed', {
           tool_name: part.toolName,
           agent_type: this.agentType,
+          agent_instance_id: this.instanceId,
           model_id: modelId,
           success: false,
           error_message: String(part.error).slice(0, 500),

--- a/apps/browser/src/backend/agents/shared/base-agent/base-agent.ts
+++ b/apps/browser/src/backend/agents/shared/base-agent/base-agent.ts
@@ -402,6 +402,14 @@ export abstract class BaseAgent<
    */
   private _pendingContinue: boolean | null = null;
 
+  /**
+   * Tracks approval IDs for which we have already emitted a
+   * `tool-approval-requested` telemetry event. The stream merge loop runs
+   * per chunk, so the same `approval-requested` state is observed many
+   * times — without this dedupe we would over-count requests by 10×+.
+   */
+  private _seenApprovalRequestIds = new Set<string>();
+
   // Handler that get's called when the agent wants to spawn a child agent.
   private readonly spawnChildAgentHandler: <
     TAgentType extends keyof AgentTypeMap,
@@ -723,12 +731,14 @@ export abstract class BaseAgent<
       this.telemetryService.capture('tool-approved', {
         tool_name: toolName,
         agent_instance_id: this.instanceId,
+        tool_call_id: approvalId,
       });
     } else {
       this.telemetryService.capture('tool-denied', {
         tool_name: toolName,
         reason,
         agent_instance_id: this.instanceId,
+        tool_call_id: approvalId,
       });
     }
 
@@ -2602,6 +2612,29 @@ export abstract class BaseAgent<
               if (part.state === 'done') {
                 existingMessage.metadata!.partsMetadata[index].endedAt ??=
                   new Date();
+              }
+            }
+
+            // Emit `tool-approval-requested` exactly once per approval id.
+            // The stream replays the approval-requested state many times as
+            // the SDK merges chunks, so dedupe via `_seenApprovalRequestIds`.
+            if (
+              (part.type === 'dynamic-tool' || part.type.startsWith('tool-')) &&
+              (part as AgentToolUIPart | DynamicToolUIPart).state ===
+                'approval-requested'
+            ) {
+              const toolPart = part as AgentToolUIPart | DynamicToolUIPart;
+              const approvalId = toolPart.approval?.id;
+              if (approvalId && !this._seenApprovalRequestIds.has(approvalId)) {
+                this._seenApprovalRequestIds.add(approvalId);
+                this.telemetryService.capture('tool-approval-requested', {
+                  tool_name:
+                    toolPart.type === 'dynamic-tool'
+                      ? 'dynamic-tool'
+                      : toolPart.type.replace('tool-', ''),
+                  agent_instance_id: this.instanceId,
+                  tool_call_id: approvalId,
+                });
               }
             }
           },

--- a/apps/browser/src/backend/agents/shared/prompts/utils/metadata-converter/slash-items.ts
+++ b/apps/browser/src/backend/agents/shared/prompts/utils/metadata-converter/slash-items.ts
@@ -1,7 +1,8 @@
 import { readFile } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
+import { createHash } from 'node:crypto';
 import matter from 'gray-matter';
-import type { SkillDefinition } from '@shared/skills';
+import type { SkillDefinition, SkillDefinitionUI } from '@shared/skills';
 import xml from 'xml';
 import specialTokens from '../special-tokens';
 
@@ -29,6 +30,37 @@ export function extractSlashIdsFromText(
   }
 
   return ids;
+}
+
+/**
+ * Sources whose skill IDs are bundled with the app binary and therefore
+ * safe to ship to telemetry as plaintext. `workspace` and `global` skill
+ * IDs are user-controlled (derived from filesystem paths) and can leak
+ * project/branch/personal names — those get hashed instead.
+ */
+const SAFE_SLASH_ID_SOURCES = new Set(['builtin', 'plugin']);
+
+/**
+ * Redact slash command IDs for telemetry. Builtin/plugin IDs pass through
+ * as plaintext; workspace/global (and any unknown) IDs are replaced with
+ * a stable `user:<hash>` token so aggregate analytics still work without
+ * leaking user-controlled strings.
+ *
+ * Unknown IDs (not present in `skills`) fail safe — hashed, not dropped,
+ * so we can still count them.
+ */
+export function redactSlashIdsForTelemetry(
+  ids: ReadonlyArray<string>,
+  skills: ReadonlyArray<Pick<SkillDefinitionUI, 'id' | 'source'>>,
+): string[] {
+  if (ids.length === 0) return [];
+  const sourceById = new Map(skills.map((s) => [s.id, s.source]));
+  return ids.map((id) => {
+    const source = sourceById.get(id);
+    if (source && SAFE_SLASH_ID_SOURCES.has(source)) return id;
+    const hash = createHash('sha256').update(id).digest('hex').slice(0, 12);
+    return `user:${hash}`;
+  });
 }
 
 /**

--- a/apps/browser/src/backend/main.ts
+++ b/apps/browser/src/backend/main.ts
@@ -11,7 +11,11 @@ import { AppMenuService } from './services/app-menu';
 import { URIHandlerService } from './services/uri-handler';
 import { IdentifierService } from './services/identifier';
 import { Logger } from './services/logger';
-import { TelemetryService } from './services/telemetry';
+import {
+  isUIEventName,
+  parseUIEventProperties,
+  TelemetryService,
+} from './services/telemetry';
 import { GlobalConfigService } from './services/global-config';
 import { PreferencesService } from './services/preferences';
 import { NotificationService } from './services/notification';
@@ -73,7 +77,10 @@ export async function main({ launchOptions: { verbose } }: MainParameters) {
     logger,
   );
 
-  telemetryService.capture('app-launched', { cold_start: true });
+  // Start launch telemetry without blocking startup. TelemetryService keeps
+  // track of the pending capture so shutdown can wait for it before emitting
+  // app-closed.
+  telemetryService.captureAppLaunched();
 
   // Global safety net: capture any unhandled errors/rejections to telemetry
   process.on('uncaughtException', (error) => {
@@ -252,10 +259,20 @@ export async function main({ launchOptions: { verbose } }: MainParameters) {
       eventName: string,
       properties?: Record<string, unknown>,
     ) => {
-      telemetryService.capture(
-        eventName as keyof import('./services/telemetry').EventProperties,
-        properties as any,
-      );
+      if (!isUIEventName(eventName)) {
+        logger.warn(`[Main] Ignoring unknown UI telemetry event: ${eventName}`);
+        return;
+      }
+
+      const parsedProperties = parseUIEventProperties(eventName, properties);
+      if (parsedProperties === null) {
+        logger.warn(
+          `[Main] Ignoring invalid UI telemetry payload for event: ${eventName}`,
+        );
+        return;
+      }
+
+      telemetryService.capture(eventName, parsedProperties);
     },
   );
 
@@ -430,18 +447,57 @@ export async function main({ launchOptions: { verbose } }: MainParameters) {
   handleCommandLineUrls(process.argv, windowLayoutService, logger);
 
   // Set up graceful shutdown to clean up database connections
-  const shutdown = () => {
-    logger.debug('[Main] Shutting down services...');
-    localPortsScannerService.teardown();
-    webDataService.teardown();
-    historyService.teardown();
-    faviconService.teardown();
-    thumbnailService.teardown();
-    diffHistoryService.teardown();
-    assetCacheService.teardown();
-    processedImageCacheService?.teardown();
-    autoUpdateService.teardown();
-    logger.debug('[Main] Services shut down');
+  let isShuttingDown = false;
+  const shutdown = (event: Electron.Event) => {
+    if (isShuttingDown) return;
+    isShuttingDown = true;
+    event.preventDefault();
+
+    const runTeardown = (name: string, teardown: () => void) => {
+      try {
+        teardown();
+      } catch (error) {
+        logger.warn(`[Main] Failed to teardown ${name}`, error);
+      }
+    };
+
+    const exitApp = () => {
+      logger.debug('[Main] Services shut down');
+      app.exit(0);
+    };
+
+    try {
+      logger.debug('[Main] Shutting down services...');
+      runTeardown('localPortsScannerService', () =>
+        localPortsScannerService.teardown(),
+      );
+      runTeardown('webDataService', () => webDataService.teardown());
+      runTeardown('historyService', () => historyService.teardown());
+      runTeardown('faviconService', () => faviconService.teardown());
+      runTeardown('thumbnailService', () => thumbnailService.teardown());
+      runTeardown('diffHistoryService', () => diffHistoryService.teardown());
+      runTeardown('assetCacheService', () => assetCacheService.teardown());
+      runTeardown('processedImageCacheService', () =>
+        processedImageCacheService?.teardown(),
+      );
+      runTeardown('autoUpdateService', () => autoUpdateService.teardown());
+
+      const telemetryTeardown = Promise.resolve()
+        .then(() => telemetryService.teardown())
+        .catch((error) => {
+          logger.warn('[Main] Failed to teardown telemetryService', error);
+        });
+
+      void Promise.race([
+        telemetryTeardown,
+        new Promise<void>((resolve) => {
+          setTimeout(resolve, 500);
+        }),
+      ]).finally(exitApp);
+    } catch (error) {
+      logger.error(`[Main] Shutdown failed: ${String(error)}`);
+      exitApp();
+    }
   };
 
   app.on('will-quit', shutdown);

--- a/apps/browser/src/backend/services/agent-manager/agent-manager.ts
+++ b/apps/browser/src/backend/services/agent-manager/agent-manager.ts
@@ -270,9 +270,10 @@ export class AgentManagerService extends DisposableService {
         _callingClientId: string,
         instanceId: string,
         mode: ToolApprovalMode,
+        source?: 'panel-combobox' | 'inline-approval-button',
       ) => {
         const parsedMode = toolApprovalModeSchema.parse(mode);
-        await this.setToolApprovalMode(instanceId, parsedMode);
+        await this.setToolApprovalMode(instanceId, parsedMode, { source });
       },
     );
     this.karton.registerServerProcedureHandler(
@@ -1007,6 +1008,7 @@ export class AgentManagerService extends DisposableService {
       connected_workspace_count: connectedWorkspaceCount,
       is_new_chat: !hasPriorUserMessage,
       ms_since_last_message: msSinceLastMessage,
+      tool_approval_mode: instance?.state.toolApprovalMode ?? 'alwaysAsk',
     });
 
     await agent.sendUserMessage(message);
@@ -1041,7 +1043,22 @@ export class AgentManagerService extends DisposableService {
    * history) because it uses a narrow DB update that bypasses the full
    * `persistAgentState` path.
    */
-  public async setToolApprovalMode(instanceId: string, mode: ToolApprovalMode) {
+  public async setToolApprovalMode(
+    instanceId: string,
+    mode: ToolApprovalMode,
+    telemetry?: {
+      /** Which UI surface triggered the change; threaded from the RPC. */
+      source?: 'panel-combobox' | 'inline-approval-button';
+      /**
+       * Only meaningful when `source === 'inline-approval-button'`:
+       * the approval ID the user was responding to. Lets analytics
+       * correlate the mode change with a specific approval request.
+       */
+      toolCallId?: string;
+      /** Tool name for `inline-approval-button`; optional otherwise. */
+      toolName?: string;
+    },
+  ) {
     const agent = this.activeAgents.get(instanceId);
 
     if (!agent) {
@@ -1049,7 +1066,10 @@ export class AgentManagerService extends DisposableService {
     }
 
     const currentMode =
-      this.karton.state.agents.instances[instanceId]?.state.toolApprovalMode;
+      this.karton.state.agents.instances[instanceId]?.state.toolApprovalMode ??
+      'alwaysAsk';
+    // No-op calls aren't logged — otherwise the combobox's onValueChange
+    // firing on a reselection would emit spurious events.
     if (currentMode === mode) return;
 
     this.karton.setState((draft) => {
@@ -1057,6 +1077,15 @@ export class AgentManagerService extends DisposableService {
     });
 
     await this.agentPersistenceDB?.updateToolApprovalMode(instanceId, mode);
+
+    this.telemetryService.capture('tool-approval-mode-changed', {
+      agent_instance_id: instanceId,
+      previous_mode: currentMode,
+      new_mode: mode,
+      source: telemetry?.source ?? 'unknown',
+      ...(telemetry?.toolCallId && { tool_call_id: telemetry.toolCallId }),
+      ...(telemetry?.toolName && { tool_name: telemetry.toolName }),
+    });
   }
 
   /**

--- a/apps/browser/src/backend/services/agent-manager/agent-manager.ts
+++ b/apps/browser/src/backend/services/agent-manager/agent-manager.ts
@@ -385,9 +385,26 @@ export class AgentManagerService extends DisposableService {
 
         // Active path: let the agent handle it so Karton state updates and
         // titleLockedByUser is set via the normal state mutation.
+        // The raw title is only transmitted at `full` telemetry. Titles
+        // frequently contain project names, snippets, or other identifying
+        // strings — `basic` should stay content-free.
+        const isFullTelemetry = this.telemetryService.telemetryLevel === 'full';
+
         const agent = this.activeAgents.get(instanceId);
         if (agent) {
           await agent.setTitle(trimmed);
+          // Read the type from Karton state rather than `agent.agentType`
+          // to stay consistent with other emit sites in this file and
+          // avoid coupling telemetry to a specific BaseAgent subclass shape.
+          const agentType =
+            this.karton.state.agents.instances[instanceId]?.type;
+          this.telemetryService.capture('agent-renamed', {
+            agent_instance_id: instanceId,
+            was_active: true,
+            new_title_length: trimmed.length,
+            ...(agentType && { agent_type: agentType }),
+            ...(isFullTelemetry && { new_title: trimmed }),
+          });
           return;
         }
 
@@ -404,6 +421,12 @@ export class AgentManagerService extends DisposableService {
         if (!updated) {
           throw new Error(`Agent with instance id ${instanceId} not found`);
         }
+        this.telemetryService.capture('agent-renamed', {
+          agent_instance_id: instanceId,
+          was_active: false,
+          new_title_length: trimmed.length,
+          ...(isFullTelemetry && { new_title: trimmed }),
+        });
       },
     );
     this.karton.registerServerProcedureHandler(

--- a/apps/browser/src/backend/services/agent-manager/agent-manager.ts
+++ b/apps/browser/src/backend/services/agent-manager/agent-manager.ts
@@ -28,9 +28,31 @@ import { generateAttachmentFilename } from '@shared/utils/attachment-filename';
 
 import type { QuestionAnswerValue } from '@shared/karton-contracts/ui/agent/tools/types';
 import { readWorkspaceMd } from '@/agents/shared/prompts/utils/read-workspace-md';
+import {
+  extractSlashIdsFromText,
+  redactSlashIdsForTelemetry,
+} from '@/agents/shared/prompts/utils/metadata-converter/slash-items';
 import { getGitInfo } from '@/utils/git-tools';
 import type { AssetCacheService } from '@/services/asset-cache';
 import type { ProcessedImageCacheService } from '@/services/processed-image-cache';
+
+function toFiniteTimestamp(value: unknown): number | undefined {
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : undefined;
+  }
+
+  if (value instanceof Date) {
+    const timestamp = value.getTime();
+    return Number.isFinite(timestamp) ? timestamp : undefined;
+  }
+
+  if (typeof value === 'string') {
+    const timestamp = new Date(value).getTime();
+    return Number.isFinite(timestamp) ? timestamp : undefined;
+  }
+
+  return undefined;
+}
 
 /**
  * @note Due to the complex type inference for all this stuff, we sometimes explicitly define types here to avoid errors.
@@ -674,6 +696,7 @@ export class AgentManagerService extends DisposableService {
 
     this.telemetryService.capture('agent-created', {
       agent_type: type,
+      agent_instance_id: agentInstanceId,
       model_id:
         this.karton.state.agents.instances[agentInstanceId]?.state
           .activeModelId ?? 'unknown',
@@ -780,6 +803,7 @@ export class AgentManagerService extends DisposableService {
 
     this.telemetryService.capture('agent-resumed', {
       agent_type: agent.type,
+      agent_instance_id: instanceId,
     });
 
     return createdAgent;
@@ -866,6 +890,7 @@ export class AgentManagerService extends DisposableService {
 
     this.telemetryService.capture('agent-deleted', {
       agent_type: agentType,
+      agent_instance_id: instanceId,
     });
   }
 
@@ -921,6 +946,11 @@ export class AgentManagerService extends DisposableService {
       delete draft.agents.instances[instanceId];
       delete draft.toolbox[instanceId];
     });
+
+    this.telemetryService.capture('agent-archived', {
+      agent_type: agent.agentType,
+      agent_instance_id: instanceId,
+    });
   }
 
   /**
@@ -944,11 +974,39 @@ export class AgentManagerService extends DisposableService {
 
     const instance = this.karton.state.agents.instances[instanceId];
     const attachmentParts = message.parts.filter((p) => p.type === 'file');
+    const slashCommandIds = extractSlashIdsFromText(
+      message.parts as ReadonlyArray<{ type: string; text?: string }>,
+    );
+    // Redact before sending to telemetry: workspace/global skill IDs are
+    // user-controlled (filesystem-derived) and can leak project/branch/
+    // personal names. Only builtin/plugin IDs pass through as plaintext.
+    const slashCommandIdsForTelemetry = redactSlashIdsForTelemetry(
+      slashCommandIds,
+      this.karton.state.skills ?? [],
+    );
+    const connectedWorkspaceCount =
+      this.karton.state.toolbox[instanceId]?.workspace?.mounts?.length ?? 0;
+
+    // Measure chat age / last-message gap *before* the message is dispatched
+    // so the numbers reflect the state the user saw when sending.
+    const historyBefore = instance?.state.history ?? [];
+    const hasPriorUserMessage = historyBefore.some((m) => m.role === 'user');
+    const lastMessage = historyBefore[historyBefore.length - 1];
+    const lastMessageTs = toFiniteTimestamp(lastMessage?.metadata?.createdAt);
+    const msSinceLastMessage =
+      lastMessageTs !== undefined ? Date.now() - lastMessageTs : undefined;
+
     this.telemetryService.capture('agent-message-sent', {
       agent_type: instance?.type ?? 'unknown',
+      agent_instance_id: instanceId,
       model_id: instance?.state.activeModelId ?? 'unknown',
       has_attachments: attachmentParts.length > 0,
       attachment_count: attachmentParts.length,
+      slash_command_ids: slashCommandIdsForTelemetry,
+      slash_command_count: slashCommandIds.length,
+      connected_workspace_count: connectedWorkspaceCount,
+      is_new_chat: !hasPriorUserMessage,
+      ms_since_last_message: msSinceLastMessage,
     });
 
     await agent.sendUserMessage(message);
@@ -1019,10 +1077,33 @@ export class AgentManagerService extends DisposableService {
       await this.stopAgent(childAgentInstanceId);
     }
 
+    const history =
+      this.karton.state.agents.instances[instanceId]?.state.history ?? [];
+    const now = Date.now();
+    let lastUserTs: number | undefined;
+    let lastAgentTs: number | undefined;
+    for (let i = history.length - 1; i >= 0; i--) {
+      const m = history[i];
+      const createdAt = m.metadata?.createdAt;
+      if (createdAt === undefined) continue;
+
+      const ts = toFiniteTimestamp(createdAt);
+      if (ts === undefined) continue;
+
+      if (lastUserTs === undefined && m.role === 'user') lastUserTs = ts;
+      if (lastAgentTs === undefined && m.role === 'assistant') lastAgentTs = ts;
+      if (lastUserTs !== undefined && lastAgentTs !== undefined) break;
+    }
+
     await agent.stop();
 
     this.telemetryService.capture('agent-stopped', {
       agent_type: agent.agentType,
+      agent_instance_id: instanceId,
+      ms_since_last_user_message:
+        lastUserTs !== undefined ? now - lastUserTs : undefined,
+      ms_since_last_agent_message:
+        lastAgentTs !== undefined ? now - lastAgentTs : undefined,
     });
   }
 
@@ -1144,6 +1225,7 @@ export class AgentManagerService extends DisposableService {
     await agent.updateActiveModelId(modelId);
     this.telemetryService.capture('agent-model-changed', {
       agent_type: agent.agentType,
+      agent_instance_id: instanceId,
       from_model: fromModel,
       to_model: modelId,
     });

--- a/apps/browser/src/backend/services/pages.ts
+++ b/apps/browser/src/backend/services/pages.ts
@@ -54,6 +54,7 @@ import type {
 } from '@shared/karton-contracts/pages-api/types';
 import { DisposableService } from './disposable';
 import type { TelemetryService } from './telemetry';
+import { isUIEventName, parseUIEventProperties } from './telemetry';
 import { discoverPlugins } from '@/utils/discover-plugins';
 import { getPluginsPath, getPlansDir } from '@/utils/paths';
 
@@ -781,6 +782,34 @@ export class PagesService extends DisposableService {
           return;
         }
         await this.openTabHandler(url, setActive);
+      },
+    );
+
+    // Bridge pages-renderer telemetry into the backend TelemetryService.
+    // Mirrors the `telemetry.capture` handler on the UI karton so internal
+    // pages (settings, account, etc.) can emit events through the same
+    // validation pipeline.
+    this.kartonServer.registerServerProcedureHandler(
+      'captureTelemetry',
+      async (
+        _callingClientId: string,
+        eventName: string,
+        properties?: Record<string, unknown>,
+      ): Promise<void> => {
+        if (!isUIEventName(eventName)) {
+          this.logger.warn(
+            `[PagesService] Ignoring unknown UI telemetry event: ${eventName}`,
+          );
+          return;
+        }
+        const parsedProperties = parseUIEventProperties(eventName, properties);
+        if (parsedProperties === null) {
+          this.logger.warn(
+            `[PagesService] Ignoring invalid UI telemetry payload for event: ${eventName}`,
+          );
+          return;
+        }
+        this.telemetryService.capture(eventName, parsedProperties);
       },
     );
 
@@ -1967,6 +1996,7 @@ export class PagesService extends DisposableService {
     this.kartonServer.removeServerProcedureHandler('getHistory');
     this.kartonServer.removeServerProcedureHandler('getFaviconBitmaps');
     this.kartonServer.removeServerProcedureHandler('openTab');
+    this.kartonServer.removeServerProcedureHandler('captureTelemetry');
     this.kartonServer.removeServerProcedureHandler('clearBrowsingData');
     this.kartonServer.removeServerProcedureHandler('getPendingEdits');
     this.kartonServer.removeServerProcedureHandler('acceptAllPendingEdits');

--- a/apps/browser/src/backend/services/telemetry.ts
+++ b/apps/browser/src/backend/services/telemetry.ts
@@ -59,6 +59,12 @@ export type EventProperties = {
      * is the first message in the chat.
      */
     ms_since_last_message?: number;
+    /**
+     * Tool approval mode configured on the agent at the moment this message
+     * is sent. `'alwaysAsk'` = prompt user for each tool call,
+     * `'alwaysAllow'` = auto-approve every tool call.
+     */
+    tool_approval_mode: 'alwaysAsk' | 'alwaysAllow';
   };
   'agent-message-queued': {
     agent_type: string;
@@ -99,11 +105,54 @@ export type EventProperties = {
   };
 
   // Tools
-  'tool-approved': { tool_name: string; agent_instance_id: string };
+  //
+  // All three lifecycle events carry `tool_call_id` (the approval's unique
+  // identifier, equal to the tool-call id) so the request, response, and
+  // any "always allow" shortcut can be linked downstream.
+  'tool-approval-requested': {
+    tool_name: string;
+    agent_instance_id: string;
+    tool_call_id: string;
+  };
+  'tool-approved': {
+    tool_name: string;
+    agent_instance_id: string;
+    tool_call_id: string;
+  };
   'tool-denied': {
     tool_name: string;
     reason?: string;
     agent_instance_id: string;
+    tool_call_id: string;
+  };
+  /**
+   * Fires whenever an agent's tool-approval mode actually changes.
+   * Emitted from the backend (`AgentManager.setToolApprovalMode`) so the
+   * single source of truth covers every UI surface. Skipped when the new
+   * mode equals the current mode (no-op calls are not logged).
+   *
+   * `source` identifies the UI entry point:
+   *   - `panel-combobox`: the persistent mode selector in the chat panel
+   *     (`ToolApprovalSelect`). Deliberate, typically preemptive.
+   *   - `inline-approval-button`: the "Always allow" button shown on an
+   *     active approval request card. Impulsive, reactive to a specific
+   *     tool call.
+   * `unknown` is used when a caller didn't specify a source (e.g.
+   *  programmatic agent-side updates, future call sites).
+   */
+  'tool-approval-mode-changed': {
+    agent_instance_id: string;
+    previous_mode: 'alwaysAsk' | 'alwaysAllow';
+    new_mode: 'alwaysAsk' | 'alwaysAllow';
+    source: 'panel-combobox' | 'inline-approval-button' | 'unknown';
+    /**
+     * When `source === 'inline-approval-button'`, the approval ID of the
+     * request the user was responding to. Lets us correlate the mode
+     * change with a specific `tool-approval-requested` event.
+     */
+    tool_call_id?: string;
+    /** Tool name for `inline-approval-button`; absent otherwise. */
+    tool_name?: string;
   };
   'tool-call-executed': {
     tool_name: string;

--- a/apps/browser/src/backend/services/telemetry.ts
+++ b/apps/browser/src/backend/services/telemetry.ts
@@ -276,6 +276,7 @@ export const UI_TELEMETRY_EVENT_NAMES = [
   'suggestion-clicked',
   'suggestion-dismissed',
   'tabs-cleaned',
+  'tool-approval-always-allowed',
   'workspace-connect-aborted',
   'workspace-connect-failed',
   'workspace-connect-finished',
@@ -323,6 +324,11 @@ const UI_TELEMETRY_EVENT_SCHEMAS = {
   }),
   'tabs-cleaned': z.object({
     closed_count: z.number(),
+  }),
+  'tool-approval-always-allowed': z.object({
+    tool_name: z.string(),
+    agent_instance_id: z.string(),
+    tool_call_id: z.string(),
   }),
   'workspace-connect-aborted': z.object({
     reason: z.enum(['picker-closed', 'suggestions-dismissed']),
@@ -595,7 +601,16 @@ export class TelemetryService extends DisposableService {
     this.logger.debug('[TelemetryService] Tearing down...');
     if (this.posthogClient) {
       try {
-        await this.pendingAppLaunchedCapture;
+        // Let the launch capture finish if it was about to, but never wait
+        // more than 250 ms. The launch snapshot itself already has a 1.5 s
+        // timeout, so an unbounded await here can push shutdown past the
+        // Electron close budget and prevent PostHog from flushing.
+        if (this.pendingAppLaunchedCapture) {
+          await Promise.race([
+            this.pendingAppLaunchedCapture,
+            new Promise<void>((resolve) => setTimeout(resolve, 250)),
+          ]);
+        }
 
         // Use a short timeout on close — we would rather lose the snapshot
         // than add up to 1.5 s to window-close latency.

--- a/apps/browser/src/backend/services/telemetry.ts
+++ b/apps/browser/src/backend/services/telemetry.ts
@@ -281,10 +281,7 @@ export type EventProperties = {
     had_validation_errors: boolean;
     any_field_touched: boolean;
   };
-  'custom-provider-add-started': {
-    /** Selected API spec (e.g. `openai-chat-completions`, `azure`). */
-    api_spec: string;
-  };
+  'custom-provider-add-started': undefined;
   'custom-provider-add-finished': {
     api_spec: string;
     /**
@@ -371,9 +368,7 @@ const UI_TELEMETRY_EVENT_SCHEMAS = {
     is_local: z.boolean().optional(),
     base_url: z.string().optional(),
   }),
-  'custom-provider-add-started': z.object({
-    api_spec: z.string(),
-  }),
+  'custom-provider-add-started': z.undefined().optional(),
   'element-selection-started': z.undefined().optional(),
   'element-selection-stopped': z.object({
     element_selected: z.boolean(),

--- a/apps/browser/src/backend/services/telemetry.ts
+++ b/apps/browser/src/backend/services/telemetry.ts
@@ -191,6 +191,10 @@ export type EventProperties = {
     suggestion_id: string;
     context: 'onboarding' | 'empty-chat';
   };
+  'suggestion-dismissed': {
+    suggestion_id: string;
+    context: 'onboarding' | 'empty-chat';
+  };
 
   // Usage limits
   'usage-limit-reached': {
@@ -270,6 +274,7 @@ export const UI_TELEMETRY_EVENT_NAMES = [
   'onboarding-demo-slide-clicked',
   'settings-opened',
   'suggestion-clicked',
+  'suggestion-dismissed',
   'tabs-cleaned',
   'workspace-connect-aborted',
   'workspace-connect-failed',
@@ -309,6 +314,10 @@ const UI_TELEMETRY_EVENT_SCHEMAS = {
   }),
   'settings-opened': z.undefined().optional(),
   'suggestion-clicked': z.object({
+    suggestion_id: z.string(),
+    context: z.enum(['onboarding', 'empty-chat']),
+  }),
+  'suggestion-dismissed': z.object({
     suggestion_id: z.string(),
     context: z.enum(['onboarding', 'empty-chat']),
   }),

--- a/apps/browser/src/backend/services/telemetry.ts
+++ b/apps/browser/src/backend/services/telemetry.ts
@@ -1,3 +1,4 @@
+import { z } from 'zod';
 import { PostHog } from 'posthog-node';
 import type { LanguageModelV3 } from '@ai-sdk/provider';
 import { withTracing } from '@posthog/ai';
@@ -6,11 +7,18 @@ import type { PreferencesService } from './preferences';
 import type { TelemetryLevel } from '@shared/karton-contracts/ui/shared-types';
 import type { Logger } from './logger';
 import { DisposableService } from './disposable';
+import { captureProcessSnapshot } from './telemetry/process-snapshot';
 
 export type EventProperties = {
   // Lifecycle
-  'app-launched': { cold_start: boolean };
-  'app-closed': undefined;
+  'app-launched': {
+    matched_process_counts: Record<string, number>;
+    total_matched_processes: number;
+  };
+  'app-closed': {
+    matched_process_counts: Record<string, number>;
+    total_matched_processes: number;
+  };
   'telemetry-level-changed': { from: TelemetryLevel; to: TelemetryLevel };
   'onboarding-completed': {
     skipped: boolean;
@@ -22,19 +30,50 @@ export type EventProperties = {
   };
 
   // Workspace
-  'workspace-mounted': { agent_type: string };
-  'workspace-unmounted': { agent_type: string };
+  'workspace-mounted': { agent_type: string; agent_instance_id: string };
+  'workspace-unmounted': { agent_type: string; agent_instance_id: string };
 
   // Agent
-  'agent-created': { agent_type: string; model_id: string };
+  'agent-created': {
+    agent_type: string;
+    agent_instance_id: string;
+    model_id: string;
+  };
   'agent-message-sent': {
     agent_type: string;
+    agent_instance_id: string;
     model_id: string;
     has_attachments: boolean;
     attachment_count: number;
+    slash_command_ids: string[];
+    slash_command_count: number;
+    connected_workspace_count: number;
+    /**
+     * True if this is the first user message in the chat (no prior user
+     * messages existed before this one was sent).
+     */
+    is_new_chat: boolean;
+    /**
+     * Milliseconds since the most recent message (user or agent) in history,
+     * measured at the moment this message is dispatched. Undefined when this
+     * is the first message in the chat.
+     */
+    ms_since_last_message?: number;
+  };
+  'agent-message-queued': {
+    agent_type: string;
+    agent_instance_id: string;
+    model_id: string;
+    queue_length_after: number;
+  };
+  'agent-queue-flushed': {
+    agent_type: string;
+    agent_instance_id: string;
+    flushed_message_count: number;
   };
   'agent-step-completed': {
     agent_type: string;
+    agent_instance_id: string;
     model_id: string;
     provider_mode: string;
     input_tokens: number;
@@ -43,21 +82,33 @@ export type EventProperties = {
     finish_reason: string;
     duration_ms: number;
   };
-  'agent-stopped': { agent_type: string };
-  'agent-resumed': { agent_type: string };
-  'agent-deleted': { agent_type: string };
+  'agent-stopped': {
+    agent_type: string;
+    agent_instance_id: string;
+    ms_since_last_user_message?: number;
+    ms_since_last_agent_message?: number;
+  };
+  'agent-resumed': { agent_type: string; agent_instance_id: string };
+  'agent-archived': { agent_type: string; agent_instance_id: string };
+  'agent-deleted': { agent_type: string; agent_instance_id: string };
   'agent-model-changed': {
     agent_type: string;
+    agent_instance_id: string;
     from_model: string;
     to_model: string;
   };
 
   // Tools
-  'tool-approved': { tool_name: string };
-  'tool-denied': { tool_name: string; reason?: string };
+  'tool-approved': { tool_name: string; agent_instance_id: string };
+  'tool-denied': {
+    tool_name: string;
+    reason?: string;
+    agent_instance_id: string;
+  };
   'tool-call-executed': {
     tool_name: string;
     agent_type: string;
+    agent_instance_id: string;
     model_id: string;
     success: boolean;
     error_message?: string;
@@ -118,9 +169,126 @@ export type EventProperties = {
     status_code?: number;
   };
 
-  // UI (routed via karton RPC)
-  'ui-interaction': { action: string; target: string; detail?: string };
+  // UI actions (routed via karton RPC from the renderer)
+  'devtools-opened': { tab_id?: string };
+  'devtools-closed': { tab_id?: string };
+  'tab-created': { tab_count_after: number };
+  'tab-destroyed': { tab_count_after: number };
+  'tabs-cleaned': { closed_count: number };
+  'tab-color-scheme-changed': { new_value: 'system' | 'light' | 'dark' };
+  'settings-opened': undefined;
+  'account-page-viewed': undefined;
+  'chat-sidebar-toggled': { new_value: 'open' | 'closed' };
+  'chat-new-agent-clicked': {
+    source: 'sidebar-top' | 'sidebar-active-agents' | 'hotkey';
+  };
+  'element-selection-started': undefined;
+  'element-selection-stopped': { element_selected: boolean };
+  'custom-model-add-started': undefined;
+  'custom-model-add-finished': undefined;
+  'custom-model-add-aborted': {
+    had_validation_errors: boolean;
+    any_field_touched: boolean;
+  };
+  'custom-provider-add-started': undefined;
+  'custom-provider-add-finished': undefined;
+  'custom-provider-add-aborted': {
+    had_validation_errors: boolean;
+    any_field_touched: boolean;
+  };
+  'workspace-connect-started': undefined;
+  'workspace-connect-finished': undefined;
+  'workspace-connect-aborted': {
+    reason: 'picker-closed' | 'suggestions-dismissed';
+  };
+  'workspace-connect-failed': {
+    source: 'picker' | 'recent-workspace';
+  };
 };
+
+export const UI_TELEMETRY_EVENT_NAMES = [
+  'account-page-viewed',
+  'chat-new-agent-clicked',
+  'chat-sidebar-toggled',
+  'custom-model-add-aborted',
+  'custom-model-add-finished',
+  'custom-model-add-started',
+  'custom-provider-add-aborted',
+  'custom-provider-add-finished',
+  'custom-provider-add-started',
+  'element-selection-started',
+  'element-selection-stopped',
+  'onboarding-demo-slide-clicked',
+  'settings-opened',
+  'suggestion-clicked',
+  'tabs-cleaned',
+  'workspace-connect-aborted',
+  'workspace-connect-failed',
+  'workspace-connect-finished',
+  'workspace-connect-started',
+] as const satisfies ReadonlyArray<keyof EventProperties>;
+
+export type UIEventName = (typeof UI_TELEMETRY_EVENT_NAMES)[number];
+export type UIEventProperties = Pick<EventProperties, UIEventName>;
+
+const UI_TELEMETRY_EVENT_SCHEMAS = {
+  'account-page-viewed': z.undefined().optional(),
+  'chat-new-agent-clicked': z.object({
+    source: z.enum(['sidebar-top', 'sidebar-active-agents', 'hotkey']),
+  }),
+  'chat-sidebar-toggled': z.object({
+    new_value: z.enum(['open', 'closed']),
+  }),
+  'custom-model-add-aborted': z.object({
+    had_validation_errors: z.boolean(),
+    any_field_touched: z.boolean(),
+  }),
+  'custom-model-add-finished': z.undefined().optional(),
+  'custom-model-add-started': z.undefined().optional(),
+  'custom-provider-add-aborted': z.object({
+    had_validation_errors: z.boolean(),
+    any_field_touched: z.boolean(),
+  }),
+  'custom-provider-add-finished': z.undefined().optional(),
+  'custom-provider-add-started': z.undefined().optional(),
+  'element-selection-started': z.undefined().optional(),
+  'element-selection-stopped': z.object({
+    element_selected: z.boolean(),
+  }),
+  'onboarding-demo-slide-clicked': z.object({
+    slide_name: z.string(),
+  }),
+  'settings-opened': z.undefined().optional(),
+  'suggestion-clicked': z.object({
+    suggestion_id: z.string(),
+    context: z.enum(['onboarding', 'empty-chat']),
+  }),
+  'tabs-cleaned': z.object({
+    closed_count: z.number(),
+  }),
+  'workspace-connect-aborted': z.object({
+    reason: z.enum(['picker-closed', 'suggestions-dismissed']),
+  }),
+  'workspace-connect-failed': z.object({
+    source: z.enum(['picker', 'recent-workspace']),
+  }),
+  'workspace-connect-finished': z.undefined().optional(),
+  'workspace-connect-started': z.undefined().optional(),
+} satisfies {
+  [K in UIEventName]: z.ZodType<UIEventProperties[K]>;
+};
+
+export function isUIEventName(eventName: string): eventName is UIEventName {
+  return (UI_TELEMETRY_EVENT_NAMES as readonly string[]).includes(eventName);
+}
+
+export function parseUIEventProperties<T extends UIEventName>(
+  eventName: T,
+  properties: unknown,
+): UIEventProperties[T] | null {
+  const result = UI_TELEMETRY_EVENT_SCHEMAS[eventName].safeParse(properties);
+  return result.success ? (result.data as UIEventProperties[T]) : null;
+}
 
 export interface UserProperties {
   user_id?: string;
@@ -136,6 +304,7 @@ export class TelemetryService extends DisposableService {
   private readonly preferencesService: PreferencesService;
   private readonly logger: Logger;
   private userProperties: UserProperties = {};
+  private pendingAppLaunchedCapture: Promise<void> | null = null;
   public posthogClient: PostHog;
 
   public constructor(
@@ -252,14 +421,39 @@ export class TelemetryService extends DisposableService {
     return wrappedModel;
   }
 
+  public captureAppLaunched(): void {
+    this.pendingAppLaunchedCapture = captureProcessSnapshot()
+      .then((launchProcessSnapshot) => {
+        this.captureSync('app-launched', {
+          matched_process_counts: launchProcessSnapshot.matched_process_counts,
+          total_matched_processes: launchProcessSnapshot.total_matched,
+        });
+      })
+      .finally(() => {
+        this.pendingAppLaunchedCapture = null;
+      });
+  }
+
   public capture<T extends keyof EventProperties>(
     eventName: T,
     properties?: EventProperties[T],
   ): void {
+    this.captureSync(eventName, properties);
+  }
+
+  private captureSync<T extends keyof EventProperties>(
+    eventName: T,
+    properties?: EventProperties[T],
+  ): void {
     try {
-      this.logger.debug(
-        `[TelemetryService] Capturing event: ${eventName} with properties: ${JSON.stringify(properties)}`,
-      );
+      // Guard the stringify — `capture` runs on every tracked event
+      // (including high-volume ones like tool-call-executed) and
+      // JSON.stringify is not free. Skip it when debug is disabled.
+      if (this.logger.isDebugEnabled) {
+        this.logger.debug(
+          `[TelemetryService] Capturing event: ${eventName} with properties: ${JSON.stringify(properties)}`,
+        );
+      }
       const telemetryLevel = this.getTelemetryLevel();
 
       // Always allow critical lifecycle events through so we can measure
@@ -301,6 +495,13 @@ export class TelemetryService extends DisposableService {
     error: Error,
     properties?: ExceptionProperties,
   ): void {
+    this.captureExceptionSync(error, properties);
+  }
+
+  private captureExceptionSync(
+    error: Error,
+    properties?: ExceptionProperties,
+  ): void {
     try {
       const telemetryLevel = this.getTelemetryLevel();
       if (telemetryLevel === 'off') return;
@@ -336,7 +537,19 @@ export class TelemetryService extends DisposableService {
     this.logger.debug('[TelemetryService] Tearing down...');
     if (this.posthogClient) {
       try {
-        this.capture('app-closed', undefined);
+        await this.pendingAppLaunchedCapture;
+
+        // Use a short timeout on close — we would rather lose the snapshot
+        // than add up to 1.5 s to window-close latency.
+        const snapshot = await captureProcessSnapshot(500);
+        // Bypass the microtask hop used by `capture()` so the event is
+        // enqueued into the PostHog client BEFORE `shutdown()` starts
+        // draining. Going through `queueMicrotask` here races shutdown and
+        // can drop `app-closed` entirely.
+        this.captureSync('app-closed', {
+          matched_process_counts: snapshot.matched_process_counts,
+          total_matched_processes: snapshot.total_matched,
+        });
         await this.posthogClient.shutdown();
       } catch (error) {
         this.logger.debug(`Failed to shutdown PostHog: ${error}`);

--- a/apps/browser/src/backend/services/telemetry.ts
+++ b/apps/browser/src/backend/services/telemetry.ts
@@ -310,7 +310,6 @@ export const UI_TELEMETRY_EVENT_NAMES = [
   'suggestion-clicked',
   'suggestion-dismissed',
   'tabs-cleaned',
-  'tool-approval-always-allowed',
   'workspace-connect-aborted',
   'workspace-connect-failed',
   'workspace-connect-finished',
@@ -367,11 +366,6 @@ const UI_TELEMETRY_EVENT_SCHEMAS = {
   }),
   'tabs-cleaned': z.object({
     closed_count: z.number(),
-  }),
-  'tool-approval-always-allowed': z.object({
-    tool_name: z.string(),
-    agent_instance_id: z.string(),
-    tool_call_id: z.string(),
   }),
   'workspace-connect-aborted': z.object({
     reason: z.enum(['picker-closed', 'suggestions-dismissed']),

--- a/apps/browser/src/backend/services/telemetry.ts
+++ b/apps/browser/src/backend/services/telemetry.ts
@@ -223,8 +223,20 @@ export type EventProperties = {
   };
 
   // UI actions (routed via karton RPC from the renderer)
-  'devtools-opened': { tab_id?: string };
-  'devtools-closed': { tab_id?: string };
+  'devtools-opened': {
+    tab_id?: string;
+    /** True when the tab's hostname is `localhost` or `127.0.0.1`. */
+    is_local?: boolean;
+    /** True when the tab's URL uses the `https:` protocol. */
+    is_https?: boolean;
+  };
+  'devtools-closed': {
+    tab_id?: string;
+    /** True when the tab's hostname is `localhost` or `127.0.0.1`. */
+    is_local?: boolean;
+    /** True when the tab's URL uses the `https:` protocol. */
+    is_https?: boolean;
+  };
   'tab-created': { tab_count_after: number };
   'tab-destroyed': { tab_count_after: number };
   'tabs-cleaned': { closed_count: number };
@@ -243,11 +255,33 @@ export type EventProperties = {
     had_validation_errors: boolean;
     any_field_touched: boolean;
   };
-  'custom-provider-add-started': undefined;
-  'custom-provider-add-finished': undefined;
+  'custom-provider-add-started': {
+    /** Selected API spec (e.g. `openai-chat-completions`, `azure`). */
+    api_spec: string;
+  };
+  'custom-provider-add-finished': {
+    api_spec: string;
+    /**
+     * True when the configured `baseUrl` hostname is `localhost` or
+     * `127.0.0.1`. Absent when the spec does not use a base URL
+     * (e.g. `amazon-bedrock`) or the field is empty.
+     */
+    is_local?: boolean;
+    /**
+     * Raw `baseUrl` as entered by the user. Only forwarded when the
+     * user has opted into `full` telemetry; omitted for `basic` and
+     * dropped entirely for `off`.
+     */
+    base_url?: string;
+  };
   'custom-provider-add-aborted': {
     had_validation_errors: boolean;
     any_field_touched: boolean;
+    api_spec: string;
+    /** See `custom-provider-add-finished` — same semantics. */
+    is_local?: boolean;
+    /** See `custom-provider-add-finished` — same semantics. */
+    base_url?: string;
   };
   'workspace-connect-started': undefined;
   'workspace-connect-finished': undefined;
@@ -303,9 +337,18 @@ const UI_TELEMETRY_EVENT_SCHEMAS = {
   'custom-provider-add-aborted': z.object({
     had_validation_errors: z.boolean(),
     any_field_touched: z.boolean(),
+    api_spec: z.string(),
+    is_local: z.boolean().optional(),
+    base_url: z.string().optional(),
   }),
-  'custom-provider-add-finished': z.undefined().optional(),
-  'custom-provider-add-started': z.undefined().optional(),
+  'custom-provider-add-finished': z.object({
+    api_spec: z.string(),
+    is_local: z.boolean().optional(),
+    base_url: z.string().optional(),
+  }),
+  'custom-provider-add-started': z.object({
+    api_spec: z.string(),
+  }),
   'element-selection-started': z.undefined().optional(),
   'element-selection-stopped': z.object({
     element_selected: z.boolean(),

--- a/apps/browser/src/backend/services/telemetry.ts
+++ b/apps/browser/src/backend/services/telemetry.ts
@@ -97,6 +97,32 @@ export type EventProperties = {
   'agent-resumed': { agent_type: string; agent_instance_id: string };
   'agent-archived': { agent_type: string; agent_instance_id: string };
   'agent-deleted': { agent_type: string; agent_instance_id: string };
+  /**
+   * Fires when a user manually renames an agent via the `agents.setTitle`
+   * RPC. Does NOT fire for auto-generated titles (those go through a
+   * separate path in `BaseAgent._performTitleGeneration` and don't touch
+   * this handler).
+   *
+   * `was_active` distinguishes renaming a currently loaded / open chat
+   * (live agent path) from renaming one in history (direct DB update).
+   * `new_title_length` lets us understand naming habits without
+   * transmitting the title itself.
+   *
+   * `agent_type` is only present on the active path — the inactive path
+   * doesn't hydrate the agent and so can't cheaply look up the type
+   * without an extra DB query.
+   *
+   * `new_title` is only attached when the user has opted into `full`
+   * telemetry. Length is always present so `basic` sessions still
+   * contribute a useful non-PII signal.
+   */
+  'agent-renamed': {
+    agent_instance_id: string;
+    was_active: boolean;
+    new_title_length: number;
+    agent_type?: string;
+    new_title?: string;
+  };
   'agent-model-changed': {
     agent_type: string;
     agent_instance_id: string;

--- a/apps/browser/src/backend/services/telemetry/process-snapshot.test.ts
+++ b/apps/browser/src/backend/services/telemetry/process-snapshot.test.ts
@@ -1,0 +1,240 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Mocking strategy: child_process.execFile is promisified inside the module
+// under test, so we mock the module itself to hand back deterministic stdout.
+// Every test starts from a pristine mock to avoid leaking stubs across cases.
+vi.mock('node:child_process', () => ({
+  execFile: vi.fn(),
+}));
+
+import { execFile } from 'node:child_process';
+import {
+  PROCESS_FILTER_TOKENS,
+  captureProcessSnapshot,
+} from './process-snapshot';
+
+const execFileMock = execFile as unknown as ReturnType<typeof vi.fn>;
+
+function mockPsStdout(lines: string[]) {
+  execFileMock.mockImplementation((_cmd, _args, _opts, cb) => {
+    // Node's execFile signature is execFile(file, args, opts, cb). When the
+    // promisified wrapper is used, it always supplies a callback.
+    cb?.(null, { stdout: lines.join('\n'), stderr: '' });
+  });
+}
+
+function mockExecFailure(err: Error) {
+  execFileMock.mockImplementation((_cmd, _args, _opts, cb) => {
+    cb?.(err, { stdout: '', stderr: String(err) });
+  });
+}
+
+const ORIGINAL_PLATFORM = process.platform;
+
+function setPlatform(value: NodeJS.Platform) {
+  Object.defineProperty(process, 'platform', {
+    value,
+    configurable: true,
+  });
+}
+
+describe('PROCESS_FILTER_TOKENS', () => {
+  it('is a non-empty, lower-cased, unique list', () => {
+    expect(PROCESS_FILTER_TOKENS.length).toBeGreaterThan(0);
+    for (const token of PROCESS_FILTER_TOKENS) {
+      expect(token).toBe(token.toLowerCase());
+    }
+    expect(new Set(PROCESS_FILTER_TOKENS).size).toBe(
+      PROCESS_FILTER_TOKENS.length,
+    );
+  });
+
+  it('includes the canonical AI/IDE tool tokens from the plan', () => {
+    const required = [
+      'cursor',
+      'claude',
+      'codex',
+      'vscode',
+      'zed',
+      'conductor',
+      'opencode',
+      'openwork',
+      'cowork',
+    ];
+    for (const token of required) {
+      expect(PROCESS_FILTER_TOKENS).toContain(token);
+    }
+  });
+});
+
+describe('captureProcessSnapshot (posix: ps)', () => {
+  beforeEach(() => {
+    setPlatform('darwin');
+    execFileMock.mockReset();
+  });
+
+  afterEach(() => {
+    setPlatform(ORIGINAL_PLATFORM);
+  });
+
+  it('returns empty counts when no process matches any token', async () => {
+    mockPsStdout(['bash', 'node', 'zsh', 'kernel_task']);
+
+    const snap = await captureProcessSnapshot();
+
+    expect(snap).toEqual({ matched_process_counts: {}, total_matched: 0 });
+  });
+
+  it('counts multiple matches per token', async () => {
+    mockPsStdout([
+      'Cursor',
+      '/Applications/Cursor.app/Contents/MacOS/Cursor Helper (Renderer)',
+      'Claude',
+      'zsh',
+    ]);
+
+    const snap = await captureProcessSnapshot();
+
+    expect(snap.matched_process_counts.cursor).toBe(2);
+    expect(snap.matched_process_counts.claude).toBe(1);
+    expect(snap.total_matched).toBe(3);
+  });
+
+  it('matches case-insensitively on the basename only', async () => {
+    // The full path contains "cursor" as a directory segment. We must match
+    // the basename ("vim"), NOT the directory, otherwise every file under
+    // ~/cursor-project would count.
+    mockPsStdout(['/Users/alice/cursor-project/bin/vim']);
+
+    const snap = await captureProcessSnapshot();
+
+    expect(snap.total_matched).toBe(0);
+    expect(snap.matched_process_counts).toEqual({});
+  });
+
+  it('counts each process once using the first matching token', async () => {
+    mockPsStdout(['vscode-helper', 'opencode']);
+
+    const snap = await captureProcessSnapshot();
+
+    expect(snap.matched_process_counts.vscode).toBe(1);
+    expect(snap.matched_process_counts.opencode).toBe(1);
+    expect(snap.total_matched).toBe(2);
+  });
+
+  it('does not match unrelated process names that merely contain code-like substrings', async () => {
+    mockPsStdout(['Xcode', 'AppCode', 'xcodebuild', 'StatusMenuBarHelper']);
+
+    const snap = await captureProcessSnapshot();
+
+    expect(snap).toEqual({ matched_process_counts: {}, total_matched: 0 });
+  });
+
+  it('ignores blank lines and trims whitespace', async () => {
+    mockPsStdout(['', '   Claude   ', '', '\t', 'zsh']);
+
+    const snap = await captureProcessSnapshot();
+
+    expect(snap.matched_process_counts.claude).toBe(1);
+    expect(snap.total_matched).toBe(1);
+  });
+
+  it('returns an empty snapshot when execFile fails', async () => {
+    mockExecFailure(new Error('spawn EACCES'));
+
+    const snap = await captureProcessSnapshot();
+
+    expect(snap).toEqual({ matched_process_counts: {}, total_matched: 0 });
+  });
+
+  it('never throws even on malformed stdout', async () => {
+    mockPsStdout([null as unknown as string]);
+
+    await expect(captureProcessSnapshot()).resolves.toEqual({
+      matched_process_counts: {},
+      total_matched: 0,
+    });
+  });
+
+  it('passes the configured timeout through to execFile', async () => {
+    mockPsStdout(['zsh']);
+
+    await captureProcessSnapshot(500);
+
+    expect(execFileMock).toHaveBeenCalledTimes(1);
+    const opts = execFileMock.mock.calls[0][2] as { timeout: number };
+    expect(opts.timeout).toBe(500);
+  });
+
+  it('defaults to a 1500ms timeout when no override is given', async () => {
+    mockPsStdout(['zsh']);
+
+    await captureProcessSnapshot();
+
+    const opts = execFileMock.mock.calls[0][2] as { timeout: number };
+    expect(opts.timeout).toBe(1500);
+  });
+
+  it('uses ps -Ao comm= on non-Windows platforms', async () => {
+    mockPsStdout(['zsh']);
+
+    await captureProcessSnapshot();
+
+    const [cmd, args] = execFileMock.mock.calls[0];
+    expect(cmd).toBe('ps');
+    expect(args).toEqual(['-Ao', 'comm=']);
+  });
+});
+
+describe('captureProcessSnapshot (win32: tasklist)', () => {
+  beforeEach(() => {
+    setPlatform('win32');
+    execFileMock.mockReset();
+  });
+
+  afterEach(() => {
+    setPlatform(ORIGINAL_PLATFORM);
+  });
+
+  it('parses CSV output from tasklist', async () => {
+    // tasklist's /fo csv /nh output format:
+    //   "image name","pid","session","session#","mem"
+    const csv = [
+      '"System Idle Process","0","Services","0","8 K"',
+      '"Cursor.exe","1234","Console","1","128,000 K"',
+      '"Code.exe","5678","Console","1","64,000 K"',
+      '"chrome.exe","9999","Console","1","200,000 K"',
+    ];
+    mockPsStdout(csv);
+
+    const snap = await captureProcessSnapshot();
+
+    expect(snap.matched_process_counts.cursor).toBe(1);
+    expect(snap.matched_process_counts.vscode).toBeUndefined();
+    expect(snap.matched_process_counts.zed).toBeUndefined();
+    expect(snap.total_matched).toBe(1);
+  });
+
+  it('uses tasklist /fo csv /nh on win32', async () => {
+    mockPsStdout([]);
+
+    await captureProcessSnapshot();
+
+    const [cmd, args] = execFileMock.mock.calls[0];
+    expect(cmd).toBe('tasklist');
+    expect(args).toEqual(['/fo', 'csv', '/nh']);
+  });
+
+  it('skips rows that do not begin with a quoted image name', async () => {
+    mockPsStdout([
+      'not,a,quoted,row',
+      '"Claude.exe","1","Console","1","1 K"',
+      '',
+    ]);
+
+    const snap = await captureProcessSnapshot();
+
+    expect(snap.total_matched).toBe(1);
+    expect(snap.matched_process_counts.claude).toBe(1);
+  });
+});

--- a/apps/browser/src/backend/services/telemetry/process-snapshot.ts
+++ b/apps/browser/src/backend/services/telemetry/process-snapshot.ts
@@ -1,0 +1,100 @@
+import { execFile } from 'node:child_process';
+import path from 'node:path';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * Anonymised filter of executable name fragments that we track in telemetry
+ * on app launch / close. Matching is case-insensitive substring against the
+ * lower-cased basename of each running process. The list is ordered and only
+ * the first matching token is counted for any given process, which avoids
+ * double-counting overlapping substrings. We intentionally report counts
+ * keyed by the filter token (not the real executable name) so this event
+ * cannot leak the user's installed binaries.
+ */
+export const PROCESS_FILTER_TOKENS = [
+  'cursor',
+  'claude',
+  'codex',
+  'vscode',
+  'zed',
+  'conductor',
+  'opencode',
+  'openwork',
+  'cowork',
+] as const;
+
+export interface ProcessSnapshot {
+  matched_process_counts: Record<string, number>;
+  total_matched: number;
+}
+
+const EMPTY_SNAPSHOT: ProcessSnapshot = {
+  matched_process_counts: {},
+  total_matched: 0,
+};
+
+/**
+ * Capture a snapshot of running processes on the host, filtered down to an
+ * allowlist of AI/IDE tools. Never throws — returns an empty snapshot on
+ * any failure or timeout. Platform-native process listing is used:
+ * `tasklist` on Windows, `ps -Ao comm=` elsewhere.
+ */
+export async function captureProcessSnapshot(
+  timeoutMs = 1500,
+): Promise<ProcessSnapshot> {
+  try {
+    const lines = await listProcessNames(timeoutMs);
+    return countMatches(lines);
+  } catch {
+    return EMPTY_SNAPSHOT;
+  }
+}
+
+async function listProcessNames(timeoutMs: number): Promise<string[]> {
+  if (process.platform === 'win32') {
+    const { stdout } = await execFileAsync('tasklist', ['/fo', 'csv', '/nh'], {
+      timeout: timeoutMs,
+      windowsHide: true,
+      maxBuffer: 4 * 1024 * 1024,
+    });
+    // CSV rows look like: "image.exe","1234","Services","0","1,234 K"
+    return stdout
+      .split(/\r?\n/)
+      .map((row) => {
+        const match = row.match(/^"([^"]+)"/);
+        return match ? match[1] : '';
+      })
+      .filter((name) => name.length > 0);
+  }
+
+  const { stdout } = await execFileAsync('ps', ['-Ao', 'comm='], {
+    timeout: timeoutMs,
+    maxBuffer: 4 * 1024 * 1024,
+  });
+  return stdout
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+}
+
+function countMatches(lines: string[]): ProcessSnapshot {
+  const counts: Record<string, number> = {};
+  let total = 0;
+  for (const raw of lines) {
+    const basename = path.basename(raw).toLowerCase();
+    if (!basename) continue;
+
+    const token = findMatchingToken(basename);
+    if (!token) continue;
+
+    counts[token] = (counts[token] ?? 0) + 1;
+    total += 1;
+  }
+  return { matched_process_counts: counts, total_matched: total };
+}
+
+function findMatchingToken(basename: string) {
+  return PROCESS_FILTER_TOKENS.find((token) => basename.includes(token));
+}

--- a/apps/browser/src/backend/services/toolbox/services/mount-manager/index.ts
+++ b/apps/browser/src/backend/services/toolbox/services/mount-manager/index.ts
@@ -285,6 +285,7 @@ export class MountManagerService extends DisposableService {
       this.uiKarton.state.agents.instances[agentInstanceId]?.type ?? 'unknown';
     this.telemetryService.capture('workspace-mounted', {
       agent_type: agentType,
+      agent_instance_id: agentInstanceId,
     });
   }
 
@@ -309,6 +310,7 @@ export class MountManagerService extends DisposableService {
     this.onMountsChanged?.(agentInstanceId);
     this.telemetryService.capture('workspace-unmounted', {
       agent_type: agentType,
+      agent_instance_id: agentInstanceId,
     });
   }
 

--- a/apps/browser/src/backend/services/window-layout/index.ts
+++ b/apps/browser/src/backend/services/window-layout/index.ts
@@ -55,6 +55,29 @@ const windowStateSchema = z.object({
 
 type WindowState = z.infer<typeof windowStateSchema>;
 
+/**
+ * Anonymous URL classification for telemetry. Returns coarse booleans
+ * (`isLocal`, `isHttps`) without exposing the host or path, so events can
+ * be segmented (e.g. prod-domain vs local-dev devtools usage) without
+ * leaking PII. Malformed URLs and non-http(s) schemes (about:, file:,
+ * internal://) all resolve to `{ isLocal: false, isHttps: false }`.
+ */
+function classifyTabUrl(url: string): {
+  isLocal: boolean;
+  isHttps: boolean;
+} {
+  if (!url) return { isLocal: false, isHttps: false };
+  try {
+    const parsed = new URL(url);
+    const isLocal =
+      parsed.hostname === 'localhost' || parsed.hostname === '127.0.0.1';
+    const isHttps = parsed.protocol === 'https:';
+    return { isLocal, isHttps };
+  } catch {
+    return { isLocal: false, isHttps: false };
+  }
+}
+
 export class WindowLayoutService extends DisposableService {
   private readonly logger: Logger;
   private readonly historyService: HistoryService;
@@ -937,11 +960,25 @@ export class WindowLayoutService extends DisposableService {
     });
 
     tab.on('devtoolsOpened', (tabId: string) => {
-      this.telemetryService?.capture('devtools-opened', { tab_id: tabId });
+      const { isLocal, isHttps } = classifyTabUrl(
+        tab.getViewContainer().webContents.getURL(),
+      );
+      this.telemetryService?.capture('devtools-opened', {
+        tab_id: tabId,
+        is_local: isLocal,
+        is_https: isHttps,
+      });
     });
 
     tab.on('devtoolsClosed', (tabId: string) => {
-      this.telemetryService?.capture('devtools-closed', { tab_id: tabId });
+      const { isLocal, isHttps } = classifyTabUrl(
+        tab.getViewContainer().webContents.getURL(),
+      );
+      this.telemetryService?.capture('devtools-closed', {
+        tab_id: tabId,
+        is_local: isLocal,
+        is_https: isHttps,
+      });
     });
 
     // Listen for webContents destroyed event to handle external tab closure

--- a/apps/browser/src/backend/services/window-layout/index.ts
+++ b/apps/browser/src/backend/services/window-layout/index.ts
@@ -871,6 +871,7 @@ export class WindowLayoutService extends DisposableService {
         void this.handleCreateTab(resolvedUrl, setActive, id);
       },
       this.thumbnailService ?? undefined,
+      this.telemetryService ?? undefined,
     );
 
     // Subscribe to state updates
@@ -933,6 +934,14 @@ export class WindowLayoutService extends DisposableService {
 
     tab.on('contentFullscreenChanged', (isFullscreen: boolean) => {
       this.handleContentFullscreenChanged(id, isFullscreen);
+    });
+
+    tab.on('devtoolsOpened', (tabId: string) => {
+      this.telemetryService?.capture('devtools-opened', { tab_id: tabId });
+    });
+
+    tab.on('devtoolsClosed', (tabId: string) => {
+      this.telemetryService?.capture('devtools-closed', { tab_id: tabId });
     });
 
     // Listen for webContents destroyed event to handle external tab closure
@@ -1005,6 +1014,10 @@ export class WindowLayoutService extends DisposableService {
     tab.setVisible(false);
     this.baseWindow!.contentView.addChildView(tab.getViewContainer());
 
+    this.telemetryService?.capture('tab-created', {
+      tab_count_after: Object.keys(this.tabs).length,
+    });
+
     // Reinforce z-order after adding new tab view to ensure UI webcontent stays on top
     // (or tab content if isWebContentInteractive is true)
     this.updateZOrder();
@@ -1043,6 +1056,10 @@ export class WindowLayoutService extends DisposableService {
       // Clean up Karton state
       this.uiKarton.setState((draft) => {
         delete draft.browser.tabs[tabId];
+      });
+
+      this.telemetryService?.capture('tab-destroyed', {
+        tab_count_after: Object.keys(this.tabs).length,
       });
 
       if (isActiveTab) {

--- a/apps/browser/src/backend/services/window-layout/tab-controller.ts
+++ b/apps/browser/src/backend/services/window-layout/tab-controller.ts
@@ -33,6 +33,7 @@ import {
 import type { HistoryService } from '../history';
 import type { FaviconService } from '../favicon';
 import type { ThumbnailService } from '../thumbnail';
+import type { TelemetryService } from '../telemetry';
 import {
   canBrowserHandleUrl,
   openFolderFirstFileInIde,
@@ -147,6 +148,8 @@ export interface TabControllerEventMap {
     },
   ];
   contentFullscreenChanged: [isFullscreen: boolean];
+  devtoolsOpened: [tabId: string];
+  devtoolsClosed: [tabId: string];
 }
 
 export class TabController extends EventEmitter<TabControllerEventMap> {
@@ -157,6 +160,7 @@ export class TabController extends EventEmitter<TabControllerEventMap> {
   private historyService: HistoryService;
   private faviconService: FaviconService;
   private thumbnailService: ThumbnailService | null = null;
+  private readonly telemetryService: TelemetryService | null;
   private kartonServer: KartonServer<TabKartonContract>;
   private kartonTransport: ElectronServerTransport;
   private selectedElementTracker: SelectedElementTracker;
@@ -275,6 +279,7 @@ export class TabController extends EventEmitter<TabControllerEventMap> {
       sourceTabId?: string,
     ) => void,
     thumbnailService?: ThumbnailService,
+    telemetryService?: TelemetryService,
   ) {
     super();
     this.id = id;
@@ -285,6 +290,7 @@ export class TabController extends EventEmitter<TabControllerEventMap> {
     this.searchUtilsConfig = searchUtilsConfig;
     this.onCreateTab = onCreateTab;
     this.thumbnailService = thumbnailService ?? null;
+    this.telemetryService = telemetryService ?? null;
 
     this.webContentsView = new WebContentsView({
       webPreferences: {
@@ -301,25 +307,6 @@ export class TabController extends EventEmitter<TabControllerEventMap> {
     this.kartonTransport = new ElectronServerTransport();
 
     // Forward keydown events when dev tools are opened
-    this.webContentsView.webContents.addListener('devtools-opened', () => {
-      this.webContentsView.webContents.devToolsWebContents?.addListener(
-        'input-event',
-        (_e, input) => {
-          const domEvent = electronInputToDomKeyboardEvent(input as Input);
-          if (input.type === 'keyDown' || input.type === 'rawKeyDown') {
-            const hotkeyDef = getHotkeyDefinitionForEvent(domEvent);
-            if (hotkeyDef?.captureDominantly)
-              this.emit('handleKeyDown', domEvent);
-          }
-        },
-      );
-      this.webContentsView.webContents.devToolsWebContents?.addListener(
-        'focus',
-        () => {
-          this.emit('tabFocused', this.id);
-        },
-      );
-    });
 
     this.kartonServer = createKartonServer<TabKartonContract>({
       initialState: defaultState,
@@ -777,13 +764,13 @@ export class TabController extends EventEmitter<TabControllerEventMap> {
     return Math.round(factor * 100);
   }
 
-  public async setColorScheme(scheme: ColorScheme) {
+  public async setColorScheme(scheme: ColorScheme): Promise<boolean> {
     const wc = this.webContentsView.webContents;
 
     // Debugger already attached by SelectedElementTracker
     if (!wc.debugger.isAttached()) {
       this.logger.error('Debugger not attached for color scheme');
-      return;
+      return false;
     }
 
     try {
@@ -802,8 +789,10 @@ export class TabController extends EventEmitter<TabControllerEventMap> {
       });
 
       this.updateState({ colorScheme: scheme });
+      return true;
     } catch (err) {
       this.logger.error(`Failed to set color scheme: ${err}`);
+      return false;
     }
   }
 
@@ -811,7 +800,13 @@ export class TabController extends EventEmitter<TabControllerEventMap> {
     const schemes: ColorScheme[] = ['system', 'dark', 'light'];
     const currentIndex = schemes.indexOf(this.currentState.colorScheme);
     const nextScheme = schemes[(currentIndex + 1) % schemes.length];
-    await this.setColorScheme(nextScheme);
+    const didSetColorScheme = await this.setColorScheme(nextScheme);
+
+    if (didSetColorScheme) {
+      this.telemetryService?.capture('tab-color-scheme-changed', {
+        new_value: nextScheme,
+      });
+    }
   }
 
   public focus() {
@@ -1478,6 +1473,7 @@ export class TabController extends EventEmitter<TabControllerEventMap> {
     });
 
     wc.on('devtools-closed', async () => {
+      this.emit('devtoolsClosed', this.id);
       this.updateState({
         devTools: { open: this.currentState.devTools.open, chromeOpen: false },
       });
@@ -1494,8 +1490,20 @@ export class TabController extends EventEmitter<TabControllerEventMap> {
     });
 
     wc.on('devtools-opened', () => {
+      this.emit('devtoolsOpened', this.id);
       this.updateState({
         devTools: { open: this.currentState.devTools.open, chromeOpen: true },
+      });
+      wc.devToolsWebContents?.addListener('input-event', (_e, input) => {
+        const domEvent = electronInputToDomKeyboardEvent(input as Input);
+        if (input.type === 'keyDown' || input.type === 'rawKeyDown') {
+          const hotkeyDef = getHotkeyDefinitionForEvent(domEvent);
+          if (hotkeyDef?.captureDominantly)
+            this.emit('handleKeyDown', domEvent);
+        }
+      });
+      wc.devToolsWebContents?.addListener('focus', () => {
+        this.emit('tabFocused', this.id);
       });
       // Attach debugger after a short delay to ensure devToolsWebContents is ready
       setTimeout(() => {

--- a/apps/browser/src/pages/hooks/use-track.ts
+++ b/apps/browser/src/pages/hooks/use-track.ts
@@ -1,0 +1,59 @@
+import { useCallback, useRef } from 'react';
+import { useKartonProcedure } from './use-karton';
+
+/**
+ * Hook that returns a `track(eventName, properties?)` function for the pages
+ * renderer, which forwards UI telemetry to the backend via the pages-API
+ * `captureTelemetry` procedure.
+ *
+ * ## Stability guarantee
+ *
+ * The returned `track` function has a stable identity across renders (it
+ * never changes for the lifetime of the component). This is essential
+ * because callers frequently include `track` in `useEffect` dep arrays to
+ * satisfy the exhaustive-deps rule. If the identity changed per render,
+ * those effects would re-run every render and any one-shot
+ * fire-once-on-mount telemetry (e.g. `*-add-started`) would loop.
+ *
+ * We cannot rely on `useKartonProcedure` returning a stable reference:
+ * Karton's procedure selector is memoized against the selector function
+ * identity, and callers pass a fresh arrow `(p) => p.captureTelemetry`
+ * per render, so the memoization invalidates every render and the proxy
+ * accessor returns a newly-constructed Proxy each time. We pin the latest
+ * capture function on a ref and dispatch through it.
+ *
+ * ## Error safety
+ *
+ * Any RPC failure (backend karton server unavailable, handler not yet
+ * registered, transport error) is silently swallowed. Telemetry must
+ * never surface as an unhandled rejection or bubble into React error
+ * boundaries.
+ *
+ * Mirrors the contract of the sidebar's `useTrack` hook, but uses the
+ * pages-API karton contract instead of the UI karton contract, because
+ * pages run under a different preload.
+ */
+export function useTrack() {
+  const capture = useKartonProcedure((p) => p.captureTelemetry);
+
+  // Keep the latest `capture` proxy accessible without changing the
+  // identity of the returned `track` function.
+  const captureRef = useRef(capture);
+  captureRef.current = capture;
+
+  // Empty deps: stable identity for the component's lifetime. The ref
+  // above ensures we still call the latest `capture` proxy each invocation.
+  return useCallback(
+    (eventName: string, properties?: Record<string, unknown>): void => {
+      // Fire-and-forget. We intentionally do not await and we explicitly
+      // catch, so a failed RPC (server unavailable, handler not registered,
+      // transport error) cannot crash the page.
+      void Promise.resolve()
+        .then(() => captureRef.current(eventName, properties))
+        .catch(() => {
+          // Telemetry failures are intentionally silent.
+        });
+    },
+    [],
+  );
+}

--- a/apps/browser/src/pages/routes/_internal-app/account.tsx
+++ b/apps/browser/src/pages/routes/_internal-app/account.tsx
@@ -32,6 +32,17 @@ function Page() {
   const sendOtp = useKartonProcedure((p) => p.sendOtp);
   const verifyOtp = useKartonProcedure((p) => p.verifyOtp);
   const logout = useKartonProcedure((p) => p.logout);
+  const track = useKartonProcedure((p) => p.telemetry.capture);
+
+  // Fire once per mounted route instance. The ref guard prevents React
+  // StrictMode's development double-invocation; intentional route remounts
+  // should still emit a fresh page-view event.
+  const didTrackViewRef = useRef(false);
+  useEffect(() => {
+    if (didTrackViewRef.current) return;
+    didTrackViewRef.current = true;
+    void track('account-page-viewed');
+  }, [track]);
 
   return (
     <div className="flex h-full w-full flex-col">

--- a/apps/browser/src/pages/routes/_internal-app/account.tsx
+++ b/apps/browser/src/pages/routes/_internal-app/account.tsx
@@ -4,6 +4,7 @@ import { Checkbox } from '@stagewise/stage-ui/components/checkbox';
 import { Input } from '@stagewise/stage-ui/components/input';
 import { InputOtp } from '@stagewise/stage-ui/components/input-otp';
 import { useKartonState, useKartonProcedure } from '@pages/hooks/use-karton';
+import { useTrack } from '@pages/hooks/use-track';
 import { useState, useCallback, useRef, useEffect } from 'react';
 import { OverlayScrollbar } from '@stagewise/stage-ui/components/overlay-scrollbar';
 import { cn } from '@pages/utils';
@@ -32,7 +33,9 @@ function Page() {
   const sendOtp = useKartonProcedure((p) => p.sendOtp);
   const verifyOtp = useKartonProcedure((p) => p.verifyOtp);
   const logout = useKartonProcedure((p) => p.logout);
-  const track = useKartonProcedure((p) => p.telemetry.capture);
+  // `useTrack` swallows RPC errors so a failed telemetry capture (e.g.
+  // backend karton server unavailable) cannot crash the page.
+  const track = useTrack();
 
   // Fire once per mounted route instance. The ref guard prevents React
   // StrictMode's development double-invocation; intentional route remounts
@@ -41,7 +44,7 @@ function Page() {
   useEffect(() => {
     if (didTrackViewRef.current) return;
     didTrackViewRef.current = true;
-    void track('account-page-viewed');
+    track('account-page-viewed');
   }, [track]);
 
   return (

--- a/apps/browser/src/pages/routes/_internal-app/agent-settings.custom-providers.tsx
+++ b/apps/browser/src/pages/routes/_internal-app/agent-settings.custom-providers.tsx
@@ -1,8 +1,9 @@
 import { createFileRoute, useNavigate } from '@tanstack/react-router';
 import { OverlayScrollbar } from '@stagewise/stage-ui/components/overlay-scrollbar';
 import { useKartonState, useKartonProcedure } from '@pages/hooks/use-karton';
+import { useTrack } from '@pages/hooks/use-track';
 import { useEffect, useRef, useState, useCallback } from 'react';
-import { useTrack } from '@ui/hooks/use-track';
+
 import type {
   ApiSpec,
   CustomEndpoint,
@@ -302,7 +303,17 @@ function CustomEndpointDialog({
   onOpenChange: (open: boolean) => void;
   onSave: (data: EndpointSaveData) => void;
 }) {
+  // Pages run under a different preload than the sidebar UI, so we cannot
+  // import `@ui/hooks/use-track` here (it reaches for `window.electron`).
+  // `useTrack` from the pages hooks routes through the pages-API
+  // `captureTelemetry` bridge and swallows RPC errors so a failed capture
+  // can never crash the page.
   const track = useTrack();
+  // `telemetryLevel` gates whether the raw `baseUrl` is forwarded. At
+  // `full` the user has consented to detailed analytics; at `basic` we
+  // keep the event but redact the URL; at `off` the backend drops the
+  // event entirely and this check is moot.
+  const telemetryLevel = useKartonState((s) => s.globalConfig.telemetryLevel);
   const isAddMode = !endpoint;
   // Set to true when onSave() fires; distinguishes a save-initiated close
   // from a cancel/dismiss close inside the shared `handleDialogOpenChange`.
@@ -352,7 +363,13 @@ function CustomEndpointDialog({
       setGoogleCredentials('');
       savedRef.current = false;
       if (isAddMode) {
-        void track('custom-provider-add-started');
+        // Fires on dialog open in add mode — report the *initial* spec so
+        // the started event is emitted before the user changes anything.
+        // We can't read `apiSpec` state here because `setApiSpec` above
+        // is not yet flushed.
+        track('custom-provider-add-started', {
+          api_spec: 'openai-chat-completions',
+        });
       }
     }
   }, [open, endpoint, isAddMode, track]);
@@ -381,11 +398,50 @@ function CustomEndpointDialog({
     location !== (endpoint?.location ?? '') ||
     googleCredentials !== '';
 
+  // A pristine, unmodified form is NOT an error — an empty required
+  // `name` field at initial state means "not filled in yet", not
+  // "validation failed". `had_validation_errors` should only be true when
+  // the user entered input that triggered a concrete validation rule
+  // (currently: invalid JSON in the model-id mapping).
+  const hadValidationErrors = mappingError !== null;
+
+  /**
+   * Build the provider-URL-related telemetry properties for the current
+   * form state. Keeps the three add-* events consistent:
+   *
+   * - `api_spec` always present — coarse selector useful for funnel splits.
+   * - `is_local` present only when a `baseUrl` was entered (so absence
+   *   distinguishes "empty field" from "non-local URL").
+   * - `base_url` present only when telemetry is set to `full` AND the
+   *   field is non-empty; we do not transmit URLs on `basic`.
+   */
+  const buildUrlProps = (): {
+    api_spec: string;
+    is_local?: boolean;
+    base_url?: string;
+  } => {
+    const trimmed = baseUrl.trim();
+    if (!trimmed) return { api_spec: apiSpec };
+    let isLocal: boolean | undefined;
+    try {
+      const host = new URL(trimmed).hostname;
+      isLocal = host === 'localhost' || host === '127.0.0.1';
+    } catch {
+      isLocal = undefined;
+    }
+    return {
+      api_spec: apiSpec,
+      ...(isLocal !== undefined && { is_local: isLocal }),
+      ...(telemetryLevel === 'full' && { base_url: trimmed }),
+    };
+  };
+
   const handleDialogOpenChange = (next: boolean) => {
     if (!next && open && isAddMode && !savedRef.current) {
-      void track('custom-provider-add-aborted', {
-        had_validation_errors: !canSave,
+      track('custom-provider-add-aborted', {
+        had_validation_errors: hadValidationErrors,
         any_field_touched: anyFieldTouched,
+        ...buildUrlProps(),
       });
     }
     onOpenChange(next);
@@ -506,7 +562,7 @@ function CustomEndpointDialog({
                 googleCredentials: googleCredentials || undefined,
               });
               if (isAddMode) {
-                void track('custom-provider-add-finished');
+                track('custom-provider-add-finished', buildUrlProps());
               }
               savedRef.current = true;
               onOpenChange(false);

--- a/apps/browser/src/pages/routes/_internal-app/agent-settings.custom-providers.tsx
+++ b/apps/browser/src/pages/routes/_internal-app/agent-settings.custom-providers.tsx
@@ -1,7 +1,8 @@
 import { createFileRoute, useNavigate } from '@tanstack/react-router';
 import { OverlayScrollbar } from '@stagewise/stage-ui/components/overlay-scrollbar';
 import { useKartonState, useKartonProcedure } from '@pages/hooks/use-karton';
-import { useEffect, useState, useCallback } from 'react';
+import { useEffect, useRef, useState, useCallback } from 'react';
+import { useTrack } from '@ui/hooks/use-track';
 import type {
   ApiSpec,
   CustomEndpoint,
@@ -301,6 +302,12 @@ function CustomEndpointDialog({
   onOpenChange: (open: boolean) => void;
   onSave: (data: EndpointSaveData) => void;
 }) {
+  const track = useTrack();
+  const isAddMode = !endpoint;
+  // Set to true when onSave() fires; distinguishes a save-initiated close
+  // from a cancel/dismiss close inside the shared `handleDialogOpenChange`.
+  const savedRef = useRef(false);
+
   const [name, setName] = useState(endpoint?.name ?? '');
   const [apiSpec, setApiSpec] = useState<ApiSpec>(
     endpoint?.apiSpec ?? 'openai-chat-completions',
@@ -343,13 +350,49 @@ function CustomEndpointDialog({
       setProjectId(endpoint?.projectId ?? '');
       setLocation(endpoint?.location ?? '');
       setGoogleCredentials('');
+      savedRef.current = false;
+      if (isAddMode) {
+        void track('custom-provider-add-started');
+      }
     }
-  }, [open, endpoint]);
+  }, [open, endpoint, isAddMode, track]);
 
   const canSave = name.trim().length > 0 && !mappingError;
 
+  // "Touched" = the user changed anything from the initial field values.
+  // Derived from current state so we don't need per-input bookkeeping.
+  // Secret-ish fields (apiKey, secretKey, googleCredentials) start empty in
+  // edit-mode by design; any non-empty value is a touch.
+  const anyFieldTouched =
+    name !== (endpoint?.name ?? '') ||
+    apiSpec !== (endpoint?.apiSpec ?? 'openai-chat-completions') ||
+    baseUrl !== (endpoint?.baseUrl ?? '') ||
+    apiKey !== '' ||
+    modelIdMappingJson !==
+      (endpoint?.modelIdMapping &&
+      Object.keys(endpoint.modelIdMapping).length > 0
+        ? JSON.stringify(endpoint.modelIdMapping, null, 2)
+        : '') ||
+    resourceName !== (endpoint?.resourceName ?? '') ||
+    apiVersion !== (endpoint?.apiVersion ?? '') ||
+    region !== (endpoint?.region ?? '') ||
+    secretKey !== '' ||
+    projectId !== (endpoint?.projectId ?? '') ||
+    location !== (endpoint?.location ?? '') ||
+    googleCredentials !== '';
+
+  const handleDialogOpenChange = (next: boolean) => {
+    if (!next && open && isAddMode && !savedRef.current) {
+      void track('custom-provider-add-aborted', {
+        had_validation_errors: !canSave,
+        any_field_touched: anyFieldTouched,
+      });
+    }
+    onOpenChange(next);
+  };
+
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog open={open} onOpenChange={handleDialogOpenChange}>
       <DialogContent className="sm:max-w-md">
         <DialogClose />
         <DialogHeader>
@@ -462,12 +505,20 @@ function CustomEndpointDialog({
                 location: location || undefined,
                 googleCredentials: googleCredentials || undefined,
               });
+              if (isAddMode) {
+                void track('custom-provider-add-finished');
+              }
+              savedRef.current = true;
               onOpenChange(false);
             }}
           >
             {endpoint ? 'Save Changes' : 'Add Provider'}
           </Button>
-          <Button variant="ghost" size="sm" onClick={() => onOpenChange(false)}>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => handleDialogOpenChange(false)}
+          >
             Cancel
           </Button>
         </DialogFooter>

--- a/apps/browser/src/pages/routes/_internal-app/agent-settings.custom-providers.tsx
+++ b/apps/browser/src/pages/routes/_internal-app/agent-settings.custom-providers.tsx
@@ -341,38 +341,43 @@ function CustomEndpointDialog({
   const [location, setLocation] = useState(endpoint?.location ?? '');
   const [googleCredentials, setGoogleCredentials] = useState('');
 
+  // Depend ONLY on `open` so the effect runs exactly on the open/close
+  // transitions. Reading `endpoint`/`isAddMode`/`track` without listing
+  // them as deps is intentional — we want their values at the moment
+  // the dialog opened, not whenever parent re-renders push new
+  // references. Without this scoping, normal parent re-renders (e.g.
+  // Karton state sync pushing a new `endpoint` array identity) would
+  // silently reset the user's in-progress form input and re-emit the
+  // `*-add-started` event.
   useEffect(() => {
-    if (open) {
-      setName(endpoint?.name ?? '');
-      setApiSpec(endpoint?.apiSpec ?? 'openai-chat-completions');
-      setBaseUrl(endpoint?.baseUrl ?? '');
-      setApiKey('');
-      setModelIdMappingJson(
-        endpoint?.modelIdMapping &&
-          Object.keys(endpoint.modelIdMapping).length > 0
-          ? JSON.stringify(endpoint.modelIdMapping, null, 2)
-          : '',
-      );
-      setMappingError(null);
-      setResourceName(endpoint?.resourceName ?? '');
-      setApiVersion(endpoint?.apiVersion ?? '');
-      setRegion(endpoint?.region ?? '');
-      setSecretKey('');
-      setProjectId(endpoint?.projectId ?? '');
-      setLocation(endpoint?.location ?? '');
-      setGoogleCredentials('');
-      savedRef.current = false;
-      if (isAddMode) {
-        // Fires on dialog open in add mode — report the *initial* spec so
-        // the started event is emitted before the user changes anything.
-        // We can't read `apiSpec` state here because `setApiSpec` above
-        // is not yet flushed.
-        track('custom-provider-add-started', {
-          api_spec: 'openai-chat-completions',
-        });
-      }
+    if (!open) return;
+    setName(endpoint?.name ?? '');
+    setApiSpec(endpoint?.apiSpec ?? 'openai-chat-completions');
+    setBaseUrl(endpoint?.baseUrl ?? '');
+    setApiKey('');
+    setModelIdMappingJson(
+      endpoint?.modelIdMapping &&
+        Object.keys(endpoint.modelIdMapping).length > 0
+        ? JSON.stringify(endpoint.modelIdMapping, null, 2)
+        : '',
+    );
+    setMappingError(null);
+    setResourceName(endpoint?.resourceName ?? '');
+    setApiVersion(endpoint?.apiVersion ?? '');
+    setRegion(endpoint?.region ?? '');
+    setSecretKey('');
+    setProjectId(endpoint?.projectId ?? '');
+    setLocation(endpoint?.location ?? '');
+    setGoogleCredentials('');
+    savedRef.current = false;
+    if (isAddMode) {
+      // No payload on `started` — `api_spec` at this point is always the
+      // default and carries no signal. It's only meaningful on `finished`
+      // (and `aborted`, to understand what spec the user was partway
+      // through configuring).
+      track('custom-provider-add-started');
     }
-  }, [open, endpoint, isAddMode, track]);
+  }, [open]);
 
   const canSave = name.trim().length > 0 && !mappingError;
 

--- a/apps/browser/src/pages/routes/_internal-app/agent-settings.models-providers.tsx
+++ b/apps/browser/src/pages/routes/_internal-app/agent-settings.models-providers.tsx
@@ -19,6 +19,7 @@ import {
 } from '@shared/karton-contracts/ui/shared-types';
 import { availableModels } from '@shared/available-models';
 import { useEffect, useState, useMemo, useCallback, useRef } from 'react';
+import { useTrack } from '@ui/hooks/use-track';
 import { cn } from '@pages/utils';
 import { useIsTruncated } from '@ui/hooks/use-is-truncated';
 import { useScrollFadeMask } from '@ui/hooks/use-scroll-fade-mask';
@@ -382,6 +383,12 @@ function CustomModelDialog({
   existingModelIds: Set<string>;
   customEndpoints: CustomEndpoint[];
 }) {
+  const track = useTrack();
+  const isAddMode = !model;
+  // Set to true when onSave() fires; distinguishes a save-initiated close
+  // from a cancel/dismiss close inside the shared `handleDialogOpenChange`.
+  const savedRef = useRef(false);
+
   const [modelId, setModelId] = useState(model?.modelId ?? '');
   const [displayName, setDisplayName] = useState(model?.displayName ?? '');
   const [description, setDescription] = useState(model?.description ?? '');
@@ -456,8 +463,54 @@ function CustomModelDialog({
       );
       setShowAdvanced(false);
       setJsonError(null);
+      savedRef.current = false;
+      if (isAddMode) {
+        void track('custom-model-add-started');
+      }
     }
-  }, [open, model]);
+  }, [open, model, isAddMode, track]);
+
+  const isDuplicate =
+    modelId.trim().length > 0 &&
+    (BUILT_IN_MODEL_IDS.has(modelId.trim()) ||
+      (existingModelIds.has(modelId.trim()) &&
+        modelId.trim() !== model?.modelId));
+
+  const canSave =
+    modelId.trim().length > 0 &&
+    displayName.trim().length > 0 &&
+    !isDuplicate &&
+    !jsonError;
+
+  // "Touched" = the user changed anything from the initial field values.
+  // Derived from current state so we don't need per-input bookkeeping.
+  const anyFieldTouched =
+    modelId !== (model?.modelId ?? '') ||
+    displayName !== (model?.displayName ?? '') ||
+    description !== (model?.description ?? '') ||
+    contextWindowSize !== (model?.contextWindowSize ?? 128000) ||
+    endpointId !== (model?.endpointId ?? 'openai') ||
+    thinkingEnabled !== (model?.thinkingEnabled ?? false) ||
+    providerOptionsJson !==
+      (model?.providerOptions && Object.keys(model.providerOptions).length > 0
+        ? JSON.stringify(model.providerOptions, null, 2)
+        : '') ||
+    headersJson !==
+      (model?.headers && Object.keys(model.headers).length > 0
+        ? JSON.stringify(model.headers, null, 2)
+        : '') ||
+    JSON.stringify(capabilities) !==
+      JSON.stringify(model?.capabilities ?? defaultCaps);
+
+  const handleDialogOpenChange = (next: boolean) => {
+    if (!next && open && isAddMode && !savedRef.current) {
+      void track('custom-model-add-aborted', {
+        had_validation_errors: !canSave,
+        any_field_touched: anyFieldTouched,
+      });
+    }
+    onOpenChange(next);
+  };
 
   const endpointOptions = useMemo(() => {
     const builtIn = [
@@ -476,18 +529,6 @@ function CustomModelDialog({
     }));
     return [...builtIn, ...custom];
   }, [customEndpoints]);
-
-  const isDuplicate =
-    modelId.trim().length > 0 &&
-    (BUILT_IN_MODEL_IDS.has(modelId.trim()) ||
-      (existingModelIds.has(modelId.trim()) &&
-        modelId.trim() !== model?.modelId));
-
-  const canSave =
-    modelId.trim().length > 0 &&
-    displayName.trim().length > 0 &&
-    !isDuplicate &&
-    !jsonError;
 
   const handleSave = () => {
     let providerOptions: Record<string, unknown> = {};
@@ -521,11 +562,15 @@ function CustomModelDialog({
       providerOptions,
       headers,
     });
+    if (isAddMode) {
+      void track('custom-model-add-finished');
+    }
+    savedRef.current = true;
     onOpenChange(false);
   };
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog open={open} onOpenChange={handleDialogOpenChange}>
       <DialogContent className="max-h-[85vh] sm:max-w-md">
         <DialogClose />
         <DialogHeader>
@@ -767,7 +812,11 @@ function CustomModelDialog({
           >
             {model ? 'Save Changes' : 'Add Model'}
           </Button>
-          <Button variant="ghost" size="sm" onClick={() => onOpenChange(false)}>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => handleDialogOpenChange(false)}
+          >
             Cancel
           </Button>
         </DialogFooter>

--- a/apps/browser/src/pages/routes/_internal-app/agent-settings.models-providers.tsx
+++ b/apps/browser/src/pages/routes/_internal-app/agent-settings.models-providers.tsx
@@ -448,33 +448,38 @@ function CustomModelDialog({
     fadeDistance: 24,
   });
 
+  // Depend ONLY on `open` so the effect runs exactly on the open/close
+  // transitions. Reading `model`/`isAddMode`/`track` without listing them
+  // as deps is intentional — we want their values at the moment the
+  // dialog opened, not whenever parent re-renders push new references.
+  // Without this scoping, normal parent re-renders would silently reset
+  // the user's in-progress form input and re-emit `*-add-started`.
   useEffect(() => {
-    if (open) {
-      setModelId(model?.modelId ?? '');
-      setDisplayName(model?.displayName ?? '');
-      setDescription(model?.description ?? '');
-      setContextWindowSize(model?.contextWindowSize ?? 128000);
-      setEndpointId(model?.endpointId ?? 'openai');
-      setThinkingEnabled(model?.thinkingEnabled ?? false);
-      setCapabilities(model?.capabilities ?? defaultCaps);
-      setProviderOptionsJson(
-        model?.providerOptions && Object.keys(model.providerOptions).length > 0
-          ? JSON.stringify(model.providerOptions, null, 2)
-          : '',
-      );
-      setHeadersJson(
-        model?.headers && Object.keys(model.headers).length > 0
-          ? JSON.stringify(model.headers, null, 2)
-          : '',
-      );
-      setShowAdvanced(false);
-      setJsonError(null);
-      savedRef.current = false;
-      if (isAddMode) {
-        track('custom-model-add-started');
-      }
+    if (!open) return;
+    setModelId(model?.modelId ?? '');
+    setDisplayName(model?.displayName ?? '');
+    setDescription(model?.description ?? '');
+    setContextWindowSize(model?.contextWindowSize ?? 128000);
+    setEndpointId(model?.endpointId ?? 'openai');
+    setThinkingEnabled(model?.thinkingEnabled ?? false);
+    setCapabilities(model?.capabilities ?? defaultCaps);
+    setProviderOptionsJson(
+      model?.providerOptions && Object.keys(model.providerOptions).length > 0
+        ? JSON.stringify(model.providerOptions, null, 2)
+        : '',
+    );
+    setHeadersJson(
+      model?.headers && Object.keys(model.headers).length > 0
+        ? JSON.stringify(model.headers, null, 2)
+        : '',
+    );
+    setShowAdvanced(false);
+    setJsonError(null);
+    savedRef.current = false;
+    if (isAddMode) {
+      track('custom-model-add-started');
     }
-  }, [open, model, isAddMode, track]);
+  }, [open]);
 
   const isDuplicate =
     modelId.trim().length > 0 &&

--- a/apps/browser/src/pages/routes/_internal-app/agent-settings.models-providers.tsx
+++ b/apps/browser/src/pages/routes/_internal-app/agent-settings.models-providers.tsx
@@ -6,6 +6,7 @@ import {
   TooltipTrigger,
 } from '@stagewise/stage-ui/components/tooltip';
 import { useKartonState, useKartonProcedure } from '@pages/hooks/use-karton';
+import { useTrack } from '@pages/hooks/use-track';
 import type {
   CustomEndpoint,
   CustomModel,
@@ -19,7 +20,7 @@ import {
 } from '@shared/karton-contracts/ui/shared-types';
 import { availableModels } from '@shared/available-models';
 import { useEffect, useState, useMemo, useCallback, useRef } from 'react';
-import { useTrack } from '@ui/hooks/use-track';
+
 import { cn } from '@pages/utils';
 import { useIsTruncated } from '@ui/hooks/use-is-truncated';
 import { useScrollFadeMask } from '@ui/hooks/use-scroll-fade-mask';
@@ -383,6 +384,11 @@ function CustomModelDialog({
   existingModelIds: Set<string>;
   customEndpoints: CustomEndpoint[];
 }) {
+  // Pages run under a different preload than the sidebar UI, so we cannot
+  // import `@ui/hooks/use-track` here (it reaches for `window.electron`).
+  // `useTrack` from the pages hooks routes through the pages-API
+  // `captureTelemetry` bridge and swallows RPC errors so a failed capture
+  // can never crash the page.
   const track = useTrack();
   const isAddMode = !model;
   // Set to true when onSave() fires; distinguishes a save-initiated close
@@ -465,7 +471,7 @@ function CustomModelDialog({
       setJsonError(null);
       savedRef.current = false;
       if (isAddMode) {
-        void track('custom-model-add-started');
+        track('custom-model-add-started');
       }
     }
   }, [open, model, isAddMode, track]);
@@ -502,10 +508,17 @@ function CustomModelDialog({
     JSON.stringify(capabilities) !==
       JSON.stringify(model?.capabilities ?? defaultCaps);
 
+  // A pristine, unmodified form is NOT an error — empty required fields
+  // at initial state mean "not filled in yet", not "validation failed".
+  // `had_validation_errors` should only be true when the user entered
+  // input that triggered a concrete validation rule (duplicate ID, invalid
+  // JSON in provider options / headers).
+  const hadValidationErrors = isDuplicate || jsonError !== null;
+
   const handleDialogOpenChange = (next: boolean) => {
     if (!next && open && isAddMode && !savedRef.current) {
-      void track('custom-model-add-aborted', {
-        had_validation_errors: !canSave,
+      track('custom-model-add-aborted', {
+        had_validation_errors: hadValidationErrors,
         any_field_touched: anyFieldTouched,
       });
     }
@@ -563,7 +576,7 @@ function CustomModelDialog({
       headers,
     });
     if (isAddMode) {
-      void track('custom-model-add-finished');
+      track('custom-model-add-finished');
     }
     savedRef.current = true;
     onOpenChange(false);

--- a/apps/browser/src/shared/karton-contracts/pages-api/index.ts
+++ b/apps/browser/src/shared/karton-contracts/pages-api/index.ts
@@ -273,6 +273,16 @@ export type PagesApiContract = {
       /** Quit the app and install the downloaded update */
       quitAndInstall: () => Promise<void>;
     };
+    /**
+     * Forward a UI telemetry event to the backend TelemetryService. The
+     * backend validates the event name against `UI_TELEMETRY_EVENT_NAMES`
+     * and the payload against a per-event Zod schema — unknown names or
+     * invalid shapes are silently dropped.
+     */
+    captureTelemetry: (
+      eventName: string,
+      properties?: Record<string, unknown>,
+    ) => Promise<void>;
   };
 };
 

--- a/apps/browser/src/shared/karton-contracts/ui/index.ts
+++ b/apps/browser/src/shared/karton-contracts/ui/index.ts
@@ -710,6 +710,13 @@ export type KartonContract = {
       setToolApprovalMode: (
         instanceId: string,
         mode: ToolApprovalMode,
+        /**
+         * Optional UI surface that triggered the change. Forwarded to the
+         * `tool-approval-mode-changed` telemetry event so analytics can
+         * distinguish deliberate panel-combobox changes from inline
+         * "Always allow" clicks made during an approval request.
+         */
+        source?: 'panel-combobox' | 'inline-approval-button',
       ) => Promise<void>;
       stop: (agentId: string) => Promise<void>;
       flushQueue: (agentId: string) => Promise<void>;

--- a/apps/browser/src/ui/hooks/use-posthog.tsx
+++ b/apps/browser/src/ui/hooks/use-posthog.tsx
@@ -92,7 +92,20 @@ export function PostHogProvider({ children }: PostHogProviderProps) {
       (!posthog._isIdentified() ||
         posthog.get_distinct_id() !== userAccount.user.id)
     ) {
-      if (posthog._isIdentified()) posthog.reset();
+      if (posthog._isIdentified()) {
+        // reset() clears super-properties too; invalidate the registration
+        // cache so the init effect re-registers them on the next run.
+        registeredSuperPropsInitKey = null;
+        posthog.reset();
+        posthog.register({
+          product: 'stagewise-browser',
+          app_name: __APP_NAME__,
+          app_version: __APP_VERSION__,
+          app_release_channel: __APP_RELEASE_CHANNEL__,
+          app_platform: __APP_PLATFORM__,
+          app_arch: __APP_ARCH__,
+        });
+      }
 
       posthog.identify(userAccount.user.id, {
         telemetryLevel: globalConfig.telemetryLevel,

--- a/apps/browser/src/ui/hooks/use-posthog.tsx
+++ b/apps/browser/src/ui/hooks/use-posthog.tsx
@@ -4,6 +4,8 @@ import { PostHogProvider as PostHogProviderOriginal } from 'posthog-js/react';
 import posthog from 'posthog-js';
 import { useKartonState } from './use-karton';
 
+let registeredSuperPropsInitKey: string | null = null;
+
 interface PostHogProviderProps {
   children: ReactNode;
 }
@@ -34,9 +36,12 @@ export function PostHogProvider({ children }: PostHogProviderProps) {
       return;
     }
 
-    // Set user properties based on karton state
-    if (userAccount?.user && internalData.posthog?.apiKey) {
-      posthog.init(internalData.posthog?.apiKey, {
+    // Initialize PostHog once config is available; user identity is handled
+    // separately below.
+    const apiKey = internalData.posthog?.apiKey;
+    const apiHost = internalData.posthog?.host;
+    if (apiKey) {
+      posthog.init(apiKey, {
         before_send: (event) => {
           // Filter out user app errors - only capture toolbar errors
           if (!event) return null; // Reject the event
@@ -44,7 +49,7 @@ export function PostHogProvider({ children }: PostHogProviderProps) {
         },
         disable_session_recording: telemetryLevel !== 'full',
         autocapture: true,
-        api_host: internalData.posthog?.host,
+        api_host: apiHost,
         ui_host: 'https://eu.posthog.com',
         capture_pageview: false, // We capture pageviews manually
         capture_pageleave: true, // Enable pageleave capture
@@ -55,10 +60,28 @@ export function PostHogProvider({ children }: PostHogProviderProps) {
           recordHeaders: false,
         },
       });
+      const initKey = `${apiKey}::${apiHost ?? ''}`;
+      if (registeredSuperPropsInitKey !== initKey) {
+        // Register common app-level super-properties once per PostHog init
+        // target so repeated effect runs do not re-register on every render.
+        posthog.register({
+          product: 'stagewise-browser',
+          app_name: __APP_NAME__,
+          app_version: __APP_VERSION__,
+          app_release_channel: __APP_RELEASE_CHANNEL__,
+          app_platform: __APP_PLATFORM__,
+          app_arch: __APP_ARCH__,
+        });
+        registeredSuperPropsInitKey = initKey;
+      }
       posthog.consent.optInOut(true);
       posthog.opt_in_capturing();
     }
-  }, [userAccount, globalConfig]);
+  }, [
+    globalConfig.telemetryLevel,
+    internalData.posthog?.apiKey,
+    internalData.posthog?.host,
+  ]);
 
   useEffect(() => {
     const telemetryLevel = globalConfig.telemetryLevel;

--- a/apps/browser/src/ui/screens/main/content/_components/dev-toolbar/widgets/color-scheme.tsx
+++ b/apps/browser/src/ui/screens/main/content/_components/dev-toolbar/widgets/color-scheme.tsx
@@ -1,6 +1,7 @@
 import { useKartonProcedure, useKartonState } from '@ui/hooks/use-karton';
 import { IconSunFill18, IconMoonFill18 } from 'nucleo-ui-fill-18';
 import { cn } from '@stagewise/stage-ui/lib/utils';
+import { useCallback } from 'react';
 import { ToggleButton } from '../primitives';
 import type { WidgetProps } from './types';
 
@@ -10,6 +11,10 @@ export function ColorSchemeWidget({ tab, sortableProps }: WidgetProps) {
     (p) => p.browser.cycleColorScheme,
   );
   const nativeColorScheme = useKartonState((s) => s.systemTheme);
+
+  const handleClick = useCallback(() => {
+    void cycleColorScheme(tab.id);
+  }, [cycleColorScheme, tab.id]);
 
   return (
     <ToggleButton
@@ -54,7 +59,7 @@ export function ColorSchemeWidget({ tab, sortableProps }: WidgetProps) {
           />
         </div>
       }
-      onClick={() => cycleColorScheme(tab.id)}
+      onClick={handleClick}
       active={tab.colorScheme !== 'system'}
       dragHandleProps={dragHandleProps}
       isDragging={isDragging}

--- a/apps/browser/src/ui/screens/main/content/index.tsx
+++ b/apps/browser/src/ui/screens/main/content/index.tsx
@@ -8,6 +8,7 @@ import {
   DND_DROP_ANIMATION_DURATION,
 } from './_components/tabs-container';
 import { useEventListener } from '@ui/hooks/use-event-listener';
+import { useTrack } from '@ui/hooks/use-track';
 import { BackgroundWithCutout } from './_components/background-with-cutout';
 import { CoreHotkeyBindings } from './_components/core-hotkey-bindings';
 import {
@@ -31,6 +32,7 @@ export function MainSection({
   );
 
   const { setTabUiState } = useTabUIState();
+  const track = useTrack();
 
   // Track interpolated border radius during tab drag (for smooth corner transition)
   const [dragBorderRadius, setDragBorderRadius] = useState<number | null>(null);
@@ -104,10 +106,22 @@ export function MainSection({
   }, [createTab, activeTabId]);
 
   const handleCleanAllTabs = useCallback(() => {
-    Object.values(tabs).forEach((tab) => {
-      if (tab.id !== activeTabId) closeTab(tab.id);
-    });
-  }, [tabs, activeTabId, closeTab]);
+    const tabIdsToClose = Object.keys(tabs).filter(
+      (tabId) => tabId !== activeTabId,
+    );
+
+    void Promise.allSettled(tabIdsToClose.map((tabId) => closeTab(tabId))).then(
+      (results) => {
+        const closedCount = results.filter(
+          (result) => result.status === 'fulfilled',
+        ).length;
+
+        if (closedCount > 0) {
+          track('tabs-cleaned', { closed_count: closedCount });
+        }
+      },
+    );
+  }, [tabs, activeTabId, closeTab, track]);
 
   const handleFocusUrlBar = useCallback(() => {
     if (activeTabId) {

--- a/apps/browser/src/ui/screens/main/index.tsx
+++ b/apps/browser/src/ui/screens/main/index.tsx
@@ -7,31 +7,52 @@ import {
 import { Sidebar } from './sidebar';
 import { MainSection } from './content';
 import { cn } from '@ui/utils';
-import { useCallback, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import { useEventListener } from '@ui/hooks/use-event-listener';
+import { useTrack } from '@ui/hooks/use-track';
 
 const layoutStorageKey = 'stagewise-panel-layout';
 
 export function DefaultLayout({ show }: { show: boolean }) {
   const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(false);
+  const track = useTrack();
+  // Mirror the collapsed state so the listeners can detect real transitions
+  // without depending on React's async state.
+  const collapsedRef = useRef(false);
+  const hasInitializedRef = useRef(false);
+
+  const applyCollapsed = useCallback(
+    (next: boolean) => {
+      const isInitial = !hasInitializedRef.current;
+      hasInitializedRef.current = true;
+      if (collapsedRef.current === next) return;
+      collapsedRef.current = next;
+      setIsSidebarCollapsed(next);
+      if (isInitial) return;
+      track('chat-sidebar-toggled', {
+        new_value: next ? 'closed' : 'open',
+      });
+    },
+    [track],
+  );
+
   useEventListener('sidebar-chat-panel-closed', () => {
-    setIsSidebarCollapsed(true);
+    applyCollapsed(true);
   });
   useEventListener('sidebar-chat-panel-opened', () => {
-    setIsSidebarCollapsed(false);
+    applyCollapsed(false);
   });
 
   const openSidebarChatPanel = useCallback(() => {
     window.dispatchEvent(new Event('sidebar-chat-panel-opened'));
   }, []);
 
-  const layoutChangeHandler = useCallback((layout: number[]) => {
-    if (layout[0] === 0) {
-      setIsSidebarCollapsed(true);
-    } else {
-      setIsSidebarCollapsed(false);
-    }
-  }, []);
+  const layoutChangeHandler = useCallback(
+    (layout: number[]) => {
+      applyCollapsed(layout[0] === 0);
+    },
+    [applyCollapsed],
+  );
 
   return (
     <div

--- a/apps/browser/src/ui/screens/main/sidebar/chat/_components/chat-history.tsx
+++ b/apps/browser/src/ui/screens/main/sidebar/chat/_components/chat-history.tsx
@@ -251,11 +251,17 @@ export const ChatHistory = () => {
   }, [removedSuggestionIds, shuffledSuggestions]);
 
   const handleRemoveSuggestion = (id: string) => {
-    track('suggestion-dismissed', {
-      suggestion_id: id,
-      context: 'empty-chat',
-    });
+    // State update first — telemetry is fire-and-forget and must never be
+    // able to block the UI reacting to the user's click.
     setRemovedSuggestionIds((prev) => new Set([...Array.from(prev), id]));
+    try {
+      track('suggestion-dismissed', {
+        suggestion_id: id,
+        context: 'empty-chat',
+      });
+    } catch {
+      // best-effort
+    }
   };
 
   // All messages after filtering and merging consecutive assistant messages.

--- a/apps/browser/src/ui/screens/main/sidebar/chat/_components/chat-history.tsx
+++ b/apps/browser/src/ui/screens/main/sidebar/chat/_components/chat-history.tsx
@@ -251,6 +251,10 @@ export const ChatHistory = () => {
   }, [removedSuggestionIds, shuffledSuggestions]);
 
   const handleRemoveSuggestion = (id: string) => {
+    track('suggestion-dismissed', {
+      suggestion_id: id,
+      context: 'empty-chat',
+    });
     setRemovedSuggestionIds((prev) => new Set([...Array.from(prev), id]));
   };
 

--- a/apps/browser/src/ui/screens/main/sidebar/chat/_components/message-part-ui/tools/execute-shell-command.tsx
+++ b/apps/browser/src/ui/screens/main/sidebar/chat/_components/message-part-ui/tools/execute-shell-command.tsx
@@ -143,7 +143,20 @@ export const ExecuteShellCommandToolPart = ({
     )
       return;
     try {
-      await setToolApprovalMode(openAgentId, 'alwaysAllow');
+      // Pass source + approval-context so the backend
+      // `tool-approval-mode-changed` event can distinguish this
+      // inline/impulsive path from the panel-combobox path and correlate
+      // it with the specific approval request the user was answering.
+      // The contract signature takes `source` as the 3rd arg; we can't
+      // pass tool metadata through the RPC, so the backend won't know
+      // `tool_name`/`tool_call_id` for this path — that's OK, analytics
+      // can join on the adjacent `tool-approved` event via
+      // `agent_instance_id` + timestamp if needed.
+      await setToolApprovalMode(
+        openAgentId,
+        'alwaysAllow',
+        'inline-approval-button',
+      );
     } catch (error) {
       console.warn('[ExecuteShellCommand] Failed to set approval mode', error);
     }

--- a/apps/browser/src/ui/screens/main/sidebar/chat/_components/panel-footer.tsx
+++ b/apps/browser/src/ui/screens/main/sidebar/chat/_components/panel-footer.tsx
@@ -170,13 +170,6 @@ export const ChatPanelFooter = memo(function ChatPanelFooter() {
   const selectionModeActive = useKartonState(
     (s) => s.browser.contextSelectionMode,
   );
-  const selectionTelemetryActiveRef = useRef(false);
-
-  useEffect(() => {
-    if (!selectionModeActive) {
-      selectionTelemetryActiveRef.current = false;
-    }
-  }, [selectionModeActive]);
 
   const elementSelectionActive = useMemo(() => {
     if (activeEditMessageId) return false;
@@ -284,27 +277,32 @@ export const ChatPanelFooter = memo(function ChatPanelFooter() {
   );
   selectedElementsStateRef.current = selectedElementsState ?? [];
 
-  // Element selector helper functions
-  const startContextSelector = useCallback(() => {
-    // Only report a telemetry start when we actually transition OFF -> ON.
-    // These helpers are called from multiple sites (hotkey, button, auto-start
-    // on sidebar open); without this guard we would double-count.
-    if (!selectionTelemetryActiveRef.current && !selectionModeActive) {
-      selectionTelemetryActiveRef.current = true;
+  // Drive element-selection telemetry off the Karton state itself so every
+  // transition is captured — including ESC-driven cancels in selector-canvas,
+  // sidebar auto-close, and any other site that flips the state directly.
+  // Wrapping the setters would miss those paths.
+  const prevSelectionModeActiveRef = useRef(selectionModeActive);
+  useEffect(() => {
+    const prev = prevSelectionModeActiveRef.current;
+    prevSelectionModeActiveRef.current = selectionModeActive;
+    if (prev === selectionModeActive) return;
+    if (selectionModeActive) {
       track('element-selection-started');
-    }
-    setContextSelectionActive(true);
-  }, [selectionModeActive, setContextSelectionActive, track]);
-
-  const stopContextSelector = useCallback(() => {
-    if (selectionTelemetryActiveRef.current) {
-      selectionTelemetryActiveRef.current = false;
+    } else {
       track('element-selection-stopped', {
         element_selected: selectedElementsStateRef.current.length > 0,
       });
     }
+  }, [selectionModeActive, track]);
+
+  // Element selector helper functions
+  const startContextSelector = useCallback(() => {
+    setContextSelectionActive(true);
+  }, [setContextSelectionActive]);
+
+  const stopContextSelector = useCallback(() => {
     setContextSelectionActive(false);
-  }, [setContextSelectionActive, track]);
+  }, [setContextSelectionActive]);
 
   // Pending early-abort revert: deferred until isWorking becomes false
   // so the stream is fully done and won't re-add the assistant message.

--- a/apps/browser/src/ui/screens/main/sidebar/chat/_components/panel-footer.tsx
+++ b/apps/browser/src/ui/screens/main/sidebar/chat/_components/panel-footer.tsx
@@ -24,6 +24,7 @@ import {
 } from '@ui/hooks/use-karton';
 import { useHotKeyListener } from '@ui/hooks/use-hotkey-listener';
 import { useEventListener } from '@ui/hooks/use-event-listener';
+import { useTrack } from '@ui/hooks/use-track';
 import {
   ChatInput,
   ChatInputActions,
@@ -169,6 +170,13 @@ export const ChatPanelFooter = memo(function ChatPanelFooter() {
   const selectionModeActive = useKartonState(
     (s) => s.browser.contextSelectionMode,
   );
+  const selectionTelemetryActiveRef = useRef(false);
+
+  useEffect(() => {
+    if (!selectionModeActive) {
+      selectionTelemetryActiveRef.current = false;
+    }
+  }, [selectionModeActive]);
 
   const elementSelectionActive = useMemo(() => {
     if (activeEditMessageId) return false;
@@ -266,14 +274,37 @@ export const ChatPanelFooter = memo(function ChatPanelFooter() {
     clearSelectedElementsProc();
   }, [clearFileAttachments, clearSelectedElementsProc]);
 
+  const track = useTrack();
+
+  // Live ref for the set of selected elements so telemetry on stop can
+  // read the latest value without adding the list to the callback deps.
+  const selectedElementsStateRef = useRef<readonly unknown[]>([]);
+  const selectedElementsState = useKartonState(
+    (s) => s.browser.selectedElements,
+  );
+  selectedElementsStateRef.current = selectedElementsState ?? [];
+
   // Element selector helper functions
   const startContextSelector = useCallback(() => {
+    // Only report a telemetry start when we actually transition OFF -> ON.
+    // These helpers are called from multiple sites (hotkey, button, auto-start
+    // on sidebar open); without this guard we would double-count.
+    if (!selectionTelemetryActiveRef.current && !selectionModeActive) {
+      selectionTelemetryActiveRef.current = true;
+      track('element-selection-started');
+    }
     setContextSelectionActive(true);
-  }, [setContextSelectionActive]);
+  }, [selectionModeActive, setContextSelectionActive, track]);
 
   const stopContextSelector = useCallback(() => {
+    if (selectionTelemetryActiveRef.current) {
+      selectionTelemetryActiveRef.current = false;
+      track('element-selection-stopped', {
+        element_selected: selectedElementsStateRef.current.length > 0,
+      });
+    }
     setContextSelectionActive(false);
-  }, [setContextSelectionActive]);
+  }, [setContextSelectionActive, track]);
 
   // Pending early-abort revert: deferred until isWorking becomes false
   // so the stream is fully done and won't re-add the assistant message.

--- a/apps/browser/src/ui/screens/main/sidebar/chat/_components/tool-approval-select.tsx
+++ b/apps/browser/src/ui/screens/main/sidebar/chat/_components/tool-approval-select.tsx
@@ -115,11 +115,16 @@ export const ToolApprovalSelect = memo(function ToolApprovalSelect({
   const handleValueChange = useCallback(
     (value: string | null) => {
       if (!openAgent || !value) return;
-      void setToolApprovalMode(openAgent, value as ToolApprovalMode).catch(
-        (error) => {
-          console.warn('[ToolApprovalSelect] Failed to set mode', error);
-        },
-      );
+      // `'panel-combobox'` tags this as a deliberate, pre-emptive change
+      // in the backend telemetry event — distinguishes it from inline
+      // "Always allow" clicks during an approval request.
+      void setToolApprovalMode(
+        openAgent,
+        value as ToolApprovalMode,
+        'panel-combobox',
+      ).catch((error) => {
+        console.warn('[ToolApprovalSelect] Failed to set mode', error);
+      });
       onToolApprovalChange?.();
     },
     [openAgent, setToolApprovalMode, onToolApprovalChange],

--- a/apps/browser/src/ui/screens/main/sidebar/chat/_components/workspace-select.tsx
+++ b/apps/browser/src/ui/screens/main/sidebar/chat/_components/workspace-select.tsx
@@ -22,6 +22,7 @@ import { CheckIcon, XIcon, Loader2Icon } from 'lucide-react';
 
 import { useKartonProcedure, useKartonState } from '@ui/hooks/use-karton';
 import { useScrollFadeMask } from '@ui/hooks/use-scroll-fade-mask';
+import { useTrack } from '@ui/hooks/use-track';
 import { IdeLogo } from '@ui/components/ide-logo';
 import { getIDEFileUrl, IDE_SELECTION_ITEMS } from '@ui/utils';
 import { getBaseName } from '@shared/path-utils';
@@ -730,10 +731,42 @@ export const WorkspaceSelect = memo(function WorkspaceSelect({
   const unmountWorkspace = useKartonProcedure(
     (p) => p.toolbox.unmountWorkspace,
   );
+  const track = useTrack();
   const allMounts = useKartonState((s) =>
     openAgent
       ? (s.toolbox[openAgent]?.workspace?.mounts ?? EMPTY_MOUNTS)
       : EMPTY_MOUNTS,
+  );
+  const mountedPaths = useMemo(
+    () => new Set(allMounts.map((mount) => mount.path)),
+    [allMounts],
+  );
+
+  // Live ref of the mount count. We assign it during render so callbacks can
+  // read the latest count after mountWorkspace() resolves without stale state.
+  const allMountsCountRef = useRef(allMounts.length);
+  allMountsCountRef.current = allMounts.length;
+
+  const trackMountOutcome = useCallback(
+    async (promise: Promise<void>, source: 'picker' | 'recent-workspace') => {
+      const before = allMountsCountRef.current;
+      try {
+        await promise;
+      } catch {
+        track('workspace-connect-failed', { source });
+        return;
+      }
+      // A mount is considered successful if the count grew. If it stayed the
+      // same and the user went through the picker, they closed it without
+      // selecting. The recent-workspace path cannot be aborted the same way,
+      // so we only track an abort for the picker case.
+      if (allMountsCountRef.current > before) {
+        track('workspace-connect-finished');
+      } else if (source === 'picker') {
+        track('workspace-connect-aborted', { reason: 'picker-closed' });
+      }
+    },
+    [track],
   );
 
   const hasMounts = allMounts.length > 0;
@@ -768,7 +801,6 @@ export const WorkspaceSelect = memo(function WorkspaceSelect({
   const menuItems = useMemo((): SelectItem[] => {
     const items: SelectItem[] = [];
 
-    const mountedPaths = new Set(allMounts.map((m) => m.path));
     const sortedWorkspaces = [...recentlyOpenedWorkspaces]
       .filter((w) => !mountedPaths.has(w.path))
       .sort((a, b) => b.openedAt - a.openedAt)
@@ -810,7 +842,7 @@ export const WorkspaceSelect = memo(function WorkspaceSelect({
     });
 
     return items;
-  }, [allMounts, recentlyOpenedWorkspaces, minimalFormatter]);
+  }, [mountedPaths, recentlyOpenedWorkspaces, minimalFormatter]);
 
   const hasRecentItems = menuItems.length > 1;
 
@@ -820,21 +852,36 @@ export const WorkspaceSelect = memo(function WorkspaceSelect({
 
       if (value.startsWith('workspace:')) {
         const path = value.replace('workspace:', '');
-        void mountWorkspace(openAgent, path);
+        if (mountedPaths.has(path)) return;
+
+        track('workspace-connect-started');
+        void trackMountOutcome(
+          mountWorkspace(openAgent, path),
+          'recent-workspace',
+        );
         onWorkspaceChange?.();
       } else if (value === 'open-folder') {
-        void mountWorkspace(openAgent, undefined);
+        track('workspace-connect-started');
+        void trackMountOutcome(mountWorkspace(openAgent, undefined), 'picker');
         onWorkspaceChange?.();
       }
     },
-    [openAgent, mountWorkspace, onWorkspaceChange],
+    [
+      mountedPaths,
+      openAgent,
+      mountWorkspace,
+      onWorkspaceChange,
+      track,
+      trackMountOutcome,
+    ],
   );
 
   const openFilePicker = useCallback(() => {
     if (!openAgent) return;
-    void mountWorkspace(openAgent, undefined);
+    track('workspace-connect-started');
+    void trackMountOutcome(mountWorkspace(openAgent, undefined), 'picker');
     onWorkspaceChange?.();
-  }, [openAgent, mountWorkspace, onWorkspaceChange]);
+  }, [openAgent, mountWorkspace, onWorkspaceChange, track, trackMountOutcome]);
 
   const renderItem = useCallback((item: SelectItem) => {
     const isRecent = String(item.value).startsWith('workspace:');

--- a/apps/browser/src/ui/screens/main/sidebar/top/index.tsx
+++ b/apps/browser/src/ui/screens/main/sidebar/top/index.tsx
@@ -26,6 +26,7 @@ import {
 import { EMPTY_MOUNTS } from '@shared/karton-contracts/ui';
 import { useEmptyAgentId } from '@ui/hooks/use-empty-agent';
 import { usePendingRemovals } from '@ui/hooks/use-pending-agent-removals';
+import { useTrack } from '@ui/hooks/use-track';
 import { AgentsSelector, type AgentGroup } from './_components/agents-selector';
 
 /** Shape returned by the activeAgentsList selector. */
@@ -378,42 +379,50 @@ export function SidebarTopSection({ isCollapsed }: { isCollapsed: boolean }) {
     });
   }, []);
 
+  const track = useTrack();
+
   // Helper to create a new chat and focus the input.
   // openAgentModelId is read via ref — it's only needed at invocation time
   // and should NOT cause this callback to be recreated on model changes.
-  const createAgentAndFocus = useCallback(async () => {
-    // Reuse an existing empty agent instead of creating a new one.
-    const existingEmpty = emptyAgentIdRef.current;
-    if (existingEmpty) {
-      setOpenAgent(existingEmpty);
-      window.dispatchEvent(new Event('sidebar-chat-panel-opened'));
-      return;
-    }
+  const createAgentAndFocus = useCallback(
+    async (source: 'sidebar-top' | 'hotkey') => {
+      void track('chat-new-agent-clicked', { source });
 
-    // Only forward the draft input if the current agent has history;
-    // an agent with no history means the user never sent a message, so
-    // the new agent should start clean.
-    const currentInputState = openAgentHasHistoryRef.current
-      ? getDraft()
-      : undefined;
-    const currentModelId = openAgentModelIdRef.current ?? undefined;
-    const paths = currentMountPathsRef.current;
-    const newAgent = await createAgent(
-      currentInputState || undefined,
-      currentModelId,
-      paths.length > 0 ? paths : undefined,
-    );
-    setOpenAgent(newAgent);
-    void getAgentsHistoryList(0, PAGE_SIZE).then(setAgentsList);
-    window.dispatchEvent(new Event('sidebar-chat-panel-opened'));
-  }, [createAgent, getDraft, getAgentsHistoryList]);
+      // Reuse an existing empty agent instead of creating a new one.
+      const existingEmpty = emptyAgentIdRef.current;
+      if (existingEmpty) {
+        setOpenAgent(existingEmpty);
+        window.dispatchEvent(new Event('sidebar-chat-panel-opened'));
+        return;
+      }
+
+      // Only forward the draft input if the current agent has history;
+      // an agent with no history means the user never sent a message, so
+      // the new agent should start clean.
+      const currentInputState = openAgentHasHistoryRef.current
+        ? getDraft()
+        : undefined;
+      const currentModelId = openAgentModelIdRef.current ?? undefined;
+      const paths = currentMountPathsRef.current;
+      const newAgent = await createAgent(
+        currentInputState || undefined,
+        currentModelId,
+        paths.length > 0 ? paths : undefined,
+      );
+      setOpenAgent(newAgent);
+      void getAgentsHistoryList(0, PAGE_SIZE).then(setAgentsList);
+      window.dispatchEvent(new Event('sidebar-chat-panel-opened'));
+    },
+    [createAgent, getDraft, getAgentsHistoryList, track],
+  );
 
   // Hotkey: CTRL+N to create new agent chat (works regardless of which section
   // shows the "Add agent" button — top section or active agents grid).
   // Disabled when the open agent is already empty (nothing to create).
   useHotKeyListener(() => {
-    if (openAgent !== null && emptyAgentIdRef.current !== openAgent)
-      void createAgentAndFocus();
+    if (openAgent !== null && emptyAgentIdRef.current !== openAgent) {
+      void createAgentAndFocus('hotkey');
+    }
   }, HotkeyActions.NEW_CHAT);
 
   const resumeAgentRef = useRef(resumeAgent);
@@ -449,8 +458,9 @@ export function SidebarTopSection({ isCollapsed }: { isCollapsed: boolean }) {
   );
 
   const handleOpenSettings = useCallback(() => {
+    track('settings-opened');
     createTab(SETTINGS_PAGE_URL, true);
-  }, [createTab]);
+  }, [createTab, track]);
 
   return (
     <div

--- a/apps/browser/src/ui/screens/onboarding/steps/02-auth.tsx
+++ b/apps/browser/src/ui/screens/onboarding/steps/02-auth.tsx
@@ -63,6 +63,10 @@ export function StepAuth({
   const [code, setCode] = useState('');
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
+  // The anonymous telemetry toggle has been removed from onboarding.
+  // Basic (anonymous) telemetry is enabled by default and is only opt-out
+  // from the settings page. This state only governs the identifiable /
+  // "full" telemetry upgrade checkbox shown below.
   const [telemetry, setTelemetry] = useState<TelemetryLevel>('anonymous');
   const emailRef = useRef<HTMLInputElement>(null);
   const otpRef = useRef<HTMLInputElement>(null);
@@ -298,37 +302,8 @@ export function StepAuth({
         <div className="app-no-drag mt-2 flex items-center gap-2">
           <Checkbox
             size="xs"
-            id="telemetry-anonymous-checkbox"
-            checked={telemetry === 'anonymous' || telemetry === 'full'}
-            onCheckedChange={(checked: boolean) => {
-              setTelemetry(checked ? 'anonymous' : 'off');
-              void preferencesUpdate([
-                {
-                  op: 'replace',
-                  path: ['privacy', 'telemetryLevel'],
-                  value: checked ? 'anonymous' : 'off',
-                },
-              ]);
-            }}
-          />
-          <label
-            htmlFor="telemetry-anonymous-checkbox"
-            className="text-muted-foreground text-xs"
-          >
-            Help improve stagewise by sharing anonymized events.
-          </label>
-        </div>
-        <div
-          className={cn(
-            'app-no-drag flex items-center gap-2',
-            telemetry === 'off' && 'pointer-events-none opacity-50',
-          )}
-        >
-          <Checkbox
-            size="xs"
             id="telemetry-full-checkbox"
             checked={telemetry === 'full'}
-            disabled={telemetry === 'off'}
             onCheckedChange={(checked: boolean) => {
               setTelemetry(checked ? 'full' : 'anonymous');
               void preferencesUpdate([
@@ -347,6 +322,10 @@ export function StepAuth({
             Share identifiable chat and usage data with stagewise.
           </label>
         </div>
+        <p className="mt-1 max-w-sm text-center text-[11px] text-muted-foreground/80">
+          Basic telemetry is enabled by default and can be configured in
+          settings.
+        </p>
       </div>
     );
   }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored telemetry into a typed, privacy-safe event system with richer agent/tool data and wider UI tracking. Adds anonymized process snapshots on launch/close, redacts user-controlled slash IDs, validates UI events end-to-end, and reliably flushes on shutdown.

- **New Features**
  - App lifecycle: `app-launched`/`app-closed` now include anonymized running-tool counts from a fast process snapshot; startup capture runs async and shutdown waits briefly to flush.
  - Agent/Tools telemetry: `agent_instance_id` added across events; new `agent-message-queued` (model and queue length) and `agent-queue-flushed`; enriched `agent-message-sent` (redacted slash IDs/count, workspace count, `is_new_chat`, `ms_since_last_message`, approval mode); deduped `tool-approval-requested` plus `tool-approved`/`tool-denied`; `tool-approval-mode-changed` now records source (`panel-combobox` vs `inline-approval-button`) with optional `tool_call_id`; `agent-stopped` gaps since last user/agent message; `agent-resumed`/`agent-archived`/`agent-deleted` include `agent_instance_id`; `workspace-mounted`/`workspace-unmounted` include `agent_instance_id`; added `agent-renamed`.
  - UI tracking: devtools opened/closed (with `is_local`/`is_https`), tab created/destroyed/cleaned and color scheme toggles, settings opened, account page viewed, chat sidebar expanded/collapsed, new-agent clicks (with source), element selection start/stop, custom model/provider add started/finished/aborted (validation/touched + provider URL privacy), workspace connect started/finished/aborted/failed, and suggestion dismissed.
  - Pages bridge: new pages `useTrack` hook and `pages-api.captureTelemetry` route UI events through the same schema validation as the main UI.

- **Refactors**
  - Strong typing and validation: centralized event schema with `zod`; main process and pages backend validate UI events and drop unknown/invalid payloads.
  - Privacy: hash user-controlled slash IDs to `user:<hash>`; only builtin/plugin IDs sent in clear; devtools/tab URLs reduced to coarse booleans (`is_local`, `is_https`).
  - Reliability: graceful shutdown sequencing; launch event captured via a non-blocking `captureAppLaunched`; PostHog super-properties registered once; lifecycle snapshots use short, bounded timeouts.
  - Data quality: corrected payload shapes for custom provider/model add telemetry events.

<sup>Written for commit 6e601708cf035107423d1253dc4c9c6a92bb74f7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded telemetry across agents, tools, tabs, mounts and queues (queue-length/flush events); tool-approval requests deduped to avoid duplicates
* **Privacy**
  * Slash-command IDs redacted to stable pseudonymous tokens for telemetry
* **UI/UX**
  * Simplified onboarding telemetry choice; added tracking for many UI actions (suggestion dismissed, settings, new-agent, workspace flows, devtools, element selection)
* **Tests**
  * Comprehensive tests added for process-snapshot telemetry collection
<!-- end of auto-generated comment: release notes by coderabbit.ai -->