### PR TITLE
fix(stagewise): harden ownership rules for plan-TODOs

### DIFF
--- a/apps/browser/bundled/skills/implement/SKILL.md
+++ b/apps/browser/bundled/skills/implement/SKILL.md
@@ -21,3 +21,4 @@ Implement the most recently created plan.
 - **Stay focused** — no unplanned features or refactors.
 - **Update the plan** — if new information or edge cases emerge, reflect them in the plan file.
 - **Completion = 100%** — every checkbox must be `[x]`. Unnecessary tasks: delete the checkbox + add brief rationale. Never leave unchecked boxes.
+- **No user-side tasks** — if a checkbox turns out to require user action (manual testing, shell commands, credential setup, etc.), delete it, move its content into a `## Follow-ups for the user` prose section, and continue. Never leave it unchecked waiting on the user.

--- a/apps/browser/bundled/skills/plan/SKILL.md
+++ b/apps/browser/bundled/skills/plan/SKILL.md
@@ -25,6 +25,7 @@ You must create a structured implementation plan. Follow these instructions:
 
 Every checkbox = one concrete, completable work item.
 
+- **Agent-completable only** — every checkbox MUST be doable by you alone with your own tools. Never write tasks that require the user to act (manual testing, running commands in their shell, restarting a dev server, exporting env vars, reviewing, clicking through a UI, obtaining credentials, etc.). If such work is genuinely needed, describe it in a prose `## Follow-ups for the user` section — never as a checkbox.
 - **Short label** — the `- [ ]` line is a concise, scannable summary (one sentence). It says *what* to do, not *how*.
 - **Details below** — implementation specifics (file paths, code snippets, sub-steps) go in indented content underneath the checkbox line. Never cram these into the checkbox line itself.
 - **No alternatives** — resolve choices in prose above, then write one task for the chosen approach.


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Make plan and implement checklists agent-only: no tasks that require user action. Any user-required steps must be removed from checkboxes and documented in a `## Follow-ups for the user` section, preventing blocked/unchecked items and reinforcing the 100% completion rule.

<sup>Written for commit 0509a3eef531bf226e8b467b90c430a6c2bcafd9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated skill implementation guidelines with a new rule requiring user-action tasks to be moved to a dedicated "Follow-ups for the user" section.
  * Added a governance requirement to the plan file specification ensuring all checkboxes are agent-completable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->