### PR TITLE
Fix app quit crash

### DIFF
--- a/apps/browser/src/backend/main.ts
+++ b/apps/browser/src/backend/main.ts
@@ -488,18 +488,36 @@ export async function main({ launchOptions: { verbose } }: MainParameters) {
       );
       runTeardown('autoUpdateService', () => autoUpdateService.teardown());
 
-      const telemetryTeardown = Promise.resolve()
-        .then(() => telemetryService.teardown())
-        .catch((error) => {
-          logger.warn('[Main] Failed to teardown telemetryService', error);
-        });
+      // Shared budget for async teardowns. Toolbox teardown kills live
+      // PTY sessions before Node env teardown begins — this is what
+      // prevents the node-pty ThreadSafeFunction crash during
+      // app.exit(). Telemetry flush is parallelised under the same cap.
+      const SHUTDOWN_BUDGET_MS = 1000;
+
+      const runAsyncTeardown = (name: string, fn: () => Promise<void> | void) =>
+        Promise.resolve()
+          .then(() => fn())
+          .catch((error) => {
+            logger.warn(`[Main] Failed to teardown ${name}`, error);
+          });
+
+      const asyncTeardowns = Promise.all([
+        runAsyncTeardown('toolboxService', () => toolboxService.teardown()),
+        runAsyncTeardown('telemetryService', () => telemetryService.teardown()),
+      ]);
 
       void Promise.race([
-        telemetryTeardown,
+        asyncTeardowns,
         new Promise<void>((resolve) => {
-          setTimeout(resolve, 500);
+          setTimeout(resolve, SHUTDOWN_BUDGET_MS);
         }),
-      ]).finally(exitApp);
+      ]).finally(() => {
+        // Defer `app.exit(0)` one event-loop turn to give libuv a final
+        // chance to drain any pending ThreadSafeFunction calls before
+        // Electron starts FreeEnvironment. Defense-in-depth; cannot
+        // deadlock because `exitApp` runs unconditionally.
+        setImmediate(exitApp);
+      });
     } catch (error) {
       logger.error(`[Main] Shutdown failed: ${String(error)}`);
       exitApp();

--- a/apps/browser/src/backend/services/toolbox/index.ts
+++ b/apps/browser/src/backend/services/toolbox/index.ts
@@ -2274,7 +2274,7 @@ export class ToolboxService extends DisposableService {
     }
   }
 
-  protected onTeardown(): Promise<void> | void {
+  protected async onTeardown(): Promise<void> {
     this.unsubPreferenceSync?.();
     this.unsubPreferenceSync = null;
 
@@ -2284,16 +2284,22 @@ export class ToolboxService extends DisposableService {
     this.stopLogsWatcher();
     this.stopGlobalSkillsWatchers();
 
-    void this.logIngestService?.teardown();
+    await this.logIngestService?.teardown();
     this.logIngestService = null;
 
-    void this.mountManagerService?.teardown();
+    await this.mountManagerService?.teardown();
     this.mountManagerService = null;
 
-    void this.sandboxService?.teardown();
+    await this.sandboxService?.teardown();
     this.sandboxService = null;
 
-    void this.shellService?.teardown();
+    // Shell teardown last — kills all live PTY processes synchronously.
+    // Ordering matters: downstream services may still hold references to
+    // the shell during their own teardown, but none of the services
+    // above use the shell, so tearing it down last is safe and keeps the
+    // PTY kill as close to `app.exit(0)` as possible, minimizing the
+    // window between kill and Node env teardown.
+    await this.shellService?.teardown();
     this.shellService = null;
   }
 }

--- a/apps/browser/src/backend/services/toolbox/services/shell/index.ts
+++ b/apps/browser/src/backend/services/toolbox/services/shell/index.ts
@@ -459,8 +459,17 @@ export class ShellService extends DisposableService {
   }
 
   protected onTeardown(): Promise<void> | void {
+    // Capture count BEFORE killAll() so the log reflects how many PTYs
+    // we actually had to tear down on shutdown. This is the signal we
+    // need in crash reports to know the teardown path ran — absence of
+    // this log line on a crash means the shutdown handler itself never
+    // fired, not that the fix was insufficient.
+    const killedCount = this.sessionManager?.getSessionCount() ?? 0;
     this.sessionManager?.killAll();
     this.sessionManager = null;
+    this.logger.debug(
+      `[ShellService] Teardown complete (killed ${killedCount} PTY session(s))`,
+    );
 
     for (const timer of this.outputFlushTimers.values()) clearTimeout(timer);
 

--- a/apps/browser/src/backend/services/toolbox/services/shell/session-manager.ts
+++ b/apps/browser/src/backend/services/toolbox/services/shell/session-manager.ts
@@ -641,6 +641,15 @@ export class SessionManager {
   }
 
   /**
+   * Total number of sessions currently tracked (alive + exited-but-not-removed).
+   * Used by ShellService teardown logging to correlate crash reports with
+   * whether the PTY-kill path actually ran on shutdown.
+   */
+  public getSessionCount(): number {
+    return this.sessions.size;
+  }
+
+  /**
    * Returns the tail of the session's captured output for use as context in
    * downstream classifiers (e.g. smart approval). Internally delegates to
    * `collectRecentOutput`; kept as a separate public method so the private


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prevents the app from crashing on quit by killing PTY sessions before Node teardown and deferring process exit. Also fixes empty-file diffs so accept/reject works and the UI reflects changes.

- **Bug Fixes**
  - App exit: added a 1s shared shutdown budget; parallelized `toolboxService` and `telemetryService` teardowns; made `ToolboxService` teardown async and awaited child teardowns; ensured `ShellService` tears down last and synchronously kills all PTYs; logged the number of PTYs killed; deferred `app.exit(0)` by one tick.
  - Diff history: synthesized empty-transition hunks for null ↔ "" changes, handled them in accept/reject by promoting/reverting whole state, and preserved contributors; aligned UI `hasRealChanges` with backend by falling back to OID comparison.

<sup>Written for commit f732c158b175809c37ce73029455e63c8b0446ac. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved application shutdown reliability with better service sequencing and timeout management.
  * Enhanced diagnostic logging during shutdown to track active background sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->