### PR TITLE
feat(stagewise): integrate AWS profiles into model provider

### DIFF
--- a/apps/browser/package.json
+++ b/apps/browser/package.json
@@ -56,6 +56,8 @@
   "devDependencies": {
     "@ai-sdk/amazon-bedrock": "^4.0.77",
     "@ai-sdk/anthropic": "3.0.58",
+    "@aws-sdk/credential-providers": "^3.908.0",
+    "@smithy/shared-ini-file-loader": "^4.4.9",
     "@ai-sdk/azure": "^3.0.42",
     "@ai-sdk/google": "3.0.43",
     "@ai-sdk/google-vertex": "^4.0.80",

--- a/apps/browser/src/backend/agents/model-provider.ts
+++ b/apps/browser/src/backend/agents/model-provider.ts
@@ -13,6 +13,7 @@ import { createOpenAI } from '@ai-sdk/openai';
 import { createGoogleGenerativeAI } from '@ai-sdk/google';
 import { createAzure } from '@ai-sdk/azure';
 import { createAmazonBedrock } from '@ai-sdk/amazon-bedrock';
+import { fromIni, fromNodeProviderChain } from '@aws-sdk/credential-providers';
 import { createVertex } from '@ai-sdk/google-vertex';
 import { createStagewise } from './stagewise-provider';
 import type { AuthService } from '@/services/auth';
@@ -51,6 +52,14 @@ export type ModelWithOptions = {
   headers: Record<string, string>;
   contextWindowSize: number;
   providerMode: ProviderMode;
+  /**
+   * When true, the agent must strip the `strict` field from every tool
+   * definition before passing them to `streamText`. Required for providers
+   * whose backend rejects unknown fields on the tool payload — notably
+   * Bedrock-on-Anthropic, where `strict` surfaces as
+   * `tools.0.custom.strict: Extra inputs are not permitted`.
+   */
+  stripStrictFromTools?: boolean;
 };
 
 /**
@@ -188,6 +197,66 @@ export class ModelProviderService {
       apiSpec: endpoint.apiSpec,
       endpoint,
     };
+  }
+
+  /**
+   * Build an Amazon Bedrock provider for a custom endpoint based on its
+   * configured auth mode:
+   *
+   * - `access-keys` (default, back-compat): static access key + secret.
+   * - `profile`: named profile from `~/.aws/config` / `~/.aws/credentials`.
+   *   Handles static, session-token, assume-role, and SSO profiles via the
+   *   AWS SDK's standard refresh machinery. SSO profiles whose token has
+   *   expired will surface an error at signing time — users must re-run
+   *   `aws sso login --profile <name>`.
+   * - `default-chain`: Node provider chain (env vars, shared credentials,
+   *   EC2/ECS instance roles, IMDS).
+   *
+   * Region resolution: UI-entered `region` always wins. When empty:
+   *   - `access-keys` falls back to `us-east-1` (preserves pre-feature
+   *     behaviour for static-credential setups with no other region
+   *     source).
+   *   - `profile` and `default-chain` pass `undefined`, letting the AWS
+   *     SDK resolve the region from the profile's `region` entry or the
+   *     `AWS_REGION` / `AWS_DEFAULT_REGION` env vars.
+   */
+  private buildBedrockProvider(endpoint: CustomEndpoint, apiKey: string) {
+    const mode = endpoint.awsAuthMode ?? 'access-keys';
+    const overrideRegion = endpoint.region?.trim() || undefined;
+
+    if (mode === 'profile') {
+      if (!endpoint.awsProfileName) {
+        throw new Error(
+          'AWS profile name is required when awsAuthMode is "profile".',
+        );
+      }
+      return createAmazonBedrock({
+        // `region` intentionally undefined when the user did not override
+        // it — `createAmazonBedrock` + the AWS SDK will resolve from the
+        // profile's `region` entry or the `AWS_REGION` env var.
+        region: overrideRegion,
+        credentialProvider: fromIni({ profile: endpoint.awsProfileName }),
+      });
+    }
+
+    if (mode === 'default-chain') {
+      return createAmazonBedrock({
+        region: overrideRegion,
+        credentialProvider: fromNodeProviderChain(),
+      });
+    }
+
+    // access-keys: no profile / env to fall back on, so keep the
+    // historical `us-east-1` default to preserve behaviour for existing
+    // setups.
+    const secretAccessKey = this.preferencesService.decryptProviderApiKey(
+      endpoint.encryptedSecretKey,
+    );
+    return createAmazonBedrock({
+      region: overrideRegion ?? 'us-east-1',
+      accessKeyId: apiKey,
+      secretAccessKey,
+    });
   }
 
   /**
@@ -592,14 +661,7 @@ export class ModelProviderService {
       }
 
       case 'amazon-bedrock': {
-        const secretAccessKey = this.preferencesService.decryptProviderApiKey(
-          endpoint.encryptedSecretKey,
-        );
-        const bedrockProvider = createAmazonBedrock({
-          region: endpoint.region ?? 'us-east-1',
-          accessKeyId: apiKey,
-          secretAccessKey,
-        });
+        const bedrockProvider = this.buildBedrockProvider(endpoint, apiKey);
         return {
           model: this.telemetryService.withTracing(
             bedrockProvider(modelId as any),
@@ -608,6 +670,7 @@ export class ModelProviderService {
           headers,
           providerOptions: modelProviderOptions as any,
           contextWindowSize,
+          stripStrictFromTools: true,
         };
       }
 
@@ -771,14 +834,7 @@ export class ModelProviderService {
 
       case 'amazon-bedrock': {
         const ep = endpoint ?? ({} as CustomEndpoint);
-        const secretAccessKey = this.preferencesService.decryptProviderApiKey(
-          ep.encryptedSecretKey,
-        );
-        const bedrockProvider = createAmazonBedrock({
-          region: ep.region ?? 'us-east-1',
-          accessKeyId: apiKey,
-          secretAccessKey,
-        });
+        const bedrockProvider = this.buildBedrockProvider(ep, apiKey);
         return {
           model: this.telemetryService.withTracing(
             bedrockProvider(customModel.modelId as any),
@@ -787,6 +843,7 @@ export class ModelProviderService {
           headers,
           providerOptions,
           contextWindowSize: customModel.contextWindowSize,
+          stripStrictFromTools: true,
         };
       }
 

--- a/apps/browser/src/backend/agents/shared/base-agent/base-agent.ts
+++ b/apps/browser/src/backend/agents/shared/base-agent/base-agent.ts
@@ -58,6 +58,7 @@ import { hashPath } from './file-read-transformer/hash';
 import { deriveMaxReadChars } from './file-read-transformer/format-utils';
 import { clearPendingApproval } from './pending-approvals-cleanup';
 import type { StagewiseToolSet } from '@shared/karton-contracts/ui/agent/tools/types';
+import { stripStrictFromToolSet } from './strip-strict-from-tools';
 import type { AgentToolUIPart } from '@shared/karton-contracts/ui/agent';
 import { AgentsMap } from '../../agents-map';
 
@@ -610,6 +611,7 @@ export abstract class BaseAgent<
 
           // Keep `pendingApprovals` free of stale entries regardless of
           // which terminal state we transition to.
+          // @ts-expect-error - We know that the tool part is a ToolUIPart
           clearPendingApproval(draft, toolPart);
 
           if (toolPart.state === 'approval-requested') {
@@ -1551,6 +1553,9 @@ export abstract class BaseAgent<
       this._toolCallDurations.clear();
       tools = this.wrapToolsWithTiming(tools);
       tools = this.wrapToolsWithOutputBudget(tools);
+      if (modelWithOptions.stripStrictFromTools) {
+        tools = this.stripStrictFromTools(tools);
+      }
       resolvedConfig = {
         ...this.config,
         ...(await this.getModelSettings(this.messages)),
@@ -3016,6 +3021,26 @@ export abstract class BaseAgent<
       ...BaseAgent.extractApiErrorContext(error),
       ...extra,
     });
+  }
+
+  /**
+   * Removes the `strict` field from each tool definition.
+   *
+   * Rationale: tool factories pass `strict: false` (OpenAI-specific; ignored
+   * by most other providers) so that Zod schemas with `z.any()` / unions are
+   * not forced through OpenAI's strict JSON-Schema subset. However, the
+   * Bedrock → Anthropic path serialises the field into the Anthropic
+   * tool payload, which rejects unknown keys with
+   * `tools.0.custom.strict: Extra inputs are not permitted`.
+   *
+   * For providers that flag `stripStrictFromTools`, we delete `strict`
+   * here as the very last step before `streamText`, leaving the existing
+   * `strict: false` defaults untouched for every other provider.
+   */
+  private stripStrictFromTools(
+    tools: Partial<StagewiseToolSet>,
+  ): Partial<StagewiseToolSet> {
+    return stripStrictFromToolSet(tools);
   }
 
   private wrapToolsWithTiming(

--- a/apps/browser/src/backend/agents/shared/base-agent/strip-strict-from-tools.test.ts
+++ b/apps/browser/src/backend/agents/shared/base-agent/strip-strict-from-tools.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import type { StagewiseToolSet } from '@shared/karton-contracts/ui/agent/tools/types';
+import { stripStrictFromToolSet } from './strip-strict-from-tools';
+
+// `StagewiseToolSet` is a tightly-typed union; the helper operates on an
+// opaque record shape. Casting through `unknown` keeps the test inputs
+// readable without pulling in the full tool factory machinery.
+function toToolSet(input: Record<string, unknown>): Partial<StagewiseToolSet> {
+  return input as unknown as Partial<StagewiseToolSet>;
+}
+
+describe('stripStrictFromToolSet', () => {
+  it('returns a tool without `strict` unchanged (structurally equal)', () => {
+    const tool = {
+      description: 'no strict here',
+      inputSchema: { type: 'object' },
+      execute: () => 'ok',
+    };
+
+    const out = stripStrictFromToolSet(toToolSet({ myTool: tool }));
+
+    expect(out).toEqual({ myTool: tool });
+  });
+
+  it('drops `strict: false` but preserves every other field', () => {
+    const tool = {
+      description: 'bedrock-hostile',
+      inputSchema: { type: 'object' },
+      execute: () => 'ok',
+      strict: false,
+    };
+
+    const out = stripStrictFromToolSet(toToolSet({ myTool: tool })) as Record<
+      string,
+      Record<string, unknown>
+    >;
+
+    expect(out.myTool).not.toHaveProperty('strict');
+    expect(out.myTool).toMatchObject({
+      description: 'bedrock-hostile',
+      inputSchema: { type: 'object' },
+    });
+    expect(typeof out.myTool.execute).toBe('function');
+  });
+
+  it('drops `strict: true` regardless of value', () => {
+    const tool = {
+      description: 'explicitly strict',
+      strict: true,
+    };
+
+    const out = stripStrictFromToolSet(toToolSet({ myTool: tool })) as Record<
+      string,
+      Record<string, unknown>
+    >;
+
+    expect(out.myTool).not.toHaveProperty('strict');
+    expect(out.myTool.description).toBe('explicitly strict');
+  });
+
+  it('passes through non-object entries without crashing', () => {
+    // Realistically the tool set never contains `undefined` values, but the
+    // helper is defensive against accidental holes; this lock-in test keeps
+    // that branch honest.
+    const input = toToolSet({
+      valid: { description: 'ok', strict: false },
+      broken: undefined as any,
+    });
+
+    const out = stripStrictFromToolSet(input) as Record<string, unknown>;
+
+    expect(out.valid).toEqual({ description: 'ok' });
+    expect(out.broken).toBeUndefined();
+  });
+});

--- a/apps/browser/src/backend/agents/shared/base-agent/strip-strict-from-tools.ts
+++ b/apps/browser/src/backend/agents/shared/base-agent/strip-strict-from-tools.ts
@@ -1,0 +1,35 @@
+import type { StagewiseToolSet } from '@shared/karton-contracts/ui/agent/tools/types';
+
+/**
+ * Removes the `strict` field from each tool definition.
+ *
+ * Rationale: tool factories pass `strict: false` (OpenAI-specific; ignored
+ * by most other providers) so that Zod schemas with `z.any()` / unions are
+ * not forced through OpenAI's strict JSON-Schema subset. However, the
+ * Bedrock → Anthropic path serialises the field into the Anthropic tool
+ * payload, which rejects unknown keys with
+ * `tools.0.custom.strict: Extra inputs are not permitted`.
+ *
+ * For providers that flag `stripStrictFromTools` on their model options,
+ * callers delete `strict` here as the very last step before `streamText`,
+ * leaving the existing `strict: false` defaults untouched for every other
+ * provider.
+ *
+ * Extracted to its own module so the unit test can import it without
+ * transitively loading the entire `BaseAgent` dependency graph (which
+ * would trigger circular-initialization errors in vitest).
+ */
+export function stripStrictFromToolSet(
+  tools: Partial<StagewiseToolSet>,
+): Partial<StagewiseToolSet> {
+  const cleaned: Partial<StagewiseToolSet> = {};
+  for (const [name, t] of Object.entries(tools)) {
+    if (!t || typeof t !== 'object') {
+      (cleaned as Record<string, unknown>)[name] = t;
+      continue;
+    }
+    const { strict: _strict, ...rest } = t as Record<string, unknown>;
+    (cleaned as Record<string, unknown>)[name] = rest;
+  }
+  return cleaned;
+}

--- a/apps/browser/src/backend/services/pages.ts
+++ b/apps/browser/src/backend/services/pages.ts
@@ -25,6 +25,7 @@ import type {
   ModelProvider,
 } from '@shared/karton-contracts/ui/shared-types';
 import { validateApiKeys } from '../utils/validate-api-keys';
+import { listAwsProfiles } from '../utils/aws-profiles';
 import type { HistoryService } from './history';
 import type { FaviconService } from './favicon';
 import type { ThumbnailService } from './thumbnail';
@@ -1547,6 +1548,13 @@ export class PagesService extends DisposableService {
     );
 
     this.kartonServer.registerServerProcedureHandler(
+      'listAwsProfiles',
+      async (_callingClientId: string) => {
+        return listAwsProfiles();
+      },
+    );
+
+    this.kartonServer.registerServerProcedureHandler(
       'validateProviderApiKey',
       async (
         _callingClientId: string,
@@ -2019,6 +2027,13 @@ export class PagesService extends DisposableService {
     this.kartonServer.removeServerProcedureHandler('clearProviderApiKey');
     this.kartonServer.removeServerProcedureHandler('setCustomEndpointApiKey');
     this.kartonServer.removeServerProcedureHandler('clearCustomEndpointApiKey');
+    this.kartonServer.removeServerProcedureHandler(
+      'setCustomEndpointSecretKey',
+    );
+    this.kartonServer.removeServerProcedureHandler(
+      'setCustomEndpointGoogleCredentials',
+    );
+    this.kartonServer.removeServerProcedureHandler('listAwsProfiles');
     this.kartonServer.removeServerProcedureHandler('validateProviderApiKey');
     this.kartonServer.removeServerProcedureHandler('sendOtp');
     this.kartonServer.removeServerProcedureHandler('verifyOtp');

--- a/apps/browser/src/backend/services/preferences.ts
+++ b/apps/browser/src/backend/services/preferences.ts
@@ -157,6 +157,10 @@ export class PreferencesService extends DisposableService {
           apiSpec: apiSpecMap[provider] as any,
           baseUrl: config.customBaseUrl,
           encryptedApiKey: config.encryptedApiKey,
+          // Default value mirrors the Zod schema — only Bedrock reads it,
+          // and the migration path only hits providers without Bedrock,
+          // but the type makes the field required.
+          awsAuthMode: 'access-keys',
         });
 
         config.customProviderId = id;

--- a/apps/browser/src/backend/services/telemetry.ts
+++ b/apps/browser/src/backend/services/telemetry.ts
@@ -300,6 +300,14 @@ export type EventProperties = {
      * dropped entirely for `off`.
      */
     base_url?: string;
+    /**
+     * Coarse AWS auth mode for Bedrock endpoints. Emitted regardless of
+     * telemetry level so we can track feature adoption. The profile
+     * *name* is deliberately NEVER reported — it can reveal internal
+     * account structure (e.g. `my-company-prod`) and is treated as
+     * PII-adjacent.
+     */
+    aws_auth_mode?: 'access-keys' | 'profile' | 'default-chain';
   };
   'custom-provider-add-aborted': {
     had_validation_errors: boolean;
@@ -309,6 +317,8 @@ export type EventProperties = {
     is_local?: boolean;
     /** See `custom-provider-add-finished` — same semantics. */
     base_url?: string;
+    /** See `custom-provider-add-finished` — same semantics. */
+    aws_auth_mode?: 'access-keys' | 'profile' | 'default-chain';
   };
   'workspace-connect-started': undefined;
   'workspace-connect-finished': undefined;
@@ -380,11 +390,17 @@ const UI_TELEMETRY_EVENT_SCHEMAS = {
     api_spec: z.string(),
     is_local: z.boolean().optional(),
     base_url: z.string().optional(),
+    aws_auth_mode: z
+      .enum(['access-keys', 'profile', 'default-chain'])
+      .optional(),
   }),
   'custom-provider-add-finished': z.object({
     api_spec: z.string(),
     is_local: z.boolean().optional(),
     base_url: z.string().optional(),
+    aws_auth_mode: z
+      .enum(['access-keys', 'profile', 'default-chain'])
+      .optional(),
   }),
   'custom-provider-add-started': z.undefined().optional(),
   'element-selection-started': z.undefined().optional(),

--- a/apps/browser/src/backend/utils/aws-profiles.ts
+++ b/apps/browser/src/backend/utils/aws-profiles.ts
@@ -1,0 +1,95 @@
+/**
+ * Helpers for reading AWS named profiles from the local ini files
+ * (`~/.aws/config` and `~/.aws/credentials`).
+ *
+ * Runs in the Electron main process only — the ini loader performs
+ * filesystem access.
+ */
+
+import { loadSharedConfigFiles } from '@smithy/shared-ini-file-loader';
+
+export interface AwsProfileInfo {
+  name: string;
+  /** Value of `region = ...` in the profile. */
+  region?: string;
+  /** Value of `sso_region = ...` in the profile (SSO-configured profiles). */
+  ssoRegion?: string;
+}
+
+export interface ListAwsProfilesResult {
+  profiles: AwsProfileInfo[];
+  /**
+   * `AWS_REGION` (preferred) or `AWS_DEFAULT_REGION` as seen by the
+   * Electron main process. Useful as a hint for `default-chain` mode,
+   * where the profile files have no region to read.
+   *
+   * Note: apps launched from Finder/Dock on macOS do not inherit shell
+   * env vars, so this is often empty in GUI launches even when the
+   * user has exported `AWS_REGION` in their shell config.
+   */
+  envRegion?: string;
+  /** Truncated error message if reading the ini files failed. */
+  error?: string;
+}
+
+/**
+ * Merge `region` / `sso_region` from the config and credentials maps,
+ * preferring whichever value exists and treating empty strings as
+ * missing. Profiles in `~/.aws/config` use the prefix `profile <name>`
+ * except for `default`; `loadSharedConfigFiles` strips that prefix so
+ * both maps key by the raw profile name.
+ */
+function pickRegion(
+  ...sections: Array<Record<string, string | undefined> | undefined>
+): string | undefined {
+  for (const s of sections) {
+    const v = s?.region;
+    if (typeof v === 'string' && v.length > 0) return v;
+  }
+  return undefined;
+}
+
+function pickSsoRegion(
+  ...sections: Array<Record<string, string | undefined> | undefined>
+): string | undefined {
+  for (const s of sections) {
+    const v = s?.sso_region;
+    if (typeof v === 'string' && v.length > 0) return v;
+  }
+  return undefined;
+}
+
+/**
+ * Enumerate profiles declared in `~/.aws/config` and
+ * `~/.aws/credentials`. Returns each profile's declared region (and
+ * sso_region, if any) so callers can compute the correct Bedrock
+ * cross-region inference profile prefix without a separate round-trip.
+ * Names are deduplicated and sorted.
+ */
+export async function listAwsProfiles(): Promise<ListAwsProfilesResult> {
+  const envRegion =
+    process.env.AWS_REGION || process.env.AWS_DEFAULT_REGION || undefined;
+  try {
+    const { configFile, credentialsFile } = await loadSharedConfigFiles();
+    const names = new Set<string>([
+      ...Object.keys(configFile ?? {}),
+      ...Object.keys(credentialsFile ?? {}),
+    ]);
+    const profiles: AwsProfileInfo[] = [...names].sort().map((name) => {
+      const cfg = configFile?.[name];
+      const creds = credentialsFile?.[name];
+      return {
+        name,
+        region: pickRegion(cfg, creds),
+        ssoRegion: pickSsoRegion(cfg, creds),
+      };
+    });
+    return { profiles, envRegion };
+  } catch (err) {
+    return {
+      profiles: [],
+      envRegion,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}

--- a/apps/browser/src/pages/routes/_internal-app/agent-settings.custom-providers.tsx
+++ b/apps/browser/src/pages/routes/_internal-app/agent-settings.custom-providers.tsx
@@ -11,6 +11,12 @@ import type {
 import { Input } from '@stagewise/stage-ui/components/input';
 import { Button } from '@stagewise/stage-ui/components/button';
 import { Select } from '@stagewise/stage-ui/components/select';
+import { Switch } from '@stagewise/stage-ui/components/switch';
+import {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+} from '@stagewise/stage-ui/components/tooltip';
 import {
   Dialog,
   DialogContent,
@@ -71,10 +77,299 @@ type EndpointSaveData = {
   apiVersion?: string;
   region?: string;
   secretKey?: string;
+  awsAuthMode?: 'access-keys' | 'profile' | 'default-chain';
+  awsProfileName?: string;
   projectId?: string;
   location?: string;
   googleCredentials?: string;
 };
+
+const AWS_AUTH_MODE_OPTIONS: {
+  value: 'access-keys' | 'profile' | 'default-chain';
+  label: string;
+}[] = [
+  { value: 'access-keys', label: 'Access Keys' },
+  { value: 'profile', label: 'Named Profile' },
+  { value: 'default-chain', label: 'Default Credential Chain' },
+];
+
+type AwsProfileInfo = {
+  name: string;
+  region?: string;
+  ssoRegion?: string;
+};
+
+/**
+ * Map an AWS region to the Bedrock cross-region inference profile
+ * prefix required by Claude 4.x and Nova. Falls back to `us.` for
+ * unrecognised regions because `us.` is the most broadly supported
+ * family and unknown inputs almost always come from typos of a
+ * US region.
+ */
+function bedrockInferencePrefix(region: string | undefined): string {
+  if (!region) return 'us.';
+  if (region.startsWith('us-') || region.startsWith('ca-')) return 'us.';
+  if (region.startsWith('eu-')) return 'eu.';
+  if (region.startsWith('ap-')) return 'apac.';
+  return 'us.';
+}
+
+/**
+ * Resolve the region the Bedrock endpoint will effectively use for
+ * model-ID prefix computation. The priority matches what the backend
+ * credential resolution does at signing time: explicit override wins,
+ * otherwise fall back to whatever the selected profile (or env) says.
+ *
+ * Returns `undefined` if nothing is known — callers should treat that
+ * as "prefix unknown" rather than defaulting silently.
+ */
+function resolveEffectiveBedrockRegion(args: {
+  regionOverride: string;
+  awsAuthMode: 'access-keys' | 'profile' | 'default-chain';
+  awsProfileName: string;
+  profiles: AwsProfileInfo[];
+  envRegion: string | undefined;
+}): string | undefined {
+  const override = args.regionOverride.trim();
+  if (override) return override;
+  if (args.awsAuthMode === 'profile' && args.awsProfileName) {
+    const p = args.profiles.find((x) => x.name === args.awsProfileName);
+    if (p?.region) return p.region;
+    if (p?.ssoRegion) return p.ssoRegion;
+  }
+  if (args.awsAuthMode === 'default-chain' && args.envRegion) {
+    return args.envRegion;
+  }
+  return undefined;
+}
+
+/**
+ * Build a suggested `modelIdMapping` JSON string for Bedrock, using
+ * the given inference-profile prefix. The mapping covers the built-in
+ * Anthropic models that Bedrock hosts; IDs are the cross-region
+ * inference profile identifiers as published in Anthropic's Bedrock
+ * reference (docs.anthropic.com → Models overview → Bedrock column).
+ *
+ * Note: the 4.6/4.7 generation uses short-form IDs without a date or
+ * `-v1:0` suffix — that is intentional on Anthropic's side, not a
+ * placeholder. Older models (4.5 and earlier) still carry the dated,
+ * versioned form.
+ */
+function buildSuggestedBedrockMapping(prefix: string): string {
+  const mapping: Record<string, string> = {
+    'claude-opus-4.7': `${prefix}anthropic.claude-opus-4-7`,
+    'claude-opus-4.6': `${prefix}anthropic.claude-opus-4-6-v1`,
+    'claude-sonnet-4.6': `${prefix}anthropic.claude-sonnet-4-6`,
+    'claude-haiku-4.5': `${prefix}anthropic.claude-haiku-4-5-20251001-v1:0`,
+  };
+  return JSON.stringify(mapping, null, 2);
+}
+
+/**
+ * Bedrock-specific fields. Split out because the auth-mode switch
+ * drives several conditional sub-panels (static keys, named profile
+ * dropdown, default chain) that would make `ProviderSpecificFields`
+ * unwieldy inline.
+ *
+ * Profile-list loading: fires once per mount when auth mode is
+ * `profile`, and re-fires on every switch back to `profile` so a user
+ * who ran `aws configure` in another terminal sees the new profile
+ * without reopening the dialog. `aborted` guards against setting state
+ * after the dialog closes (listAwsProfiles never rejects — it returns
+ * `{ profiles: [], error }` — so we only need to care about unmount).
+ */
+function BedrockFields({
+  endpoint,
+  region,
+  setRegion,
+  apiKey,
+  setApiKey,
+  secretKey,
+  setSecretKey,
+  awsAuthMode,
+  setAwsAuthMode,
+  awsProfileName,
+  setAwsProfileName,
+  keyPlaceholder,
+  profiles,
+  profilesLoading,
+  profilesError,
+  envRegion,
+  detectedRegion,
+}: {
+  endpoint?: CustomEndpoint;
+  region: string;
+  setRegion: (v: string) => void;
+  apiKey: string;
+  setApiKey: (v: string) => void;
+  secretKey: string;
+  setSecretKey: (v: string) => void;
+  awsAuthMode: 'access-keys' | 'profile' | 'default-chain';
+  setAwsAuthMode: (v: 'access-keys' | 'profile' | 'default-chain') => void;
+  awsProfileName: string;
+  setAwsProfileName: (v: string) => void;
+  keyPlaceholder: string;
+  /** Loaded by `CustomEndpointDialog` so both the dropdown and the
+   *  mapping-suggest button see the same list. */
+  profiles: AwsProfileInfo[];
+  profilesLoading: boolean;
+  profilesError: string | undefined;
+  /** `AWS_REGION` / `AWS_DEFAULT_REGION` as seen by the main process. */
+  envRegion: string | undefined;
+  /**
+   * Region computed from override → profile → env fallback chain.
+   * Shown as a hint under the override input so the user can see what
+   * the request will actually sign against without digging into ~/.aws.
+   */
+  detectedRegion: string | undefined;
+}) {
+  // Build the dropdown items. When the saved profile is no longer in
+  // the ini files (e.g. user removed it in another tool), keep it as a
+  // selectable stale entry so the form doesn't silently drop it.
+  const profileItems = (() => {
+    const items = profiles.map((p) => ({ value: p.name, label: p.name }));
+    if (
+      awsProfileName &&
+      !profiles.some((p) => p.name === awsProfileName) &&
+      !profilesLoading
+    ) {
+      items.unshift({
+        value: awsProfileName,
+        label: `${awsProfileName} (not found)`,
+      });
+    }
+    return items;
+  })();
+
+  return (
+    <>
+      <div className="space-y-1.5">
+        <p className="font-medium text-foreground text-xs">
+          AWS Region{' '}
+          {awsAuthMode !== 'access-keys' && (
+            <span className="font-normal text-muted-foreground">
+              (optional override)
+            </span>
+          )}
+        </p>
+        <Input
+          placeholder={
+            awsAuthMode === 'access-keys'
+              ? 'us-east-1'
+              : detectedRegion
+                ? detectedRegion
+                : 'from profile / AWS_REGION'
+          }
+          value={region}
+          onValueChange={setRegion}
+          size="sm"
+        />
+        {awsAuthMode !== 'access-keys' && detectedRegion && !region && (
+          <p className="text-muted-foreground text-xs">
+            Detected region: <code className="font-mono">{detectedRegion}</code>
+            {awsAuthMode === 'default-chain' && envRegion === detectedRegion
+              ? ' (from AWS_REGION)'
+              : ''}
+          </p>
+        )}
+      </div>
+
+      <div className="space-y-1.5">
+        <p className="font-medium text-foreground text-xs">
+          Authentication Method
+        </p>
+        <Select
+          value={awsAuthMode}
+          onValueChange={(val) =>
+            setAwsAuthMode(val as 'access-keys' | 'profile' | 'default-chain')
+          }
+          items={AWS_AUTH_MODE_OPTIONS}
+          size="sm"
+          triggerClassName="w-full"
+        />
+      </div>
+
+      {awsAuthMode === 'access-keys' && (
+        <>
+          <div className="space-y-1.5">
+            <p className="font-medium text-foreground text-xs">Access Key ID</p>
+            <Input
+              type="password"
+              placeholder={keyPlaceholder}
+              value={apiKey}
+              onValueChange={setApiKey}
+              size="sm"
+            />
+          </div>
+          <div className="space-y-1.5">
+            <p className="font-medium text-foreground text-xs">
+              Secret Access Key
+            </p>
+            <Input
+              type="password"
+              placeholder={
+                endpoint?.encryptedSecretKey
+                  ? 'Leave blank to keep current key'
+                  : 'Enter secret access key...'
+              }
+              value={secretKey}
+              onValueChange={setSecretKey}
+              size="sm"
+            />
+          </div>
+        </>
+      )}
+
+      {awsAuthMode === 'profile' && (
+        <div className="space-y-1.5">
+          <p className="font-medium text-foreground text-xs">AWS Profile</p>
+          {profileItems.length > 0 ? (
+            <Select<string>
+              value={awsProfileName || ''}
+              onValueChange={(val) => setAwsProfileName(val ?? '')}
+              items={profileItems}
+              placeholder="Select a profile..."
+              size="sm"
+              triggerClassName="w-full"
+            />
+          ) : (
+            <Input
+              placeholder={profilesLoading ? 'Loading profiles…' : 'default'}
+              value={awsProfileName}
+              onValueChange={setAwsProfileName}
+              size="sm"
+            />
+          )}
+          {profilesError && (
+            <p className="text-error-foreground text-xs">{profilesError}</p>
+          )}
+          {!profilesError && !profilesLoading && profiles.length === 0 && (
+            <p className="text-muted-foreground text-xs">
+              No profiles found in ~/.aws/config or ~/.aws/credentials. Type a
+              name manually if needed.
+            </p>
+          )}
+          <p className="text-muted-foreground text-xs">
+            SSO profiles require an active session. If requests fail with an
+            expired-token error, run{' '}
+            <code className="font-mono">
+              aws sso login --profile &lt;name&gt;
+            </code>{' '}
+            in your terminal.
+          </p>
+        </div>
+      )}
+
+      {awsAuthMode === 'default-chain' && (
+        <p className="text-muted-foreground text-xs">
+          Credentials will be resolved from the standard AWS provider chain:
+          environment variables, shared credentials file, ECS/EC2 instance
+          metadata, and SSO.
+        </p>
+      )}
+    </>
+  );
+}
 
 /** Form fields that vary by provider type */
 function ProviderSpecificFields({
@@ -98,6 +393,15 @@ function ProviderSpecificFields({
   setLocation,
   googleCredentials,
   setGoogleCredentials,
+  awsAuthMode,
+  setAwsAuthMode,
+  awsProfileName,
+  setAwsProfileName,
+  awsProfiles,
+  awsProfilesLoading,
+  awsProfilesError,
+  awsEnvRegion,
+  bedrockDetectedRegion,
 }: {
   apiSpec: ApiSpec;
   endpoint?: CustomEndpoint;
@@ -119,6 +423,15 @@ function ProviderSpecificFields({
   setLocation: (v: string) => void;
   googleCredentials: string;
   setGoogleCredentials: (v: string) => void;
+  awsAuthMode: 'access-keys' | 'profile' | 'default-chain';
+  setAwsAuthMode: (v: 'access-keys' | 'profile' | 'default-chain') => void;
+  awsProfileName: string;
+  setAwsProfileName: (v: string) => void;
+  awsProfiles: AwsProfileInfo[];
+  awsProfilesLoading: boolean;
+  awsProfilesError: string | undefined;
+  awsEnvRegion: string | undefined;
+  bedrockDetectedRegion: string | undefined;
 }) {
   const hasKey = !!endpoint?.encryptedApiKey;
   const keyPlaceholder = hasKey
@@ -181,43 +494,25 @@ function ProviderSpecificFields({
 
     case 'amazon-bedrock':
       return (
-        <>
-          <div className="space-y-1.5">
-            <p className="font-medium text-foreground text-xs">AWS Region</p>
-            <Input
-              placeholder="us-east-1"
-              value={region}
-              onValueChange={setRegion}
-              size="sm"
-            />
-          </div>
-          <div className="space-y-1.5">
-            <p className="font-medium text-foreground text-xs">Access Key ID</p>
-            <Input
-              type="password"
-              placeholder={keyPlaceholder}
-              value={apiKey}
-              onValueChange={setApiKey}
-              size="sm"
-            />
-          </div>
-          <div className="space-y-1.5">
-            <p className="font-medium text-foreground text-xs">
-              Secret Access Key
-            </p>
-            <Input
-              type="password"
-              placeholder={
-                endpoint?.encryptedSecretKey
-                  ? 'Leave blank to keep current key'
-                  : 'Enter secret access key...'
-              }
-              value={secretKey}
-              onValueChange={setSecretKey}
-              size="sm"
-            />
-          </div>
-        </>
+        <BedrockFields
+          endpoint={endpoint}
+          region={region}
+          setRegion={setRegion}
+          apiKey={apiKey}
+          setApiKey={setApiKey}
+          secretKey={secretKey}
+          setSecretKey={setSecretKey}
+          awsAuthMode={awsAuthMode}
+          setAwsAuthMode={setAwsAuthMode}
+          awsProfileName={awsProfileName}
+          setAwsProfileName={setAwsProfileName}
+          keyPlaceholder={keyPlaceholder}
+          profiles={awsProfiles}
+          profilesLoading={awsProfilesLoading}
+          profilesError={awsProfilesError}
+          envRegion={awsEnvRegion}
+          detectedRegion={bedrockDetectedRegion}
+        />
       );
 
     case 'google-vertex':
@@ -331,15 +626,113 @@ function CustomEndpointDialog({
       : '',
   );
   const [mappingError, setMappingError] = useState<string | null>(null);
+  // Auto-suggestion toggle for the Bedrock model-id mapping. On by
+  // default when there is no existing mapping so new Bedrock users
+  // immediately get the correct cross-region inference-profile IDs
+  // for their region; off for endpoints that already have a saved
+  // mapping (treat it as a manual override we must not clobber).
+  // User can re-enable at any time to regenerate; any manual edit to
+  // the textarea flips it back off.
+  const [bedrockSuggestionEnabled, setBedrockSuggestionEnabled] = useState(
+    () => {
+      if (endpoint?.apiSpec !== 'amazon-bedrock') return true;
+      return (
+        !endpoint?.modelIdMapping ||
+        Object.keys(endpoint.modelIdMapping).length === 0
+      );
+    },
+  );
   const [resourceName, setResourceName] = useState(
     endpoint?.resourceName ?? '',
   );
   const [apiVersion, setApiVersion] = useState(endpoint?.apiVersion ?? '');
   const [region, setRegion] = useState(endpoint?.region ?? '');
   const [secretKey, setSecretKey] = useState('');
+  const [awsAuthMode, setAwsAuthMode] = useState<
+    'access-keys' | 'profile' | 'default-chain'
+  >(endpoint?.awsAuthMode ?? 'access-keys');
+  const [awsProfileName, setAwsProfileName] = useState(
+    endpoint?.awsProfileName ?? '',
+  );
   const [projectId, setProjectId] = useState(endpoint?.projectId ?? '');
   const [location, setLocation] = useState(endpoint?.location ?? '');
   const [googleCredentials, setGoogleCredentials] = useState('');
+
+  // Profile-list loading is lifted to the dialog so both `BedrockFields`
+  // (for the dropdown + detected-region hint) and the "Suggest mapping"
+  // button in the Model ID Mapping section share a single source of
+  // truth. Reloading every time the user switches to `profile` covers
+  // the "user ran `aws configure` in another terminal" flow without
+  // forcing them to reopen the dialog.
+  const listAwsProfiles = useKartonProcedure((p) => p.listAwsProfiles);
+  const [awsProfiles, setAwsProfiles] = useState<AwsProfileInfo[]>([]);
+  const [awsEnvRegion, setAwsEnvRegion] = useState<string | undefined>();
+  const [awsProfilesError, setAwsProfilesError] = useState<
+    string | undefined
+  >();
+  const [awsProfilesLoading, setAwsProfilesLoading] = useState(false);
+
+  useEffect(() => {
+    if (!open) return;
+    if (apiSpec !== 'amazon-bedrock') return;
+    // Access-keys mode has nothing useful to do with the profile list
+    // or env region, so skip the RPC entirely.
+    if (awsAuthMode === 'access-keys') return;
+    let aborted = false;
+    setAwsProfilesLoading(true);
+    listAwsProfiles()
+      .then((res) => {
+        if (aborted) return;
+        setAwsProfiles(res.profiles);
+        setAwsEnvRegion(res.envRegion);
+        setAwsProfilesError(res.error);
+      })
+      .catch((err: unknown) => {
+        // Backend handler is try/catch'd and never rejects, but the
+        // Karton RPC transport itself can fail (disconnect, serialization).
+        // Without this branch `awsProfilesLoading` would stay true forever
+        // and the dropdown would sit on "Loading profiles…".
+        if (aborted) return;
+        setAwsProfiles([]);
+        setAwsEnvRegion(undefined);
+        setAwsProfilesError(
+          err instanceof Error ? err.message : 'Failed to load AWS profiles',
+        );
+      })
+      .finally(() => {
+        if (!aborted) setAwsProfilesLoading(false);
+      });
+    return () => {
+      aborted = true;
+    };
+  }, [open, apiSpec, awsAuthMode, listAwsProfiles]);
+
+  const bedrockDetectedRegion = resolveEffectiveBedrockRegion({
+    regionOverride: region,
+    awsAuthMode,
+    awsProfileName,
+    profiles: awsProfiles,
+    envRegion: awsEnvRegion,
+  });
+
+  // Regenerate the suggested mapping whenever anything that could
+  // change the effective inference-profile prefix changes — region
+  // override, selected profile (which carries its own region), or the
+  // profile list loading in. We only write when the suggestion toggle
+  // is on, which is off the moment the user edits the textarea
+  // manually, so user overrides are never clobbered.
+  useEffect(() => {
+    if (!open) return;
+    if (apiSpec !== 'amazon-bedrock') return;
+    if (!bedrockSuggestionEnabled) return;
+    const next = buildSuggestedBedrockMapping(
+      bedrockInferencePrefix(bedrockDetectedRegion),
+    );
+    // Avoid a redundant state write (and the "field touched" side
+    // effect downstream) when the mapping is already up-to-date.
+    setModelIdMappingJson((prev) => (prev === next ? prev : next));
+    setMappingError(null);
+  }, [open, apiSpec, bedrockSuggestionEnabled, bedrockDetectedRegion]);
 
   // Depend ONLY on `open` so the effect runs exactly on the open/close
   // transitions. Reading `endpoint`/`isAddMode`/`track` without listing
@@ -362,10 +755,17 @@ function CustomEndpointDialog({
         : '',
     );
     setMappingError(null);
+    setBedrockSuggestionEnabled(
+      endpoint?.apiSpec !== 'amazon-bedrock' ||
+        !endpoint?.modelIdMapping ||
+        Object.keys(endpoint.modelIdMapping).length === 0,
+    );
     setResourceName(endpoint?.resourceName ?? '');
     setApiVersion(endpoint?.apiVersion ?? '');
     setRegion(endpoint?.region ?? '');
     setSecretKey('');
+    setAwsAuthMode(endpoint?.awsAuthMode ?? 'access-keys');
+    setAwsProfileName(endpoint?.awsProfileName ?? '');
     setProjectId(endpoint?.projectId ?? '');
     setLocation(endpoint?.location ?? '');
     setGoogleCredentials('');
@@ -379,7 +779,16 @@ function CustomEndpointDialog({
     }
   }, [open]);
 
-  const canSave = name.trim().length > 0 && !mappingError;
+  // Bedrock profile auth requires a non-empty profile name — without it the
+  // backend's buildBedrockProvider() throws at call time. Block save here so
+  // a whitespace-only value can't produce a backend-invalid endpoint.
+  const bedrockProfileInvalid =
+    apiSpec === 'amazon-bedrock' &&
+    awsAuthMode === 'profile' &&
+    awsProfileName.trim().length === 0;
+
+  const canSave =
+    name.trim().length > 0 && !mappingError && !bedrockProfileInvalid;
 
   // "Touched" = the user changed anything from the initial field values.
   // Derived from current state so we don't need per-input bookkeeping.
@@ -399,6 +808,8 @@ function CustomEndpointDialog({
     apiVersion !== (endpoint?.apiVersion ?? '') ||
     region !== (endpoint?.region ?? '') ||
     secretKey !== '' ||
+    awsAuthMode !== (endpoint?.awsAuthMode ?? 'access-keys') ||
+    awsProfileName !== (endpoint?.awsProfileName ?? '') ||
     projectId !== (endpoint?.projectId ?? '') ||
     location !== (endpoint?.location ?? '') ||
     googleCredentials !== '';
@@ -424,9 +835,14 @@ function CustomEndpointDialog({
     api_spec: string;
     is_local?: boolean;
     base_url?: string;
+    aws_auth_mode?: 'access-keys' | 'profile' | 'default-chain';
   } => {
+    // Coarse Bedrock auth-mode tag. Never include the profile name —
+    // it's redacted by policy (see telemetry event schema).
+    const bedrockProps =
+      apiSpec === 'amazon-bedrock' ? { aws_auth_mode: awsAuthMode } : {};
     const trimmed = baseUrl.trim();
-    if (!trimmed) return { api_spec: apiSpec };
+    if (!trimmed) return { api_spec: apiSpec, ...bedrockProps };
     let isLocal: boolean | undefined;
     try {
       const host = new URL(trimmed).hostname;
@@ -438,6 +854,7 @@ function CustomEndpointDialog({
       api_spec: apiSpec,
       ...(isLocal !== undefined && { is_local: isLocal }),
       ...(telemetryLevel === 'full' && { base_url: trimmed }),
+      ...bedrockProps,
     };
   };
 
@@ -508,27 +925,80 @@ function CustomEndpointDialog({
             setLocation={setLocation}
             googleCredentials={googleCredentials}
             setGoogleCredentials={setGoogleCredentials}
+            awsAuthMode={awsAuthMode}
+            setAwsAuthMode={setAwsAuthMode}
+            awsProfileName={awsProfileName}
+            setAwsProfileName={setAwsProfileName}
+            awsProfiles={awsProfiles}
+            awsProfilesLoading={awsProfilesLoading}
+            awsProfilesError={awsProfilesError}
+            awsEnvRegion={awsEnvRegion}
+            bedrockDetectedRegion={bedrockDetectedRegion}
           />
 
           <div className="space-y-1.5 border-derived border-t pt-3">
-            <p className="font-medium text-foreground text-xs">
-              Model ID Mapping{' '}
-              <span className="font-normal text-muted-foreground">
-                (optional)
-              </span>
-            </p>
+            <div className="flex items-center justify-between gap-2">
+              <p className="font-medium text-foreground text-xs">
+                Model ID Mapping{' '}
+                <span className="font-normal text-muted-foreground">
+                  (optional)
+                </span>
+              </p>
+              {apiSpec === 'amazon-bedrock' && (
+                // Bedrock-only shortcut: Claude/Nova on Bedrock require
+                // cross-region inference-profile IDs (prefixed `us.`,
+                // `eu.`, `apac.`) rather than the bare Anthropic IDs. A
+                // toggle (rather than one-shot button) keeps the textarea
+                // in sync when region-affecting settings change, so users
+                // switching profile/region mid-config get the correct
+                // prefix without having to notice and re-click. Toggle is
+                // flipped off on any manual edit below to preserve user
+                // overrides.
+                <Tooltip>
+                  <TooltipTrigger delay={300}>
+                    <span
+                      className="flex cursor-pointer select-none items-center gap-1.5 text-muted-foreground text-xs"
+                      onClick={() => setBedrockSuggestionEnabled((v) => !v)}
+                    >
+                      <Switch
+                        size="xs"
+                        checked={bedrockSuggestionEnabled}
+                        onCheckedChange={(checked) =>
+                          setBedrockSuggestionEnabled(checked)
+                        }
+                        onClick={(e) => e.stopPropagation()}
+                      />
+                      Suggested mapping
+                    </span>
+                  </TooltipTrigger>
+                  <TooltipContent side="top" align="end">
+                    <p className="max-w-xs text-xs leading-relaxed">
+                      Map the built-in Claude models to the matching Bedrock
+                      cross-region inference profiles for your region. Turn off
+                      to edit the mapping manually.
+                    </p>
+                  </TooltipContent>
+                </Tooltip>
+              )}
+            </div>
             <p className="text-muted-foreground text-xs">
               Map built-in model IDs to the IDs this endpoint expects, e.g. when
               the provider uses different naming.
             </p>
             <textarea
-              className="w-full rounded-lg border border-derived p-2 font-mono text-foreground text-xs focus:outline-none focus:ring-1 focus:ring-muted-foreground/35"
-              rows={3}
-              placeholder='{"claude-opus-4-6": "claude-3-opus-20240229"}'
+              className="scrollbar-subtle w-full resize-y rounded-lg border border-derived p-2 font-mono text-foreground text-xs focus:outline-none focus:ring-1 focus:ring-muted-foreground/35"
+              rows={8}
+              placeholder='{"claude-opus-4.7": "anthropic.claude-opus-4-7"}'
               value={modelIdMappingJson}
               onChange={(e) => {
                 setModelIdMappingJson(e.target.value);
                 setMappingError(null);
+                // Any manual edit means the user has taken over;
+                // stop auto-regenerating so the effect above cannot
+                // overwrite their changes when region/profile shifts.
+                if (bedrockSuggestionEnabled) {
+                  setBedrockSuggestionEnabled(false);
+                }
               }}
             />
             {mappingError && (
@@ -562,6 +1032,12 @@ function CustomEndpointDialog({
                 apiVersion: apiVersion || undefined,
                 region: region || undefined,
                 secretKey: secretKey || undefined,
+                awsAuthMode:
+                  apiSpec === 'amazon-bedrock' ? awsAuthMode : undefined,
+                awsProfileName:
+                  apiSpec === 'amazon-bedrock' && awsAuthMode === 'profile'
+                    ? awsProfileName.trim() || undefined
+                    : undefined,
                 projectId: projectId || undefined,
                 location: location || undefined,
                 googleCredentials: googleCredentials || undefined,
@@ -601,9 +1077,34 @@ function CustomEndpointCard({
     API_SPEC_OPTIONS.find((o) => o.value === endpoint.apiSpec)?.label ??
     endpoint.apiSpec;
 
+  const bedrockModeLabel =
+    endpoint.apiSpec === 'amazon-bedrock'
+      ? endpoint.awsAuthMode === 'profile'
+        ? `profile:${endpoint.awsProfileName || '?'}`
+        : endpoint.awsAuthMode === 'default-chain'
+          ? 'default chain'
+          : 'access keys'
+      : null;
+
+  // Mode-aware region label. Only access-keys auth has a hard-coded
+  // `us-east-1` backend fallback, so only that mode can truthfully
+  // show it. For profile / default-chain the region is resolved at
+  // call time from the profile file or the environment, so we show
+  // the *source* instead of inventing a region.
+  const bedrockRegionLabel =
+    endpoint.apiSpec === 'amazon-bedrock'
+      ? endpoint.region
+        ? endpoint.region
+        : endpoint.awsAuthMode === 'profile'
+          ? 'from profile'
+          : endpoint.awsAuthMode === 'default-chain'
+            ? 'from environment'
+            : 'us-east-1'
+      : null;
+
   const subtitle =
     endpoint.apiSpec === 'amazon-bedrock'
-      ? `${specLabel} \u00b7 ${endpoint.region || 'us-east-1'}`
+      ? `${specLabel} \u00b7 ${bedrockModeLabel} \u00b7 ${bedrockRegionLabel}`
       : endpoint.apiSpec === 'google-vertex'
         ? `${specLabel} \u00b7 ${endpoint.projectId || 'no project'} \u00b7 ${endpoint.location || 'us-central1'}`
         : endpoint.apiSpec === 'azure'
@@ -672,6 +1173,14 @@ function CustomEndpointsSection() {
           ep.resourceName = data.resourceName;
           ep.apiVersion = data.apiVersion;
           ep.region = data.region;
+          // Only Bedrock reads `awsAuthMode` / `awsProfileName`. Touching
+          // the fields for other apiSpecs would silently pollute saved
+          // state; leave them alone so Zod defaults + prior Bedrock state
+          // never leak across apiSpec switches.
+          if (data.apiSpec === 'amazon-bedrock') {
+            ep.awsAuthMode = data.awsAuthMode ?? 'access-keys';
+            ep.awsProfileName = data.awsProfileName;
+          }
           ep.projectId = data.projectId;
           ep.location = data.location;
         });
@@ -701,6 +1210,18 @@ function CustomEndpointsSection() {
             resourceName: data.resourceName,
             apiVersion: data.apiVersion,
             region: data.region,
+            // `awsAuthMode` is schema-required, so we always set a value.
+            // For non-Bedrock specs we pin it to the schema default so the
+            // field is inert (not surfaced in the UI, ignored at the call
+            // site) and `awsProfileName` is left undefined.
+            awsAuthMode:
+              data.apiSpec === 'amazon-bedrock'
+                ? (data.awsAuthMode ?? 'access-keys')
+                : 'access-keys',
+            awsProfileName:
+              data.apiSpec === 'amazon-bedrock'
+                ? data.awsProfileName
+                : undefined,
             projectId: data.projectId,
             location: data.location,
           });

--- a/apps/browser/src/shared/karton-contracts/pages-api/index.ts
+++ b/apps/browser/src/shared/karton-contracts/pages-api/index.ts
@@ -217,6 +217,27 @@ export type PagesApiContract = {
       endpointId: string,
       credentials: string,
     ) => Promise<void>;
+    /**
+     * Enumerate AWS profiles declared in `~/.aws/config` and
+     * `~/.aws/credentials`. Each entry carries the profile's declared
+     * region (and `sso_region`, if set) so the UI can pick the
+     * correct Bedrock cross-region inference profile prefix without
+     * a second round-trip. Returns an empty list (with an error
+     * message) when the ini files cannot be read.
+     *
+     * `envRegion` mirrors `AWS_REGION` / `AWS_DEFAULT_REGION` from
+     * the Electron main process env — mainly useful as a fallback
+     * for `default-chain` mode where the profile files don't apply.
+     */
+    listAwsProfiles: () => Promise<{
+      profiles: Array<{
+        name: string;
+        region?: string;
+        ssoRegion?: string;
+      }>;
+      envRegion?: string;
+      error?: string;
+    }>;
     /** Validate a provider API key by making a lightweight test request */
     validateProviderApiKey: (
       provider: ModelProvider,

--- a/apps/browser/src/shared/karton-contracts/ui/shared-types.ts
+++ b/apps/browser/src/shared/karton-contracts/ui/shared-types.ts
@@ -92,6 +92,16 @@ export const customEndpointSchema = z.object({
   // Amazon Bedrock-specific fields
   region: z.string().optional(),
   encryptedSecretKey: z.string().optional(),
+  /**
+   * Amazon Bedrock auth mode. Defaults to 'access-keys' for backward
+   * compatibility with endpoints created before this field existed
+   * (they all used static access keys).
+   */
+  awsAuthMode: z
+    .enum(['access-keys', 'profile', 'default-chain'])
+    .default('access-keys'),
+  /** Named AWS profile to use when awsAuthMode === 'profile'. */
+  awsProfileName: z.string().optional(),
   // Google Vertex-specific fields
   projectId: z.string().optional(),
   location: z.string().optional(),

--- a/apps/browser/src/ui/screens/main/sidebar/chat/_components/model-select.tsx
+++ b/apps/browser/src/ui/screens/main/sidebar/chat/_components/model-select.tsx
@@ -76,6 +76,10 @@ interface ModelSelectProps {
   onModelChange?: () => void;
 }
 
+// Sentinel value for the "Open model settings" row. Picked to be
+// impossible to collide with any real `ModelId` (leading `@@` + spaces).
+const OPEN_MODEL_SETTINGS_VALUE = '@@open model settings@@';
+
 export const ModelSelect = memo(function ModelSelect({
   onModelChange,
 }: ModelSelectProps) {
@@ -221,7 +225,15 @@ export const ModelSelect = memo(function ModelSelect({
 
   const handleValueChange = useCallback(
     (value: string | null) => {
-      if (!openAgent || !value) return;
+      if (!value) return;
+      if (value === OPEN_MODEL_SETTINGS_VALUE) {
+        // Navigate via the in-app deep link; matches the pattern used by
+        // `not-signed-in.tsx` and `message-runtime-error.tsx`.
+        window.location.href =
+          'stagewise://internal/agent-settings/models-providers';
+        return;
+      }
+      if (!openAgent) return;
       setSelectedModel(openAgent, value as ModelId);
       onModelChange?.();
     },
@@ -288,12 +300,12 @@ export const ModelSelect = memo(function ModelSelect({
                 />
               </div>
 
-              <div
-                ref={listScrollRef}
-                className="mask-alpha scrollbar-subtle max-h-48 overflow-y-auto"
-                style={listMaskStyle}
-              >
-                <ComboboxList>
+              <ComboboxList>
+                <div
+                  ref={listScrollRef}
+                  className="mask-alpha scrollbar-subtle max-h-48 overflow-y-auto"
+                  style={listMaskStyle}
+                >
                   {filteredGroupedModels.map(({ label, models }) =>
                     label ? (
                       <ComboboxGroup key={label}>
@@ -316,14 +328,19 @@ export const ModelSelect = memo(function ModelSelect({
                       ))
                     ),
                   )}
-                </ComboboxList>
-              </div>
-
-              {!hasFilteredResults && (
-                <div className="px-2 py-1.5 text-muted-foreground text-xs">
-                  No results
                 </div>
-              )}
+
+                {!hasFilteredResults && (
+                  <div className="px-2 py-1.5 text-muted-foreground text-xs">
+                    No results
+                  </div>
+                )}
+
+                <ComboboxItem value={OPEN_MODEL_SETTINGS_VALUE} size="xs">
+                  <ComboboxItemIndicator />
+                  <span className="col-start-2 truncate">Model settings</span>
+                </ComboboxItem>
+              </ComboboxList>
             </ComboboxBase.Popup>
 
             {/* Animated side panel for model details */}

--- a/package.json
+++ b/package.json
@@ -96,6 +96,8 @@
   "dependencies": {
     "@ai-sdk/amazon-bedrock": "^4.0.77",
     "@ai-sdk/azure": "^3.0.42",
+    "@aws-sdk/credential-providers": "^3.908.0",
+    "@smithy/shared-ini-file-loader": "^4.4.9",
     "@ai-sdk/google-vertex": "^4.0.80",
     "@ai-sdk/openai-compatible": "^2.0.35",
     "@better-auth/electron": "^1.5.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,9 +27,15 @@ importers:
       '@ai-sdk/openai-compatible':
         specifier: ^2.0.35
         version: 2.0.35(zod@4.3.6)
+      '@aws-sdk/credential-providers':
+        specifier: ^3.908.0
+        version: 3.1041.0
       '@better-auth/electron':
         specifier: ^1.5.3
         version: 1.5.3(@better-auth/core@1.5.3(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-auth@1.5.3(drizzle-kit@0.31.8)(drizzle-orm@0.45.1(@libsql/client@0.15.15(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@opentelemetry/api@1.9.0)(@types/sql.js@1.4.10)(kysely@0.28.11)(sql.js@1.14.1))(next@16.2.3(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(solid-js@1.9.10)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@22.15.2)(jiti@2.6.1)(jsdom@26.1.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)))(better-call@1.3.2(zod@4.3.6))(electron@40.6.1)
+      '@smithy/shared-ini-file-loader':
+        specifier: ^4.4.9
+        version: 4.4.9
       '@streamdown/math':
         specifier: ^1.0.2
         version: 1.0.2(react@19.2.3)
@@ -258,6 +264,9 @@ importers:
       '@ai-sdk/provider':
         specifier: 3.0.8
         version: 3.0.8
+      '@aws-sdk/credential-providers':
+        specifier: ^3.908.0
+        version: 3.1041.0
       '@dnd-kit/core':
         specifier: ^6.3.1
         version: 6.3.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -312,6 +321,9 @@ importers:
       '@shikijs/colorized-brackets':
         specifier: 3.21.0
         version: 3.21.0
+      '@smithy/shared-ini-file-loader':
+        specifier: ^4.4.9
+        version: 4.4.9
       '@stagewise/agent-runtime-node':
         specifier: workspace:*
         version: link:../../agent/runtime-node
@@ -1028,12 +1040,142 @@ packages:
     resolution: {integrity: sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==}
     engines: {node: '>=16.0.0'}
 
+  '@aws-crypto/sha256-browser@5.2.0':
+    resolution: {integrity: sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==}
+
+  '@aws-crypto/sha256-js@5.2.0':
+    resolution: {integrity: sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==}
+    engines: {node: '>=16.0.0'}
+
+  '@aws-crypto/supports-web-crypto@5.2.0':
+    resolution: {integrity: sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==}
+
   '@aws-crypto/util@5.2.0':
     resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==}
+
+  '@aws-sdk/client-cognito-identity@3.1041.0':
+    resolution: {integrity: sha512-h8DxvCsv95RSHTZPyEwGCqOyiQYVWQ4tFe5im4d0qFvFc9xRmseTu3ZsQ9nd+uOzU9rkCoDHClyqUxXU7nm90Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/core@3.974.8':
+    resolution: {integrity: sha512-njR2qoG6ZuB0kvAS2FyICsFZJ6gmCcf2X/7JcD14sUvGDm26wiZ5BrA6LOiUxKFEF+IVe7kdroxyE00YlkiYsw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-cognito-identity@3.972.31':
+    resolution: {integrity: sha512-W5JtzDp3ejzhOOknXlnt+vJsNN2GZdAcBK+hR7HQ1DCacXqS0UpmnIyihIU7CK0IB+XYWeBaN3bBv4pXavp7Vg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-env@3.972.34':
+    resolution: {integrity: sha512-XT0jtf8Fw9JE6ppsQeoNnZRiG+jqRixMT1v1ZR17G60UvVdsQmTG8nbEyHuEPfMxDXEhfdARaM/XiEhca4lGHQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-http@3.972.36':
+    resolution: {integrity: sha512-DPoGWfy7J7RKxvbf5kOKIGQkD2ek3dbKgzKIGrnLuvZBz5myU+Im/H6pmc14QcnFbqHMqxvtWSgRDSJW3qXLQg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-ini@3.972.38':
+    resolution: {integrity: sha512-oDzUBu2MGJFgoar05sPMCwSrhw44ASyccrHzj66vO69OZqi7I6hZZxXfuPLC8OCzW7C+sU+bI73XHij41yekgQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.38':
+    resolution: {integrity: sha512-g1NosS8qe4OF++G2UFCM5ovSkgipC7YYor5KCWatG0UoMSO5YFj9C8muePlyVmOBV/WTI16Jo3/s1NUo/o1Bww==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-node@3.972.39':
+    resolution: {integrity: sha512-HEswDQyxUtadoZ/bJsPPENHg7R0Lzym5LuMksJeHvqhCOpP+rtkDLKI4/ZChH4w3cf5kG8n6bZuI8PzajoiqMg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.972.34':
+    resolution: {integrity: sha512-T3IFs4EVmVi1dVN5RciFnklCANSzvrQd/VuHY9ThHSQmYkTogjcGkoJEr+oNUPQZnso52183088NqysMPji1/Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-sso@3.972.38':
+    resolution: {integrity: sha512-5ZxG+t0+3Q3QPh8KEjX6syskhgNf7I0MN7oGioTf6Lm1NTjfP7sIcYGNsthXC2qR8vcD3edNZwCr2ovfSSWuRA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.38':
+    resolution: {integrity: sha512-lYHFF30DGI20jZcYX8cm6Ns0V7f1dDN6g/MBDLTyD/5iw+bXs3yBr2iAiHDkx4RFU5JgsnZvCHYKiRVPRdmOgw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-providers@3.1041.0':
+    resolution: {integrity: sha512-Ps7dcWV1JbXKoFy8QpWhTpWkX0x2tiZFmDdgojK98/rqyybPdwEtGB8xY/N2uJjE0MZkrV9X7T3Xrnk/rGFoNw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-host-header@3.972.10':
+    resolution: {integrity: sha512-IJSsIMeVQ8MMCPbuh1AbltkFhLBLXn7aejzfX5YKT/VLDHn++Dcz8886tXckE+wQssyPUhaXrJhdakO2VilRhg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-logger@3.972.10':
+    resolution: {integrity: sha512-OOuGvvz1Dm20SjZo5oEBePFqxt5nf8AwkNDSyUHvD9/bfNASmstcYxFAHUowy4n6Io7mWUZ04JURZwSBvyQanQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-recursion-detection@3.972.11':
+    resolution: {integrity: sha512-+zz6f79Kj9V5qFK2P+D8Ehjnw4AhphAlCAsPjUqEcInA9umtSSKMrHbSagEeOIsDNuvVrH98bjRHcyQukTrhaQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-sdk-s3@3.972.37':
+    resolution: {integrity: sha512-Km7M+i8DrLArVzrid1gfxeGhYHBd3uxvE77g0s5a52zPSVosxzQBnJ0gwWb6NIp/DOk8gsBMhi7V+cpJG0ndTA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-user-agent@3.972.38':
+    resolution: {integrity: sha512-iz+B29TXcAZsJpwB+AwG/TTGA5l/VnmMZ2UxtiySOZjI6gCdmviXPwdgzcmuazMy16rXoPY4mYCGe7zdNKfx5A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/nested-clients@3.997.6':
+    resolution: {integrity: sha512-WBDnqatJl+kGObpfmfSxqnXeYTu3Me8wx8WCtvoxX3pfWrrTv8I4WTMSSs7PZqcRcVh8WeUKMgGFjMG+52SR1w==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/region-config-resolver@3.972.13':
+    resolution: {integrity: sha512-CvJ2ZIjK/jVD/lbOpowBVElJyC1YxLTIJ13yM0AEo0t2v7swOzGjSA6lJGH+DwZXQhcjUjoYwc8bVYCX5MDr1A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/signature-v4-multi-region@3.996.25':
+    resolution: {integrity: sha512-+CMIt3e1VzlklAECmG+DtP1sV8iKq25FuA0OKpnJ4KA0kxUtd7CgClY7/RU6VzJBQwbN4EJ9Ue6plvqx1qGadw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1041.0':
+    resolution: {integrity: sha512-Th7kPI6YPtvJUcdznooXJMy+9rQWjmEF81LxaJssngBzuysK4a/x+l8kjm1zb7nYsUPbndnBdUnwng/3PLvtGw==}
+    engines: {node: '>=20.0.0'}
 
   '@aws-sdk/types@3.973.4':
     resolution: {integrity: sha512-RW60aH26Bsc016Y9B98hC0Plx6fK5P2v/iQYwMzrSjiDh1qRMUCP6KrXHYEHe3uFvKiOC93Z9zk4BJsUi6Tj1Q==}
     engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/types@3.973.8':
+    resolution: {integrity: sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-arn-parser@3.972.3':
+    resolution: {integrity: sha512-HzSD8PMFrvgi2Kserxuff5VitNq2sgf3w9qxmskKDiDTThWfVteJxuCS9JXiPIPtmCrp+7N9asfIaVhBFORllA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-endpoints@3.996.8':
+    resolution: {integrity: sha512-oOZHcRDihk5iEe5V25NVWg45b3qEA8OpHWVdU/XQh8Zj4heVPAJqWvMphQnU7LkufmUo10EpvFPZuQMiFLJK3g==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-locate-window@3.965.5':
+    resolution: {integrity: sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-user-agent-browser@3.972.10':
+    resolution: {integrity: sha512-FAzqXvfEssGdSIz8ejatan0bOdx1qefBWKF/gWmVBXIP1HkS7v/wjjaqrAGGKvyihrXTXW00/2/1nTJtxpXz7g==}
+
+  '@aws-sdk/util-user-agent-node@3.973.24':
+    resolution: {integrity: sha512-ZWwlkjcIp7cEL8ZfTpTAPNkwx25p7xol0xlKoWVVf22+nsjwmLcHYtTPjIV1cSpmB/b6DaK4cb1fSkvCXHgRdw==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      aws-crt: '>=1.0.0'
+    peerDependenciesMeta:
+      aws-crt:
+        optional: true
+
+  '@aws-sdk/xml-builder@3.972.22':
+    resolution: {integrity: sha512-PMYKKtJd70IsSG0yHrdAbxBr+ZWBKLvzFZfD3/urxgf6hXVMzuU5M+3MJ5G67RpOmLBu1fAUN65SbWuKUCOlAA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws/lambda-invoke-store@0.2.4':
+    resolution: {integrity: sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==}
+    engines: {node: '>=18.0.0'}
 
   '@babel/code-frame@7.27.1':
     resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
@@ -2860,6 +3002,9 @@ packages:
     resolution: {integrity: sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==}
     engines: {node: '>= 20.19.0'}
 
+  '@nodable/entities@2.1.0':
+    resolution: {integrity: sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==}
+
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -3602,8 +3747,32 @@ packages:
     resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
     engines: {node: '>=10'}
 
+  '@smithy/config-resolver@4.4.17':
+    resolution: {integrity: sha512-TzDZcAnhTyAHbXVxWZo7/tEcrIeFq20IBk8So3OLOetWpR8EwY/yEqBMBFaJMeyEiREDq4NfEl+qO3OAUD+vbQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/core@3.23.17':
+    resolution: {integrity: sha512-x7BlLbUFL8NWCGjMF9C+1N5cVCxcPa7g6Tv9B4A2luWx3be3oU8hQ96wIwxe/s7OhIzvoJH73HAUSg5JXVlEtQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/credential-provider-imds@4.2.14':
+    resolution: {integrity: sha512-Au28zBN48ZAoXdooGUHemuVBrkE+Ie6RPmGNIAJsFqj33Vhb6xAgRifUydZ2aY+M+KaMAETAlKk5NC5h1G7wpg==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/eventstream-codec@4.2.10':
     resolution: {integrity: sha512-A4ynrsFFfSXUHicfTcRehytppFBcY3HQxEGYiyGktPIOye3Ot7fxpiy4VR42WmtGI4Wfo6OXt/c1Ky1nUFxYYQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/fetch-http-handler@5.3.17':
+    resolution: {integrity: sha512-bXOvQzaSm6MnmLaWA1elgfQcAtN4UP3vXqV97bHuoOrHQOJiLT3ds6o9eo5bqd0TJfRFpzdGnDQdW3FACiAVdw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/hash-node@4.2.14':
+    resolution: {integrity: sha512-8ZBDY2DD4wr+GGjTpPtiglEsqr0lUP+KHqgZcWczFf6qeZ/YRjMIOoQWVQlmwu7EtxKTd8YXD8lblmYcpBIA1g==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/invalid-dependency@4.2.14':
+    resolution: {integrity: sha512-c21qJiTSb25xvvOp+H2TNZzPCngrvl5vIPqPB8zQ/DmJF4QWXO19x1dWfMJZ6wZuuWUPPm0gV8C0cU3+ifcWuw==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/is-array-buffer@2.2.0':
@@ -3614,8 +3783,92 @@ packages:
     resolution: {integrity: sha512-Yfu664Qbf1B4IYIsYgKoABt010daZjkaCRvdU/sPnZG6TtHOB0md0RjNdLGzxe5UIdn9js4ftPICzmkRa9RJ4Q==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/is-array-buffer@4.2.2':
+    resolution: {integrity: sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-content-length@4.2.14':
+    resolution: {integrity: sha512-xhHq7fX4/3lv5NHxLUk3OeEvl0xZ+Ek3qIbWaCL4f9JwgDZEclPBElljaZCAItdGPQl/kSM4LPMOpy1MYgprpw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-endpoint@4.4.32':
+    resolution: {integrity: sha512-ZZkgyjnJppiZbIm6Qbx92pbXYi1uzenIvGhBSCDlc7NwuAkiqSgS75j1czAD25ZLs2FjMjYy1q7gyRVWG6JA0Q==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-retry@4.5.7':
+    resolution: {integrity: sha512-bRt6ZImqVSeTk39Nm81K20ObIiAZ3WefY7G6+iz/0tZjs4dgRRjvRX2sgsH+zi6iDCRR/aQvQofLKxxz4rPBZg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-serde@4.2.20':
+    resolution: {integrity: sha512-Lx9JMO9vArPtiChE3wbEZ5akMIDQpWQtlu90lhACQmNOXcGXRbaDywMHDzuDZ2OkZzP+9wQfZi3YJT9F67zTQQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-stack@4.2.14':
+    resolution: {integrity: sha512-2dvkUKLuFdKsCRmOE4Mn63co0Djtsm+JMh0bYZQupN1pJwMeE8FmQmRLLzzEMN0dnNi7CDCYYH8F0EVwWiPBeA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/node-config-provider@4.3.14':
+    resolution: {integrity: sha512-S+gFjyo/weSVL0P1b9Ts8C/CwIfNCgUPikk3sl6QVsfE/uUuO+QsF+NsE/JkpvWqqyz1wg7HFdiaZuj5CoBMRg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/node-http-handler@4.6.1':
+    resolution: {integrity: sha512-iB+orM4x3xrr57X3YaXazfKnntl0LHlZB1kcXSGzMV1Tt0+YwEjGlbjk/44qEGtBzXAz6yFDzkYTKSV6Pj2HUg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/property-provider@4.2.14':
+    resolution: {integrity: sha512-WuM31CgfsnQ/10i7NYr0PyxqknD72Y5uMfUMVSniPjbEPceiTErb4eIqJQ+pdxNEAUEWrewrGjIRjVbVHsxZiQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/protocol-http@5.3.14':
+    resolution: {integrity: sha512-dN5F8kHx8RNU0r+pCwNmFZyz6ChjMkzShy/zup6MtkRmmix4vZzJdW+di7x//b1LiynIev88FM18ie+wwPcQtQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/querystring-builder@4.2.14':
+    resolution: {integrity: sha512-XYA5Z0IqTeF+5XDdh4BBmSA0HvbgVZIyv4cmOoUheDNR57K1HgBp9ukUMx3Cr3XpDHHpLBnexPE3LAtDsZkj2A==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/querystring-parser@4.2.14':
+    resolution: {integrity: sha512-hr+YyqBD23GVvRxGGrcc/oOeNlK3PzT5Fu4dzrDXxzS1LpFiuL2PQQqKPs87M79aW7ziMs+nvB3qdw77SqE7Lw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/service-error-classification@4.3.1':
+    resolution: {integrity: sha512-aUQuDGh760ts/8MU+APjIZhlLPKhIIfqyzZaJikLEIMrdxFvxuLYD0WxWzaYWpmLbQlXDe9p7EWM3HsBe0K6Gw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/shared-ini-file-loader@4.4.9':
+    resolution: {integrity: sha512-495/V2I15SHgedSJoDPD23JuSfKAp726ZI1V0wtjB07Wh7q/0tri/0e0DLefZCHgxZonrGKt/OCTpAtP1wE1kQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/signature-v4@5.3.14':
+    resolution: {integrity: sha512-1D9Y/nmlVjCeSivCbhZ7hgEpmHyY1h0GvpSZt3l0xcD9JjmjVC1CHOozS6+Gh+/ldMH8JuJ6cujObQqfayAVFA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/smithy-client@4.12.13':
+    resolution: {integrity: sha512-y/Pcj1V9+qG98gyu1gvftHB7rDpdh+7kIBIggs55yGm3JdtBV8GT8IFF3a1qxZ79QnaJHX9GXzvBG6tAd+czJA==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/types@4.13.0':
     resolution: {integrity: sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/types@4.14.1':
+    resolution: {integrity: sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/url-parser@4.2.14':
+    resolution: {integrity: sha512-p06BiBigJ8bTA3MgnOfCtDUWnAMY0YfedO/GRpmc7p+wg3KW8vbXy1xwSu5ASy0wV7rRYtlfZOIKH4XqfhjSQQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-base64@4.3.2':
+    resolution: {integrity: sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-body-length-browser@4.2.2':
+    resolution: {integrity: sha512-JKCrLNOup3OOgmzeaKQwi4ZCTWlYR5H4Gm1r2uTMVBXoemo1UEghk5vtMi1xSu2ymgKVGW631e2fp9/R610ZjQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-body-length-node@4.2.3':
+    resolution: {integrity: sha512-ZkJGvqBzMHVHE7r/hcuCxlTY8pQr1kMtdsVPs7ex4mMU+EAbcXppfo5NmyxMYi2XU49eqaz56j2gsk4dHHPG/g==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/util-buffer-from@2.2.0':
@@ -3626,8 +3879,48 @@ packages:
     resolution: {integrity: sha512-/swhmt1qTiVkaejlmMPPDgZhEaWb/HWMGRBheaxwuVkusp/z+ErJyQxO6kaXumOciZSWlmq6Z5mNylCd33X7Ig==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/util-buffer-from@4.2.2':
+    resolution: {integrity: sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-config-provider@4.2.2':
+    resolution: {integrity: sha512-dWU03V3XUprJwaUIFVv4iOnS1FC9HnMHDfUrlNDSh4315v0cWyaIErP8KiqGVbf5z+JupoVpNM7ZB3jFiTejvQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-defaults-mode-browser@4.3.49':
+    resolution: {integrity: sha512-a5bNrdiONYB/qE2BuKegvUMd/+ZDwdg4vsNuuSzYE8qs2EYAdK9CynL+Rzn29PbPiUqoz/cbpRbcLzD5lEevHw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-defaults-mode-node@4.2.54':
+    resolution: {integrity: sha512-g1cvrJvOnzeJgEdf7AE4luI7gp6L8weE0y9a9wQUSGtjb8QRHDbCJYuE4Sy0SD9N8RrnNPFsPltAz/OSoBR9Zw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-endpoints@3.4.2':
+    resolution: {integrity: sha512-a55Tr+3OKld4TTtnT+RhKOQHyPxm3j/xL4OR83WBUhLJaKDS9dnJ7arRMOp3t31dcLhApwG9bgvrRXBHlLdIkg==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/util-hex-encoding@4.2.1':
     resolution: {integrity: sha512-c1hHtkgAWmE35/50gmdKajgGAKV3ePJ7t6UtEmpfCWJmQE9BQAQPz0URUVI89eSkcDqCtzqllxzG28IQoZPvwA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-hex-encoding@4.2.2':
+    resolution: {integrity: sha512-Qcz3W5vuHK4sLQdyT93k/rfrUwdJ8/HZ+nMUOyGdpeGA1Wxt65zYwi3oEl9kOM+RswvYq90fzkNDahPS8K0OIg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-middleware@4.2.14':
+    resolution: {integrity: sha512-1Su2vj9RYNDEv/V+2E+jXkkwGsgR7dc4sfHn9Z7ruzQHJIEni9zzw5CauvRXlFJfmgcqYP8fWa0dkh2Q2YaQyw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-retry@4.3.8':
+    resolution: {integrity: sha512-LUIxbTBi+OpvXpg91poGA6BdyoleMDLnfXjVDqyi2RvZmTveY5loE/FgYUBCR5LU2BThW2SoZRh8dTIIy38IPw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-stream@4.5.25':
+    resolution: {integrity: sha512-/PFpG4k8Ze8Ei+mMKj3oiPICYekthuzePZMgZbCqMiXIHHf4n2aZ4Ps0aSRShycFTGuj/J6XldmC0x0DwednIA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-uri-escape@4.2.2':
+    resolution: {integrity: sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/util-utf8@2.3.0':
@@ -3636,6 +3929,14 @@ packages:
 
   '@smithy/util-utf8@4.2.1':
     resolution: {integrity: sha512-DSIwNaWtmzrNQHv8g7DBGR9mulSit65KSj5ymGEIAknmIN8IpbZefEep10LaMG/P/xquwbmJ1h9ectz8z6mV6g==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-utf8@4.2.2':
+    resolution: {integrity: sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/uuid@1.1.2':
+    resolution: {integrity: sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g==}
     engines: {node: '>=18.0.0'}
 
   '@so-ric/colorspace@1.1.6':
@@ -6545,6 +6846,13 @@ packages:
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
 
+  fast-xml-builder@1.1.7:
+    resolution: {integrity: sha512-Yh7/7rQuMXICNr0oMYDR2yHP6oUvmQsTToFeOWj/kIDhAwQ+c4Ol/lbcwOmEM5OHYQmh6S6EQSQ1sljCKP36bQ==}
+
+  fast-xml-parser@5.7.2:
+    resolution: {integrity: sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w==}
+    hasBin: true
+
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
 
@@ -8805,6 +9113,10 @@ packages:
     resolution: {integrity: sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
+  path-expression-matcher@1.5.0:
+    resolution: {integrity: sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==}
+    engines: {node: '>=14.0.0'}
+
   path-is-absolute@1.0.1:
     resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
     engines: {node: '>=0.10.0'}
@@ -10029,6 +10341,9 @@ packages:
     resolution: {integrity: sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==}
     engines: {node: '>=0.10.0'}
 
+  strnum@2.2.3:
+    resolution: {integrity: sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==}
+
   strtok3@10.3.5:
     resolution: {integrity: sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==}
     engines: {node: '>=18'}
@@ -11214,16 +11529,404 @@ snapshots:
       '@aws-sdk/types': 3.973.4
       tslib: 2.8.1
 
+  '@aws-crypto/sha256-browser@5.2.0':
+    dependencies:
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-crypto/supports-web-crypto': 5.2.0
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-locate-window': 3.965.5
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-crypto/sha256-js@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.8
+      tslib: 2.8.1
+
+  '@aws-crypto/supports-web-crypto@5.2.0':
+    dependencies:
+      tslib: 2.8.1
+
   '@aws-crypto/util@5.2.0':
     dependencies:
       '@aws-sdk/types': 3.973.4
       '@smithy/util-utf8': 2.3.0
       tslib: 2.8.1
 
+  '@aws-sdk/client-cognito-identity@3.1041.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/credential-provider-node': 3.972.39
+      '@aws-sdk/middleware-host-header': 3.972.10
+      '@aws-sdk/middleware-logger': 3.972.10
+      '@aws-sdk/middleware-recursion-detection': 3.972.11
+      '@aws-sdk/middleware-user-agent': 3.972.38
+      '@aws-sdk/region-config-resolver': 3.972.13
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-endpoints': 3.996.8
+      '@aws-sdk/util-user-agent-browser': 3.972.10
+      '@aws-sdk/util-user-agent-node': 3.973.24
+      '@smithy/config-resolver': 4.4.17
+      '@smithy/core': 3.23.17
+      '@smithy/fetch-http-handler': 5.3.17
+      '@smithy/hash-node': 4.2.14
+      '@smithy/invalid-dependency': 4.2.14
+      '@smithy/middleware-content-length': 4.2.14
+      '@smithy/middleware-endpoint': 4.4.32
+      '@smithy/middleware-retry': 4.5.7
+      '@smithy/middleware-serde': 4.2.20
+      '@smithy/middleware-stack': 4.2.14
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/node-http-handler': 4.6.1
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.14.1
+      '@smithy/url-parser': 4.2.14
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-body-length-browser': 4.2.2
+      '@smithy/util-body-length-node': 4.2.3
+      '@smithy/util-defaults-mode-browser': 4.3.49
+      '@smithy/util-defaults-mode-node': 4.2.54
+      '@smithy/util-endpoints': 3.4.2
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-retry': 4.3.8
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/core@3.974.8':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/xml-builder': 3.972.22
+      '@smithy/core': 3.23.17
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/property-provider': 4.2.14
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/signature-v4': 5.3.14
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.14.1
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-retry': 4.3.8
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-cognito-identity@3.972.31':
+    dependencies:
+      '@aws-sdk/nested-clients': 3.997.6
+      '@aws-sdk/types': 3.973.8
+      '@smithy/property-provider': 4.2.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-provider-env@3.972.34':
+    dependencies:
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/types': 3.973.8
+      '@smithy/property-provider': 4.2.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.36':
+    dependencies:
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/types': 3.973.8
+      '@smithy/fetch-http-handler': 5.3.17
+      '@smithy/node-http-handler': 4.6.1
+      '@smithy/property-provider': 4.2.14
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.14.1
+      '@smithy/util-stream': 4.5.25
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-ini@3.972.38':
+    dependencies:
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/credential-provider-env': 3.972.34
+      '@aws-sdk/credential-provider-http': 3.972.36
+      '@aws-sdk/credential-provider-login': 3.972.38
+      '@aws-sdk/credential-provider-process': 3.972.34
+      '@aws-sdk/credential-provider-sso': 3.972.38
+      '@aws-sdk/credential-provider-web-identity': 3.972.38
+      '@aws-sdk/nested-clients': 3.997.6
+      '@aws-sdk/types': 3.973.8
+      '@smithy/credential-provider-imds': 4.2.14
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-provider-login@3.972.38':
+    dependencies:
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/nested-clients': 3.997.6
+      '@aws-sdk/types': 3.973.8
+      '@smithy/property-provider': 4.2.14
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-provider-node@3.972.39':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.34
+      '@aws-sdk/credential-provider-http': 3.972.36
+      '@aws-sdk/credential-provider-ini': 3.972.38
+      '@aws-sdk/credential-provider-process': 3.972.34
+      '@aws-sdk/credential-provider-sso': 3.972.38
+      '@aws-sdk/credential-provider-web-identity': 3.972.38
+      '@aws-sdk/types': 3.973.8
+      '@smithy/credential-provider-imds': 4.2.14
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-provider-process@3.972.34':
+    dependencies:
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/types': 3.973.8
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-sso@3.972.38':
+    dependencies:
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/nested-clients': 3.997.6
+      '@aws-sdk/token-providers': 3.1041.0
+      '@aws-sdk/types': 3.973.8
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-provider-web-identity@3.972.38':
+    dependencies:
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/nested-clients': 3.997.6
+      '@aws-sdk/types': 3.973.8
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-providers@3.1041.0':
+    dependencies:
+      '@aws-sdk/client-cognito-identity': 3.1041.0
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/credential-provider-cognito-identity': 3.972.31
+      '@aws-sdk/credential-provider-env': 3.972.34
+      '@aws-sdk/credential-provider-http': 3.972.36
+      '@aws-sdk/credential-provider-ini': 3.972.38
+      '@aws-sdk/credential-provider-login': 3.972.38
+      '@aws-sdk/credential-provider-node': 3.972.39
+      '@aws-sdk/credential-provider-process': 3.972.34
+      '@aws-sdk/credential-provider-sso': 3.972.38
+      '@aws-sdk/credential-provider-web-identity': 3.972.38
+      '@aws-sdk/nested-clients': 3.997.6
+      '@aws-sdk/types': 3.973.8
+      '@smithy/config-resolver': 4.4.17
+      '@smithy/core': 3.23.17
+      '@smithy/credential-provider-imds': 4.2.14
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/property-provider': 4.2.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/middleware-host-header@3.972.10':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-logger@3.972.10':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-recursion-detection@3.972.11':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@aws/lambda-invoke-store': 0.2.4
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-sdk-s3@3.972.37':
+    dependencies:
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-arn-parser': 3.972.3
+      '@smithy/core': 3.23.17
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/signature-v4': 5.3.14
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.14.1
+      '@smithy/util-config-provider': 4.2.2
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-stream': 4.5.25
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-user-agent@3.972.38':
+    dependencies:
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-endpoints': 3.996.8
+      '@smithy/core': 3.23.17
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      '@smithy/util-retry': 4.3.8
+      tslib: 2.8.1
+
+  '@aws-sdk/nested-clients@3.997.6':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/middleware-host-header': 3.972.10
+      '@aws-sdk/middleware-logger': 3.972.10
+      '@aws-sdk/middleware-recursion-detection': 3.972.11
+      '@aws-sdk/middleware-user-agent': 3.972.38
+      '@aws-sdk/region-config-resolver': 3.972.13
+      '@aws-sdk/signature-v4-multi-region': 3.996.25
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-endpoints': 3.996.8
+      '@aws-sdk/util-user-agent-browser': 3.972.10
+      '@aws-sdk/util-user-agent-node': 3.973.24
+      '@smithy/config-resolver': 4.4.17
+      '@smithy/core': 3.23.17
+      '@smithy/fetch-http-handler': 5.3.17
+      '@smithy/hash-node': 4.2.14
+      '@smithy/invalid-dependency': 4.2.14
+      '@smithy/middleware-content-length': 4.2.14
+      '@smithy/middleware-endpoint': 4.4.32
+      '@smithy/middleware-retry': 4.5.7
+      '@smithy/middleware-serde': 4.2.20
+      '@smithy/middleware-stack': 4.2.14
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/node-http-handler': 4.6.1
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.14.1
+      '@smithy/url-parser': 4.2.14
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-body-length-browser': 4.2.2
+      '@smithy/util-body-length-node': 4.2.3
+      '@smithy/util-defaults-mode-browser': 4.3.49
+      '@smithy/util-defaults-mode-node': 4.2.54
+      '@smithy/util-endpoints': 3.4.2
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-retry': 4.3.8
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/region-config-resolver@3.972.13':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/config-resolver': 4.4.17
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/signature-v4-multi-region@3.996.25':
+    dependencies:
+      '@aws-sdk/middleware-sdk-s3': 3.972.37
+      '@aws-sdk/types': 3.973.8
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/signature-v4': 5.3.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.1041.0':
+    dependencies:
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/nested-clients': 3.997.6
+      '@aws-sdk/types': 3.973.8
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
   '@aws-sdk/types@3.973.4':
     dependencies:
       '@smithy/types': 4.13.0
       tslib: 2.8.1
+
+  '@aws-sdk/types@3.973.8':
+    dependencies:
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/util-arn-parser@3.972.3':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-sdk/util-endpoints@3.996.8':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/types': 4.14.1
+      '@smithy/url-parser': 4.2.14
+      '@smithy/util-endpoints': 3.4.2
+      tslib: 2.8.1
+
+  '@aws-sdk/util-locate-window@3.965.5':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-sdk/util-user-agent-browser@3.972.10':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/types': 4.14.1
+      bowser: 2.13.1
+      tslib: 2.8.1
+
+  '@aws-sdk/util-user-agent-node@3.973.24':
+    dependencies:
+      '@aws-sdk/middleware-user-agent': 3.972.38
+      '@aws-sdk/types': 3.973.8
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/types': 4.14.1
+      '@smithy/util-config-provider': 4.2.2
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.22':
+    dependencies:
+      '@nodable/entities': 2.1.0
+      '@smithy/types': 4.14.1
+      fast-xml-parser: 5.7.2
+      tslib: 2.8.1
+
+  '@aws/lambda-invoke-store@0.2.4': {}
 
   '@babel/code-frame@7.27.1':
     dependencies:
@@ -13016,6 +13719,8 @@ snapshots:
 
   '@noble/hashes@2.0.1': {}
 
+  '@nodable/entities@2.1.0': {}
+
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -13711,11 +14416,61 @@ snapshots:
 
   '@sindresorhus/is@4.6.0': {}
 
+  '@smithy/config-resolver@4.4.17':
+    dependencies:
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/types': 4.14.1
+      '@smithy/util-config-provider': 4.2.2
+      '@smithy/util-endpoints': 3.4.2
+      '@smithy/util-middleware': 4.2.14
+      tslib: 2.8.1
+
+  '@smithy/core@3.23.17':
+    dependencies:
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      '@smithy/url-parser': 4.2.14
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-body-length-browser': 4.2.2
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-stream': 4.5.25
+      '@smithy/util-utf8': 4.2.2
+      '@smithy/uuid': 1.1.2
+      tslib: 2.8.1
+
+  '@smithy/credential-provider-imds@4.2.14':
+    dependencies:
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/property-provider': 4.2.14
+      '@smithy/types': 4.14.1
+      '@smithy/url-parser': 4.2.14
+      tslib: 2.8.1
+
   '@smithy/eventstream-codec@4.2.10':
     dependencies:
       '@aws-crypto/crc32': 5.2.0
       '@smithy/types': 4.13.0
       '@smithy/util-hex-encoding': 4.2.1
+      tslib: 2.8.1
+
+  '@smithy/fetch-http-handler@5.3.17':
+    dependencies:
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/querystring-builder': 4.2.14
+      '@smithy/types': 4.14.1
+      '@smithy/util-base64': 4.3.2
+      tslib: 2.8.1
+
+  '@smithy/hash-node@4.2.14':
+    dependencies:
+      '@smithy/types': 4.14.1
+      '@smithy/util-buffer-from': 4.2.2
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/invalid-dependency@4.2.14':
+    dependencies:
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@smithy/is-array-buffer@2.2.0':
@@ -13726,7 +14481,142 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  '@smithy/is-array-buffer@4.2.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/middleware-content-length@4.2.14':
+    dependencies:
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/middleware-endpoint@4.4.32':
+    dependencies:
+      '@smithy/core': 3.23.17
+      '@smithy/middleware-serde': 4.2.20
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      '@smithy/url-parser': 4.2.14
+      '@smithy/util-middleware': 4.2.14
+      tslib: 2.8.1
+
+  '@smithy/middleware-retry@4.5.7':
+    dependencies:
+      '@smithy/core': 3.23.17
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/service-error-classification': 4.3.1
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.14.1
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-retry': 4.3.8
+      '@smithy/uuid': 1.1.2
+      tslib: 2.8.1
+
+  '@smithy/middleware-serde@4.2.20':
+    dependencies:
+      '@smithy/core': 3.23.17
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/middleware-stack@4.2.14':
+    dependencies:
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/node-config-provider@4.3.14':
+    dependencies:
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/node-http-handler@4.6.1':
+    dependencies:
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/querystring-builder': 4.2.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/property-provider@4.2.14':
+    dependencies:
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/protocol-http@5.3.14':
+    dependencies:
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/querystring-builder@4.2.14':
+    dependencies:
+      '@smithy/types': 4.14.1
+      '@smithy/util-uri-escape': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/querystring-parser@4.2.14':
+    dependencies:
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/service-error-classification@4.3.1':
+    dependencies:
+      '@smithy/types': 4.14.1
+
+  '@smithy/shared-ini-file-loader@4.4.9':
+    dependencies:
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/signature-v4@5.3.14':
+    dependencies:
+      '@smithy/is-array-buffer': 4.2.2
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      '@smithy/util-hex-encoding': 4.2.2
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-uri-escape': 4.2.2
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/smithy-client@4.12.13':
+    dependencies:
+      '@smithy/core': 3.23.17
+      '@smithy/middleware-endpoint': 4.4.32
+      '@smithy/middleware-stack': 4.2.14
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      '@smithy/util-stream': 4.5.25
+      tslib: 2.8.1
+
   '@smithy/types@4.13.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/types@4.14.1':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/url-parser@4.2.14':
+    dependencies:
+      '@smithy/querystring-parser': 4.2.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/util-base64@4.3.2':
+    dependencies:
+      '@smithy/util-buffer-from': 4.2.2
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/util-body-length-browser@4.2.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-body-length-node@4.2.3':
     dependencies:
       tslib: 2.8.1
 
@@ -13740,7 +14630,69 @@ snapshots:
       '@smithy/is-array-buffer': 4.2.1
       tslib: 2.8.1
 
+  '@smithy/util-buffer-from@4.2.2':
+    dependencies:
+      '@smithy/is-array-buffer': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/util-config-provider@4.2.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-defaults-mode-browser@4.3.49':
+    dependencies:
+      '@smithy/property-provider': 4.2.14
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/util-defaults-mode-node@4.2.54':
+    dependencies:
+      '@smithy/config-resolver': 4.4.17
+      '@smithy/credential-provider-imds': 4.2.14
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/property-provider': 4.2.14
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/util-endpoints@3.4.2':
+    dependencies:
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
   '@smithy/util-hex-encoding@4.2.1':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-hex-encoding@4.2.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-middleware@4.2.14':
+    dependencies:
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/util-retry@4.3.8':
+    dependencies:
+      '@smithy/service-error-classification': 4.3.1
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/util-stream@4.5.25':
+    dependencies:
+      '@smithy/fetch-http-handler': 5.3.17
+      '@smithy/node-http-handler': 4.6.1
+      '@smithy/types': 4.14.1
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-buffer-from': 4.2.2
+      '@smithy/util-hex-encoding': 4.2.2
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/util-uri-escape@4.2.2':
     dependencies:
       tslib: 2.8.1
 
@@ -13752,6 +14704,15 @@ snapshots:
   '@smithy/util-utf8@4.2.1':
     dependencies:
       '@smithy/util-buffer-from': 4.2.1
+      tslib: 2.8.1
+
+  '@smithy/util-utf8@4.2.2':
+    dependencies:
+      '@smithy/util-buffer-from': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/uuid@1.1.2':
+    dependencies:
       tslib: 2.8.1
 
   '@so-ric/colorspace@1.1.6':
@@ -17198,6 +18159,17 @@ snapshots:
 
   fast-uri@3.1.0: {}
 
+  fast-xml-builder@1.1.7:
+    dependencies:
+      path-expression-matcher: 1.5.0
+
+  fast-xml-parser@5.7.2:
+    dependencies:
+      '@nodable/entities': 2.1.0
+      fast-xml-builder: 1.1.7
+      path-expression-matcher: 1.5.0
+      strnum: 2.2.3
+
   fastq@1.20.1:
     dependencies:
       reusify: 1.1.0
@@ -19954,6 +20926,8 @@ snapshots:
 
   path-exists@5.0.0: {}
 
+  path-expression-matcher@1.5.0: {}
+
   path-is-absolute@1.0.1: {}
 
   path-key@2.0.1: {}
@@ -21392,6 +22366,8 @@ snapshots:
   strip-outer@1.0.1:
     dependencies:
       escape-string-regexp: 1.0.5
+
+  strnum@2.2.3: {}
 
   strtok3@10.3.5:
     dependencies:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds AWS named profile and default credential chain support for Amazon Bedrock custom providers so users can use credentials from `~/.aws` or env/IMDS without pasting keys. Also adds a region‑aware Bedrock model ID mapping suggester and fixes Bedrock→Anthropic tool‑call errors by stripping unsupported `strict` fields.

- **New Features**
  - Bedrock auth modes: `access-keys`, `profile`, `default-chain` (via `@aws-sdk/credential-providers`).
  - Region rules: UI override wins; SDK resolves for `profile`/`default-chain`; `us-east-1` default for `access-keys`.
  - UI: choose auth method, pick a named profile (loaded via new `listAwsProfiles`), see detected region (from profile or `AWS_REGION`), and see auth mode on endpoint cards.
  - Bedrock-only: “Suggested mapping” auto‑fills Anthropic IDs to Bedrock cross‑region inference profiles (`us.`/`eu.`/`apac.`); updates when region/profile changes; toggle to edit.
  - Telemetry adds `aws_auth_mode` for Bedrock (profile names are never sent). Added `@smithy/shared-ini-file-loader`.

- **Bug Fixes**
  - Prevent Bedrock→Anthropic “Extra inputs are not permitted” by removing `strict` from tool payloads; added unit test for `stripStrictFromToolSet`.
  - Model picker: added “Model settings” quick action.

<sup>Written for commit 6796609536ab0270f220d764fc720545b98ee1bd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for multiple AWS Bedrock authentication methods: access keys, AWS profiles, and default credential chain.
  * Added AWS profile listing and selection in custom provider setup.
  * Added shortcut to model settings from the model selector.

* **Improvements**
  * Enhanced custom provider dialog with Bedrock-specific authentication and region detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->