### PR TITLE
fix(stagewise): prevent shell-history leakage for shell tool-calls

### DIFF
--- a/apps/browser/src/backend/services/toolbox/services/shell/sanitize-env.ts
+++ b/apps/browser/src/backend/services/toolbox/services/shell/sanitize-env.ts
@@ -140,6 +140,15 @@ export function sanitizeEnv(
     }
   }
 
+  // Defense-in-depth: disable persistent shell history for agent PTYs.
+  // The integration scripts also do this (and override anything rc files
+  // set), but env-level values cover the `sh` branch and the rare fallback
+  // where integration sourcing fails. User rc files that unconditionally
+  // export HISTFILE will beat this — that case is handled by the scripts.
+  env.HISTFILE = '/dev/null';
+  env.HISTSIZE = '0';
+  env.SAVEHIST = '0';
+
   env.STAGEWISE_SHELL = '1';
 
   return env;

--- a/apps/browser/src/backend/services/toolbox/services/shell/session-manager.ts
+++ b/apps/browser/src/backend/services/toolbox/services/shell/session-manager.ts
@@ -95,6 +95,10 @@ export function applyHeadTailCap(lines: string[]): string {
 const BASH_INTEGRATION = `
 if [ -n "$__STAGEWISE_SHELL_INTEGRATION" ]; then return 0 2>/dev/null || true; fi
 export __STAGEWISE_SHELL_INTEGRATION=1
+{ unset HISTFILE; } 2>/dev/null
+HISTSIZE=0 2>/dev/null
+HISTFILESIZE=0 2>/dev/null
+set +o history 2>/dev/null
 __stagewise_command_executed=0
 __stagewise_prompt_command() {
   local exit_code=$?
@@ -122,6 +126,10 @@ printf '\\033]133;A\\007'
 const ZSH_INTEGRATION = `
 if [[ -n "$__STAGEWISE_SHELL_INTEGRATION" ]]; then return 0 2>/dev/null || true; fi
 export __STAGEWISE_SHELL_INTEGRATION=1
+{ unset HISTFILE; } 2>/dev/null
+HISTSIZE=0 2>/dev/null
+SAVEHIST=0 2>/dev/null
+unsetopt SHARE_HISTORY INC_APPEND_HISTORY APPEND_HISTORY 2>/dev/null
 PROMPT_EOL_MARK=''
 __stagewise_command_executed=0
 autoload -Uz add-zsh-hook 2>/dev/null
@@ -182,6 +190,7 @@ function Global:Prompt() {
 }
 $Global:__StagewiseState.HasPSReadLine = $false
 if (Get-Module -Name PSReadLine) {
+  Set-PSReadLineOption -HistorySaveStyle SaveNothing
   $Global:__StagewiseState.HasPSReadLine = $true
   $Global:__StagewiseState.OriginalPSConsoleHostReadLine = $function:PSConsoleHostReadLine
   function Global:PSConsoleHostReadLine {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Shell sessions now avoid persistent command history for Bash, zsh, and PowerShell — history is disabled or configured not to be written for the duration of each session, improving transient-session privacy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->