### PR TITLE
feat(stagewise): allow collapsing of sidebar

### DIFF
--- a/apps/browser/src/backend/services/window-layout/index.ts
+++ b/apps/browser/src/backend/services/window-layout/index.ts
@@ -34,6 +34,7 @@ import {
   createSearchUtils,
 } from './utils/search-utils';
 import { HOME_PAGE_URL } from '@shared/internal-urls';
+import { MACOS_TRAFFIC_LIGHT_X, MACOS_TRAFFIC_LIGHT_Y } from '@shared/titlebar';
 import { SessionPermissionRegistry } from './tab-permission-handler/session-registry';
 import { z } from 'zod';
 import {
@@ -233,7 +234,10 @@ export class WindowLayoutService extends DisposableService {
             ),
           }
         : {}),
-      trafficLightPosition: { x: 14, y: 16 },
+      trafficLightPosition: {
+        x: MACOS_TRAFFIC_LIGHT_X,
+        y: MACOS_TRAFFIC_LIGHT_Y,
+      },
       vibrancy: 'sidebar',
       backgroundMaterial: 'mica',
       autoHideMenuBar: true,

--- a/apps/browser/src/shared/hotkeys.ts
+++ b/apps/browser/src/shared/hotkeys.ts
@@ -24,6 +24,7 @@ export interface HotkeyDefinition {
 export enum HotkeyActions {
   // Stagewise specific
   TOGGLE_CONTEXT_SELECTOR = 'toggle_context_selector',
+  TOGGLE_SIDEBAR = 'toggle_sidebar',
   NEW_CHAT = 'new_chat',
   DOWNLOADS = 'downloads',
 
@@ -81,6 +82,14 @@ export const hotkeyDefinitions: Record<HotkeyActions, HotkeyDefinition> = {
   [HotkeyActions.TOGGLE_CONTEXT_SELECTOR]: {
     accelerator: 'Mod+I',
     captureDominantly: true,
+  },
+  [HotkeyActions.TOGGLE_SIDEBAR]: {
+    // Matches Codex / VS Code / GitHub Desktop convention.
+    // NOT capture-dominant: Cmd/Ctrl+B is the universal "bold" shortcut
+    // inside rich-text editors (TipTap), so we let native editable
+    // elements consume the event first via `shouldNativeInputConsumeEvent`.
+    accelerator: 'Mod+B',
+    captureDominantly: false,
   },
   [HotkeyActions.NEW_CHAT]: {
     accelerator: 'Mod+N',

--- a/apps/browser/src/shared/native-input-events.ts
+++ b/apps/browser/src/shared/native-input-events.ts
@@ -38,6 +38,13 @@ export function shouldNativeInputConsumeEvent(e: KeyboardEvent): boolean {
         // 1. Standard Editing Shortcuts (Copy, Paste, Undo, Select All)
         if (['a', 'c', 'v', 'x', 'z', 'y'].includes(key)) return true;
 
+        // 1b. Rich-text formatting shortcuts (bold, italic, underline).
+        // Used by contentEditable editors like TipTap. Only protect when
+        // the target is actually rich (contentEditable) — plain <input>
+        // and <textarea> don't interpret these.
+        if (target.isContentEditable && ['b', 'i', 'u'].includes(key))
+          return true;
+
         // 2. Text Navigation (Cmd+Arrows on Mac, Ctrl+Arrows on Win)
         if (['arrowup', 'arrowdown', 'arrowleft', 'arrowright'].includes(key))
           return true;

--- a/apps/browser/src/shared/titlebar.ts
+++ b/apps/browser/src/shared/titlebar.ts
@@ -1,0 +1,32 @@
+/**
+ * Shared titlebar geometry constants.
+ *
+ * Single source of truth consumed by both the Electron main process (for
+ * `trafficLightPosition`) and the renderer (for the titlebar row that hosts
+ * the sidebar toggle button). Keeping these values here guarantees that the
+ * OS-drawn traffic lights and the DOM-drawn toggle button never drift apart.
+ */
+
+/** Height of the titlebar region in px. */
+export const TITLEBAR_HEIGHT = 40;
+
+/** Diameter of a macOS traffic-light button in px (fixed by the OS). */
+export const TRAFFIC_LIGHT_HEIGHT = 12;
+
+/** Reserved horizontal space for the macOS traffic-light cluster in px. */
+export const TRAFFIC_LIGHT_GUTTER_WIDTH = 78;
+
+/** X offset passed to Electron's `trafficLightPosition`. */
+export const MACOS_TRAFFIC_LIGHT_X = 14;
+
+/** Derived Y offset passed to Electron's `trafficLightPosition`. */
+export const MACOS_TRAFFIC_LIGHT_Y =
+  (TITLEBAR_HEIGHT - TRAFFIC_LIGHT_HEIGHT) / 2;
+
+/**
+ * Optical Y-offset for the sidebar toggle icon. The icon glyph is top-heavy
+ * (the "tab" notch pulls visual weight upward), so flex-centering puts its
+ * geometric center on the traffic-light center but its optical center above.
+ * Nudging it down by a few pixels aligns the perceived centers.
+ */
+export const TITLEBAR_ICON_OPTICAL_OFFSET = 3;

--- a/apps/browser/src/ui/hooks/use-auto-select-agent.tsx
+++ b/apps/browser/src/ui/hooks/use-auto-select-agent.tsx
@@ -1,0 +1,57 @@
+import { useEffect, useMemo } from 'react';
+import { useComparingSelector, useKartonState } from '@ui/hooks/use-karton';
+import { useOpenAgent } from '@ui/hooks/use-open-chat';
+import { usePendingRemovals } from '@ui/hooks/use-pending-agent-removals';
+
+/**
+ * Central, headless auto-selector: whenever `openAgent` is null (or points
+ * at an id that is no longer active), pick the first active agent.
+ *
+ * Lives at the root of the main layout so it runs regardless of whether
+ * the sidebar — which historically hosted this effect inside
+ * `AgentsSelector` — is mounted. Without this, restarting the app with a
+ * collapsed sidebar left `ChatPanel` stuck on the "No agent selected"
+ * empty state because the effect-bearing component never rendered.
+ */
+export function useAutoSelectFirstAgent(): void {
+  const [openAgent, setOpenAgent, removeFromHistory] = useOpenAgent();
+
+  const activeAgentIdsRaw = useKartonState(
+    useComparingSelector((s) => Object.keys(s.agents.instances)),
+  );
+  const { pending: pendingRemovals } = usePendingRemovals();
+
+  // Filter out ids that are being optimistically removed (Archive/Delete).
+  // Including them in auto-select would ping-pong openAgent back onto an
+  // id the grid is trying to evict, looping infinitely until the backend
+  // catches up.
+  const activeAgentIds = useMemo(
+    () =>
+      pendingRemovals.size === 0
+        ? activeAgentIdsRaw
+        : activeAgentIdsRaw.filter((id) => !pendingRemovals.has(id)),
+    [activeAgentIdsRaw, pendingRemovals],
+  );
+  const activeAgentIdSet = useMemo(
+    () => new Set(activeAgentIds),
+    [activeAgentIds],
+  );
+
+  useEffect(() => {
+    if (openAgent && !activeAgentIdSet.has(openAgent)) {
+      // The open agent was removed — pop it from the history stack. The
+      // fallback ensures that when the stack is empty we jump straight to
+      // the first active agent in one render instead of going through
+      // null → pick.
+      removeFromHistory(openAgent, activeAgentIds[0] ?? null);
+    } else if (!openAgent && activeAgentIds.length > 0) {
+      setOpenAgent(activeAgentIds[0]!);
+    }
+  }, [
+    openAgent,
+    activeAgentIdSet,
+    activeAgentIds,
+    removeFromHistory,
+    setOpenAgent,
+  ]);
+}

--- a/apps/browser/src/ui/screens/main/_components/sidebar-collapsed-context.tsx
+++ b/apps/browser/src/ui/screens/main/_components/sidebar-collapsed-context.tsx
@@ -1,0 +1,87 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+  type ReactNode,
+} from 'react';
+
+const STORAGE_KEY = 'stagewise-sidebar-collapsed';
+
+interface SidebarCollapsedCtx {
+  collapsed: boolean;
+  setCollapsed: (value: boolean) => void;
+  toggle: () => void;
+}
+
+const SidebarCollapsedContext = createContext<SidebarCollapsedCtx | null>(null);
+
+/**
+ * Read the persisted collapsed state synchronously. Exported so callers
+ * (e.g. the sidebar panel) can seed `defaultSize` on the very first render
+ * and avoid a one-frame expand-then-collapse flash when the user's saved
+ * state is "collapsed".
+ */
+export function readInitialSidebarCollapsed(): boolean {
+  try {
+    return localStorage.getItem(STORAGE_KEY) === '1';
+  } catch {
+    return false;
+  }
+}
+
+function persist(value: boolean) {
+  try {
+    localStorage.setItem(STORAGE_KEY, value ? '1' : '0');
+  } catch {
+    // ignore (e.g. private mode, disabled storage)
+  }
+}
+
+export function SidebarCollapsedProvider({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  const [collapsed, setCollapsedState] = useState<boolean>(
+    readInitialSidebarCollapsed,
+  );
+
+  const setCollapsed = useCallback((value: boolean) => {
+    setCollapsedState((prev) => {
+      if (prev === value) return prev;
+      persist(value);
+      return value;
+    });
+  }, []);
+
+  const toggle = useCallback(() => {
+    setCollapsedState((prev) => {
+      const next = !prev;
+      persist(next);
+      return next;
+    });
+  }, []);
+
+  const value = useMemo<SidebarCollapsedCtx>(
+    () => ({ collapsed, setCollapsed, toggle }),
+    [collapsed, setCollapsed, toggle],
+  );
+
+  return (
+    <SidebarCollapsedContext.Provider value={value}>
+      {children}
+    </SidebarCollapsedContext.Provider>
+  );
+}
+
+export function useSidebarCollapsed(): SidebarCollapsedCtx {
+  const ctx = useContext(SidebarCollapsedContext);
+  if (!ctx) {
+    throw new Error(
+      'useSidebarCollapsed must be used inside SidebarCollapsedProvider',
+    );
+  }
+  return ctx;
+}

--- a/apps/browser/src/ui/screens/main/_components/sidebar-titlebar-row.tsx
+++ b/apps/browser/src/ui/screens/main/_components/sidebar-titlebar-row.tsx
@@ -1,0 +1,47 @@
+import { TITLEBAR_HEIGHT } from '@shared/titlebar';
+import { cn } from '@ui/utils';
+import { SidebarToggleButton } from './sidebar-toggle-button';
+import { TrafficLightGutter } from './traffic-light-gutter';
+
+/**
+ * Titlebar row containing the macOS traffic-light gutter and the sidebar
+ * toggle button. Rendered inside the sidebar when open, and overlaid at the
+ * top-left of the agent-chat panel when the sidebar is collapsed, so the
+ * toggle button stays at the same screen position in both states.
+ *
+ * Vertical centering is done via flexbox against `TITLEBAR_HEIGHT`, which is
+ * the same constant that drives `trafficLightPosition.y` in the main process
+ * — so the toggle button and the macOS traffic lights cannot drift apart.
+ */
+export function SidebarTitlebarRow({
+  absolute = false,
+}: {
+  absolute?: boolean;
+}) {
+  return (
+    <div
+      style={{
+        height: TITLEBAR_HEIGHT,
+        // Sub-pixel nudge: flex-centering puts our icons' geometric center on
+        // the traffic-light center, but AA + icon-grid rounding makes them
+        // read as ~0.5px too high. A CSS transform is the only way to express
+        // a fractional offset — `marginTop` would round on non-Retina. Applied
+        // at the container so any future icons added to this row inherit the
+        // same optical alignment without per-icon tweaks.
+        transform: 'translateY(0.5px)',
+      }}
+      className={cn(
+        'flex shrink-0 items-center gap-1',
+        absolute && 'absolute inset-x-0 top-0 z-10',
+      )}
+    >
+      <TrafficLightGutter />
+      <SidebarToggleButton />
+      {/* Trailing drag region: fills the rest of the row so the area right
+          of the toggle button remains a window grab handle (matches the
+          pre-collapse sidebar behavior where the whole titlebar was
+          draggable). `shrink-0` + `flex-1` gives it all remaining width. */}
+      <div aria-hidden className="app-drag min-h-full flex-1" />
+    </div>
+  );
+}

--- a/apps/browser/src/ui/screens/main/_components/sidebar-toggle-button.tsx
+++ b/apps/browser/src/ui/screens/main/_components/sidebar-toggle-button.tsx
@@ -1,0 +1,43 @@
+import { HotkeyActions } from '@shared/hotkeys';
+import { TITLEBAR_ICON_OPTICAL_OFFSET } from '@shared/titlebar';
+import { Button } from '@stagewise/stage-ui/components/button';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@stagewise/stage-ui/components/tooltip';
+import { HotkeyComboText } from '@ui/components/hotkey-combo-text';
+import { useKartonState } from '@ui/hooks/use-karton';
+import { IconSidebarLeftOutline18 } from 'nucleo-ui-outline-18';
+import { useSidebarCollapsed } from './sidebar-collapsed-context';
+
+export function SidebarToggleButton() {
+  const { collapsed, toggle } = useSidebarCollapsed();
+  // The optical offset was tuned to align the icon's perceived center
+  // with the macOS traffic-light cluster. On Windows/Linux there are no
+  // traffic lights to align against, so we skip the nudge and let the
+  // icon sit on the flex-center of the titlebar row.
+  const isMacOs = useKartonState((s) => s.appInfo.platform === 'darwin');
+  const label = collapsed ? 'Show sidebar' : 'Hide sidebar';
+  return (
+    <Tooltip>
+      <TooltipTrigger>
+        <Button
+          variant="ghost"
+          size="icon-sm"
+          aria-label={label}
+          className="app-no-drag shrink-0"
+          style={
+            isMacOs ? { marginTop: TITLEBAR_ICON_OPTICAL_OFFSET } : undefined
+          }
+          onClick={toggle}
+        >
+          <IconSidebarLeftOutline18 className="size-4" />
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent side="bottom">
+        {label} (<HotkeyComboText action={HotkeyActions.TOGGLE_SIDEBAR} />)
+      </TooltipContent>
+    </Tooltip>
+  );
+}

--- a/apps/browser/src/ui/screens/main/_components/traffic-light-gutter.tsx
+++ b/apps/browser/src/ui/screens/main/_components/traffic-light-gutter.tsx
@@ -1,0 +1,22 @@
+import { TITLEBAR_HEIGHT, TRAFFIC_LIGHT_GUTTER_WIDTH } from '@shared/titlebar';
+import { useKartonState } from '@ui/hooks/use-karton';
+
+/**
+ * Reserves horizontal space for macOS traffic-light window controls (hidden
+ * titlebar). Used inside the sidebar titlebar row so the toggle button lands
+ * at the same x-position whether the sidebar is open or collapsed.
+ */
+export function TrafficLightGutter() {
+  const isMacOs = useKartonState((s) => s.appInfo.platform === 'darwin');
+  const isFullScreen = useKartonState((s) => s.appInfo.isFullScreen);
+  if (!isMacOs || isFullScreen) return null;
+  return (
+    <div
+      className="app-drag shrink-0"
+      style={{
+        height: TITLEBAR_HEIGHT,
+        width: TRAFFIC_LIGHT_GUTTER_WIDTH,
+      }}
+    />
+  );
+}

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/chat-history.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/chat-history.tsx
@@ -31,6 +31,19 @@ import { isEmptyAssistantMessage, areAllPartsSettled } from './message-utils';
 import { useOpenAgent } from '@ui/hooks/use-open-chat';
 import { calculateChatItemHeights } from '@ui/utils/calculate-chat-item-height';
 
+// Top inset reserved for titlebar-level chrome (sidebar toggle, future
+// top-right buttons). Sits as a sibling spacer ABOVE Virtuoso so items can
+// never scroll into it. Height matches the Tabs component (~32px) so the
+// chrome band feels consistent with other top-of-panel UI.
+const CHAT_TOP_INSET = 32;
+
+// Height of the soft fade at Virtuoso's top edge. Applied via mask-image
+// on the scroller itself so content visually dissolves before hitting the
+// clip line — no hard cut. The fade distance lerps with scrollTop so the
+// first message stays fully crisp at scrollTop=0 and only starts fading
+// once the user actually scrolls.
+const CHAT_FADE = 16;
+
 // Stable empty array to avoid infinite re-renders with useSyncExternalStore
 const EMPTY_HISTORY: AgentMessage[] = [];
 
@@ -144,6 +157,9 @@ export const ChatHistory = () => {
 
   // Track scroller element for spacerHeight calculation
   const [scroller, setScroller] = useState<HTMLElement | null>(null);
+  // Track scroll offset to drive the top fade overlay. We only need an
+  // approximate value (used to fade between 0 and 16px) so no throttling.
+  const [scrollTop, setScrollTop] = useState(0);
   const scrollerRef = useCallback(
     (element: HTMLElement | Window | null) => {
       // Chain to auto-scroll hook
@@ -205,6 +221,25 @@ export const ChatHistory = () => {
       await clearPendingOnboardingSuggestion();
     })();
   }, [pendingSuggestion, openAgent]);
+
+  // Scroll listener for the top fade overlay. Attached to the scroller
+  // element tracked above. `passive: true` because we never preventDefault.
+  // We clamp to CHAT_FADE because past that threshold the mask string is
+  // identical — bailing out here prevents a re-render on every scroll
+  // pixel once the user is more than CHAT_FADE px into the list.
+  useEffect(() => {
+    if (!scroller) return;
+    const onScroll = () => {
+      setScrollTop((prev) => {
+        const next = Math.min(CHAT_FADE, scroller.scrollTop);
+        return prev === next ? prev : next;
+      });
+    };
+    scroller.addEventListener('scroll', onScroll, { passive: true });
+    // Initialize with current offset so the overlay reflects state on mount.
+    setScrollTop(Math.min(CHAT_FADE, scroller.scrollTop));
+    return () => scroller.removeEventListener('scroll', onScroll);
+  }, [scroller]);
 
   // Track container height to set the spacer
   useEffect(() => {
@@ -1026,6 +1061,7 @@ export const ChatHistory = () => {
             className={cn(
               'pointer-events-auto block h-max min-h-[inherit] text-foreground text-sm focus-within:outline-none focus:outline-none',
             )}
+            style={{ paddingTop: CHAT_TOP_INSET }}
           >
             {EmptyPlaceholder()}
           </section>
@@ -1037,20 +1073,40 @@ export const ChatHistory = () => {
   return (
     <MountedPathsProvider value={resolvedMounts}>
       <AttachmentMetadataProvider messages={filteredMessages}>
-        <Virtuoso
-          initialTopMostItemIndex={Math.max(0, filteredMessages.length - 2)}
-          style={{ scrollbarGutter: 'stable' }}
-          key={openAgent ?? 'no-chat'}
-          data={filteredMessages}
-          className="scrollbar-hover-only virtuoso-contain -mr-[2px]"
-          scrollerRef={scrollerRef}
-          increaseViewportBy={{ top: 400, bottom: 400 }} // Render items above and below viewport
-          heightEstimates={estimatedHeights}
-          itemContent={itemContent}
-          followOutput={false} // We use our own auto-scroll logic
-          computeItemKey={(_, message) => message.id}
-          totalCount={filteredMessages.length}
-        />
+        <div className="relative flex h-full flex-col">
+          {/* Sibling spacer above Virtuoso. Reserves the chrome band so
+              items never paint into the titlebar area. Kept transparent —
+              the parent's bg-background shows through. */}
+          <div
+            aria-hidden
+            className="shrink-0"
+            style={{ height: CHAT_TOP_INSET }}
+          />
+          <Virtuoso
+            initialTopMostItemIndex={Math.max(0, filteredMessages.length - 2)}
+            style={{
+              scrollbarGutter: 'stable',
+              minHeight: 0,
+              flex: 1,
+              // Fade Virtuoso's own top edge. The fade distance grows with
+              // scrollTop (clamped to CHAT_FADE), so at scrollTop=0 the
+              // mask is identity (no fade on the first item) and scrolling
+              // smoothly reveals the fade without any hard cut.
+              maskImage: `linear-gradient(to bottom, transparent 0, black ${Math.min(CHAT_FADE, scrollTop)}px, black 100%)`,
+              WebkitMaskImage: `linear-gradient(to bottom, transparent 0, black ${Math.min(CHAT_FADE, scrollTop)}px, black 100%)`,
+            }}
+            key={openAgent ?? 'no-chat'}
+            data={filteredMessages}
+            className="scrollbar-hover-only virtuoso-contain -mr-[2px]"
+            scrollerRef={scrollerRef}
+            increaseViewportBy={{ top: 400, bottom: 400 }} // Render items above and below viewport
+            heightEstimates={estimatedHeights}
+            itemContent={itemContent}
+            followOutput={false} // We use our own auto-scroll logic
+            computeItemKey={(_, message) => message.id}
+            totalCount={filteredMessages.length}
+          />
+        </div>
       </AttachmentMetadataProvider>
     </MountedPathsProvider>
   );

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/index.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/index.tsx
@@ -36,7 +36,8 @@ export function ChatPanel() {
   );
 
   // Auto-selecting the first agent when openAgent is null is handled
-  // centrally by SidebarTopSection — no need to duplicate it here.
+  // centrally by `useAutoSelectFirstAgent` at the main layout root —
+  // no need to duplicate it here.
 
   // Track drag-over state for visual feedback
   const [isDragOver, setIsDragOver] = useState(false);

--- a/apps/browser/src/ui/screens/main/agent-chat/index.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/index.tsx
@@ -4,14 +4,17 @@ import {
   type ImperativePanelHandle,
 } from '@stagewise/stage-ui/components/resizable';
 import { useRef } from 'react';
-import { PendingRemovalsProvider } from '@ui/hooks/use-pending-agent-removals';
+import { TITLEBAR_HEIGHT } from '@shared/titlebar';
 import { useKartonState } from '@ui/hooks/use-karton';
+import { useSidebarCollapsed } from '../_components/sidebar-collapsed-context';
+import { SidebarTitlebarRow } from '../_components/sidebar-titlebar-row';
 
 export function AgentChat() {
   const panelRef = useRef<ImperativePanelHandle>(null);
   const previousSizeRef = useRef<number | null>(null);
 
   const isMacOS = useKartonState((s) => s.appInfo.platform === 'darwin');
+  const { collapsed } = useSidebarCollapsed();
 
   return (
     <ResizablePanel
@@ -26,15 +29,19 @@ export function AgentChat() {
         // Only store if size is greater than 0 (not collapsed) and we're not currently collapsing
         if (size > 0) previousSizeRef.current = size;
       }}
-      className="@container group overflow-visible! z-10 flex h-full flex-col items-stretch justify-between bg-background p-1"
+      className="@container group overflow-visible! relative z-10 flex h-full flex-col items-stretch justify-between bg-background"
     >
       {/* Add a small draggable area for macOS hidden-titlebar windows */}
       {isMacOS && (
-        <div className="-z-10 app-drag absolute top-0 left-0 h-8 w-full" />
+        <div
+          className="-z-10 app-drag absolute top-0 left-0 w-full"
+          style={{ height: TITLEBAR_HEIGHT }}
+        />
       )}
-      <PendingRemovalsProvider>
+      {collapsed && <SidebarTitlebarRow absolute />}
+      <div className="flex h-full flex-col items-stretch justify-between p-1">
         <Chat />
-      </PendingRemovalsProvider>
+      </div>
     </ResizablePanel>
   );
 }

--- a/apps/browser/src/ui/screens/main/content/_components/core-hotkey-bindings.tsx
+++ b/apps/browser/src/ui/screens/main/content/_components/core-hotkey-bindings.tsx
@@ -4,6 +4,7 @@ import { useKartonState, useKartonProcedure } from '@ui/hooks/use-karton';
 import { useCallback, useMemo } from 'react';
 import { useTabUIState } from '@ui/hooks/use-tab-ui-state';
 import { HOME_PAGE_URL } from '@shared/internal-urls';
+import { useSidebarCollapsed } from '../../_components/sidebar-collapsed-context';
 
 export function CoreHotkeyBindings({
   onCreateTab,
@@ -22,6 +23,7 @@ export function CoreHotkeyBindings({
   const togglePanelKeyboardFocus = useKartonProcedure(
     (p) => p.browser.layout.togglePanelKeyboardFocus,
   );
+  const { toggle: toggleSidebar } = useSidebarCollapsed();
   const tabIds = useMemo(() => Object.keys(tabs), [tabs]);
   const tabCount = useMemo(() => tabIds.length, [tabIds]);
 
@@ -221,6 +223,13 @@ export function CoreHotkeyBindings({
   }, [activeTabId, setZoomPercentage]);
 
   useHotKeyListener(handleResetZoom, HotkeyActions.ZOOM_RESET);
+
+  // SIDEBAR
+
+  // Toggle sidebar collapsed state (Mod+B).
+  useHotKeyListener(() => {
+    toggleSidebar();
+  }, HotkeyActions.TOGGLE_SIDEBAR);
 
   return null;
 }

--- a/apps/browser/src/ui/screens/main/index.tsx
+++ b/apps/browser/src/ui/screens/main/index.tsx
@@ -12,60 +12,81 @@ import { Sidebar } from './sidebar';
 import { useKartonState } from '@ui/hooks/use-karton';
 import { OpenAgentProvider } from '@ui/hooks/use-open-chat';
 import { ChatDraftProvider } from '@ui/hooks/use-chat-draft';
+import { PendingRemovalsProvider } from '@ui/hooks/use-pending-agent-removals';
+import { useAutoSelectFirstAgent } from '@ui/hooks/use-auto-select-agent';
+import {
+  SidebarCollapsedProvider,
+  useSidebarCollapsed,
+} from './_components/sidebar-collapsed-context';
 
 const rootLayoutStorageKey = 'stagewise-panel-layout-root';
 const layoutStorageKey = 'stagewise-panel-layout';
 
 export function DefaultLayout({ show }: { show: boolean }) {
-  const isMacOs = useKartonState((s) => s.appInfo.platform === 'darwin');
-  const isFullScreen = useKartonState((s) => s.appInfo.isFullScreen);
-
   return (
     <OpenAgentProvider>
       <ChatDraftProvider>
-        <div
+        <SidebarCollapsedProvider>
+          <PendingRemovalsProvider>
+            <DefaultLayoutInner show={show} />
+          </PendingRemovalsProvider>
+        </SidebarCollapsedProvider>
+      </ChatDraftProvider>
+    </OpenAgentProvider>
+  );
+}
+
+function DefaultLayoutInner({ show }: { show: boolean }) {
+  const isMacOs = useKartonState((s) => s.appInfo.platform === 'darwin');
+  const isFullScreen = useKartonState((s) => s.appInfo.isFullScreen);
+  const { collapsed } = useSidebarCollapsed();
+
+  // Headless: keeps `openAgent` valid regardless of whether the sidebar
+  // (which used to own this effect) is mounted.
+  useAutoSelectFirstAgent();
+
+  return (
+    <div
+      className={cn(
+        'root pointer-events-auto inset-0 flex size-full flex-row items-stretch justify-between transition-[opacity,filter] delay-150 duration-300 ease-out',
+        !show && 'pointer-events-none opacity-0 blur-lg',
+      )}
+    >
+      {/* Thin draggable strip at the very top for macOS hidden-titlebar windows */}
+      {isMacOs && !isFullScreen && (
+        <div className="app-drag fixed top-0 right-0 left-0 h-2" />
+      )}
+      <ResizablePanelGroup
+        direction="horizontal"
+        autoSaveId={rootLayoutStorageKey}
+        className="overflow-visible! h-full w-full"
+      >
+        <Sidebar />
+
+        {!collapsed && <ResizableHandle />}
+
+        <ResizablePanel
+          id="content-panel"
+          order={1}
+          defaultSize={65}
           className={cn(
-            'root pointer-events-auto inset-0 flex size-full flex-row items-stretch justify-between transition-[opacity,filter] delay-150 duration-300 ease-out',
-            !show && 'pointer-events-none opacity-0 blur-lg',
+            'h-full overflow-hidden rounded-l-xl ring-1 ring-derived-subtle',
+            !isMacOs && 'mt-px',
           )}
         >
-          {/* Thin draggable strip at the very top for macOS hidden-titlebar windows */}
-          {isMacOs && !isFullScreen && (
-            <div className="app-drag fixed top-0 right-0 left-0 h-2" />
-          )}
           <ResizablePanelGroup
             direction="horizontal"
-            autoSaveId={rootLayoutStorageKey}
-            className="overflow-visible! h-full w-full"
+            autoSaveId={layoutStorageKey}
+            className="h-full divide-x divide-surface-1"
           >
-            <Sidebar />
+            <AgentChat />
 
             <ResizableHandle />
 
-            <ResizablePanel
-              id="content-panel"
-              order={1}
-              defaultSize={65}
-              className={cn(
-                'h-full overflow-hidden rounded-l-xl ring-1 ring-derived-subtle',
-                !isMacOs && 'mt-px',
-              )}
-            >
-              <ResizablePanelGroup
-                direction="horizontal"
-                autoSaveId={layoutStorageKey}
-                className="h-full divide-x divide-surface-1"
-              >
-                <AgentChat />
-
-                <ResizableHandle />
-
-                <MainSection />
-              </ResizablePanelGroup>
-            </ResizablePanel>
+            <MainSection />
           </ResizablePanelGroup>
-        </div>
-      </ChatDraftProvider>
-    </OpenAgentProvider>
+        </ResizablePanel>
+      </ResizablePanelGroup>
+    </div>
   );
 }

--- a/apps/browser/src/ui/screens/main/sidebar/agents-list/_components/agents-selector.tsx
+++ b/apps/browser/src/ui/screens/main/sidebar/agents-list/_components/agents-selector.tsx
@@ -455,7 +455,7 @@ export function AgentsSelector() {
   const getAgentsHistoryList = useKartonProcedure(
     (p) => p.agents.getAgentsHistoryList,
   );
-  const [openAgent, setOpenAgent, removeFromHistory] = useOpenAgent();
+  const [openAgent, setOpenAgent] = useOpenAgent();
 
   // Narrow selector: only re-renders when the open agent's model changes.
   // Used by createAgentAndFocus (via ref) to seed the new chat with the same model.
@@ -580,24 +580,11 @@ export function AgentsSelector() {
     });
   }, [activeAgentIds]);
 
-  // If the open agent was removed, pop it from the history stack. The
-  // fallback parameter ensures that when the stack is empty, we jump
-  // straight to the first active agent in one render instead of going
-  // through null → pick.
-  // On initial load (openAgent === null), pick the first active agent.
-  useEffect(() => {
-    if (openAgent && !activeAgentIdSet.has(openAgent)) {
-      removeFromHistory(openAgent, activeAgentIds[0] ?? null);
-    } else if (!openAgent && activeAgentIds.length > 0) {
-      setOpenAgent(activeAgentIds[0]!);
-    }
-  }, [
-    openAgent,
-    activeAgentIdSet,
-    activeAgentIds,
-    removeFromHistory,
-    setOpenAgent,
-  ]);
+  // Auto-selection (picking the first active agent when `openAgent` is
+  // null, and popping evicted agents from the history stack) is now
+  // handled centrally by `useAutoSelectFirstAgent` at the main layout
+  // root, so it keeps working even when the sidebar is collapsed and
+  // this component is unmounted.
 
   // Mark the open agent as read when the user switches to it.
   useEffect(() => {

--- a/apps/browser/src/ui/screens/main/sidebar/index.tsx
+++ b/apps/browser/src/ui/screens/main/sidebar/index.tsx
@@ -2,7 +2,7 @@ import {
   ResizablePanel,
   type ImperativePanelHandle,
 } from '@stagewise/stage-ui/components/resizable';
-import { useRef, useCallback } from 'react';
+import { useRef, useCallback, useEffect } from 'react';
 import { Button } from '@stagewise/stage-ui/components/button';
 import {
   IconGear2Outline18,
@@ -17,17 +17,23 @@ import {
 import { SETTINGS_PAGE_URL, ACCOUNT_PAGE_URL } from '@shared/internal-urls';
 import { useTrack } from '@ui/hooks/use-track';
 import { useKartonProcedure, useKartonState } from '@ui/hooks/use-karton';
+import { TITLEBAR_HEIGHT } from '@shared/titlebar';
+import { SidebarTitlebarRow } from '../_components/sidebar-titlebar-row';
+import {
+  readInitialSidebarCollapsed,
+  useSidebarCollapsed,
+} from '../_components/sidebar-collapsed-context';
+
+// Read the persisted collapsed state *once* at module eval so we can seed
+// `defaultSize` on first render. Without this the panel mounts expanded
+// (`defaultSize={12}`) and then collapses via effect on the next frame,
+// producing a visible flash when the user last left the sidebar collapsed.
+const INITIAL_COLLAPSED = readInitialSidebarCollapsed();
+const DEFAULT_EXPANDED_SIZE = 12;
+
 function getPlanLabel(plan: string | undefined): string {
   if (!plan) return 'Free';
   return plan.charAt(0).toUpperCase() + plan.slice(1).toLowerCase();
-}
-
-/** Reserves space for macOS traffic-light window controls (hidden titlebar). */
-function MacOsTitlebarPlaceholder() {
-  const isMacOs = useKartonState((s) => s.appInfo.platform === 'darwin');
-  const isFullScreen = useKartonState((s) => s.appInfo.isFullScreen);
-  if (!isMacOs || isFullScreen) return null;
-  return <div className="app-drag h-8 w-full" />;
 }
 
 export function Sidebar() {
@@ -35,6 +41,8 @@ export function Sidebar() {
 
   const track = useTrack();
   const createTab = useKartonProcedure((p) => p.browser.createTab);
+
+  const { collapsed, setCollapsed } = useSidebarCollapsed();
 
   const userAccount = useKartonState((s) => s.userAccount);
 
@@ -55,73 +63,97 @@ export function Sidebar() {
     createTab(ACCOUNT_PAGE_URL, true);
   }, [createTab, track]);
 
+  // Sync context-driven collapse state to the imperative panel handle.
+  // Guards prevent infinite loops with onCollapse/onExpand callbacks.
+  useEffect(() => {
+    const panel = panelRef.current;
+    if (!panel) return;
+    const isPanelCollapsed = panel.isCollapsed();
+    if (collapsed && !isPanelCollapsed) {
+      panel.collapse();
+    } else if (!collapsed && isPanelCollapsed) {
+      panel.expand();
+    }
+  }, [collapsed]);
+
   return (
     <ResizablePanel
       ref={panelRef}
       id="new-sidebar-panel"
       order={0}
-      defaultSize={12}
-      minSize={12}
+      defaultSize={INITIAL_COLLAPSED ? 0 : DEFAULT_EXPANDED_SIZE}
+      minSize={DEFAULT_EXPANDED_SIZE}
       maxSize={50}
-      className="@container group overflow-visible! flex h-full min-w-44 max-w-2xl flex-col items-stretch p-2"
+      collapsible
+      collapsedSize={0}
+      onCollapse={() => setCollapsed(true)}
+      onExpand={() => setCollapsed(false)}
+      className="@container group overflow-visible! relative flex h-full min-w-44 max-w-2xl flex-col items-stretch data-[panel-size='0.0']:min-w-0"
     >
-      <MacOsTitlebarPlaceholder />
-      <AgentsList />
+      <SidebarTitlebarRow absolute />
+      {!collapsed && (
+        <div
+          className="flex h-full flex-col items-stretch p-2"
+          style={{ paddingTop: TITLEBAR_HEIGHT + 8 }}
+        >
+          <AgentsList />
 
-      {/* Bottom auth section */}
-      <div className="mt-8 flex flex-col gap-2">
-        <div className="flex flex-row items-center justify-between gap-2">
-          {isAuthenticated ? (
-            <button
-              type="button"
-              className="app-no-drag flex min-w-0 flex-1 flex-row items-center gap-2 rounded-lg px-1 py-1 hover:bg-foreground/8 active:bg-foreground/12"
-              onClick={handleOpenAccount}
-            >
-              {/* Avatar */}
-              <div className="flex size-8 shrink-0 items-center justify-center rounded-full bg-surface-3 font-medium text-foreground text-sm">
-                {avatarChar}
-              </div>
-              {/* Plan + email */}
-              <div className="flex w-full min-w-0 flex-col items-start gap-px overflow-hidden">
-                <span className="truncate font-medium text-foreground text-sm leading-tight">
-                  {getPlanLabel(plan)}
-                </span>
-                <span className="truncate text-muted-foreground text-xs leading-tight">
-                  {email ?? 'Unknown'}
-                </span>
-              </div>
-            </button>
-          ) : (
-            <button
-              type="button"
-              className="app-no-drag flex h-9 min-w-0 flex-1 flex-row items-center gap-2 rounded-lg px-1 py-1 hover:bg-foreground/8 active:bg-foreground/12"
-              onClick={handleOpenAccount}
-            >
-              <div className="flex min-w-0 flex-row items-center gap-2">
-                <IconOpenRectArrowInOutline18 className="size-5 text-foreground" />
-                <span className="font-medium text-foreground text-sm leading-tight">
-                  Not signed in
-                </span>
-              </div>
-            </button>
-          )}
+          {/* Bottom auth section */}
+          <div className="mt-8 flex flex-col gap-2">
+            <div className="flex flex-row items-center justify-between gap-2">
+              {isAuthenticated ? (
+                <button
+                  type="button"
+                  className="app-no-drag flex min-w-0 flex-1 flex-row items-center gap-2 rounded-lg px-1 py-1 hover:bg-foreground/8 active:bg-foreground/12"
+                  onClick={handleOpenAccount}
+                >
+                  {/* Avatar */}
+                  <div className="flex size-8 shrink-0 items-center justify-center rounded-full bg-surface-3 font-medium text-foreground text-sm">
+                    {avatarChar}
+                  </div>
+                  {/* Plan + email */}
+                  <div className="flex w-full min-w-0 flex-col items-start gap-px overflow-hidden">
+                    <span className="truncate font-medium text-foreground text-sm leading-tight">
+                      {getPlanLabel(plan)}
+                    </span>
+                    <span className="truncate text-muted-foreground text-xs leading-tight">
+                      {email ?? 'Unknown'}
+                    </span>
+                  </div>
+                </button>
+              ) : (
+                <button
+                  type="button"
+                  className="app-no-drag flex h-9 min-w-0 flex-1 flex-row items-center gap-2 rounded-lg px-1 py-1 hover:bg-foreground/8 active:bg-foreground/12"
+                  onClick={handleOpenAccount}
+                >
+                  <div className="flex min-w-0 flex-row items-center gap-2">
+                    <IconOpenRectArrowInOutline18 className="size-5 text-foreground" />
+                    <span className="font-medium text-foreground text-sm leading-tight">
+                      Not signed in
+                    </span>
+                  </div>
+                </button>
+              )}
 
-          <Tooltip>
-            <TooltipTrigger>
-              <Button
-                variant="ghost"
-                size="icon-sm"
-                aria-label="Settings"
-                className="app-no-drag shrink-0"
-                onClick={handleOpenSettings}
-              >
-                <IconGear2Outline18 className="size-4" />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent side="top">Settings</TooltipContent>
-          </Tooltip>
+              <Tooltip>
+                <TooltipTrigger>
+                  <Button
+                    variant="ghost"
+                    size="icon-sm"
+                    aria-label="Settings"
+                    className="app-no-drag shrink-0"
+                    onClick={handleOpenSettings}
+                  >
+                    <IconGear2Outline18 className="size-4" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent side="top">Settings</TooltipContent>
+              </Tooltip>
+            </div>
+          </div>
         </div>
-      </div>
+      )}
     </ResizablePanel>
   );
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a collapsible left sidebar with a persistent toggle (button + Mod+B). The toggle stays anchored to the titlebar (aligned with macOS traffic lights), and chat gets a reserved titlebar band with a soft top fade.

- **New Features**
  - Collapse/expand the sidebar; state persists in `localStorage` and loads on first paint (no flash).
  - Titlebar toggle button with tooltip; shown inside the sidebar or overlaid when collapsed so its position never moves.
  - Mod+B (`toggle_sidebar`) hotkey; respects rich‑text editors by letting native bold/italic/underline consume events.
  - Chat panel reserves a titlebar‑height band and adds a smooth top fade‑on‑scroll.

- **Bug Fixes**
  - Auto‑selects the first agent at the layout root so chat never gets stuck on “No agent selected” when the sidebar is collapsed or unmounted.
  - Fixed macOS titlebar alignment by sharing geometry via `@shared/titlebar` and reserving a traffic‑light gutter; keeps the toggle perfectly aligned and maintains drag regions.

<sup>Written for commit 32dbf4632381a9b79962761904ebb9797f6d4f3b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sidebar toggle UI with persistent collapsed state and keyboard shortcut (Mod+B)
  * Improved macOS titlebar/layout alignment and reserved space for window controls
  * Auto-select behavior centralized to ensure consistent agent selection

* **Bug Fixes**
  * Rich-text formatting shortcuts (bold/italic/underline) now respected in editable content
  * Chat history now has a top inset and a smooth scroll fade to prevent overlap with titlebar
<!-- end of auto-generated comment: release notes by coderabbit.ai -->