### PR TITLE
refactor(stagewise): enrich telemetry in onboarding

### DIFF
--- a/apps/browser/src/backend/services/experience.ts
+++ b/apps/browser/src/backend/services/experience.ts
@@ -21,6 +21,14 @@ import { API_URL } from './auth/server-interop';
 import { DisposableService } from './disposable';
 import { readPersistedData, writePersistedData } from '../utils/persisted-data';
 import type { TelemetryService } from './telemetry';
+import type { ModelProvider } from '@shared/karton-contracts/ui/shared-types';
+import type { CodingPlanId } from '@shared/coding-plans';
+
+export type OnboardingAuthCompletion = {
+  auth_method: 'stagewise' | 'api-keys' | 'coding-plan' | 'unknown';
+  provider?: ModelProvider;
+  plan_id?: CodingPlanId;
+};
 
 export class UserExperienceService extends DisposableService {
   private readonly logger: Logger;
@@ -147,8 +155,13 @@ export class UserExperienceService extends DisposableService {
     );
     this.uiKarton.registerServerProcedureHandler(
       'userExperience.setHasSeenOnboardingFlow',
-      async (_callingClientId: string, value: boolean) => {
-        await this.setHasSeenOnboardingFlow(value);
+      async (
+        _callingClientId: string,
+        input: boolean | { value: boolean; auth?: OnboardingAuthCompletion },
+      ) => {
+        const value = typeof input === 'boolean' ? input : input.value;
+        const auth = typeof input === 'boolean' ? undefined : input.auth;
+        await this.setHasSeenOnboardingFlow(value, auth);
       },
     );
     this.uiKarton.registerServerProcedureHandler(
@@ -433,7 +446,10 @@ export class UserExperienceService extends DisposableService {
     };
   }
 
-  public async setHasSeenOnboardingFlow(value: boolean) {
+  public async setHasSeenOnboardingFlow(
+    value: boolean,
+    auth: OnboardingAuthCompletion = { auth_method: 'unknown' },
+  ) {
     try {
       await this.writeOnboardingState(value);
       // Update UI state with combined data
@@ -450,6 +466,7 @@ export class UserExperienceService extends DisposableService {
         this.telemetryService.capture('onboarding-completed', {
           skipped: false,
           telemetry_level: this.telemetryService.telemetryLevel,
+          ...auth,
         });
       }
     } catch (error) {

--- a/apps/browser/src/backend/services/pages.ts
+++ b/apps/browser/src/backend/services/pages.ts
@@ -27,6 +27,7 @@ import type {
 import { validateApiKeys } from '../utils/validate-api-keys';
 import { listAwsProfiles } from '../utils/aws-profiles';
 import type { CodingPlanId } from '@shared/coding-plans';
+import type { OnboardingAuthCompletion } from './experience';
 import type { HistoryService } from './history';
 import type { FaviconService } from './favicon';
 import type { ThumbnailService } from './thumbnail';
@@ -1222,14 +1223,24 @@ export class PagesService extends DisposableService {
 
     this.kartonServer.registerServerProcedureHandler(
       'setHasSeenOnboardingFlow',
-      async (_callingClientId: string, value: boolean): Promise<void> => {
+      async (
+        _callingClientId: string,
+        input:
+          | boolean
+          | {
+              value: boolean;
+              auth?: OnboardingAuthCompletion;
+            },
+      ): Promise<void> => {
         if (!this.userExperienceService) {
           this.logger.warn(
             '[PagesService] setHasSeenOnboardingFlow called but UserExperienceService not set',
           );
           return;
         }
-        await this.userExperienceService.setHasSeenOnboardingFlow(value);
+        const value = typeof input === 'boolean' ? input : input.value;
+        const auth = typeof input === 'boolean' ? undefined : input.auth;
+        await this.userExperienceService.setHasSeenOnboardingFlow(value, auth);
       },
     );
 

--- a/apps/browser/src/backend/services/telemetry.ts
+++ b/apps/browser/src/backend/services/telemetry.ts
@@ -4,13 +4,49 @@ import type { LanguageModelV3 } from '@ai-sdk/provider';
 import { withTracing } from '@posthog/ai';
 import type { IdentifierService } from './identifier';
 import type { PreferencesService } from './preferences';
-import type {
-  TelemetryLevel,
-  ToolApprovalMode,
+import {
+  modelProviderSchema,
+  type ModelProvider,
+  type TelemetryLevel,
+  type ToolApprovalMode,
 } from '@shared/karton-contracts/ui/shared-types';
+import type { CodingPlanId } from '@shared/coding-plans';
 import type { Logger } from './logger';
 import { DisposableService } from './disposable';
 import { captureProcessSnapshot } from './telemetry/process-snapshot';
+
+type OnboardingAuthMethod = 'stagewise' | 'api-keys' | 'coding-plan';
+type OnboardingAuthCompletionMethod = OnboardingAuthMethod | 'unknown';
+type OnboardingAuthFailureKind =
+  | 'validation-error'
+  | 'network-error'
+  | 'unknown-error';
+type OnboardingOtpFailureKind =
+  | 'backend-error'
+  | 'network-error'
+  | 'turnstile-not-ready';
+
+const onboardingAuthMethodSchema = z.enum([
+  'stagewise',
+  'api-keys',
+  'coding-plan',
+]);
+const codingPlanIdSchema = z.enum([
+  'glm-coding-plan',
+  'kimi-plan',
+  'qwen-plan',
+  'minimax-plan',
+]);
+const onboardingAuthFailureKindSchema = z.enum([
+  'validation-error',
+  'network-error',
+  'unknown-error',
+]);
+const onboardingOtpFailureKindSchema = z.enum([
+  'backend-error',
+  'network-error',
+  'turnstile-not-ready',
+]);
 
 export type EventProperties = {
   // Lifecycle
@@ -27,9 +63,47 @@ export type EventProperties = {
     skipped: boolean;
     suggestion_id?: string;
     telemetry_level: TelemetryLevel;
+    auth_method?: OnboardingAuthCompletionMethod;
+    provider?: ModelProvider;
+    plan_id?: CodingPlanId;
   };
   'onboarding-demo-slide-clicked': {
     slide_name: string;
+  };
+  'onboarding-auth-mode-switched': {
+    from: OnboardingAuthMethod;
+    to: OnboardingAuthMethod;
+  };
+  'onboarding-auth-providers-expanded': {
+    expanded: boolean;
+  };
+  'onboarding-auth-api-key-input-focused': {
+    provider: ModelProvider;
+  };
+  'onboarding-auth-coding-plan-opened': {
+    plan_id: CodingPlanId;
+    provider: ModelProvider;
+  };
+  'onboarding-auth-otp-requested': undefined;
+  'onboarding-auth-otp-verified': undefined;
+  'onboarding-auth-otp-failed': {
+    error_kind: OnboardingOtpFailureKind;
+  };
+  'onboarding-auth-method-completed': {
+    auth_method: OnboardingAuthMethod;
+    provider?: ModelProvider;
+    plan_id?: CodingPlanId;
+  };
+  'onboarding-auth-method-failed': {
+    auth_method: OnboardingAuthMethod;
+    provider?: ModelProvider;
+    plan_id?: CodingPlanId;
+    error_kind: OnboardingAuthFailureKind;
+  };
+  'onboarding-auth-provider-disconnected': {
+    auth_method: 'api-keys' | 'coding-plan';
+    provider: ModelProvider;
+    plan_id?: CodingPlanId;
   };
 
   // Workspace
@@ -356,6 +430,16 @@ export const UI_TELEMETRY_EVENT_NAMES = [
   'custom-provider-add-started',
   'element-selection-started',
   'element-selection-stopped',
+  'onboarding-auth-api-key-input-focused',
+  'onboarding-auth-coding-plan-opened',
+  'onboarding-auth-method-completed',
+  'onboarding-auth-method-failed',
+  'onboarding-auth-mode-switched',
+  'onboarding-auth-otp-failed',
+  'onboarding-auth-otp-requested',
+  'onboarding-auth-otp-verified',
+  'onboarding-auth-provider-disconnected',
+  'onboarding-auth-providers-expanded',
   'onboarding-demo-slide-clicked',
   'settings-opened',
   'suggestion-clicked',
@@ -406,6 +490,41 @@ const UI_TELEMETRY_EVENT_SCHEMAS = {
   'element-selection-started': z.undefined().optional(),
   'element-selection-stopped': z.object({
     element_selected: z.boolean(),
+  }),
+  'onboarding-auth-api-key-input-focused': z.object({
+    provider: modelProviderSchema,
+  }),
+  'onboarding-auth-coding-plan-opened': z.object({
+    plan_id: codingPlanIdSchema,
+    provider: modelProviderSchema,
+  }),
+  'onboarding-auth-method-completed': z.object({
+    auth_method: onboardingAuthMethodSchema,
+    provider: modelProviderSchema.optional(),
+    plan_id: codingPlanIdSchema.optional(),
+  }),
+  'onboarding-auth-method-failed': z.object({
+    auth_method: onboardingAuthMethodSchema,
+    provider: modelProviderSchema.optional(),
+    plan_id: codingPlanIdSchema.optional(),
+    error_kind: onboardingAuthFailureKindSchema,
+  }),
+  'onboarding-auth-mode-switched': z.object({
+    from: onboardingAuthMethodSchema,
+    to: onboardingAuthMethodSchema,
+  }),
+  'onboarding-auth-otp-failed': z.object({
+    error_kind: onboardingOtpFailureKindSchema,
+  }),
+  'onboarding-auth-otp-requested': z.undefined().optional(),
+  'onboarding-auth-otp-verified': z.undefined().optional(),
+  'onboarding-auth-provider-disconnected': z.object({
+    auth_method: z.enum(['api-keys', 'coding-plan']),
+    provider: modelProviderSchema,
+    plan_id: codingPlanIdSchema.optional(),
+  }),
+  'onboarding-auth-providers-expanded': z.object({
+    expanded: z.boolean(),
   }),
   'onboarding-demo-slide-clicked': z.object({
     slide_name: z.string(),

--- a/apps/browser/src/shared/karton-contracts/pages-api/index.ts
+++ b/apps/browser/src/shared/karton-contracts/pages-api/index.ts
@@ -29,11 +29,11 @@ import type {
   GlobalConfig,
   ModelProvider,
 } from '../ui/shared-types';
+import type { CodingPlanId } from '../../coding-plans';
 import type { ApiKeyValidationResult, AuthStatus, PlanEntry } from '../ui';
 import type { FileDiff } from '../ui/shared-types';
 import { defaultUserPreferences } from '../ui/shared-types';
 import type { PluginDefinition } from '../../plugins';
-import type { CodingPlanId } from '../../coding-plans';
 
 export type WorkspaceMountInfo = {
   prefix: string;
@@ -184,7 +184,22 @@ export type PagesApiContract = {
       limit: number;
     }) => Promise<InspirationWebsite>;
     /** Set whether user has seen the onboarding flow */
-    setHasSeenOnboardingFlow: (value: boolean) => Promise<void>;
+    setHasSeenOnboardingFlow: (
+      input:
+        | boolean
+        | {
+            value: boolean;
+            auth?: {
+              auth_method: 'stagewise' | 'api-keys' | 'coding-plan' | 'unknown';
+              provider?: ModelProvider;
+              plan_id?:
+                | 'glm-coding-plan'
+                | 'kimi-plan'
+                | 'qwen-plan'
+                | 'minimax-plan';
+            };
+          },
+    ) => Promise<void>;
     /**
      * Trust a certificate for a specific origin in a tab and reload.
      * This adds the origin to a per-tab whitelist that allows certificate errors.

--- a/apps/browser/src/shared/karton-contracts/ui/index.ts
+++ b/apps/browser/src/shared/karton-contracts/ui/index.ts
@@ -856,8 +856,25 @@ export type KartonContract = {
         ) => Promise<void>;
       };
       setHasSeenOnboardingFlow: (
-        value: boolean,
-        suggestion?: { id: string; url: string; prompt: string },
+        input:
+          | boolean
+          | {
+              value: boolean;
+              auth?: {
+                auth_method:
+                  | 'stagewise'
+                  | 'api-keys'
+                  | 'coding-plan'
+                  | 'unknown';
+                provider?: ModelProvider;
+                plan_id?:
+                  | 'glm-coding-plan'
+                  | 'kimi-plan'
+                  | 'qwen-plan'
+                  | 'minimax-plan';
+              };
+              suggestion?: { id: string; url: string; prompt: string };
+            },
       ) => Promise<void>;
       clearPendingOnboardingSuggestion: () => Promise<void>;
     };

--- a/apps/browser/src/ui/screens/onboarding/index.tsx
+++ b/apps/browser/src/ui/screens/onboarding/index.tsx
@@ -9,7 +9,7 @@ import { IconArrowLeftFill18, IconArrowRightFill18 } from 'nucleo-ui-fill-18';
 import { useKartonProcedure } from '@ui/hooks/use-karton';
 import { cn } from '@ui/utils';
 import { StepWelcome } from './steps/01-welcome';
-import { StepAuth } from './steps/02-auth';
+import { StepAuth, type OnboardingAuthCompletion } from './steps/02-auth';
 import { StepDemo } from './steps/03-demo';
 const stepIds = ['welcome', 'auth', 'demo'];
 
@@ -22,6 +22,8 @@ export function OnboardingWizard() {
   const [currentStep, setCurrentStep] = useState(0);
   const [canProceed, setCanProceed] = useState(false);
   const [blockReason, setBlockReason] = useState<string | null>(null);
+  const [authCompletion, setAuthCompletion] =
+    useState<OnboardingAuthCompletion | null>(null);
   const setHasSeenOnboardingFlow = useKartonProcedure(
     (p) => p.userExperience.setHasSeenOnboardingFlow,
   );
@@ -58,8 +60,11 @@ export function OnboardingWizard() {
   }, []);
 
   const complete = useCallback(() => {
-    setHasSeenOnboardingFlow(true);
-  }, [setHasSeenOnboardingFlow]);
+    setHasSeenOnboardingFlow({
+      value: true,
+      auth: authCompletion ?? { auth_method: 'unknown' },
+    });
+  }, [authCompletion, setHasSeenOnboardingFlow]);
 
   return (
     <div
@@ -88,6 +93,7 @@ export function OnboardingWizard() {
             isActive={currentStep === 1}
             onValidityChange={handleValidityChange}
             onStepComplete={() => goNext()}
+            onAuthCompleted={setAuthCompletion}
           />
         </div>
         {currentStep === 2 && <StepDemo />}

--- a/apps/browser/src/ui/screens/onboarding/steps/02-auth.tsx
+++ b/apps/browser/src/ui/screens/onboarding/steps/02-auth.tsx
@@ -7,6 +7,7 @@ import { OverlayScrollbar } from '@stagewise/stage-ui/components/overlay-scrollb
 import { useKartonProcedure, useKartonState } from '@ui/hooks/use-karton';
 import { useState, useCallback, useRef, useEffect, useMemo } from 'react';
 import { useScrollFadeMask } from '@ui/hooks/use-scroll-fade-mask';
+import { useTrack } from '@ui/hooks/use-track';
 import { useTurnstile } from '@ui/hooks/use-turnstile';
 import {
   Tooltip,
@@ -53,13 +54,21 @@ const API_KEY_PROVIDERS: ProviderKey[] = [
 
 type ConnectResult = { success: true } | { success: false; error: string };
 
+export type OnboardingAuthCompletion = {
+  auth_method: AuthMode;
+  provider?: ModelProvider;
+  plan_id?: CodingPlanId;
+};
+
 export function StepAuth({
   isActive,
   onValidityChange,
+  onAuthCompleted,
 }: {
   isActive: boolean;
   onStepComplete?: () => void;
   onValidityChange?: StepValidityCallback;
+  onAuthCompleted?: (completion: OnboardingAuthCompletion) => void;
 }) {
   const sendOtp = useKartonProcedure((p) => p.userAccount.sendOtp);
   const verifyOtp = useKartonProcedure((p) => p.userAccount.verifyOtp);
@@ -74,6 +83,7 @@ export function StepAuth({
   );
   const preferencesUpdate = useKartonProcedure((p) => p.preferences.update);
   const openExternalUrl = useKartonProcedure((p) => p.openExternalUrl);
+  const track = useTrack();
   const authStatus = useKartonState((s) => s.userAccount.status);
   const preferences = useKartonState((s) => s.preferences);
   const userEmail = useKartonState((s) =>
@@ -125,19 +135,6 @@ export function StepAuth({
   });
 
   useEffect(() => {
-    if (
-      authStatus === 'unauthenticated' &&
-      phase === 'authentication-validated'
-    ) {
-      setPhase('form-input');
-      setMode('stagewise');
-      setCode('');
-      setError(null);
-      setSelectedCodingPlanId(null);
-    }
-  }, [authStatus]);
-
-  useEffect(() => {
     if (isActive && mode === 'stagewise' && phase === 'form-input')
       requestAnimationFrame(() => emailRef.current?.focus());
   }, [isActive, mode, phase]);
@@ -167,24 +164,74 @@ export function StepAuth({
     (mode === 'api-keys' && hasConnectedApiKey) ||
     (mode === 'coding-plan' && hasConnectedCodingPlan);
 
+  const switchMode = useCallback(
+    (to: AuthMode) => {
+      setMode((from) => {
+        if (from !== to) {
+          void track('onboarding-auth-mode-switched', { from, to });
+        }
+        return to;
+      });
+    },
+    [track],
+  );
+
+  useEffect(() => {
+    if (
+      authStatus === 'unauthenticated' &&
+      phase === 'authentication-validated'
+    ) {
+      setPhase('form-input');
+      switchMode('stagewise');
+      setCode('');
+      setError(null);
+      setSelectedCodingPlanId(null);
+    }
+  }, [authStatus, phase, switchMode]);
+
+  const trackAuthCompleted = useCallback(
+    (completion: OnboardingAuthCompletion) => {
+      void track('onboarding-auth-method-completed', completion);
+      onAuthCompleted?.(completion);
+    },
+    [onAuthCompleted, track],
+  );
+
   const handleConnectSingleKey = useCallback(
     async (provider: ProviderKey, apiKey: string): Promise<ConnectResult> => {
-      // Delegate to the backend's atomic `connectProvider` procedure.
-      // It validates the key, encrypts+stores it, and flips the provider's
-      // endpoint mode to `'official'` in a single RPC. No partial-state
-      // window: if any step fails, nothing is persisted.
-      return connectProvider(provider, apiKey);
+      try {
+        const result = await connectProvider(provider, apiKey);
+        if (result.success) {
+          trackAuthCompleted({ auth_method: 'api-keys', provider });
+        } else {
+          void track('onboarding-auth-method-failed', {
+            auth_method: 'api-keys',
+            provider,
+            error_kind: 'validation-error',
+          });
+        }
+        return result;
+      } catch (error) {
+        void track('onboarding-auth-method-failed', {
+          auth_method: 'api-keys',
+          provider,
+          error_kind: 'network-error',
+        });
+        throw error;
+      }
     },
-    [connectProvider],
+    [connectProvider, track, trackAuthCompleted],
   );
 
   const handleDisconnectApiKey = useCallback(
     async (provider: ProviderKey) => {
-      // Atomic: flips mode back to 'stagewise' AND clears the encrypted key
-      // in a single patch update on the backend. No partial-state window.
       await disconnectProvider(provider);
+      void track('onboarding-auth-provider-disconnected', {
+        auth_method: 'api-keys',
+        provider,
+      });
     },
-    [disconnectProvider],
+    [disconnectProvider, track],
   );
 
   useEffect(() => {
@@ -199,20 +246,30 @@ export function StepAuth({
   const handleSendOtp = useCallback(async () => {
     if (!email.trim()) return;
     if (turnstileEnabled && !turnstileToken && !turnstileError) {
+      void track('onboarding-auth-otp-failed', {
+        error_kind: 'turnstile-not-ready',
+      });
       setError('Security verification not ready. Please wait a moment.');
       return;
     }
+    void track('onboarding-auth-otp-requested');
     setError(null);
     setLoading(true);
     try {
       const result = await sendOtp(email.trim(), turnstileToken ?? '');
       if (result?.error) {
+        void track('onboarding-auth-otp-failed', {
+          error_kind: 'backend-error',
+        });
         setError(result.error);
         resetTurnstile();
       } else {
         setPhase('waiting-for-otp');
       }
     } catch {
+      void track('onboarding-auth-otp-failed', {
+        error_kind: 'network-error',
+      });
       setError('Failed to send verification code.');
       resetTurnstile();
     } finally {
@@ -221,6 +278,7 @@ export function StepAuth({
   }, [
     email,
     sendOtp,
+    track,
     turnstileToken,
     turnstileEnabled,
     resetTurnstile,
@@ -239,13 +297,35 @@ export function StepAuth({
       planId: CodingPlanId,
       apiKey: string,
     ): Promise<{ success: true } | { success: false; error: string }> => {
-      // Delegate to the backend's atomic `connectCodingPlan` procedure.
-      // It validates the key, encrypts+stores it, and flips the provider's
-      // endpoint mode to `'official'` in a single RPC. No partial state
-      // window: if any step fails, nothing is persisted.
-      return connectCodingPlan(planId, apiKey);
+      const provider = CODING_PLANS[planId].provider;
+      try {
+        const result = await connectCodingPlan(planId, apiKey);
+        if (result.success) {
+          trackAuthCompleted({
+            auth_method: 'coding-plan',
+            provider,
+            plan_id: planId,
+          });
+        } else {
+          void track('onboarding-auth-method-failed', {
+            auth_method: 'coding-plan',
+            provider,
+            plan_id: planId,
+            error_kind: 'validation-error',
+          });
+        }
+        return result;
+      } catch (error) {
+        void track('onboarding-auth-method-failed', {
+          auth_method: 'coding-plan',
+          provider,
+          plan_id: planId,
+          error_kind: 'network-error',
+        });
+        throw error;
+      }
     },
-    [connectCodingPlan],
+    [connectCodingPlan, track, trackAuthCompleted],
   );
 
   const handleGetApiKey = useCallback(
@@ -261,8 +341,13 @@ export function StepAuth({
       // Atomic: flips mode back to 'stagewise' AND clears the encrypted key
       // in a single patch update on the backend. No partial-state window.
       await disconnectProvider(provider);
+      void track('onboarding-auth-provider-disconnected', {
+        auth_method: 'coding-plan',
+        provider,
+        plan_id: planId,
+      });
     },
-    [disconnectProvider],
+    [disconnectProvider, track],
   );
 
   const handleVerifyOtp = useCallback(async () => {
@@ -271,14 +356,33 @@ export function StepAuth({
     setLoading(true);
     try {
       const result = await verifyOtp(email.trim(), code.trim());
-      if (result?.error) setError(result.error);
-      else setPhase('authentication-validated');
+      if (result?.error) {
+        void track('onboarding-auth-otp-failed', {
+          error_kind: 'backend-error',
+        });
+        void track('onboarding-auth-method-failed', {
+          auth_method: 'stagewise',
+          error_kind: 'validation-error',
+        });
+        setError(result.error);
+      } else {
+        void track('onboarding-auth-otp-verified');
+        trackAuthCompleted({ auth_method: 'stagewise' });
+        setPhase('authentication-validated');
+      }
     } catch {
+      void track('onboarding-auth-otp-failed', {
+        error_kind: 'network-error',
+      });
+      void track('onboarding-auth-method-failed', {
+        auth_method: 'stagewise',
+        error_kind: 'network-error',
+      });
       setError('Failed to verify code.');
     } finally {
       setLoading(false);
     }
-  }, [email, code, verifyOtp]);
+  }, [email, code, verifyOtp, track, trackAuthCompleted]);
 
   if (phase === 'authentication-validated' && mode === 'stagewise') {
     return (
@@ -452,6 +556,11 @@ export function StepAuth({
               }
               onConnect={handleConnectSingleKey}
               onDisconnect={handleDisconnectApiKey}
+              onFocusProvider={(provider) => {
+                void track('onboarding-auth-api-key-input-focused', {
+                  provider,
+                });
+              }}
             />
             <ApiKeyRow
               provider="openai"
@@ -462,6 +571,11 @@ export function StepAuth({
               }
               onConnect={handleConnectSingleKey}
               onDisconnect={handleDisconnectApiKey}
+              onFocusProvider={(provider) => {
+                void track('onboarding-auth-api-key-input-focused', {
+                  provider,
+                });
+              }}
             />
             <ApiKeyRow
               provider="google"
@@ -472,6 +586,11 @@ export function StepAuth({
               }
               onConnect={handleConnectSingleKey}
               onDisconnect={handleDisconnectApiKey}
+              onFocusProvider={(provider) => {
+                void track('onboarding-auth-api-key-input-focused', {
+                  provider,
+                });
+              }}
             />
             {showMoreProviders && (
               <>
@@ -486,6 +605,11 @@ export function StepAuth({
                   }
                   onConnect={handleConnectSingleKey}
                   onDisconnect={handleDisconnectApiKey}
+                  onFocusProvider={(provider) => {
+                    void track('onboarding-auth-api-key-input-focused', {
+                      provider,
+                    });
+                  }}
                 />
                 <ApiKeyRow
                   provider="alibaba"
@@ -498,6 +622,11 @@ export function StepAuth({
                   }
                   onConnect={handleConnectSingleKey}
                   onDisconnect={handleDisconnectApiKey}
+                  onFocusProvider={(provider) => {
+                    void track('onboarding-auth-api-key-input-focused', {
+                      provider,
+                    });
+                  }}
                 />
                 <ApiKeyRow
                   provider="deepseek"
@@ -510,6 +639,11 @@ export function StepAuth({
                   }
                   onConnect={handleConnectSingleKey}
                   onDisconnect={handleDisconnectApiKey}
+                  onFocusProvider={(provider) => {
+                    void track('onboarding-auth-api-key-input-focused', {
+                      provider,
+                    });
+                  }}
                 />
                 <ApiKeyRow
                   provider="z-ai"
@@ -522,6 +656,11 @@ export function StepAuth({
                   }
                   onConnect={handleConnectSingleKey}
                   onDisconnect={handleDisconnectApiKey}
+                  onFocusProvider={(provider) => {
+                    void track('onboarding-auth-api-key-input-focused', {
+                      provider,
+                    });
+                  }}
                 />
               </>
             )}
@@ -531,7 +670,7 @@ export function StepAuth({
               variant="ghost"
               size="xs"
               onClick={() => {
-                setMode('stagewise');
+                switchMode('stagewise');
                 setError(null);
                 setSelectedCodingPlanId(null);
               }}
@@ -541,7 +680,15 @@ export function StepAuth({
             <Button
               variant="ghost"
               size="xs"
-              onClick={() => setShowMoreProviders((v) => !v)}
+              onClick={() => {
+                setShowMoreProviders((expanded) => {
+                  const next = !expanded;
+                  void track('onboarding-auth-providers-expanded', {
+                    expanded: next,
+                  });
+                  return next;
+                });
+              }}
             >
               {showMoreProviders ? 'Show less' : 'Show 4 more providers'}
             </Button>
@@ -567,7 +714,13 @@ export function StepAuth({
                   displayName={plan.displayName}
                   tagline={plan.tagline}
                   isConnected={isConnected}
-                  onClick={() => setSelectedCodingPlanId(plan.id)}
+                  onClick={() => {
+                    void track('onboarding-auth-coding-plan-opened', {
+                      plan_id: plan.id,
+                      provider: plan.provider,
+                    });
+                    setSelectedCodingPlanId(plan.id);
+                  }}
                 />
               );
             })}
@@ -577,7 +730,7 @@ export function StepAuth({
               variant="ghost"
               size="xs"
               onClick={() => {
-                setMode('stagewise');
+                switchMode('stagewise');
                 setError(null);
                 setSelectedCodingPlanId(null);
               }}
@@ -636,7 +789,7 @@ export function StepAuth({
             variant="ghost"
             size="xs"
             onClick={() => {
-              setMode('api-keys');
+              switchMode('api-keys');
               setError(null);
             }}
           >
@@ -648,7 +801,7 @@ export function StepAuth({
               variant="ghost"
               size="xs"
               onClick={() => {
-                setMode('coding-plan');
+                switchMode('coding-plan');
                 setError(null);
               }}
             >
@@ -669,6 +822,7 @@ function ApiKeyRow({
   config,
   onConnect,
   onDisconnect,
+  onFocusProvider,
 }: {
   provider: ProviderKey;
   label: string;
@@ -680,6 +834,7 @@ function ApiKeyRow({
   };
   onConnect: (provider: ProviderKey, apiKey: string) => Promise<ConnectResult>;
   onDisconnect: (provider: ProviderKey) => Promise<void>;
+  onFocusProvider?: (provider: ProviderKey) => void;
 }) {
   const isConnected = !!config.encryptedApiKey && config.mode === 'official';
   const [localInput, setLocalInput] = useState('');
@@ -692,6 +847,7 @@ function ApiKeyRow({
   // otherwise each see `isConnecting === false` and double-fire the RPC.
   const connectInFlightRef = useRef(false);
   const disconnectInFlightRef = useRef(false);
+  const focusTrackedRef = useRef(false);
   useEffect(
     () => () => {
       connectInFlightRef.current = false;
@@ -779,6 +935,14 @@ function ApiKeyRow({
                   setLocalError(null);
                 }
           }
+          onFocus={(e) => {
+            if (isConnected || focusTrackedRef.current) return;
+            // Ignore programmatic focus (e.g. autoFocus on mount) so the
+            // provider-focus telemetry reflects genuine user intent only.
+            if (!e.isTrusted) return;
+            focusTrackedRef.current = true;
+            onFocusProvider?.(provider);
+          }}
           onKeyDown={(e) => {
             if (isConnected) return;
             if (e.key === 'Enter' && localInput.trim() && !isConnecting) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enriched onboarding telemetry to capture the exact auth path and granular interactions. The UI now emits detailed auth events and passes the final auth summary to the backend so `onboarding-completed` includes context for better funnel insights.

- **New Features**
  - Added telemetry for mode switched, providers expanded, OTP requested/verified/failed (with error kinds), API key input focused, coding plan opened, method completed/failed, and provider disconnected.
  - `onboarding-completed` now includes `auth_method`, `provider`, and `plan_id`; `StepAuth` emits these events and reports auth completion; `OnboardingWizard` forwards it via `setHasSeenOnboardingFlow({ value, auth })`; schemas/validation updated and `@shared/karton-contracts/ui` and `@shared/karton-contracts/pages-api` accept the new input (backward compatible).

<sup>Written for commit c818c250f365c983c7d78714a6cbd3f1ea69e019. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Onboarding completion now records the authentication method and optional provider/plan info so completion events carry richer context.
  * The onboarding UI reports structured auth completion data when users finish setup.

* **Chores**
  * Expanded telemetry for onboarding auth flows: mode switches, OTP and API-key/coding-plan interactions, success/failure details, and focused input tracking for more accurate analytics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->