### PR TITLE
fix(stagewise): fix delete-popover location

### DIFF
--- a/apps/browser/src/ui/screens/main/_components/delete-confirm-popover.tsx
+++ b/apps/browser/src/ui/screens/main/_components/delete-confirm-popover.tsx
@@ -8,8 +8,16 @@ import {
   PopoverClose,
 } from '@stagewise/stage-ui/components/popover';
 import { Button } from '@stagewise/stage-ui/components/button';
-import { useRef } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
+import { useKartonState } from '@ui/hooks/use-karton';
 import { useFloatingIsolation } from './use-floating-isolation';
+
+/**
+ * Top viewport padding reserved for the macOS traffic-light controls when
+ * the window uses a hidden titlebar. Matches the `h-8` (32px) titlebar
+ * placeholder plus a small visual margin.
+ */
+const MAC_TRAFFIC_LIGHT_PADDING = 40;
 
 /**
  * Confirmation popover for permanently deleting an agent.
@@ -19,29 +27,86 @@ import { useFloatingIsolation } from './use-floating-isolation';
  * ambient floating surface such as an open Combobox — the right-click
  * context-menu flow is the main case. Isolation stops clicks inside this
  * popover from dismissing the ambient surface. See `useFloatingIsolation`.
+ *
+ * When `anchorPoint` is set, the popover spawns just above that viewport
+ * coordinate (typically the cursor position captured at right-click time).
+ * Without it, the popover falls back to the static zero-sized trigger span,
+ * which anchors against its nearest positioned ancestor.
  */
 export function DeleteConfirmPopover({
   open,
   onOpenChange,
   onConfirm,
   isolated = false,
+  anchorPoint,
 }: {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   onConfirm: () => void;
   isolated?: boolean;
+  anchorPoint?: { x: number; y: number };
 }) {
+  // On macOS with a hidden titlebar, keep the popover clear of the
+  // traffic-light overlay that sits at the top of the window.
+  const isMacOs = useKartonState((s) => s.appInfo.platform === 'darwin');
+  const isFullScreen = useKartonState((s) => s.appInfo.isFullScreen);
+  const collisionPadding = useMemo(
+    () =>
+      isMacOs && !isFullScreen ? { top: MAC_TRAFFIC_LIGHT_PADDING } : undefined,
+    [isMacOs, isFullScreen],
+  );
+
   // PopoverContent doesn't forwardRef — mount an internal `display: contents`
   // wrapper we can ref and use as the isolation boundary.
   const shieldRef = useRef<HTMLDivElement>(null);
   useFloatingIsolation(shieldRef, isolated && open);
+
+  // Retain the last anchor point through the close animation. If we drop
+  // back to `undefined` the moment the parent clears its state, base-ui
+  // falls back to the static `<span>` trigger (bottom-right of the nearest
+  // positioned ancestor) for the remainder of the ~150ms exit transition,
+  // causing a visible flash at the bottom of the sidebar. Same pattern as
+  // SharedAgentContextMenuHost's `lastTargetRef` — render-phase ref
+  // mutation keeps the coords around without forcing an extra render each
+  // time the parent hands us a fresh `{ x, y }` object.
+  const lastAnchorRef = useRef<{ x: number; y: number } | null>(null);
+  if (anchorPoint) lastAnchorRef.current = anchorPoint;
+  const activeAnchor = anchorPoint ?? lastAnchorRef.current ?? undefined;
+
+  // Release the retained anchor shortly after the close animation settles.
+  // 300ms is comfortably longer than the 150ms popup transition.
+  useEffect(() => {
+    if (open) return;
+    const t = setTimeout(() => {
+      lastAnchorRef.current = null;
+    }, 300);
+    return () => clearTimeout(t);
+  }, [open]);
+
+  // Virtual anchor built from the captured cursor coordinates. base-ui's
+  // positioner only needs `getBoundingClientRect()`. Memoized on the coords
+  // so the anchor identity is stable across renders while `open`.
+  const anchorX = activeAnchor?.x;
+  const anchorY = activeAnchor?.y;
+  const anchor = useMemo(() => {
+    if (anchorX === undefined || anchorY === undefined) return undefined;
+    return {
+      getBoundingClientRect: () =>
+        DOMRect.fromRect({ x: anchorX, y: anchorY, width: 0, height: 0 }),
+    };
+  }, [anchorX, anchorY]);
 
   return (
     <Popover open={open} onOpenChange={onOpenChange}>
       <PopoverTrigger nativeButton={false}>
         <span className="pointer-events-none absolute right-0 bottom-0 size-0" />
       </PopoverTrigger>
-      <PopoverContent>
+      <PopoverContent
+        anchor={anchor}
+        side={anchor ? 'top' : undefined}
+        align={anchor ? 'center' : undefined}
+        collisionPadding={collisionPadding}
+      >
         <div ref={shieldRef} className="contents">
           <PopoverTitle>Delete agent?</PopoverTitle>
           <PopoverDescription>

--- a/apps/browser/src/ui/screens/main/_components/shared-agent-context-menu.tsx
+++ b/apps/browser/src/ui/screens/main/_components/shared-agent-context-menu.tsx
@@ -1,7 +1,7 @@
 import { Menu as MenuBase } from '@base-ui/react/menu';
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { cn } from '@stagewise/stage-ui/lib/utils';
-import { useKartonProcedure } from '@ui/hooks/use-karton';
+import { useKartonProcedure, useKartonState } from '@ui/hooks/use-karton';
 import { IconTrash2Outline24 } from 'nucleo-core-outline-24';
 import {
   IconBoxArchiveOutline18,
@@ -96,8 +96,10 @@ export interface SharedAgentContextMenuHostProps {
   onClose: () => void;
   /** Archive an active agent (only shown when `target.isActive` is true). */
   onArchive: (id: string) => void;
-  /** User picked "Permanently delete" — caller is expected to show a confirm dialog. */
-  onDeleteRequest: (id: string) => void;
+  /** User picked "Permanently delete" — caller is expected to show a confirm dialog.
+   * Cursor coordinates are forwarded so the confirm popover can anchor
+   * right above the click position. */
+  onDeleteRequest: (id: string, x: number, y: number) => void;
 }
 
 export const SharedAgentContextMenuHost = memo(
@@ -109,6 +111,16 @@ export const SharedAgentContextMenuHost = memo(
   }: SharedAgentContextMenuHostProps) {
     const revealWorkingDirectory = useKartonProcedure(
       (p) => p.agents.revealWorkingDirectory,
+    );
+
+    // Keep the menu clear of the macOS traffic-light overlay (hidden
+    // titlebar). Matches the `h-8` (32px) titlebar placeholder plus a
+    // small visual margin; same padding used by DeleteConfirmPopover.
+    const isMacOs = useKartonState((s) => s.appInfo.platform === 'darwin');
+    const isFullScreen = useKartonState((s) => s.appInfo.isFullScreen);
+    const collisionPadding = useMemo(
+      () => (isMacOs && !isFullScreen ? { top: 40 } : undefined),
+      [isMacOs, isFullScreen],
     );
 
     const popupRef = useRef<HTMLDivElement>(null);
@@ -168,6 +180,7 @@ export const SharedAgentContextMenuHost = memo(
             align="start"
             side="bottom"
             sideOffset={4}
+            collisionPadding={collisionPadding}
             className="z-50"
           >
             <MenuBase.Popup
@@ -203,7 +216,7 @@ export const SharedAgentContextMenuHost = memo(
               </AgentMenuItem>
               <AgentMenuItem
                 onClick={() => {
-                  onDeleteRequest(agentId);
+                  onDeleteRequest(agentId, anchorX, anchorY);
                   onClose();
                 }}
               >

--- a/apps/browser/src/ui/screens/main/sidebar/agents-list/_components/agents-selector.tsx
+++ b/apps/browser/src/ui/screens/main/sidebar/agents-list/_components/agents-selector.tsx
@@ -862,18 +862,25 @@ export function AgentsSelector() {
   // menu closing and the combobox closing — the menu's dismissal would
   // otherwise propagate to the combobox and reset the row-local
   // `pendingDeleteId` before the popover ever mounts.
-  const [ctxDeleteId, setCtxDeleteId] = useState<string | null>(null);
-  const handleCtxDeleteRequest = useCallback((id: string) => {
-    setCtxDeleteId(id);
-  }, []);
+  const [ctxDelete, setCtxDelete] = useState<{
+    id: string;
+    x: number;
+    y: number;
+  } | null>(null);
+  const handleCtxDeleteRequest = useCallback(
+    (id: string, x: number, y: number) => {
+      setCtxDelete({ id, x, y });
+    },
+    [],
+  );
   const handleCtxDeleteCancel = useCallback(() => {
-    setCtxDeleteId(null);
+    setCtxDelete(null);
   }, []);
   const handleCtxDeleteConfirm = useCallback(() => {
-    const id = ctxDeleteId;
-    setCtxDeleteId(null);
+    const id = ctxDelete?.id;
+    setCtxDelete(null);
     if (id) handleDeleteAgent(id);
-  }, [ctxDeleteId, handleDeleteAgent]);
+  }, [ctxDelete, handleDeleteAgent]);
 
   // Filter groups by search input — skip entirely when closed
   const filteredGroups = useMemo(() => {
@@ -1210,8 +1217,9 @@ export function AgentsSelector() {
         onDeleteRequest={handleCtxDeleteRequest}
       />
       <DeleteConfirmPopover
-        open={ctxDeleteId !== null}
+        open={ctxDelete !== null}
         isolated
+        anchorPoint={ctxDelete ? { x: ctxDelete.x, y: ctxDelete.y } : undefined}
         onOpenChange={(open) => {
           if (!open) handleCtxDeleteCancel();
         }}

--- a/apps/browser/src/ui/screens/main/sidebar/agents-list/index.tsx
+++ b/apps/browser/src/ui/screens/main/sidebar/agents-list/index.tsx
@@ -407,15 +407,22 @@ export function AgentsList() {
   // Delete confirmation triggered from the context menu. Hoisted out of
   // AgentCard so the popover can survive the card losing hover / the menu
   // closing without tearing down the confirmation UI.
-  const [ctxDeleteId, setCtxDeleteId] = useState<string | null>(null);
-  const handleCtxDeleteRequest = useCallback((id: string) => {
-    setCtxDeleteId(id);
-  }, []);
+  const [ctxDelete, setCtxDelete] = useState<{
+    id: string;
+    x: number;
+    y: number;
+  } | null>(null);
+  const handleCtxDeleteRequest = useCallback(
+    (id: string, x: number, y: number) => {
+      setCtxDelete({ id, x, y });
+    },
+    [],
+  );
   const handleCtxDeleteConfirm = useCallback(() => {
-    const id = ctxDeleteId;
-    setCtxDeleteId(null);
+    const id = ctxDelete?.id;
+    setCtxDelete(null);
     if (id) handleDelete(id);
-  }, [ctxDeleteId, handleDelete]);
+  }, [ctxDelete, handleDelete]);
 
   if (!showActiveAgents) return null;
 
@@ -489,10 +496,11 @@ export function AgentsList() {
         onDeleteRequest={handleCtxDeleteRequest}
       />
       <DeleteConfirmPopover
-        open={ctxDeleteId !== null}
+        open={ctxDelete !== null}
         isolated
+        anchorPoint={ctxDelete ? { x: ctxDelete.x, y: ctxDelete.y } : undefined}
         onOpenChange={(open) => {
-          if (!open) setCtxDeleteId(null);
+          if (!open) setCtxDelete(null);
         }}
         onConfirm={handleCtxDeleteConfirm}
       />

--- a/packages/stage-ui/src/components/popover.tsx
+++ b/packages/stage-ui/src/components/popover.tsx
@@ -27,11 +27,18 @@ export type PopoverContentProps = React.ComponentProps<
 export const PopoverContent = ({
   children,
   className,
+  anchor,
+  positionMethod,
   side,
   sideOffset,
   align,
   alignOffset,
+  collisionBoundary,
+  collisionPadding,
+  arrowPadding,
   sticky,
+  disableAnchorTracking,
+  collisionAvoidance,
   ...props
 }: PopoverContentProps) => {
   return (
@@ -41,11 +48,18 @@ export const PopoverContent = ({
         onClick={(e) => e.stopPropagation()}
       />
       <PopoverBase.Positioner
-        sideOffset={sideOffset ?? 4}
+        anchor={anchor}
+        positionMethod={positionMethod}
         side={side}
+        sideOffset={sideOffset ?? 4}
         align={align}
         alignOffset={alignOffset}
+        collisionBoundary={collisionBoundary}
+        collisionPadding={collisionPadding}
+        arrowPadding={arrowPadding}
         sticky={sticky}
+        disableAnchorTracking={disableAnchorTracking}
+        collisionAvoidance={collisionAvoidance}
         className="z-50"
       >
         <PopoverBase.Popup

--- a/packages/stage-ui/src/stories/Popover.stories.tsx
+++ b/packages/stage-ui/src/stories/Popover.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useMemo, useState } from 'react';
 import {
   Popover,
   PopoverTrigger,
@@ -60,4 +61,70 @@ export const WithFooter: Story = {
       </PopoverContent>
     </Popover>
   ),
+};
+
+/**
+ * Demonstrates the `anchor` prop on `PopoverContent`. Instead of anchoring to
+ * the trigger element, the popover is positioned at an arbitrary viewport
+ * coordinate — here, wherever the user right-clicks inside the demo surface.
+ * The trigger is a zero-sized `<span>` (the same fallback pattern used by
+ * `DeleteConfirmPopover` in the browser app).
+ */
+export const AnchoredToCursor: Story = {
+  render: () => {
+    const CursorAnchorDemo = () => {
+      const [point, setPoint] = useState<{ x: number; y: number } | null>(null);
+      const anchor = useMemo(() => {
+        if (!point) return undefined;
+        return {
+          getBoundingClientRect: () =>
+            DOMRect.fromRect({
+              x: point.x,
+              y: point.y,
+              width: 0,
+              height: 0,
+            }),
+        };
+      }, [point]);
+      return (
+        <div
+          onContextMenu={(e) => {
+            e.preventDefault();
+            setPoint({ x: e.clientX, y: e.clientY });
+          }}
+          className="flex h-64 w-full select-none items-center justify-center rounded-md border border-zinc-300 border-dashed text-sm text-zinc-500"
+        >
+          Right-click anywhere in this box
+          <Popover
+            open={point !== null}
+            onOpenChange={(open) => {
+              if (!open) setPoint(null);
+            }}
+          >
+            <PopoverTrigger nativeButton={false}>
+              <span className="pointer-events-none absolute size-0" />
+            </PopoverTrigger>
+            <PopoverContent anchor={anchor} side="top" align="center">
+              <PopoverClose />
+              <PopoverTitle>Anchored to cursor</PopoverTitle>
+              <PopoverDescription>
+                This popover is positioned at the viewport coordinate captured
+                from the right-click event.
+              </PopoverDescription>
+              <PopoverFooter>
+                <Button
+                  variant="secondary"
+                  size="sm"
+                  onClick={() => setPoint(null)}
+                >
+                  Close
+                </Button>
+              </PopoverFooter>
+            </PopoverContent>
+          </Popover>
+        </div>
+      );
+    };
+    return <CursorAnchorDemo />;
+  },
 };


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the delete confirmation popover so it opens at the right‑click position and stays put during its close animation, removing the bottom-right flash. Adds macOS traffic‑light safe-area padding and updates `@stagewise/stage-ui` popover to support virtual anchors.

- **Bug Fixes**
  - Delete popover anchors to the cursor via a virtual `anchor`; last cursor point is retained briefly after close to prevent flicker.
  - Context menu forwards cursor coordinates to the confirm popover.
  - Adds top collision padding on macOS (hidden titlebar) for both the context menu and the confirm popover to avoid overlapping window controls.

- **New Features**
  - `PopoverContent` now supports `anchor` plus additional Positioner props (`positionMethod`, `collisionPadding`, etc.); Storybook demo added for cursor-anchored popovers.
  - `AgentsList` and `AgentsSelector` pass context-menu cursor coordinates through to the confirmation popover.

<sup>Written for commit 6755c234d502f8d14f0043cc21ba39ea257c0e4e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Delete confirmation dialogs now open at the original click location for clearer context.
  * Popovers avoid macOS window controls so they no longer overlap traffic‑light buttons.
  * Popover open/close now animates without flashing fallback positions, giving smoother, more stable placement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->