### PR TITLE
Fix text clip position

### DIFF
--- a/apps/browser/src/backend/services/window-layout/tab-controller.ts
+++ b/apps/browser/src/backend/services/window-layout/tab-controller.ts
@@ -1084,12 +1084,25 @@ export class TabController extends EventEmitter<TabControllerEventMap> {
   }
 
   public setContextSelectionMouseCoordinates(x: number, y: number) {
-    // Compensate for scroll position when emitting input events
-    // The coordinates are relative to the viewport, but we need to account for scroll
+    // Incoming (x, y) are UI-renderer CSS pixels relative to the WebContentsView
+    // overlay. We must convert them into the page's own CSS-pixel coordinate space
+    // before handing them to sendInputEvent() / DOM.getNodeForLocation(), which
+    // both interpret their inputs as page CSS pixels.
+    //
+    // Two multiplicative contractions can be in play:
+    //   - scale: DevTools device-emulation scale (1 outside device mode)
+    //   - zoom:  Chromium page zoom (user Cmd+-/+, persisted per origin)
+    //
+    // UI px = page px * zoom * scale, so page px = UI px / (zoom * scale).
+    // Previously only `scale` was divided out, which caused a coordinate offset
+    // that scales with the cursor's distance from the origin whenever page zoom
+    // was not 100% (e.g. ~30px offset at 90% zoom, ~2x that at 50%).
 
     const scale = this.currentViewportSize?.scale || 1;
-    const adjustedX = Math.floor(x / scale);
-    const adjustedY = Math.floor(y / scale);
+    const zoom = this.currentViewportLayout?.zoom || 1;
+    const factor = scale * zoom;
+    const adjustedX = Math.floor(x / factor);
+    const adjustedY = Math.floor(y / factor);
 
     // TODO: In some cases the coords are not right when changing to a small device in emulation and not reloading the page. I don't know why (glenn) but we should fix this sometime. For now this takes too much time.
 
@@ -1122,9 +1135,13 @@ export class TabController extends EventEmitter<TabControllerEventMap> {
     deltaX: number;
     deltaY: number;
   }) {
+    // Same coordinate-space conversion as setContextSelectionMouseCoordinates:
+    // UI px -> page px by dividing out both device-emulation scale and page zoom.
     const scale = this.currentViewportSize?.scale || 1;
-    const adjustedX = Math.floor(event.x / scale);
-    const adjustedY = Math.floor(event.y / scale);
+    const zoom = this.currentViewportLayout?.zoom || 1;
+    const factor = scale * zoom;
+    const adjustedX = Math.floor(event.x / factor);
+    const adjustedY = Math.floor(event.y / factor);
 
     const ev: Electron.MouseWheelInputEvent = {
       type: 'mouseWheel',

--- a/apps/browser/src/ui/hooks/use-file-attachments.tsx
+++ b/apps/browser/src/ui/hooks/use-file-attachments.tsx
@@ -83,7 +83,10 @@ export interface UseFileAttachmentsReturn {
   /** Current attachments */
   attachments: AttachmentMetadata[];
   /** Add a file attachment, returns the created attachment */
-  addFileAttachment: (file: File) => Promise<AttachmentMetadata>;
+  addFileAttachment: (
+    file: File,
+    insertPos?: number,
+  ) => Promise<AttachmentMetadata>;
   /** Remove an attachment by path */
   removeAttachment: (path: string) => void;
   /** Clear all attachments */
@@ -119,7 +122,7 @@ export function useFileAttachments(
   ) as Mount[];
 
   const addFileAttachment = useCallback(
-    async (file: File): Promise<AttachmentMetadata> => {
+    async (file: File, insertPos?: number): Promise<AttachmentMetadata> => {
       const mediaType = file.type || 'application/octet-stream';
       // Only store a meaningful originalFileName. Clipboard pastes in Electron
       // produce a generic name like "image.png" or "blob"; fall back to a
@@ -144,6 +147,7 @@ export function useFileAttachments(
         if (insertIntoEditor && chatInputRef?.current) {
           chatInputRef.current.insertAttachment(
             attachmentToAttachmentAttributes(placeholder),
+            insertPos,
           );
         }
         return placeholder;
@@ -161,6 +165,7 @@ export function useFileAttachments(
           if (insertIntoEditor && chatInputRef?.current) {
             chatInputRef.current.insertAttachment(
               attachmentToAttachmentAttributes(attachment),
+              insertPos,
             );
           }
           return attachment;
@@ -210,6 +215,7 @@ export function useFileAttachments(
       if (insertIntoEditor && chatInputRef?.current) {
         chatInputRef.current.insertAttachment(
           attachmentToAttachmentAttributes(attachment),
+          insertPos,
         );
       }
 

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/chat-input.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/chat-input.tsx
@@ -88,7 +88,7 @@ export interface ChatInputProps {
   onEscape?: () => void;
 
   // File paste handling
-  onPasteFiles?: (files: File[]) => void;
+  onPasteFiles?: (files: File[], insertPos?: number) => void;
 
   // Attachment removal callback (when badges are deleted from editor)
   onAttachmentRemoved?: (
@@ -113,7 +113,7 @@ export interface ChatInputHandle {
   focus: () => void;
   blur: () => void;
   /** Insert an attachment mention at the current cursor position */
-  insertAttachment: (attrs: AttachmentAttributes) => void;
+  insertAttachment: (attrs: AttachmentAttributes, position?: number) => void;
   getTextContent: () => string;
   /** Get the current TipTap JSON content as a string */
   getJsonContent: () => string;
@@ -275,9 +275,14 @@ export const ChatInput = memo(function ChatInput({
         }
         return false;
       },
-      handlePaste: (_view, event) => {
+      handlePaste: (view, event) => {
         const items = event.clipboardData?.items;
         if (!items || !onPasteFiles) return false;
+
+        // Snapshot the caret position synchronously here — the subsequent
+        // `addFileAttachment` flow awaits an IPC roundtrip to the blob store
+        // before inserting the badge, during which the selection may move.
+        const insertPos = view.state.selection.from;
 
         const files: File[] = [];
         for (let i = 0; i < items.length; i++) {
@@ -290,7 +295,7 @@ export const ChatInput = memo(function ChatInput({
 
         if (files.length > 0) {
           event.preventDefault();
-          onPasteFiles(files);
+          onPasteFiles(files, insertPos);
           return true;
         }
 
@@ -315,7 +320,7 @@ export const ChatInput = memo(function ChatInput({
           const file = new File([blob], fileName, {
             type: 'text/x-textclip',
           });
-          onPasteFiles([file]);
+          onPasteFiles([file], insertPos);
           return true;
         }
 
@@ -468,11 +473,11 @@ export const ChatInput = memo(function ChatInput({
     blur: () => {
       editor?.commands.blur();
     },
-    insertAttachment: (attrs: AttachmentAttributes) => {
+    insertAttachment: (attrs: AttachmentAttributes, position?: number) => {
       if (editor) {
         // Mark as internal change so valueEffect doesn't reset content
         isInternalChangeRef.current = true;
-        editor.commands.insertAttachment(attrs);
+        editor.commands.insertAttachment(attrs, position);
       }
     },
     getTextContent: () => {

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/panel-footer.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/panel-footer.tsx
@@ -853,14 +853,20 @@ export const ChatPanelFooter = memo(function ChatPanelFooter() {
   );
 
   /**
-   * Handle files pasted into the editor
+   * Handle files pasted into the editor.
+   *
+   * `insertPos` is captured synchronously inside the TipTap paste handler
+   * (before any async blob-store work) so the resulting badge is inserted
+   * at the caret position rather than wherever the selection happens to be
+   * when the IPC roundtrip resolves. Do NOT add a `focus('end')` call here:
+   * the editor already holds focus during paste, and `focus('end')` would
+   * reset the caret and undo this fix.
    */
   const handlePasteFiles = useCallback(
-    (files: File[]) => {
+    (files: File[], insertPos?: number) => {
       files.forEach((file) => {
-        addFileAttachment(file);
+        addFileAttachment(file, insertPos);
       });
-      chatInputRef.current?.focus();
     },
     [addFileAttachment],
   );

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/rich-text/attachments/index.ts
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/rich-text/attachments/index.ts
@@ -41,7 +41,10 @@ export const AllAttachmentExtensions = [Attachment, ElementAttachment] as const;
 declare module '@tiptap/core' {
   interface Commands<ReturnType> {
     attachmentCommands: {
-      insertAttachment: (attrs: AttachmentAttributes) => ReturnType;
+      insertAttachment: (
+        attrs: AttachmentAttributes,
+        position?: number,
+      ) => ReturnType;
     };
   }
 }
@@ -56,23 +59,34 @@ export const AttachmentCommands = Extension.create({
   addCommands() {
     return {
       insertAttachment:
-        (attrs: AttachmentAttributes) =>
-        ({ chain }) => {
+        (attrs: AttachmentAttributes, position?: number) =>
+        ({ chain, state }) => {
           const nodeName = ATTACHMENT_NODE_NAMES[attrs.type];
           const { type: _type, ...nodeAttrs } = attrs;
+          const content = [
+            {
+              type: nodeName,
+              attrs: nodeAttrs,
+            },
+            {
+              type: 'text',
+              text: ' ',
+            },
+          ];
 
-          return chain()
-            .insertContent([
-              {
-                type: nodeName,
-                attrs: nodeAttrs,
-              },
-              {
-                type: 'text',
-                text: ' ',
-              },
-            ])
-            .run();
+          if (position !== undefined) {
+            // Clamp to valid doc range. A freshly-cleared doc has
+            // content.size === 2 (one empty paragraph: open+close tokens),
+            // so positions 1..size-1 are the safe inline insertion points.
+            // This guards against stale positions after the doc has been
+            // shortened or cleared while an async blob-store call was
+            // in flight.
+            const max = Math.max(1, state.doc.content.size - 1);
+            const safePos = Math.min(Math.max(position, 1), max);
+            return chain().insertContentAt(safePos, content).run();
+          }
+
+          return chain().insertContent(content).run();
         },
     };
   },


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes element selection offset on zoomed pages and ensures pasted attachments (including text clips) insert at the original caret position.

- **Bug Fixes**
  - Convert UI coordinates to page CSS pixels by dividing by both device emulation scale and page zoom in the tab controller (for context selection and mouse wheel).
  - Preserve caret position on paste: capture selection before async work and insert attachments at that position; plumb optional insert position through `addFileAttachment` and the editor's `insertAttachment`, with clamping to a safe range.
  - Remove focus-on-paste so the caret isn’t moved; badges now appear where the paste happened.

<sup>Written for commit 6c0afb8bf2362c51c89d984a0e649e06aaed8a87. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed coordinate offset issues when using DevTools device emulation or page zoom levels with cursor and scroll interactions.

* **New Features**
  * Attachments and pasted files can now be inserted at specific cursor positions, preserving the insertion point even during asynchronous processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->