### PR TITLE
fix(stagewise): reduce chat-input padding

### DIFF
--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/panel-footer.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/panel-footer.tsx
@@ -1040,10 +1040,10 @@ export const ChatPanelFooter = memo(function ChatPanelFooter() {
   if (!allowUserInput) return null;
 
   return (
-    <footer className="z-20 flex shrink-0 flex-col items-stretch gap-1 px-2 pb-2">
+    <footer className="z-20 flex shrink-0 flex-col items-stretch gap-1 px-1 pb-1">
       <div
         className={cn(
-          'relative flex flex-row items-stretch gap-1 rounded-md bg-background p-3 shadow-elevation-1 ring-1 ring-derived-strong transition-colors dark:bg-surface-1',
+          'relative flex flex-row items-stretch gap-1 rounded-md bg-background p-2 shadow-elevation-1 ring-1 ring-derived-strong transition-colors dark:bg-surface-1',
           isDragOver && 'bg-hover-derived!',
         )}
         id="chat-input-container-box"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Reduced chat input padding to make the composer more compact and free up vertical space in the chat view. Footer padding adjusted from px-2/pb-2 to px-1/pb-1, and the input container from p-3 to p-2.

<sup>Written for commit 030a56ab0f7033a5b4c78ab2481fe571b025dc3f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted padding and margins in the chat panel footer layout for improved spacing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->