### PR TITLE
fix(stagewise): add app-drag to tabs containerQ

### DIFF
--- a/apps/browser/src/ui/screens/main/content/index.tsx
+++ b/apps/browser/src/ui/screens/main/content/index.tsx
@@ -70,7 +70,8 @@ function AudioMuteButton({ tab }: { tab: TabState }) {
 // ---------------------------------------------------------------------------
 
 export function MainSection() {
-  const _isMacOs = useKartonState((s) => s.appInfo.platform === 'darwin');
+  const isMacOs = useKartonState((s) => s.appInfo.platform === 'darwin');
+  const isFullScreen = useKartonState((s) => s.appInfo.isFullScreen);
   const tabs = useKartonState((s) => s.browser.tabs);
   const activeTabId = useKartonState((s) => s.browser.activeTabId);
   const createTab = useKartonProcedure((p) => p.browser.createTab);
@@ -262,12 +263,16 @@ export function MainSection() {
       />
       <div className="flex h-full w-full flex-col">
         {/* Tab bar */}
-        <div className="flex shrink-0 flex-row items-start bg-background">
+        <div className="flex shrink-0 flex-row items-stretch bg-background">
           <SortableTabs
             value={activeTabId ?? ''}
             onValueChange={(id) => {
               if (id) void switchTab(id);
             }}
+            // Override default `w-full` so the tab list shrinks to content
+            // width, leaving the trailing draggable strip room to grow into
+            // the empty space.
+            className="w-auto min-w-0 shrink"
           >
             <SortableTabsList
               variant="bar"
@@ -277,6 +282,11 @@ export function MainSection() {
               onAddItem={handleCreateTab}
             />
           </SortableTabs>
+          {/* Trailing drag strip for macOS hidden-titlebar windows — fills
+              the empty row space so users can drag the window. */}
+          {isMacOs && !isFullScreen && (
+            <div className="app-drag h-8 grow" aria-hidden="true" />
+          )}
         </div>
         {/* Content area with per-tab UI */}
         <div className="relative flex size-full flex-col">


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes window dragging on macOS hidden-titlebar windows by adding a trailing `app-drag` region to the tab bar and adjusting layout so empty space is draggable. Restores window drag without affecting tab clicks and hides the strip in fullscreen.

- **Bug Fixes**
  - Added a trailing `app-drag` strip on macOS when not fullscreen.
  - Set the tab list to `w-auto min-w-0 shrink` so the strip grows into remaining space.
  - Aligned the tab bar container with `items-stretch` for a consistent drag area height.

<sup>Written for commit f1c8141592c536a5b77b12f4da3bcec63f3e6551. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI Improvements**
  * Added a trailing draggable strip on macOS when not in fullscreen for easier window dragging.
  * Adjusted tab bar layout so tabs size to their content, allowing the drag strip to occupy remaining space.
  * Improved tab row alignment and spacing for a cleaner, more consistent appearance on macOS.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->