### PR TITLE
feat(browser): request ability to hide the left sidebar (chat history)

### DIFF
--- a/FEATURE_REQUEST_hide_left_sidebar.md
+++ b/FEATURE_REQUEST_hide_left_sidebar.md
@@ -1,0 +1,20 @@
+# Feature Request: Ability to hide the left sidebar (chat history)
+
+It would be great to have a way to **fully hide the left sidebar** containing the agents/chat history list.
+
+Currently, even when collapsed to its minimum size (12%), it occupies a significant amount of horizontal space. This is especially noticeable on smaller screens or when the user wants to focus entirely on the browser content and chat panel.
+
+## Proposed solution
+
+1. Add a collapse button in the sidebar (e.g., a chevron icon at the top-right or bottom of the sidebar).
+2. When collapsed, the sidebar should be completely hidden (0 width).
+3. Show a toggle button (e.g., in the top-left corner of the content area) to re-open the sidebar.
+4. Use the existing `collapsedSize` prop from `react-resizable-panels` which is already available in the codebase but not currently wired up for the sidebar.
+
+## Notes
+
+- The sidebar (`apps/browser/src/ui/screens/main/sidebar/index.tsx`) already has a `panelRef` of type `ImperativePanelHandle` declared but unused, and `react-resizable-panels` supports `collapsedSize`, `onCollapse`, and `onExpand` props.
+- There's also an `AgentPreviewBadge` component (`apps/browser/src/ui/screens/main/content/_components/agent-preview-badge.tsx`) with a "Toggle chat panel" button that is currently orphaned (not imported anywhere).
+- The `react-resizable-panels` library's `ImperativePanelHandle.collapse()` and `.expand()` methods can be used for programmatic control.
+
+So most of the necessary infrastructure is already in place — it mainly needs to be connected.


### PR DESCRIPTION
## Feature Request: Ability to hide the left sidebar (chat history)

It would be great to have a way to **fully hide the left sidebar** containing the agents/chat history list.

Currently, even when collapsed to its minimum size (12%), it occupies a significant amount of horizontal space. This is especially noticeable on smaller screens or when the user wants to focus entirely on the browser content and chat panel.

## Proposed solution

1. Add a collapse button in the sidebar (e.g., a chevron icon at the top-right or bottom of the sidebar).
2. When collapsed, the sidebar should be completely hidden (0 width).
3. Show a toggle button (e.g., in the top-left corner of the content area) to re-open the sidebar.
4. Use the existing `collapsedSize` prop from `react-resizable-panels` which is already available in the codebase but not currently wired up for the sidebar.

## Notes

- The sidebar (`apps/browser/src/ui/screens/main/sidebar/index.tsx`) already has a `panelRef` of type `ImperativePanelHandle` declared but unused, and `react-resizable-panels` supports `collapsedSize`, `onCollapse`, and `onExpand` props.
- There is also an `AgentPreviewBadge` component (`apps/browser/src/ui/screens/main/content/_components/agent-preview-badge.tsx`) with a "Toggle chat panel" button that is currently orphaned (not imported anywhere).
- The `react-resizable-panels` library `ImperativePanelHandle.collapse()` / `.expand()` methods can be used for programmatic control.

So most of the necessary infrastructure is already in place — it mainly needs to be wired up.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change adding a feature request; no runtime code paths are modified.
> 
> **Overview**
> Adds `FEATURE_REQUEST_hide_left_sidebar.md`, documenting a proposal to let users fully collapse the browser left sidebar (chat history) to 0 width and re-open it via a toggle, leveraging existing `react-resizable-panels` collapse/expand APIs and related UI components.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ba2d667fe153ea105f3897dfc2386049db27eba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a feature request doc to enable fully hiding the left sidebar (chat history).
Proposes a collapse/expand toggle, a 0‑width collapsed state via `react-resizable-panels` (`collapsedSize`, `onCollapse`/`onExpand`, `ImperativePanelHandle.collapse/expand`), and reusing the existing `AgentPreviewBadge` toggle.

<sup>Written for commit 2ba2d667fe153ea105f3897dfc2386049db27eba. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a feature request describing the ability to fully hide the left sidebar (collapse it to zero width) and reopen it via a separate toggle, including suggested UI controls and notes about wiring existing collapse/expand hooks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->