### PR TITLE
feat(stagewise): add minimax-M2.7

### DIFF
--- a/apps/browser/src/backend/utils/validate-api-keys.ts
+++ b/apps/browser/src/backend/utils/validate-api-keys.ts
@@ -67,7 +67,7 @@ const providerConfigs: Record<
     createOpenAI({
       apiKey,
       baseURL: baseURL ?? 'https://api.minimax.io/v1',
-    }).chat('MiniMax-M2'),
+    }).chat('minimax-m2.7'),
 };
 
 /**

--- a/apps/browser/src/shared/available-models.ts
+++ b/apps/browser/src/shared/available-models.ts
@@ -957,6 +957,44 @@ export const availableModels = [
   },
   {
     officialProvider: 'minimax',
+    modelId: 'minimax-m2.7',
+    modelDisplayName: 'MiniMax M2.7',
+    modelDescription:
+      'Next-gen MiniMax model with enhanced agentic and multi-agent capabilities.',
+    modelContext: '200k context',
+    modelContextRaw: 204_800,
+    headers: {},
+    providerOptions: {
+      stagewise: {
+        reasoning: { enabled: true, effort: 'medium' },
+      },
+    },
+    thinkingEnabled: true,
+    pricing: {
+      inputPerMillion: 0.3,
+      outputPerMillion: 1.2,
+      relativeMultiplier: 0.25,
+    },
+    capabilities: {
+      inputModalities: {
+        text: true,
+        audio: false,
+        image: false,
+        video: false,
+        file: false,
+      },
+      outputModalities: {
+        text: true,
+        audio: false,
+        image: false,
+        video: false,
+        file: false,
+      },
+      toolCalling: true,
+    },
+  },
+  {
+    officialProvider: 'minimax',
     modelId: 'MiniMax-M2',
     modelDisplayName: 'MiniMax M2',
     modelDescription:
@@ -971,9 +1009,9 @@ export const availableModels = [
     },
     thinkingEnabled: true,
     pricing: {
-      inputPerMillion: 1.2,
-      outputPerMillion: 8.0,
-      relativeMultiplier: 1,
+      inputPerMillion: 0.255,
+      outputPerMillion: 1.0,
+      relativeMultiplier: 0.25,
     },
     capabilities: {
       inputModalities: {

--- a/apps/browser/src/shared/coding-plans.ts
+++ b/apps/browser/src/shared/coding-plans.ts
@@ -78,7 +78,7 @@ export const CODING_PLANS: Record<CodingPlanId, CodingPlan> = {
     apiKeyUrl:
       'https://platform.minimax.io/user-center/basic-information/interface-key',
     helpText: 'Create one at platform.minimax.io → User Center → Interface key',
-    featuredModelIds: ['MiniMax-M2'],
+    featuredModelIds: ['minimax-m2.7'],
   },
 };
 

--- a/apps/browser/src/shared/karton-contracts/ui/shared-types.ts
+++ b/apps/browser/src/shared/karton-contracts/ui/shared-types.ts
@@ -566,7 +566,7 @@ export const defaultUserPreferences: UserPreferences = {
   sidebar: { showActiveAgents: true },
   agent: {
     workspaceSettings: {},
-    disabledModelIds: ['claude-opus-4.6', 'kimi-k2.5', 'gpt-5.4'],
+    disabledModelIds: ['claude-opus-4.6', 'kimi-k2.5', 'gpt-5.4', 'MiniMax-M2'],
     disabledPluginIds: [],
   },
   providerConfigs: {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds MiniMax M2.7 with 200k context and Stagewise reasoning, and makes it the featured MiniMax model. Also updates API key validation to use `minimax-m2.7` and lowers `MiniMax-M2` pricing.

- **New Features**
  - Added `minimax-m2.7` with Stagewise reasoning (effort: medium), 200k context, tool calling, and pricing: $0.30/M input, $1.20/M output.
  - Set `minimax-m2.7` as the featured MiniMax model and validate API keys against it.
  - Updated `MiniMax-M2` pricing to $0.255/M input and $1.00/M output.

- **Migration**
  - `MiniMax-M2` is disabled by default. Re-enable it in Preferences → Models if you still need it.

<sup>Written for commit 5c56a5e86d0bc3c7aaada0674c34fd00b5f37521. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for minimax-m2.7 model with text-based interaction and updated pricing.

* **Updates**
  * Updated pricing structure for MiniMax models.
  * MiniMax-M2 is now disabled by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->