### PR TITLE
fix(stagewise): fix diff-history hunks for empty files

### DIFF
--- a/apps/browser/src/backend/services/diff-history/index.ts
+++ b/apps/browser/src/backend/services/diff-history/index.ts
@@ -1658,7 +1658,4 @@ export class DiffHistoryService extends DisposableService {
   private logDebug(debug: string) {
     this.logger.debug(`[DiffHistory] ${debug}`);
   }
-  private logInfo(info: string) {
-    this.logger.info(`[DiffHistory] ${info}`);
-  }
 }

--- a/apps/browser/src/backend/services/diff-history/utils/diff.test.ts
+++ b/apps/browser/src/backend/services/diff-history/utils/diff.test.ts
@@ -612,13 +612,22 @@ describe('diff utilities', () => {
     });
 
     it('creates FileDiff with empty hunks when no changes', () => {
+      // Production invariant: identical content -> identical oid (computeOid is
+      // content-deterministic). Pin both ops to the same oid so this fixture
+      // matches reality; otherwise the synthetic-hunk guard in
+      // createFileDiffsFromGenerations legitimately fires on the oid mismatch.
+      const sharedOid = 'oid-same-content';
       const ops: OperationWithContent[] = [
         createOpWithContent(
-          createBaselineOp({ reason: 'init', filepath: '/readme.md' }),
+          createBaselineOp({
+            reason: 'init',
+            filepath: '/readme.md',
+            snapshot_oid: sharedOid,
+          }),
           'same content',
         ),
         createOpWithContent(
-          createEditOp({ filepath: '/readme.md' }),
+          createEditOp({ filepath: '/readme.md', snapshot_oid: sharedOid }),
           'same content',
         ),
       ];

--- a/apps/browser/src/backend/services/diff-history/utils/diff.ts
+++ b/apps/browser/src/backend/services/diff-history/utils/diff.ts
@@ -550,14 +550,49 @@ export function createFileDiffsFromGenerations(
       contributors: [...(hunkContributorSets.get(h.id) ?? [])],
     }));
 
+    // Step 7a: Synthesize an empty-transition hunk for state changes that
+    // produce no structural hunks (e.g. empty file creation null -> "", or
+    // deletion of an empty file "" -> null). Without this, the UI has no
+    // hunk id to pass to accept/reject and the file stays pending forever.
+    //
+    // The condition mirrors the UI's `hasRealChanges` predicate: we treat a
+    // diff as requiring a synthetic hunk whenever either the text differs or
+    // the snapshot OIDs differ. Under the content-addressable OID contract
+    // these are equivalent, but keeping both arms guards against future
+    // cases where OIDs carry metadata beyond text (encoding, BOM, etc.) and
+    // keeps backend/UI predicates structurally aligned.
+    const baselineOid = startsWithBaseline ? firstOp.snapshot_oid : null;
+    const currentOid = lastOp.snapshot_oid;
+    if (
+      hunks.length === 0 &&
+      (baseline !== current || baselineOid !== currentOid)
+    ) {
+      hunks.push({
+        oldStart: 0,
+        oldLines: 0,
+        newStart: 0,
+        newLines: 0,
+        lines: [],
+        id: generateDeterministicHunkId(
+          path,
+          0,
+          0,
+          0,
+          0,
+          `empty-transition:${baselineOid ?? 'null'}:${currentOid ?? 'null'}`,
+        ),
+        contributors: [lastOp.contributor],
+      });
+    }
+
     result.push({
       fileId,
       path,
       isExternal: false,
       baseline,
       current,
-      baselineOid: startsWithBaseline ? firstOp.snapshot_oid : null,
-      currentOid: lastOp.snapshot_oid,
+      baselineOid,
+      currentOid,
       lineChanges,
       hunks,
     });
@@ -644,6 +679,17 @@ export function acceptAndRejectHunks(
     // Skip if no hunks to process for this FileDiff
     if (hunksToAccept.length === 0 && hunksToReject.length === 0) continue;
 
+    // Synthetic empty-transition hunks (oldLines=0 && newLines=0 && lines=[])
+    // cannot be processed via applyPatch. They represent a whole-state
+    // transition (e.g. null -> "" empty file creation) and must promote/revert
+    // baseline/current directly. Split them out from the real hunk set.
+    const isEmptyTransitionHunk = (h: BlamedHunk) =>
+      h.oldLines === 0 && h.newLines === 0 && h.lines.length === 0;
+    const syntheticAccepts = hunksToAccept.filter(isEmptyTransitionHunk);
+    const syntheticRejects = hunksToReject.filter(isEmptyTransitionHunk);
+    const realAccepts = hunksToAccept.filter((h) => !isEmptyTransitionHunk(h));
+    const realRejects = hunksToReject.filter((h) => !isEmptyTransitionHunk(h));
+
     // Get working copies of baseline/current (convert null to '' for diffing)
     const diffBaseline = textFileDiff.baseline ?? '';
     const diffCurrent = textFileDiff.current ?? '';
@@ -654,8 +700,21 @@ export function acceptAndRejectHunks(
     let baselineChanged = false;
     let currentChanged = false;
 
+    // Apply synthetic empty-transition accepts/rejects first. Accept promotes
+    // baseline wholesale to the current state; reject reverts current to the
+    // baseline state. These bypass applyPatch because there is nothing to
+    // patch structurally.
+    if (syntheticAccepts.length > 0) {
+      workingBaseline = textFileDiff.current;
+      baselineChanged = true;
+    }
+    if (syntheticRejects.length > 0) {
+      workingCurrent = textFileDiff.baseline;
+      currentChanged = true;
+    }
+
     // Apply accepts (batch with fallback)
-    if (hunksToAccept.length > 0) {
+    if (realAccepts.length > 0) {
       // Build patch structure for accepted hunks
       const basePatch = structuredPatch(
         '',
@@ -665,7 +724,7 @@ export function acceptAndRejectHunks(
         '',
         '',
       );
-      const acceptPatch = { ...basePatch, hunks: hunksToAccept };
+      const acceptPatch = { ...basePatch, hunks: realAccepts };
       const patchString = formatPatch(acceptPatch);
 
       // Try batch apply first
@@ -678,7 +737,7 @@ export function acceptAndRejectHunks(
       } else {
         // Fallback: apply one-by-one to identify failures
         let currentWorkingBaseline = workingBaselineStr;
-        for (const hunk of hunksToAccept) {
+        for (const hunk of realAccepts) {
           const singlePatch = { ...basePatch, hunks: [hunk] };
           const singlePatchString = formatPatch(singlePatch);
           const singleResult = applyPatch(
@@ -696,7 +755,7 @@ export function acceptAndRejectHunks(
     }
 
     // Apply rejects (batch with fallback)
-    if (hunksToReject.length > 0) {
+    if (realRejects.length > 0) {
       // Build reversed patch structure for rejected hunks
       const basePatch = structuredPatch(
         '',
@@ -706,7 +765,7 @@ export function acceptAndRejectHunks(
         '',
         '',
       );
-      const rejectPatch = { ...basePatch, hunks: hunksToReject };
+      const rejectPatch = { ...basePatch, hunks: realRejects };
       const reversedPatch = reversePatch(rejectPatch);
       const patchString = formatPatch(reversedPatch);
 
@@ -720,7 +779,7 @@ export function acceptAndRejectHunks(
       } else {
         // Fallback: apply one-by-one to identify failures
         let currentWorkingCurrent = workingCurrentStr;
-        for (const hunk of hunksToReject) {
+        for (const hunk of realRejects) {
           const singlePatch = { ...basePatch, hunks: [hunk] };
           const reversedSingle = reversePatch(singlePatch);
           const singlePatchString = formatPatch(reversedSingle);
@@ -796,6 +855,14 @@ export function createFileDiffSnapshot(diff: FileDiff): FileDiffSnapshot {
     ),
   ];
 
+  // Fallback for empty-transition hunks (null <-> ""): lineChanges is empty
+  // because diffLines produces no add/remove entries, so the hunk itself
+  // carries the blame. Union hunk contributors to preserve the fingerprint.
+  const contributors =
+    uniqueContributors.length === 0
+      ? [...new Set(diff.hunks.flatMap((h) => h.contributors))]
+      : uniqueContributors;
+
   return {
     path: diff.path,
     fileId: diff.fileId,
@@ -803,7 +870,7 @@ export function createFileDiffSnapshot(diff: FileDiff): FileDiffSnapshot {
     baselineOid: diff.baselineOid,
     currentOid: diff.currentOid,
     hunkIds: diff.hunks.map((h) => h.id),
-    contributors: uniqueContributors,
+    contributors,
   };
 }
 

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/footer-status-card/shared.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/footer-status-card/shared.tsx
@@ -43,7 +43,11 @@ export function getLineStats(diff: FormattedFileDiff): {
 /** Check if diff represents a real change (not a noop) */
 export function hasRealChanges(diff: FormattedFileDiff): boolean {
   if (diff.isExternal) return diff.baselineOid !== diff.currentOid;
-  return diff.lineChanges.some((c) => c.added || c.removed);
+  // Line changes alone miss empty-file transitions (null -> "" / "" -> null)
+  // where diffLines produces no add/remove entries. Fall back to the oid
+  // transition, which matches the backend's synthetic-hunk criterion.
+  if (diff.lineChanges.some((c) => c.added || c.removed)) return true;
+  return diff.baselineOid !== diff.currentOid;
 }
 
 /** Get hunk IDs for accept/reject operations */


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stagewise diff history for empty file create/delete so these changes can be accepted or rejected. Adds a synthetic hunk for empty transitions, aligns backend/UI detection on snapshot OIDs, and preserves contributor attribution to avoid stuck pending diffs.

- **Bug Fixes**
  - Backend: synthesize an empty-transition hunk (null <-> "") with a deterministic id when no structural hunks exist and text or snapshot OIDs differ.
  - Backend: accept/reject synthetic hunks by promoting/reverting baseline/current directly (skip applyPatch).
  - Backend: snapshot contributors fall back to the union of hunk contributors on empty transitions.
  - UI: hasRealChanges falls back to baselineOid !== currentOid to match the backend rule.

- **Refactors**
  - Remove unused logInfo in `DiffHistoryService`.

<sup>Written for commit 254d8b908cfda7046410def73b665b599a89a2f7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deterministic IDs for generated hunks, improving stability for empty-file transitions.
  * Synthesized entries ensure created/deleted empty files are represented and actionable.

* **Bug Fixes**
  * Accept/reject flow correctly applies or reverts synthetic empty-file changes.
  * Change detection now treats differing snapshot IDs as real changes when no line-level adds/removals exist.

* **Improvements**
  * Contributor attribution updated for empty-transition diffs.

* **Tests**
  * Fixtures adjusted to assert identical content yields identical snapshot IDs.

* **Chores**
  * Reduced diff-history logging verbosity (info → debug).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->