### PR TITLE
Fix #1046: make browser tabs per-agent

### DIFF
--- a/apps/browser/src/backend/services/agent-manager/agent-manager.ts
+++ b/apps/browser/src/backend/services/agent-manager/agent-manager.ts
@@ -827,6 +827,11 @@ export class AgentManagerService extends DisposableService {
       }
     }
 
+    await this.toolbox.restoreAssociatedBrowserTabsFromPersistence(
+      instanceId,
+      agent.associatedBrowserTabs,
+    );
+
     this.telemetryService.capture('agent-resumed', {
       agent_type: agent.type,
       agent_instance_id: instanceId,
@@ -854,6 +859,8 @@ export class AgentManagerService extends DisposableService {
 
     const mountedWorkspaces =
       this.toolbox.getWorkspaceSnapshotForPersistence(instanceId);
+    const associatedBrowserTabs =
+      this.toolbox.getAssociatedBrowserTabsForPersistence(instanceId);
 
     await this.agentPersistenceDB?.storeAgentInstance(
       {
@@ -871,6 +878,7 @@ export class AgentManagerService extends DisposableService {
         inputState: agentState.inputState,
         usedTokens: agentState.usedTokens,
         mountedWorkspaces,
+        associatedBrowserTabs,
       },
       agentState.history,
       dirtyMessageIndices,
@@ -931,6 +939,15 @@ export class AgentManagerService extends DisposableService {
 
     if (!agent) {
       return;
+    }
+
+    try {
+      await this.persistAgentState(instanceId);
+    } catch (error) {
+      this.logger.error(
+        `[AgentManager] Failed to persist agent ${instanceId} before archive`,
+        error,
+      );
     }
 
     await agent.stop();

--- a/apps/browser/src/backend/services/agent-manager/persistence/migrations/index.ts
+++ b/apps/browser/src/backend/services/agent-manager/persistence/migrations/index.ts
@@ -7,6 +7,7 @@ import { up as v006Up } from './v006-rename-readfile-to-read';
 import { up as v007Up } from './v007-normalize-history';
 import { up as v008Up } from './v008-add-title-locked-by-user';
 import { up as v009Up } from './v009-add-tool-approval-mode';
+import { up as v010Up } from './v010-add-associated-browser-tabs';
 
 const registry: MigrationScript[] = [
   { version: 2, name: 'add-mounted-workspaces', up: v002Up },
@@ -17,7 +18,8 @@ const registry: MigrationScript[] = [
   { version: 7, name: 'normalize-history', up: v007Up },
   { version: 8, name: 'add-title-locked-by-user', up: v008Up },
   { version: 9, name: 'add-tool-approval-mode', up: v009Up },
+  { version: 10, name: 'add-associated-browser-tabs', up: v010Up },
 ];
-const schemaVersion = 9;
+const schemaVersion = 10;
 
 export { registry, schemaVersion };

--- a/apps/browser/src/backend/services/agent-manager/persistence/migrations/v010-add-associated-browser-tabs.ts
+++ b/apps/browser/src/backend/services/agent-manager/persistence/migrations/v010-add-associated-browser-tabs.ts
@@ -1,0 +1,14 @@
+import { sql } from 'drizzle-orm';
+import type { MigrationScript } from '@/utils/migrate-database/types';
+
+/**
+ * v10 — add-associated-browser-tabs
+ *
+ * Stores a versioned JSON snapshot of browser tabs explicitly associated with
+ * an archived agent so they can be restored when that agent is resumed.
+ */
+export const up: MigrationScript['up'] = async (db) => {
+  await db.run(
+    sql`ALTER TABLE agentInstances ADD COLUMN associated_browser_tabs TEXT`,
+  );
+};

--- a/apps/browser/src/backend/services/agent-manager/persistence/schema.sql
+++ b/apps/browser/src/backend/services/agent-manager/persistence/schema.sql
@@ -1,4 +1,4 @@
--- VERSION: 9
+-- VERSION: 10
 
 CREATE TABLE IF NOT EXISTS meta(
   key LONGVARCHAR NOT NULL UNIQUE PRIMARY KEY,
@@ -20,6 +20,7 @@ CREATE TABLE IF NOT EXISTS agentInstances(
   input_state TEXT NOT NULL,
   used_tokens INTEGER NOT NULL,
   mounted_workspaces TEXT,
+  associated_browser_tabs TEXT,
   tool_approval_mode TEXT NOT NULL DEFAULT 'alwaysAsk'
 );
 

--- a/apps/browser/src/backend/services/agent-manager/persistence/schema.ts
+++ b/apps/browser/src/backend/services/agent-manager/persistence/schema.ts
@@ -91,6 +91,14 @@ const _sqliteJson = customType<{ data: unknown; driverData: string }>({
 
 export const meta = metaTable;
 
+export type PersistedBrowserTabs = {
+  version: 1;
+  tabs: Array<{
+    url: string;
+    active: boolean;
+  }>;
+};
+
 export const agentInstances = sqliteTable(
   'agentInstances',
   {
@@ -117,6 +125,9 @@ export const agentInstances = sqliteTable(
       _sqliteJson('mounted_workspaces').$type<
         Array<{ path: string; permissions: MountPermission[] }>
       >(),
+    associatedBrowserTabs: _sqliteJson(
+      'associated_browser_tabs',
+    ).$type<PersistedBrowserTabs>(),
     toolApprovalMode: toolApprovalMode('tool_approval_mode')
       .notNull()
       .$defaultFn(() => DEFAULT_TOOL_APPROVAL_MODE),

--- a/apps/browser/src/backend/services/toolbox/index.ts
+++ b/apps/browser/src/backend/services/toolbox/index.ts
@@ -1198,13 +1198,22 @@ export class ToolboxService extends DisposableService {
     this.shellService?.killSession(sessionId);
   }
 
-  public getBrowserSnapshot(): BrowserSnapshot {
+  public getBrowserSnapshot(agentInstanceId?: string): BrowserSnapshot {
     const browser = this.uiKarton.state.browser;
-    const activeTab = browser.activeTabId
-      ? browser.tabs[browser.activeTabId]
+    const useAgentBrowserGroup =
+      !!agentInstanceId && agentInstanceId !== browser.activeAgentId;
+    const agentBrowserState = useAgentBrowserGroup
+      ? browser.tabsByAgent[agentInstanceId]
       : null;
+    const browserTabs = useAgentBrowserGroup
+      ? (agentBrowserState?.tabs ?? {})
+      : browser.tabs;
+    const activeTabId = useAgentBrowserGroup
+      ? (agentBrowserState?.activeTabId ?? null)
+      : browser.activeTabId;
+    const activeTab = activeTabId ? browserTabs[activeTabId] : null;
 
-    const allTabs = Object.values(browser.tabs)
+    const allTabs = Object.values(browserTabs)
       .sort((a, b) => b.lastFocusedAt - a.lastFocusedAt)
       .map((tab) => ({
         id: tab.id,
@@ -1231,14 +1240,14 @@ export class ToolboxService extends DisposableService {
           }
         : null,
       tabs: allTabs,
-      totalTabCount: Object.keys(browser.tabs).length,
+      totalTabCount: Object.keys(browserTabs).length,
     };
   }
 
   public async captureEnvironmentSnapshot(
     agentInstanceId: string,
   ): Promise<EnvironmentSnapshot> {
-    const browserState = this.getBrowserSnapshot();
+    const browserState = this.getBrowserSnapshot(agentInstanceId);
     const workspaceState =
       this.mountManagerService?.getWorkspaceSnapshot(agentInstanceId);
     const toolboxState = this.uiKarton.state.toolbox[agentInstanceId];

--- a/apps/browser/src/backend/services/toolbox/index.ts
+++ b/apps/browser/src/backend/services/toolbox/index.ts
@@ -100,6 +100,7 @@ import {
   type QuestionAnswerValue,
 } from '@shared/karton-contracts/ui/agent/tools/types';
 import type { BrowserSnapshot, WorkspaceSnapshot } from './types';
+import type { PersistedBrowserTabs } from '@/services/agent-manager/persistence/schema';
 import type {
   EnvironmentSnapshot,
   MountPermission,
@@ -1243,6 +1244,30 @@ export class ToolboxService extends DisposableService {
       tabs: allTabs,
       totalTabCount: Object.keys(browserTabs).length,
     };
+  }
+
+  public getAssociatedBrowserTabsForPersistence(
+    agentInstanceId: string,
+  ): PersistedBrowserTabs | null {
+    const tabs = Object.values(this.uiKarton.state.browser.tabs)
+      .filter((tab) => tab.associatedAgentInstanceId === agentInstanceId)
+      .slice(0, 50)
+      .map((tab) => ({
+        url: tab.url.slice(0, 4096),
+        active: tab.id === this.uiKarton.state.browser.activeTabId,
+      }));
+
+    return tabs.length > 0 ? { version: 1, tabs } : null;
+  }
+
+  public async restoreAssociatedBrowserTabsFromPersistence(
+    agentInstanceId: string,
+    persistedTabs: PersistedBrowserTabs | null | undefined,
+  ): Promise<void> {
+    await this.windowLayoutService.restoreAssociatedTabsForAgent(
+      agentInstanceId,
+      persistedTabs,
+    );
   }
 
   public async captureEnvironmentSnapshot(

--- a/apps/browser/src/backend/services/toolbox/index.ts
+++ b/apps/browser/src/backend/services/toolbox/index.ts
@@ -1200,17 +1200,18 @@ export class ToolboxService extends DisposableService {
 
   public getBrowserSnapshot(agentInstanceId?: string): BrowserSnapshot {
     const browser = this.uiKarton.state.browser;
-    const useAgentBrowserGroup =
-      !!agentInstanceId && agentInstanceId !== browser.activeAgentId;
-    const agentBrowserState = useAgentBrowserGroup
-      ? browser.tabsByAgent[agentInstanceId]
-      : null;
-    const browserTabs = useAgentBrowserGroup
-      ? (agentBrowserState?.tabs ?? {})
-      : browser.tabs;
-    const activeTabId = useAgentBrowserGroup
-      ? (agentBrowserState?.activeTabId ?? null)
-      : browser.activeTabId;
+    const browserTabs = Object.fromEntries(
+      Object.entries(browser.tabs).filter(
+        ([, tab]) =>
+          !agentInstanceId ||
+          tab.associatedAgentInstanceId == null ||
+          tab.associatedAgentInstanceId === agentInstanceId,
+      ),
+    );
+    const activeTabId =
+      browser.activeTabId && browserTabs[browser.activeTabId]
+        ? browser.activeTabId
+        : null;
     const activeTab = activeTabId ? browserTabs[activeTabId] : null;
 
     const allTabs = Object.values(browserTabs)

--- a/apps/browser/src/backend/services/window-layout/chat-state-controller.ts
+++ b/apps/browser/src/backend/services/window-layout/chat-state-controller.ts
@@ -1,14 +1,21 @@
 import type { KartonService } from '../karton';
 import type { TabController } from './tab-controller';
 import type { SelectedElement } from '@shared/selected-elements';
+import type { AppState } from '@shared/karton-contracts/ui';
 
 export class ChatStateController {
   private uiKarton: KartonService;
   private tabs: Record<string, TabController>;
+  private getActiveBrowserGroupId: () => string;
 
-  constructor(uiKarton: KartonService, tabs: Record<string, TabController>) {
+  constructor(
+    uiKarton: KartonService,
+    tabs: Record<string, TabController>,
+    getActiveBrowserGroupId: () => string,
+  ) {
     this.uiKarton = uiKarton;
     this.tabs = tabs;
+    this.getActiveBrowserGroupId = getActiveBrowserGroupId;
   }
 
   /**
@@ -32,6 +39,7 @@ export class ChatStateController {
       // Add if not exists
       if (!elements.some((e) => e.stagewiseId === element.stagewiseId))
         elements.push(element);
+      this.syncGroupSelection(draft.browser.tabsByAgent, elements);
     });
     this.broadcastSelectionUpdate();
   }
@@ -45,6 +53,10 @@ export class ChatStateController {
       draft.browser.selectedElements = draft.browser.selectedElements.filter(
         (e) => e.stagewiseId !== elementId,
       );
+      this.syncGroupSelection(
+        draft.browser.tabsByAgent,
+        draft.browser.selectedElements,
+      );
     });
     this.broadcastSelectionUpdate();
   }
@@ -55,6 +67,10 @@ export class ChatStateController {
   public clearElements(): void {
     this.uiKarton.setState((draft) => {
       draft.browser.selectedElements = [];
+      this.syncGroupSelection(
+        draft.browser.tabsByAgent,
+        draft.browser.selectedElements,
+      );
     });
     this.broadcastSelectionUpdate();
   }
@@ -66,6 +82,10 @@ export class ChatStateController {
   public restoreElements(elements: SelectedElement[]): void {
     this.uiKarton.setState((draft) => {
       draft.browser.selectedElements = [...elements];
+      this.syncGroupSelection(
+        draft.browser.tabsByAgent,
+        draft.browser.selectedElements,
+      );
     });
     this.broadcastSelectionUpdate();
   }
@@ -89,5 +109,15 @@ export class ChatStateController {
     Object.values(this.tabs).forEach((tab) => {
       tab.updateContextSelection(allSelectedElements);
     });
+  }
+
+  private syncGroupSelection(
+    tabsByAgent: AppState['browser']['tabsByAgent'],
+    selectedElements: SelectedElement[],
+  ): void {
+    const group = tabsByAgent[this.getActiveBrowserGroupId()];
+    if (group) {
+      group.selectedElements = [...selectedElements];
+    }
   }
 }

--- a/apps/browser/src/backend/services/window-layout/chat-state-controller.ts
+++ b/apps/browser/src/backend/services/window-layout/chat-state-controller.ts
@@ -1,21 +1,14 @@
 import type { KartonService } from '../karton';
 import type { TabController } from './tab-controller';
 import type { SelectedElement } from '@shared/selected-elements';
-import type { AppState } from '@shared/karton-contracts/ui';
 
 export class ChatStateController {
   private uiKarton: KartonService;
   private tabs: Record<string, TabController>;
-  private getActiveBrowserGroupId: () => string;
 
-  constructor(
-    uiKarton: KartonService,
-    tabs: Record<string, TabController>,
-    getActiveBrowserGroupId: () => string,
-  ) {
+  constructor(uiKarton: KartonService, tabs: Record<string, TabController>) {
     this.uiKarton = uiKarton;
     this.tabs = tabs;
-    this.getActiveBrowserGroupId = getActiveBrowserGroupId;
   }
 
   /**
@@ -39,7 +32,6 @@ export class ChatStateController {
       // Add if not exists
       if (!elements.some((e) => e.stagewiseId === element.stagewiseId))
         elements.push(element);
-      this.syncGroupSelection(draft.browser.tabsByAgent, elements);
     });
     this.broadcastSelectionUpdate();
   }
@@ -53,10 +45,6 @@ export class ChatStateController {
       draft.browser.selectedElements = draft.browser.selectedElements.filter(
         (e) => e.stagewiseId !== elementId,
       );
-      this.syncGroupSelection(
-        draft.browser.tabsByAgent,
-        draft.browser.selectedElements,
-      );
     });
     this.broadcastSelectionUpdate();
   }
@@ -67,10 +55,6 @@ export class ChatStateController {
   public clearElements(): void {
     this.uiKarton.setState((draft) => {
       draft.browser.selectedElements = [];
-      this.syncGroupSelection(
-        draft.browser.tabsByAgent,
-        draft.browser.selectedElements,
-      );
     });
     this.broadcastSelectionUpdate();
   }
@@ -82,10 +66,6 @@ export class ChatStateController {
   public restoreElements(elements: SelectedElement[]): void {
     this.uiKarton.setState((draft) => {
       draft.browser.selectedElements = [...elements];
-      this.syncGroupSelection(
-        draft.browser.tabsByAgent,
-        draft.browser.selectedElements,
-      );
     });
     this.broadcastSelectionUpdate();
   }
@@ -109,15 +89,5 @@ export class ChatStateController {
     Object.values(this.tabs).forEach((tab) => {
       tab.updateContextSelection(allSelectedElements);
     });
-  }
-
-  private syncGroupSelection(
-    tabsByAgent: AppState['browser']['tabsByAgent'],
-    selectedElements: SelectedElement[],
-  ): void {
-    const group = tabsByAgent[this.getActiveBrowserGroupId()];
-    if (group) {
-      group.selectedElements = [...selectedElements];
-    }
   }
 }

--- a/apps/browser/src/backend/services/window-layout/index.ts
+++ b/apps/browser/src/backend/services/window-layout/index.ts
@@ -43,6 +43,7 @@ import {
 import { writeBlob } from '@/utils/attachment-blobs';
 import { generateAttachmentFilename } from '@shared/utils/attachment-filename';
 import sharp from 'sharp';
+import type { PersistedBrowserTabs } from '@/services/agent-manager/persistence/schema';
 
 const windowStateSchema = z.object({
   width: z.number(),
@@ -872,6 +873,55 @@ export class WindowLayoutService extends DisposableService {
     return this.activeTab;
   }
 
+  public async restoreAssociatedTabsForAgent(
+    agentInstanceId: string,
+    persistedTabs: PersistedBrowserTabs | null | undefined,
+  ): Promise<void> {
+    if (!persistedTabs || persistedTabs.version !== 1) return;
+
+    const existingTabIds = Object.values(this.uiKarton.state.browser.tabs)
+      .filter((tab) => tab.associatedAgentInstanceId === agentInstanceId)
+      .map((tab) => tab.id);
+    if (existingTabIds.length > 0) return;
+
+    const tabsToRestore = persistedTabs.tabs
+      .filter((tab) => tab.url.length > 0)
+      .slice(0, 50);
+    if (tabsToRestore.length === 0) return;
+
+    let activeTabId: string | null = null;
+    const now = Date.now();
+
+    for (const [index, tab] of tabsToRestore.entries()) {
+      const restoredTabId = await this.createTab(
+        tab.url,
+        false,
+        undefined,
+        agentInstanceId,
+      );
+      if (tab.active || activeTabId === null) {
+        activeTabId = restoredTabId;
+      }
+
+      this.uiKarton.setState((draft) => {
+        const restoredTab = draft.browser.tabs[restoredTabId];
+        if (restoredTab) {
+          restoredTab.lastFocusedAt = tab.active
+            ? now + tabsToRestore.length
+            : now + index;
+        }
+      });
+    }
+
+    if (
+      activeTabId &&
+      this.activeBrowserAgentId === agentInstanceId &&
+      this.isTabVisibleForActiveAgent(activeTabId)
+    ) {
+      await this.handleSwitchTab(activeTabId);
+    }
+  }
+
   private handleSetActiveAgent = async (agentId: string | null) => {
     if (agentId === this.activeBrowserAgentId) return;
 
@@ -953,14 +1003,18 @@ export class WindowLayoutService extends DisposableService {
     url: string | undefined,
     setActive: boolean,
     sourceTabId?: string,
+    associatedAgentInstanceIdOverride?: string | null,
   ): Promise<string> {
     const id = generateTabId();
     const sourceTabState = sourceTabId
       ? this.uiKarton.state.browser.tabs[sourceTabId]
       : undefined;
-    const associatedAgentInstanceId = sourceTabState
-      ? (sourceTabState.associatedAgentInstanceId ?? null)
-      : this.activeBrowserAgentId;
+    const associatedAgentInstanceId =
+      associatedAgentInstanceIdOverride !== undefined
+        ? associatedAgentInstanceIdOverride
+        : sourceTabState
+          ? (sourceTabState.associatedAgentInstanceId ?? null)
+          : this.activeBrowserAgentId;
 
     // Create search utilities config that reads from current Karton state and preferences
     const searchUtilsConfig: SearchUtilsConfig = {

--- a/apps/browser/src/backend/services/window-layout/index.ts
+++ b/apps/browser/src/backend/services/window-layout/index.ts
@@ -1,6 +1,11 @@
 import { BaseWindow, app, ipcMain, nativeTheme, session } from 'electron';
 import path from 'node:path';
-import type { SelectedElement } from '@shared/karton-contracts/ui';
+import type {
+  AppState,
+  BrowserAgentState,
+  SelectedElement,
+  TabState,
+} from '@shared/karton-contracts/ui';
 import { getHotkeyDefinitionForEvent } from '@shared/hotkeys';
 import { generateTabId, resetTabIdCounter } from './tab-id';
 import { getBrowserSessionId } from './browser-session';
@@ -78,6 +83,39 @@ function classifyTabUrl(url: string): {
   }
 }
 
+const GLOBAL_BROWSER_GROUP_ID = '__stagewise_global_browser__';
+
+type BrowserTabGroup = {
+  tabs: Record<string, TabController>;
+  activeTabId: string | null;
+  contextSelectionMode: boolean;
+  selectedElements: SelectedElement[];
+  hoveredElement: SelectedElement | null;
+  viewportSize: AppState['browser']['viewportSize'];
+};
+
+function createEmptyBrowserTabGroup(): BrowserTabGroup {
+  return {
+    tabs: {},
+    activeTabId: null,
+    contextSelectionMode: false,
+    selectedElements: [],
+    hoveredElement: null,
+    viewportSize: null,
+  };
+}
+
+function createEmptyBrowserAgentState(): BrowserAgentState {
+  return {
+    tabs: {},
+    activeTabId: null,
+    contextSelectionMode: false,
+    selectedElements: [],
+    hoveredElement: null,
+    viewportSize: null,
+  };
+}
+
 export class WindowLayoutService extends DisposableService {
   private readonly logger: Logger;
   private readonly historyService: HistoryService;
@@ -89,6 +127,11 @@ export class WindowLayoutService extends DisposableService {
 
   private baseWindow: BaseWindow | null = null;
   private uiController: UIController | null = null;
+  private activeBrowserAgentId: string | null = null;
+  private activeBrowserGroupId = GLOBAL_BROWSER_GROUP_ID;
+  private readonly tabGroups: Record<string, BrowserTabGroup> = {
+    [GLOBAL_BROWSER_GROUP_ID]: createEmptyBrowserTabGroup(),
+  };
   private tabs: Record<string, TabController> = {};
   private activeTabId: string | null = null;
   private chatStateController: ChatStateController | null = null;
@@ -140,6 +183,7 @@ export class WindowLayoutService extends DisposableService {
     super();
     // Reset to 1 on every cold start — mimics Chrome's per-session tab IDs.
     resetTabIdCounter();
+    this.tabs = this.tabGroups[GLOBAL_BROWSER_GROUP_ID]!.tabs;
     this.logger = logger;
     this.historyService = historyService;
     this.faviconService = faviconService;
@@ -315,6 +359,10 @@ export class WindowLayoutService extends DisposableService {
     // Initialize browser state
     this.uiKarton.setState((draft) => {
       draft.browser = {
+        activeAgentId: null,
+        tabsByAgent: {
+          [GLOBAL_BROWSER_GROUP_ID]: createEmptyBrowserAgentState(),
+        },
         tabs: {},
         activeTabId: null,
         sessionId: getBrowserSessionId(),
@@ -333,6 +381,7 @@ export class WindowLayoutService extends DisposableService {
     this.chatStateController = new ChatStateController(
       this.uiKarton,
       this.tabs,
+      () => this.activeBrowserGroupId,
     );
 
     // Determine initial tab URL based on startup page preference
@@ -651,6 +700,7 @@ export class WindowLayoutService extends DisposableService {
     if (!this.uiController) return;
 
     this.uiController.on('uiReady', this.handleUIReady);
+    this.uiController.on('setActiveAgent', this.handleSetActiveAgent);
     this.uiController.on('createTab', this.handleCreateTab);
     this.uiController.on('closeTab', this.handleCloseTab);
     this.uiController.on('switchTab', this.handleSwitchTab);
@@ -799,6 +849,86 @@ export class WindowLayoutService extends DisposableService {
     return this.tabs[this.activeTabId];
   }
 
+  private getBrowserGroupId(agentId: string | null): string {
+    return agentId ?? GLOBAL_BROWSER_GROUP_ID;
+  }
+
+  private getCurrentBrowserGroup(): BrowserTabGroup {
+    return this.getOrCreateBrowserGroup(this.activeBrowserGroupId);
+  }
+
+  private getOrCreateBrowserGroup(groupId: string): BrowserTabGroup {
+    if (!this.tabGroups[groupId]) {
+      this.tabGroups[groupId] = createEmptyBrowserTabGroup();
+    }
+    return this.tabGroups[groupId]!;
+  }
+
+  private setCurrentTabs(tabs: Record<string, TabController>): void {
+    this.tabs = tabs;
+    this.getCurrentBrowserGroup().tabs = tabs;
+    this.chatStateController?.updateTabsReference(this.tabs);
+  }
+
+  private setCurrentActiveTabId(tabId: string | null): void {
+    this.activeTabId = tabId;
+    this.getCurrentBrowserGroup().activeTabId = tabId;
+  }
+
+  private buildBrowserAgentState(group: BrowserTabGroup): BrowserAgentState {
+    const tabs: Record<string, TabState> = {};
+    for (const [id, tab] of Object.entries(group.tabs)) {
+      tabs[id] = {
+        id,
+        ...tab.getState(),
+      };
+    }
+
+    return {
+      tabs,
+      activeTabId: group.activeTabId,
+      contextSelectionMode: group.contextSelectionMode,
+      selectedElements: [...group.selectedElements],
+      hoveredElement: group.hoveredElement,
+      viewportSize: group.viewportSize,
+    };
+  }
+
+  private ensureDraftBrowserGroup(
+    tabsByAgent: AppState['browser']['tabsByAgent'],
+    groupId: string,
+  ): BrowserAgentState {
+    tabsByAgent[groupId] ??= createEmptyBrowserAgentState();
+    return tabsByAgent[groupId]!;
+  }
+
+  private syncCurrentBrowserGroupFromKarton(): void {
+    const group = this.getCurrentBrowserGroup();
+    const browser = this.uiKarton.state.browser;
+    group.contextSelectionMode = browser.contextSelectionMode;
+    group.selectedElements = [...browser.selectedElements];
+    group.hoveredElement = browser.hoveredElement;
+    group.viewportSize = browser.viewportSize;
+  }
+
+  private syncKartonBrowserFromCurrentGroup(): void {
+    const group = this.getCurrentBrowserGroup();
+    const groupId = this.activeBrowserGroupId;
+    const agentId = this.activeBrowserAgentId;
+    const state = this.buildBrowserAgentState(group);
+
+    this.uiKarton.setState((draft) => {
+      draft.browser.activeAgentId = agentId;
+      draft.browser.tabs = state.tabs;
+      draft.browser.activeTabId = state.activeTabId;
+      draft.browser.contextSelectionMode = state.contextSelectionMode;
+      draft.browser.selectedElements = state.selectedElements;
+      draft.browser.hoveredElement = state.hoveredElement;
+      draft.browser.viewportSize = state.viewportSize;
+      draft.browser.tabsByAgent[groupId] = state;
+    });
+  }
+
   /**
    * Get a tab by ID, or the active tab if no ID is provided.
    * Used by services like DevToolAPIService to access tabs.
@@ -812,6 +942,46 @@ export class WindowLayoutService extends DisposableService {
     }
     return this.activeTab;
   }
+
+  private handleSetActiveAgent = async (agentId: string | null) => {
+    const nextGroupId = this.getBrowserGroupId(agentId);
+
+    if (nextGroupId === this.activeBrowserGroupId) {
+      this.syncKartonBrowserFromCurrentGroup();
+      return;
+    }
+
+    this.syncCurrentBrowserGroupFromKarton();
+    this.syncKartonBrowserFromCurrentGroup();
+
+    if (this.activeTabId && this.contentFullscreenTabId === this.activeTabId) {
+      await this.tabs[this.activeTabId]?.exitContentFullscreen();
+      this.contentFullscreenTabId = null;
+    }
+
+    this.activeTab?.setVisible(false);
+
+    this.activeBrowserGroupId = nextGroupId;
+    this.activeBrowserAgentId = agentId;
+
+    const nextGroup = this.getOrCreateBrowserGroup(nextGroupId);
+    this.setCurrentTabs(nextGroup.tabs);
+
+    const nextActiveTabId = nextGroup.activeTabId;
+    this.setCurrentActiveTabId(null);
+    this.syncKartonBrowserFromCurrentGroup();
+
+    if (Object.keys(this.tabs).length === 0) {
+      await this.handleCreateTab(undefined, true);
+      return;
+    }
+
+    if (nextActiveTabId) {
+      await this.handleSwitchTab(nextActiveTabId);
+    } else {
+      this.syncKartonBrowserFromCurrentGroup();
+    }
+  };
 
   private handleCreateTab = async (
     url?: string,
@@ -862,6 +1032,7 @@ export class WindowLayoutService extends DisposableService {
     sourceTabId?: string,
   ): Promise<string> {
     const id = generateTabId();
+    const ownerGroupId = this.activeBrowserGroupId;
 
     // Create search utilities config that reads from current Karton state and preferences
     const searchUtilsConfig: SearchUtilsConfig = {
@@ -893,9 +1064,20 @@ export class WindowLayoutService extends DisposableService {
     // Subscribe to state updates
     tab.on('stateUpdated', (updates) => {
       this.uiKarton.setState((draft) => {
-        const tabState = draft.browser.tabs[id];
-        if (tabState) {
-          Object.assign(tabState, updates);
+        const groupState = this.ensureDraftBrowserGroup(
+          draft.browser.tabsByAgent,
+          ownerGroupId,
+        );
+        const storedTabState = groupState.tabs[id];
+        if (storedTabState) {
+          Object.assign(storedTabState, updates);
+        }
+
+        if (ownerGroupId === this.activeBrowserGroupId) {
+          const tabState = draft.browser.tabs[id];
+          if (tabState) {
+            Object.assign(tabState, updates);
+          }
         }
       });
     });
@@ -927,9 +1109,18 @@ export class WindowLayoutService extends DisposableService {
 
     tab.on('elementHovered', (element) => {
       // Only update if this is the active tab
-      if (this.activeTabId === id) {
+      if (
+        ownerGroupId === this.activeBrowserGroupId &&
+        this.activeTabId === id
+      ) {
+        this.getCurrentBrowserGroup().hoveredElement = element;
         this.uiKarton.setState((draft) => {
           draft.browser.hoveredElement = element;
+          const groupState = this.ensureDraftBrowserGroup(
+            draft.browser.tabsByAgent,
+            ownerGroupId,
+          );
+          groupState.hoveredElement = element;
         });
       }
     });
@@ -941,9 +1132,18 @@ export class WindowLayoutService extends DisposableService {
 
     tab.on('viewportSizeChanged', (size) => {
       // Only update if this is the active tab
-      if (this.activeTabId === id) {
+      if (
+        ownerGroupId === this.activeBrowserGroupId &&
+        this.activeTabId === id
+      ) {
+        this.getCurrentBrowserGroup().viewportSize = size;
         this.uiKarton.setState((draft) => {
           draft.browser.viewportSize = size;
+          const groupState = this.ensureDraftBrowserGroup(
+            draft.browser.tabsByAgent,
+            ownerGroupId,
+          );
+          groupState.viewportSize = size;
         });
       }
     });
@@ -1005,7 +1205,7 @@ export class WindowLayoutService extends DisposableService {
           newTabs[id] = tab;
         }
       }
-      this.tabs = newTabs;
+      this.setCurrentTabs(newTabs);
     } else {
       // Append to end (default behavior for UI-created tabs)
       this.tabs[id] = tab;
@@ -1024,19 +1224,32 @@ export class WindowLayoutService extends DisposableService {
       if (shouldInsertAfterSource && sourceTabId) {
         // Reconstruct tabs object to maintain order
         const newBrowserTabs: typeof draft.browser.tabs = {};
+        const newGroupTabs: typeof draft.browser.tabs = {};
+        const groupState = this.ensureDraftBrowserGroup(
+          draft.browser.tabsByAgent,
+          ownerGroupId,
+        );
         for (const [existingId, existingState] of Object.entries(
           draft.browser.tabs,
         )) {
           newBrowserTabs[existingId] = existingState;
+          newGroupTabs[existingId] = groupState.tabs[existingId]!;
           if (existingId === sourceTabId) {
             // Insert new tab right after source
             newBrowserTabs[id] = newTabState;
+            newGroupTabs[id] = newTabState;
           }
         }
         draft.browser.tabs = newBrowserTabs;
+        groupState.tabs = newGroupTabs;
       } else {
         // Append to end (default behavior)
         draft.browser.tabs[id] = newTabState;
+        const groupState = this.ensureDraftBrowserGroup(
+          draft.browser.tabsByAgent,
+          ownerGroupId,
+        );
+        groupState.tabs[id] = newTabState;
       }
     });
 
@@ -1064,6 +1277,7 @@ export class WindowLayoutService extends DisposableService {
   private handleCloseTab = async (tabId: string) => {
     const tab = this.tabs[tabId];
     if (tab) {
+      const ownerGroupId = this.activeBrowserGroupId;
       // Get tab order before deletion to determine next/previous tab
       const tabIdsBeforeDeletion = Object.keys(this.tabs);
       const currentIndex = tabIdsBeforeDeletion.indexOf(tabId);
@@ -1086,6 +1300,11 @@ export class WindowLayoutService extends DisposableService {
       // Clean up Karton state
       this.uiKarton.setState((draft) => {
         delete draft.browser.tabs[tabId];
+        const groupState = this.ensureDraftBrowserGroup(
+          draft.browser.tabsByAgent,
+          ownerGroupId,
+        );
+        delete groupState.tabs[tabId];
       });
 
       this.telemetryService?.capture('tab-destroyed', {
@@ -1109,6 +1328,7 @@ export class WindowLayoutService extends DisposableService {
         if (nextTabId) {
           await this.handleSwitchTab(nextTabId);
         } else {
+          this.setCurrentActiveTabId(null);
           // If no other tabs exist, create a new one
           const preferences = this.preferencesService.get();
           const newTabPage = preferences.general.newTabPage;
@@ -1134,7 +1354,7 @@ export class WindowLayoutService extends DisposableService {
       // The contentFullscreenChanged handler will clean up state
     }
 
-    this.activeTabId = tabId;
+    this.setCurrentActiveTabId(tabId);
     const newTab = this.tabs[tabId]!;
 
     // Show new tab BEFORE hiding old tab to prevent flicker.
@@ -1174,6 +1394,12 @@ export class WindowLayoutService extends DisposableService {
     this.uiKarton.setState((draft) => {
       draft.browser.activeTabId = tabId;
       draft.browser.viewportSize = newTab.getViewportSize();
+      const groupState = this.ensureDraftBrowserGroup(
+        draft.browser.tabsByAgent,
+        this.activeBrowserGroupId,
+      );
+      groupState.activeTabId = tabId;
+      groupState.viewportSize = newTab.getViewportSize();
     });
   };
 
@@ -1191,18 +1417,22 @@ export class WindowLayoutService extends DisposableService {
     for (const id of validTabIds) {
       newTabs[id] = this.tabs[id]!;
     }
-    this.tabs = newTabs;
-
-    // Update ChatStateController tabs reference
-    this.chatStateController?.updateTabsReference(this.tabs);
+    this.setCurrentTabs(newTabs);
 
     // Update Karton state with new tab order
     this.uiKarton.setState((draft) => {
       const newBrowserTabs: typeof draft.browser.tabs = {};
+      const newGroupTabs: typeof draft.browser.tabs = {};
+      const groupState = this.ensureDraftBrowserGroup(
+        draft.browser.tabsByAgent,
+        this.activeBrowserGroupId,
+      );
       for (const id of validTabIds) {
         newBrowserTabs[id] = draft.browser.tabs[id]!;
+        newGroupTabs[id] = groupState.tabs[id]!;
       }
       draft.browser.tabs = newBrowserTabs;
+      groupState.tabs = newGroupTabs;
     });
   };
 
@@ -1350,6 +1580,13 @@ export class WindowLayoutService extends DisposableService {
     this.uiKarton.setState((draft) => {
       if (draft.browser.tabs[tabId]) {
         draft.browser.tabs[tabId].isContentFullscreen = isFullscreen;
+      }
+      const groupState = this.ensureDraftBrowserGroup(
+        draft.browser.tabsByAgent,
+        this.activeBrowserGroupId,
+      );
+      if (groupState.tabs[tabId]) {
+        groupState.tabs[tabId].isContentFullscreen = isFullscreen;
       }
     });
   };
@@ -1547,6 +1784,11 @@ export class WindowLayoutService extends DisposableService {
       // Turn off for the currently active message ID
       this.uiKarton.setState((draft) => {
         draft.browser.contextSelectionMode = false;
+        const groupState = this.ensureDraftBrowserGroup(
+          draft.browser.tabsByAgent,
+          this.activeBrowserGroupId,
+        );
+        groupState.contextSelectionMode = false;
       });
 
       // Brief delay to ensure UI updates
@@ -1567,7 +1809,13 @@ export class WindowLayoutService extends DisposableService {
     }
     this.uiKarton.setState((draft) => {
       draft.browser.contextSelectionMode = active;
+      const groupState = this.ensureDraftBrowserGroup(
+        draft.browser.tabsByAgent,
+        this.activeBrowserGroupId,
+      );
+      groupState.contextSelectionMode = active;
     });
+    this.getCurrentBrowserGroup().contextSelectionMode = active;
   };
 
   private handleSelectHoveredElement = () => {
@@ -1744,6 +1992,14 @@ export class WindowLayoutService extends DisposableService {
       if (tab) {
         tab.isSearchBarActive = true;
       }
+      const groupState = this.ensureDraftBrowserGroup(
+        draft.browser.tabsByAgent,
+        this.activeBrowserGroupId,
+      );
+      const groupTab = groupState.tabs[this.activeTabId!];
+      if (groupTab) {
+        groupTab.isSearchBarActive = true;
+      }
     });
   };
 
@@ -1753,6 +2009,14 @@ export class WindowLayoutService extends DisposableService {
       const tab = draft.browser.tabs[this.activeTabId!];
       if (tab) {
         tab.isSearchBarActive = false;
+      }
+      const groupState = this.ensureDraftBrowserGroup(
+        draft.browser.tabsByAgent,
+        this.activeBrowserGroupId,
+      );
+      const groupTab = groupState.tabs[this.activeTabId!];
+      if (groupTab) {
+        groupTab.isSearchBarActive = false;
       }
     });
     // Also stop any active search

--- a/apps/browser/src/backend/services/window-layout/index.ts
+++ b/apps/browser/src/backend/services/window-layout/index.ts
@@ -1,11 +1,6 @@
 import { BaseWindow, app, ipcMain, nativeTheme, session } from 'electron';
 import path from 'node:path';
-import type {
-  AppState,
-  BrowserAgentState,
-  SelectedElement,
-  TabState,
-} from '@shared/karton-contracts/ui';
+import type { SelectedElement } from '@shared/karton-contracts/ui';
 import { getHotkeyDefinitionForEvent } from '@shared/hotkeys';
 import { generateTabId, resetTabIdCounter } from './tab-id';
 import { getBrowserSessionId } from './browser-session';
@@ -83,39 +78,6 @@ function classifyTabUrl(url: string): {
   }
 }
 
-const GLOBAL_BROWSER_GROUP_ID = '__stagewise_global_browser__';
-
-type BrowserTabGroup = {
-  tabs: Record<string, TabController>;
-  activeTabId: string | null;
-  contextSelectionMode: boolean;
-  selectedElements: SelectedElement[];
-  hoveredElement: SelectedElement | null;
-  viewportSize: AppState['browser']['viewportSize'];
-};
-
-function createEmptyBrowserTabGroup(): BrowserTabGroup {
-  return {
-    tabs: {},
-    activeTabId: null,
-    contextSelectionMode: false,
-    selectedElements: [],
-    hoveredElement: null,
-    viewportSize: null,
-  };
-}
-
-function createEmptyBrowserAgentState(): BrowserAgentState {
-  return {
-    tabs: {},
-    activeTabId: null,
-    contextSelectionMode: false,
-    selectedElements: [],
-    hoveredElement: null,
-    viewportSize: null,
-  };
-}
-
 export class WindowLayoutService extends DisposableService {
   private readonly logger: Logger;
   private readonly historyService: HistoryService;
@@ -128,10 +90,6 @@ export class WindowLayoutService extends DisposableService {
   private baseWindow: BaseWindow | null = null;
   private uiController: UIController | null = null;
   private activeBrowserAgentId: string | null = null;
-  private activeBrowserGroupId = GLOBAL_BROWSER_GROUP_ID;
-  private readonly tabGroups: Record<string, BrowserTabGroup> = {
-    [GLOBAL_BROWSER_GROUP_ID]: createEmptyBrowserTabGroup(),
-  };
   private tabs: Record<string, TabController> = {};
   private activeTabId: string | null = null;
   private chatStateController: ChatStateController | null = null;
@@ -183,7 +141,6 @@ export class WindowLayoutService extends DisposableService {
     super();
     // Reset to 1 on every cold start — mimics Chrome's per-session tab IDs.
     resetTabIdCounter();
-    this.tabs = this.tabGroups[GLOBAL_BROWSER_GROUP_ID]!.tabs;
     this.logger = logger;
     this.historyService = historyService;
     this.faviconService = faviconService;
@@ -360,9 +317,6 @@ export class WindowLayoutService extends DisposableService {
     this.uiKarton.setState((draft) => {
       draft.browser = {
         activeAgentId: null,
-        tabsByAgent: {
-          [GLOBAL_BROWSER_GROUP_ID]: createEmptyBrowserAgentState(),
-        },
         tabs: {},
         activeTabId: null,
         sessionId: getBrowserSessionId(),
@@ -381,7 +335,6 @@ export class WindowLayoutService extends DisposableService {
     this.chatStateController = new ChatStateController(
       this.uiKarton,
       this.tabs,
-      () => this.activeBrowserGroupId,
     );
 
     // Determine initial tab URL based on startup page preference
@@ -488,9 +441,12 @@ export class WindowLayoutService extends DisposableService {
     this.logger.debug(`[WindowLayoutService] openUrl called with url: ${url}`);
 
     // Check if we should reuse the active tab (if it's new/default)
+    const visibleTabCount = this.getVisibleTabIds(
+      this.activeBrowserAgentId,
+    ).length;
     const shouldReuseActiveTab =
       this.activeTab &&
-      Object.keys(this.tabs).length === 1 &&
+      visibleTabCount === 1 &&
       this.activeTab.getState().url === HOME_PAGE_URL &&
       !this.activeTab.getState().navigationHistory.canGoBack;
 
@@ -701,6 +657,7 @@ export class WindowLayoutService extends DisposableService {
 
     this.uiController.on('uiReady', this.handleUIReady);
     this.uiController.on('setActiveAgent', this.handleSetActiveAgent);
+    this.uiController.on('setTabAssociation', this.handleSetTabAssociation);
     this.uiController.on('createTab', this.handleCreateTab);
     this.uiController.on('closeTab', this.handleCloseTab);
     this.uiController.on('switchTab', this.handleSwitchTab);
@@ -849,84 +806,56 @@ export class WindowLayoutService extends DisposableService {
     return this.tabs[this.activeTabId];
   }
 
-  private getBrowserGroupId(agentId: string | null): string {
-    return agentId ?? GLOBAL_BROWSER_GROUP_ID;
+  private isTabVisibleForActiveAgent(tabId: string): boolean {
+    return this.isTabVisibleForAgent(tabId, this.activeBrowserAgentId);
   }
 
-  private getCurrentBrowserGroup(): BrowserTabGroup {
-    return this.getOrCreateBrowserGroup(this.activeBrowserGroupId);
+  private isTabVisibleForAgent(tabId: string, agentId: string | null): boolean {
+    const tabState = this.uiKarton.state.browser.tabs[tabId];
+    if (!tabState) return false;
+    return (
+      tabState.associatedAgentInstanceId == null ||
+      tabState.associatedAgentInstanceId === agentId
+    );
   }
 
-  private getOrCreateBrowserGroup(groupId: string): BrowserTabGroup {
-    if (!this.tabGroups[groupId]) {
-      this.tabGroups[groupId] = createEmptyBrowserTabGroup();
-    }
-    return this.tabGroups[groupId]!;
+  private getVisibleTabIds(agentId: string | null): string[] {
+    return Object.values(this.uiKarton.state.browser.tabs)
+      .filter(
+        (tab) =>
+          tab.associatedAgentInstanceId == null ||
+          tab.associatedAgentInstanceId === agentId,
+      )
+      .map((tab) => tab.id);
   }
 
-  private setCurrentTabs(tabs: Record<string, TabController>): void {
-    this.tabs = tabs;
-    this.getCurrentBrowserGroup().tabs = tabs;
-    this.chatStateController?.updateTabsReference(this.tabs);
-  }
-
-  private setCurrentActiveTabId(tabId: string | null): void {
-    this.activeTabId = tabId;
-    this.getCurrentBrowserGroup().activeTabId = tabId;
-  }
-
-  private buildBrowserAgentState(group: BrowserTabGroup): BrowserAgentState {
-    const tabs: Record<string, TabState> = {};
-    for (const [id, tab] of Object.entries(group.tabs)) {
-      tabs[id] = {
-        id,
-        ...tab.getState(),
-      };
+  private async ensureActiveTabVisible(): Promise<void> {
+    if (this.activeTabId && this.isTabVisibleForActiveAgent(this.activeTabId)) {
+      return;
     }
 
-    return {
-      tabs,
-      activeTabId: group.activeTabId,
-      contextSelectionMode: group.contextSelectionMode,
-      selectedElements: [...group.selectedElements],
-      hoveredElement: group.hoveredElement,
-      viewportSize: group.viewportSize,
-    };
-  }
+    if (this.activeTabId) {
+      this.tabs[this.activeTabId]?.setVisible(false);
+    }
 
-  private ensureDraftBrowserGroup(
-    tabsByAgent: AppState['browser']['tabsByAgent'],
-    groupId: string,
-  ): BrowserAgentState {
-    tabsByAgent[groupId] ??= createEmptyBrowserAgentState();
-    return tabsByAgent[groupId]!;
-  }
+    const nextTabId = this.getVisibleTabIds(this.activeBrowserAgentId).sort(
+      (a, b) =>
+        (this.uiKarton.state.browser.tabs[b]?.lastFocusedAt ?? 0) -
+        (this.uiKarton.state.browser.tabs[a]?.lastFocusedAt ?? 0),
+    )[0];
 
-  private syncCurrentBrowserGroupFromKarton(): void {
-    const group = this.getCurrentBrowserGroup();
-    const browser = this.uiKarton.state.browser;
-    group.contextSelectionMode = browser.contextSelectionMode;
-    group.selectedElements = [...browser.selectedElements];
-    group.hoveredElement = browser.hoveredElement;
-    group.viewportSize = browser.viewportSize;
-  }
+    if (nextTabId) {
+      this.activeTabId = null;
+      await this.handleSwitchTab(nextTabId);
+      return;
+    }
 
-  private syncKartonBrowserFromCurrentGroup(): void {
-    const group = this.getCurrentBrowserGroup();
-    const groupId = this.activeBrowserGroupId;
-    const agentId = this.activeBrowserAgentId;
-    const state = this.buildBrowserAgentState(group);
-
+    this.activeTabId = null;
     this.uiKarton.setState((draft) => {
-      draft.browser.activeAgentId = agentId;
-      draft.browser.tabs = state.tabs;
-      draft.browser.activeTabId = state.activeTabId;
-      draft.browser.contextSelectionMode = state.contextSelectionMode;
-      draft.browser.selectedElements = state.selectedElements;
-      draft.browser.hoveredElement = state.hoveredElement;
-      draft.browser.viewportSize = state.viewportSize;
-      draft.browser.tabsByAgent[groupId] = state;
+      draft.browser.activeTabId = null;
+      draft.browser.viewportSize = null;
     });
+    await this.handleCreateTab(undefined, true);
   }
 
   /**
@@ -944,43 +873,35 @@ export class WindowLayoutService extends DisposableService {
   }
 
   private handleSetActiveAgent = async (agentId: string | null) => {
-    const nextGroupId = this.getBrowserGroupId(agentId);
-
-    if (nextGroupId === this.activeBrowserGroupId) {
-      this.syncKartonBrowserFromCurrentGroup();
-      return;
-    }
-
-    this.syncCurrentBrowserGroupFromKarton();
-    this.syncKartonBrowserFromCurrentGroup();
+    if (agentId === this.activeBrowserAgentId) return;
 
     if (this.activeTabId && this.contentFullscreenTabId === this.activeTabId) {
       await this.tabs[this.activeTabId]?.exitContentFullscreen();
       this.contentFullscreenTabId = null;
     }
 
-    this.activeTab?.setVisible(false);
-
-    this.activeBrowserGroupId = nextGroupId;
     this.activeBrowserAgentId = agentId;
+    this.uiKarton.setState((draft) => {
+      draft.browser.activeAgentId = agentId;
+    });
 
-    const nextGroup = this.getOrCreateBrowserGroup(nextGroupId);
-    this.setCurrentTabs(nextGroup.tabs);
+    await this.ensureActiveTabVisible();
+  };
 
-    const nextActiveTabId = nextGroup.activeTabId;
-    this.setCurrentActiveTabId(null);
-    this.syncKartonBrowserFromCurrentGroup();
+  private handleSetTabAssociation = async (
+    tabId: string,
+    agentInstanceId: string | null,
+  ) => {
+    if (!this.tabs[tabId]) return;
 
-    if (Object.keys(this.tabs).length === 0) {
-      await this.handleCreateTab(undefined, true);
-      return;
-    }
+    this.uiKarton.setState((draft) => {
+      const tab = draft.browser.tabs[tabId];
+      if (tab) {
+        tab.associatedAgentInstanceId = agentInstanceId;
+      }
+    });
 
-    if (nextActiveTabId) {
-      await this.handleSwitchTab(nextActiveTabId);
-    } else {
-      this.syncKartonBrowserFromCurrentGroup();
-    }
+    await this.ensureActiveTabVisible();
   };
 
   private handleCreateTab = async (
@@ -1013,7 +934,9 @@ export class WindowLayoutService extends DisposableService {
     if (targetUrl?.startsWith('stagewise://')) {
       const existingTab = Object.entries(this.tabs).find(
         ([id, tab]) =>
-          id !== this.activeTabId && tab.getState().url === targetUrl,
+          id !== this.activeTabId &&
+          this.isTabVisibleForActiveAgent(id) &&
+          tab.getState().url === targetUrl,
       );
 
       if (existingTab) {
@@ -1032,7 +955,12 @@ export class WindowLayoutService extends DisposableService {
     sourceTabId?: string,
   ): Promise<string> {
     const id = generateTabId();
-    const ownerGroupId = this.activeBrowserGroupId;
+    const sourceTabState = sourceTabId
+      ? this.uiKarton.state.browser.tabs[sourceTabId]
+      : undefined;
+    const associatedAgentInstanceId = sourceTabState
+      ? (sourceTabState.associatedAgentInstanceId ?? null)
+      : this.activeBrowserAgentId;
 
     // Create search utilities config that reads from current Karton state and preferences
     const searchUtilsConfig: SearchUtilsConfig = {
@@ -1064,20 +992,9 @@ export class WindowLayoutService extends DisposableService {
     // Subscribe to state updates
     tab.on('stateUpdated', (updates) => {
       this.uiKarton.setState((draft) => {
-        const groupState = this.ensureDraftBrowserGroup(
-          draft.browser.tabsByAgent,
-          ownerGroupId,
-        );
-        const storedTabState = groupState.tabs[id];
-        if (storedTabState) {
-          Object.assign(storedTabState, updates);
-        }
-
-        if (ownerGroupId === this.activeBrowserGroupId) {
-          const tabState = draft.browser.tabs[id];
-          if (tabState) {
-            Object.assign(tabState, updates);
-          }
+        const tabState = draft.browser.tabs[id];
+        if (tabState) {
+          Object.assign(tabState, updates);
         }
       });
     });
@@ -1109,18 +1026,9 @@ export class WindowLayoutService extends DisposableService {
 
     tab.on('elementHovered', (element) => {
       // Only update if this is the active tab
-      if (
-        ownerGroupId === this.activeBrowserGroupId &&
-        this.activeTabId === id
-      ) {
-        this.getCurrentBrowserGroup().hoveredElement = element;
+      if (this.activeTabId === id) {
         this.uiKarton.setState((draft) => {
           draft.browser.hoveredElement = element;
-          const groupState = this.ensureDraftBrowserGroup(
-            draft.browser.tabsByAgent,
-            ownerGroupId,
-          );
-          groupState.hoveredElement = element;
         });
       }
     });
@@ -1132,18 +1040,9 @@ export class WindowLayoutService extends DisposableService {
 
     tab.on('viewportSizeChanged', (size) => {
       // Only update if this is the active tab
-      if (
-        ownerGroupId === this.activeBrowserGroupId &&
-        this.activeTabId === id
-      ) {
-        this.getCurrentBrowserGroup().viewportSize = size;
+      if (this.activeTabId === id) {
         this.uiKarton.setState((draft) => {
           draft.browser.viewportSize = size;
-          const groupState = this.ensureDraftBrowserGroup(
-            draft.browser.tabsByAgent,
-            ownerGroupId,
-          );
-          groupState.viewportSize = size;
         });
       }
     });
@@ -1205,7 +1104,7 @@ export class WindowLayoutService extends DisposableService {
           newTabs[id] = tab;
         }
       }
-      this.setCurrentTabs(newTabs);
+      this.tabs = newTabs;
     } else {
       // Append to end (default behavior for UI-created tabs)
       this.tabs[id] = tab;
@@ -1219,37 +1118,25 @@ export class WindowLayoutService extends DisposableService {
       const newTabState = {
         id,
         ...tab.getState(),
+        associatedAgentInstanceId,
       };
 
       if (shouldInsertAfterSource && sourceTabId) {
         // Reconstruct tabs object to maintain order
         const newBrowserTabs: typeof draft.browser.tabs = {};
-        const newGroupTabs: typeof draft.browser.tabs = {};
-        const groupState = this.ensureDraftBrowserGroup(
-          draft.browser.tabsByAgent,
-          ownerGroupId,
-        );
         for (const [existingId, existingState] of Object.entries(
           draft.browser.tabs,
         )) {
           newBrowserTabs[existingId] = existingState;
-          newGroupTabs[existingId] = groupState.tabs[existingId]!;
           if (existingId === sourceTabId) {
             // Insert new tab right after source
             newBrowserTabs[id] = newTabState;
-            newGroupTabs[id] = newTabState;
           }
         }
         draft.browser.tabs = newBrowserTabs;
-        groupState.tabs = newGroupTabs;
       } else {
         // Append to end (default behavior)
         draft.browser.tabs[id] = newTabState;
-        const groupState = this.ensureDraftBrowserGroup(
-          draft.browser.tabsByAgent,
-          ownerGroupId,
-        );
-        groupState.tabs[id] = newTabState;
       }
     });
 
@@ -1277,9 +1164,10 @@ export class WindowLayoutService extends DisposableService {
   private handleCloseTab = async (tabId: string) => {
     const tab = this.tabs[tabId];
     if (tab) {
-      const ownerGroupId = this.activeBrowserGroupId;
       // Get tab order before deletion to determine next/previous tab
-      const tabIdsBeforeDeletion = Object.keys(this.tabs);
+      const tabIdsBeforeDeletion = Object.keys(this.tabs).filter(
+        (id) => id === tabId || this.isTabVisibleForActiveAgent(id),
+      );
       const currentIndex = tabIdsBeforeDeletion.indexOf(tabId);
       const isActiveTab = this.activeTabId === tabId;
 
@@ -1300,11 +1188,6 @@ export class WindowLayoutService extends DisposableService {
       // Clean up Karton state
       this.uiKarton.setState((draft) => {
         delete draft.browser.tabs[tabId];
-        const groupState = this.ensureDraftBrowserGroup(
-          draft.browser.tabsByAgent,
-          ownerGroupId,
-        );
-        delete groupState.tabs[tabId];
       });
 
       this.telemetryService?.capture('tab-destroyed', {
@@ -1312,8 +1195,9 @@ export class WindowLayoutService extends DisposableService {
       });
 
       if (isActiveTab) {
-        // Get remaining tabs after deletion
-        const remainingTabIds = Object.keys(this.tabs);
+        const remainingTabIds = Object.keys(this.tabs).filter((id) =>
+          this.isTabVisibleForActiveAgent(id),
+        );
 
         // Try next tab first
         let nextTabId: string | undefined;
@@ -1328,7 +1212,7 @@ export class WindowLayoutService extends DisposableService {
         if (nextTabId) {
           await this.handleSwitchTab(nextTabId);
         } else {
-          this.setCurrentActiveTabId(null);
+          this.activeTabId = null;
           // If no other tabs exist, create a new one
           const preferences = this.preferencesService.get();
           const newTabPage = preferences.general.newTabPage;
@@ -1344,6 +1228,7 @@ export class WindowLayoutService extends DisposableService {
 
   private handleSwitchTab = async (tabId: string) => {
     if (!this.tabs[tabId]) return;
+    if (!this.isTabVisibleForActiveAgent(tabId)) return;
     if (this.activeTabId === tabId) return;
 
     const previousTabId = this.activeTabId;
@@ -1354,7 +1239,7 @@ export class WindowLayoutService extends DisposableService {
       // The contentFullscreenChanged handler will clean up state
     }
 
-    this.setCurrentActiveTabId(tabId);
+    this.activeTabId = tabId;
     const newTab = this.tabs[tabId]!;
 
     // Show new tab BEFORE hiding old tab to prevent flicker.
@@ -1394,45 +1279,38 @@ export class WindowLayoutService extends DisposableService {
     this.uiKarton.setState((draft) => {
       draft.browser.activeTabId = tabId;
       draft.browser.viewportSize = newTab.getViewportSize();
-      const groupState = this.ensureDraftBrowserGroup(
-        draft.browser.tabsByAgent,
-        this.activeBrowserGroupId,
-      );
-      groupState.activeTabId = tabId;
-      groupState.viewportSize = newTab.getViewportSize();
     });
   };
 
   private handleReorderTabs = async (tabIds: string[]) => {
     // Validate that all provided tab IDs exist
-    const validTabIds = tabIds.filter((id) => this.tabs[id]);
+    const validTabIds = tabIds.filter(
+      (id) => this.tabs[id] && this.isTabVisibleForActiveAgent(id),
+    );
     if (validTabIds.length !== tabIds.length) {
       this.logger.warn(
         '[WindowLayoutService] Some tab IDs in reorder request are invalid',
       );
     }
 
-    // Reorder internal tabs record
+    // Reorder the visible strip while preserving hidden associated tabs.
+    const hiddenTabIds = Object.keys(this.tabs).filter(
+      (id) => !validTabIds.includes(id),
+    );
+    const orderedTabIds = [...validTabIds, ...hiddenTabIds];
     const newTabs: Record<string, TabController> = {};
-    for (const id of validTabIds) {
+    for (const id of orderedTabIds) {
       newTabs[id] = this.tabs[id]!;
     }
-    this.setCurrentTabs(newTabs);
+    this.tabs = newTabs;
 
     // Update Karton state with new tab order
     this.uiKarton.setState((draft) => {
       const newBrowserTabs: typeof draft.browser.tabs = {};
-      const newGroupTabs: typeof draft.browser.tabs = {};
-      const groupState = this.ensureDraftBrowserGroup(
-        draft.browser.tabsByAgent,
-        this.activeBrowserGroupId,
-      );
-      for (const id of validTabIds) {
+      for (const id of orderedTabIds) {
         newBrowserTabs[id] = draft.browser.tabs[id]!;
-        newGroupTabs[id] = groupState.tabs[id]!;
       }
       draft.browser.tabs = newBrowserTabs;
-      groupState.tabs = newGroupTabs;
     });
   };
 
@@ -1580,13 +1458,6 @@ export class WindowLayoutService extends DisposableService {
     this.uiKarton.setState((draft) => {
       if (draft.browser.tabs[tabId]) {
         draft.browser.tabs[tabId].isContentFullscreen = isFullscreen;
-      }
-      const groupState = this.ensureDraftBrowserGroup(
-        draft.browser.tabsByAgent,
-        this.activeBrowserGroupId,
-      );
-      if (groupState.tabs[tabId]) {
-        groupState.tabs[tabId].isContentFullscreen = isFullscreen;
       }
     });
   };
@@ -1784,11 +1655,6 @@ export class WindowLayoutService extends DisposableService {
       // Turn off for the currently active message ID
       this.uiKarton.setState((draft) => {
         draft.browser.contextSelectionMode = false;
-        const groupState = this.ensureDraftBrowserGroup(
-          draft.browser.tabsByAgent,
-          this.activeBrowserGroupId,
-        );
-        groupState.contextSelectionMode = false;
       });
 
       // Brief delay to ensure UI updates
@@ -1809,13 +1675,7 @@ export class WindowLayoutService extends DisposableService {
     }
     this.uiKarton.setState((draft) => {
       draft.browser.contextSelectionMode = active;
-      const groupState = this.ensureDraftBrowserGroup(
-        draft.browser.tabsByAgent,
-        this.activeBrowserGroupId,
-      );
-      groupState.contextSelectionMode = active;
     });
-    this.getCurrentBrowserGroup().contextSelectionMode = active;
   };
 
   private handleSelectHoveredElement = () => {
@@ -1992,14 +1852,6 @@ export class WindowLayoutService extends DisposableService {
       if (tab) {
         tab.isSearchBarActive = true;
       }
-      const groupState = this.ensureDraftBrowserGroup(
-        draft.browser.tabsByAgent,
-        this.activeBrowserGroupId,
-      );
-      const groupTab = groupState.tabs[this.activeTabId!];
-      if (groupTab) {
-        groupTab.isSearchBarActive = true;
-      }
     });
   };
 
@@ -2009,14 +1861,6 @@ export class WindowLayoutService extends DisposableService {
       const tab = draft.browser.tabs[this.activeTabId!];
       if (tab) {
         tab.isSearchBarActive = false;
-      }
-      const groupState = this.ensureDraftBrowserGroup(
-        draft.browser.tabsByAgent,
-        this.activeBrowserGroupId,
-      );
-      const groupTab = groupState.tabs[this.activeTabId!];
-      if (groupTab) {
-        groupTab.isSearchBarActive = false;
       }
     });
     // Also stop any active search

--- a/apps/browser/src/backend/services/window-layout/ui-controller.ts
+++ b/apps/browser/src/backend/services/window-layout/ui-controller.ts
@@ -141,6 +141,7 @@ declare const MAIN_WINDOW_VITE_NAME: string;
 export interface UIControllerEventMap {
   uiReady: [];
   viewRecreated: [oldView: WebContentsView, newView: WebContentsView];
+  setActiveAgent: [agentId: string | null];
   createTab: [url?: string, setActive?: boolean];
   closeTab: [tabId: string];
   switchTab: [tabId: string];
@@ -667,6 +668,12 @@ export class UIController extends EventEmitter<UIControllerEventMap> {
       },
     );
     this.uiKarton.registerServerProcedureHandler(
+      'browser.setActiveAgent',
+      async (_callingClientId: string, agentId: string | null) => {
+        this.emit('setActiveAgent', agentId);
+      },
+    );
+    this.uiKarton.registerServerProcedureHandler(
       'browser.createTab',
       async (_callingClientId: string, url?: string, setActive?: boolean) => {
         this.emit('createTab', url, setActive);
@@ -1088,6 +1095,7 @@ export class UIController extends EventEmitter<UIControllerEventMap> {
 
   public unregisterKartonProcedures() {
     this.uiKarton.removeServerProcedureHandler('openExternalUrl');
+    this.uiKarton.removeServerProcedureHandler('browser.setActiveAgent');
     this.uiKarton.removeServerProcedureHandler('browser.createTab');
     this.uiKarton.removeServerProcedureHandler('browser.closeTab');
     this.uiKarton.removeServerProcedureHandler('browser.switchTab');

--- a/apps/browser/src/backend/services/window-layout/ui-controller.ts
+++ b/apps/browser/src/backend/services/window-layout/ui-controller.ts
@@ -142,6 +142,7 @@ export interface UIControllerEventMap {
   uiReady: [];
   viewRecreated: [oldView: WebContentsView, newView: WebContentsView];
   setActiveAgent: [agentId: string | null];
+  setTabAssociation: [tabId: string, agentInstanceId: string | null];
   createTab: [url?: string, setActive?: boolean];
   closeTab: [tabId: string];
   switchTab: [tabId: string];
@@ -674,6 +675,16 @@ export class UIController extends EventEmitter<UIControllerEventMap> {
       },
     );
     this.uiKarton.registerServerProcedureHandler(
+      'browser.setTabAssociation',
+      async (
+        _callingClientId: string,
+        tabId: string,
+        agentInstanceId: string | null,
+      ) => {
+        this.emit('setTabAssociation', tabId, agentInstanceId);
+      },
+    );
+    this.uiKarton.registerServerProcedureHandler(
       'browser.createTab',
       async (_callingClientId: string, url?: string, setActive?: boolean) => {
         this.emit('createTab', url, setActive);
@@ -1096,6 +1107,7 @@ export class UIController extends EventEmitter<UIControllerEventMap> {
   public unregisterKartonProcedures() {
     this.uiKarton.removeServerProcedureHandler('openExternalUrl');
     this.uiKarton.removeServerProcedureHandler('browser.setActiveAgent');
+    this.uiKarton.removeServerProcedureHandler('browser.setTabAssociation');
     this.uiKarton.removeServerProcedureHandler('browser.createTab');
     this.uiKarton.removeServerProcedureHandler('browser.closeTab');
     this.uiKarton.removeServerProcedureHandler('browser.switchTab');

--- a/apps/browser/src/shared/karton-contracts/ui/index.ts
+++ b/apps/browser/src/shared/karton-contracts/ui/index.ts
@@ -388,6 +388,8 @@ export type TabState = {
   isContentFullscreen: boolean;
   /** Pending HTTP Basic Auth request for this tab */
   authenticationRequest: AuthenticationRequest | null;
+  /** `null` means global; otherwise this tab belongs to an agent instance. */
+  associatedAgentInstanceId?: string | null;
 };
 
 export type HistoryEntry = {
@@ -395,21 +397,6 @@ export type HistoryEntry = {
   title: string;
   faviconUrls: string[];
   lastVisitedAt: Date;
-};
-
-export type BrowserAgentState = {
-  tabs: Record<string, TabState>;
-  activeTabId: string | null;
-  contextSelectionMode: boolean;
-  selectedElements: SelectedElement[];
-  hoveredElement: SelectedElement | null;
-  viewportSize: {
-    top: number;
-    left: number;
-    width: number;
-    height: number;
-    scale: number;
-  } | null;
 };
 
 /** Suggestions returned by getOmniboxSuggestions */
@@ -622,14 +609,8 @@ export type AppState = {
 
   // Browser state
   browser: {
-    /**
-     * Agent currently owning the visible tab strip. `null` is used before any
-     * agent chat is open.
-     */
+    /** Agent currently driving agent-associated tab visibility. */
     activeAgentId: string | null;
-    /** Per-agent browser tab groups, keyed by agent instance ID. */
-    tabsByAgent: Record<string, BrowserAgentState>;
-    /** Visible tab strip for `activeAgentId` (kept for existing consumers). */
     tabs: Record<string, TabState>;
     activeTabId: string | null;
     /** Unique identifier for the current browser process lifetime. Changes on restart. */
@@ -908,6 +889,10 @@ export type KartonContract = {
     };
     browser: {
       setActiveAgent: (agentId: string | null) => Promise<void>;
+      setTabAssociation: (
+        tabId: string,
+        agentInstanceId: string | null,
+      ) => Promise<void>;
       createTab: (url?: string, setActive?: boolean) => Promise<void>;
       closeTab: (tabId: string) => Promise<void>;
       switchTab: (tabId: string) => Promise<void>;
@@ -1224,7 +1209,6 @@ export const defaultState: KartonContract['state'] = {
   notifications: [],
   browser: {
     activeAgentId: null,
-    tabsByAgent: {},
     tabs: {},
     activeTabId: null,
     sessionId: '',

--- a/apps/browser/src/shared/karton-contracts/ui/index.ts
+++ b/apps/browser/src/shared/karton-contracts/ui/index.ts
@@ -397,6 +397,21 @@ export type HistoryEntry = {
   lastVisitedAt: Date;
 };
 
+export type BrowserAgentState = {
+  tabs: Record<string, TabState>;
+  activeTabId: string | null;
+  contextSelectionMode: boolean;
+  selectedElements: SelectedElement[];
+  hoveredElement: SelectedElement | null;
+  viewportSize: {
+    top: number;
+    left: number;
+    width: number;
+    height: number;
+    scale: number;
+  } | null;
+};
+
 /** Suggestions returned by getOmniboxSuggestions */
 export type OmniboxSuggestions = {
   /** History entries matching the input */
@@ -607,6 +622,14 @@ export type AppState = {
 
   // Browser state
   browser: {
+    /**
+     * Agent currently owning the visible tab strip. `null` is used before any
+     * agent chat is open.
+     */
+    activeAgentId: string | null;
+    /** Per-agent browser tab groups, keyed by agent instance ID. */
+    tabsByAgent: Record<string, BrowserAgentState>;
+    /** Visible tab strip for `activeAgentId` (kept for existing consumers). */
     tabs: Record<string, TabState>;
     activeTabId: string | null;
     /** Unique identifier for the current browser process lifetime. Changes on restart. */
@@ -884,6 +907,7 @@ export type KartonContract = {
       ) => Promise<void>;
     };
     browser: {
+      setActiveAgent: (agentId: string | null) => Promise<void>;
       createTab: (url?: string, setActive?: boolean) => Promise<void>;
       closeTab: (tabId: string) => Promise<void>;
       switchTab: (tabId: string) => Promise<void>;
@@ -1199,6 +1223,8 @@ export const defaultState: KartonContract['state'] = {
   },
   notifications: [],
   browser: {
+    activeAgentId: null,
+    tabsByAgent: {},
     tabs: {},
     activeTabId: null,
     sessionId: '',

--- a/apps/browser/src/ui/hooks/use-open-chat.tsx
+++ b/apps/browser/src/ui/hooks/use-open-chat.tsx
@@ -2,10 +2,12 @@ import {
   createContext,
   useCallback,
   useContext,
+  useEffect,
   useMemo,
   useRef,
   useState,
 } from 'react';
+import { useKartonProcedure } from './use-karton';
 
 type OpenAgentState = [
   /** Currently open agent ID (top of the history stack). */
@@ -41,6 +43,13 @@ export const OpenAgentProvider = ({
   // derived `openAgent` state is the single source of truth for React.
   const stackRef = useRef<string[]>([]);
   const [openAgent, setOpenAgentRaw] = useState<string | null>(null);
+  const setActiveBrowserAgent = useKartonProcedure(
+    (p) => p.browser.setActiveAgent,
+  );
+
+  useEffect(() => {
+    void setActiveBrowserAgent(openAgent);
+  }, [openAgent, setActiveBrowserAgent]);
 
   const setOpenAgent = useCallback((id: string | null) => {
     const stack = stackRef.current;

--- a/apps/browser/src/ui/screens/main/content/_components/core-hotkey-bindings.tsx
+++ b/apps/browser/src/ui/screens/main/content/_components/core-hotkey-bindings.tsx
@@ -18,11 +18,22 @@ export function CoreHotkeyBindings({
 }) {
   const activeTabId = useKartonState((s) => s.browser.activeTabId);
   const tabs = useKartonState((s) => s.browser.tabs);
+  const activeAgentId = useKartonState((s) => s.browser.activeAgentId);
   const { removeTabUiState } = useTabUIState();
   const togglePanelKeyboardFocus = useKartonProcedure(
     (p) => p.browser.layout.togglePanelKeyboardFocus,
   );
-  const tabIds = useMemo(() => Object.keys(tabs), [tabs]);
+  const tabIds = useMemo(
+    () =>
+      Object.values(tabs)
+        .filter(
+          (tab) =>
+            tab.associatedAgentInstanceId == null ||
+            tab.associatedAgentInstanceId === activeAgentId,
+        )
+        .map((tab) => tab.id),
+    [tabs, activeAgentId],
+  );
   const tabCount = useMemo(() => tabIds.length, [tabIds]);
 
   const tabNeighborsToActiveTab = useMemo(() => {

--- a/apps/browser/src/ui/screens/main/content/index.tsx
+++ b/apps/browser/src/ui/screens/main/content/index.tsx
@@ -72,6 +72,7 @@ function AudioMuteButton({ tab }: { tab: TabState }) {
 export function MainSection() {
   const _isMacOs = useKartonState((s) => s.appInfo.platform === 'darwin');
   const tabs = useKartonState((s) => s.browser.tabs);
+  const activeAgentId = useKartonState((s) => s.browser.activeAgentId);
   const activeTabId = useKartonState((s) => s.browser.activeTabId);
   const createTab = useKartonProcedure((p) => p.browser.createTab);
   const closeTab = useKartonProcedure((p) => p.browser.closeTab);
@@ -90,7 +91,14 @@ export function MainSection() {
   // mutation (title / URL / loading state) — only the set/order of IDs matters.
   // ---------------------------------------------------------------------------
   const tabIdsSelector = useComparingSelector<KartonContract, string[]>(
-    (s) => Object.keys(s.browser.tabs),
+    (s) =>
+      Object.values(s.browser.tabs)
+        .filter(
+          (tab) =>
+            tab.associatedAgentInstanceId == null ||
+            tab.associatedAgentInstanceId === s.browser.activeAgentId,
+        )
+        .map((tab) => tab.id),
     (a, b) => a.length === b.length && a.every((id, i) => id === b[i]),
   );
   const serverTabIds = useKartonState(tabIdsSelector);
@@ -114,11 +122,23 @@ export function MainSection() {
   // ---------------------------------------------------------------------------
   // Build SortableTabItem[] from optimistic order + Karton tab state
   // ---------------------------------------------------------------------------
+  const visibleTabs = useMemo(
+    () =>
+      Object.fromEntries(
+        Object.entries(tabs).filter(
+          ([, tab]) =>
+            tab.associatedAgentInstanceId == null ||
+            tab.associatedAgentInstanceId === activeAgentId,
+        ),
+      ),
+    [tabs, activeAgentId],
+  );
+
   const tabItems = useMemo<SortableTabItem[]>(() => {
-    const isOnlyTab = Object.keys(tabs).length === 1;
+    const isOnlyTab = Object.keys(visibleTabs).length === 1;
     return optimisticTabIds
       .map((id): SortableTabItem | null => {
-        const tab = tabs[id];
+        const tab = visibleTabs[id];
         if (!tab) return null;
         const isInternalPage =
           tab.url?.startsWith('stagewise://internal/') ?? false;
@@ -154,7 +174,7 @@ export function MainSection() {
         };
       })
       .filter((item): item is SortableTabItem => item !== null);
-  }, [optimisticTabIds, tabs, activeTabId, closeTab, removeTabUiState]);
+  }, [optimisticTabIds, visibleTabs, activeTabId, closeTab, removeTabUiState]);
 
   // ---------------------------------------------------------------------------
   // Omnibox focus plumbing (unchanged)
@@ -185,7 +205,7 @@ export function MainSection() {
         return () => clearTimeout(timeoutId);
       }
     }
-  }, [activeTabId, tabs, togglePanelKeyboardFocus]);
+  }, [activeTabId, visibleTabs, togglePanelKeyboardFocus]);
 
   const handleCreateTab = useCallback(() => {
     pendingOmniboxFocusFromTabIdRef.current = activeTabId;
@@ -193,7 +213,7 @@ export function MainSection() {
   }, [createTab, activeTabId]);
 
   const handleCleanAllTabs = useCallback(() => {
-    const tabIdsToClose = Object.keys(tabs).filter(
+    const tabIdsToClose = Object.keys(visibleTabs).filter(
       (tabId) => tabId !== activeTabId,
     );
     void Promise.allSettled(tabIdsToClose.map((tabId) => closeTab(tabId))).then(
@@ -206,7 +226,7 @@ export function MainSection() {
         }
       },
     );
-  }, [tabs, activeTabId, closeTab, track]);
+  }, [visibleTabs, activeTabId, closeTab, track]);
 
   const handleFocusUrlBar = useCallback(() => {
     if (activeTabId) {
@@ -292,7 +312,7 @@ export function MainSection() {
               }
             />
             {/* Per-tab content instances */}
-            {Object.keys(tabs).map((tabId) => (
+            {Object.keys(visibleTabs).map((tabId) => (
               <PerTabContent
                 key={tabId}
                 ref={(ref) => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Replace fixed per-agent tab groups with a single browser tab pool where each tab has an optional `associatedAgentInstanceId` (`null`/unset = global).
- Add `browser.setTabAssociation(tabId, agentInstanceId | null)` so tabs can be associated with an agent or made global.
- Keep tab strip and tab hotkeys scoped to global tabs plus tabs associated with the currently open agent.
- Persist agent-associated tabs in agent archive state and restore them when an archived agent is resumed.
- Filter agent browser snapshots to global tabs plus tabs associated with that agent.

## Verification
- `pnpm check:fix`
- `pnpm -F stagewise typecheck`
- `pnpm -F stagewise test`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-24d938c9-0ac2-4119-88ec-abc26e8ff4b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-24d938c9-0ac2-4119-88ec-abc26e8ff4b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make browser tabs agent-scoped so the strip shows global tabs plus those for the active agent. Also persist agent-associated tabs on archive and restore them when the agent resumes. Addresses #1046.

- **New Features**
  - Agent-scoped tab model: `associatedAgentInstanceId` on `TabState` and `browser.activeAgentId`; UI, hotkeys, open/reuse/close/reorder/switch now operate on the visible set.
  - New procedures: `browser.setActiveAgent(agentId)` and `browser.setTabAssociation(tabId, agentId|null)`; `OpenAgentProvider` drives the active agent.
  - Persistence: archive stores up to 50 associated tabs per agent in `associated_browser_tabs` (schema v10) and restores them on resume; new tabs inherit from the source tab or active agent; snapshots (`ToolboxService.getBrowserSnapshot(agentId?)` and environment) filter to global + matching-agent tabs.

<sup>Written for commit e82355ba0c74b3946f94063e68bb45578393ef33. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

