### PR TITLE
fix(stagewise): fix text-colors in browser downloads

### DIFF
--- a/apps/browser/src/pages/routes/_internal-app/downloads.tsx
+++ b/apps/browser/src/pages/routes/_internal-app/downloads.tsx
@@ -369,7 +369,7 @@ function RowComponent({
                 {row.filename}
               </span>
               {!row.fileExists && !row.isActive && (
-                <span className="text-destructive text-xs">(Deleted)</span>
+                <span className="text-muted-foreground text-xs">(Deleted)</span>
               )}
             </div>
             <div className="flex items-center gap-2 text-muted-foreground text-xs">
@@ -1030,7 +1030,7 @@ function Page() {
           ) : error ? (
             <div className="flex h-full flex-col items-center justify-center px-4">
               <div className="max-w-md space-y-2 text-center">
-                <p className="font-medium text-destructive text-sm">
+                <p className="font-medium text-error-foreground text-sm">
                   {error.message}
                 </p>
                 {import.meta.env.DEV && error.stack && (

--- a/apps/browser/src/pages/routes/_internal-app/history.tsx
+++ b/apps/browser/src/pages/routes/_internal-app/history.tsx
@@ -625,7 +625,7 @@ function Page() {
           ) : error ? (
             <div className="flex h-full flex-col items-center justify-center px-4">
               <div className="max-w-md space-y-2 text-center">
-                <p className="font-medium text-destructive text-sm">
+                <p className="font-medium text-error-foreground text-sm">
                   {error.message}
                 </p>
                 {import.meta.env.DEV && error.stack && (

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/footer-status-card/user-question-section.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/footer-status-card/user-question-section.tsx
@@ -425,9 +425,7 @@ function FieldRenderer({
         >
           <span className="font-medium text-foreground text-xs">
             <InlineMarkdown>{field.label}</InlineMarkdown>
-            {field.required && (
-              <span className="text-destructive-solid"> *</span>
-            )}
+            {field.required && <span className="text-error-solid"> *</span>}
           </span>
           {field.description && (
             <span className="text-2xs text-muted-foreground">
@@ -507,9 +505,7 @@ function FieldRenderer({
         >
           <span className="font-medium text-foreground text-xs">
             <InlineMarkdown>{field.label}</InlineMarkdown>
-            {field.required && (
-              <span className="text-destructive-solid"> *</span>
-            )}
+            {field.required && <span className="text-error-solid"> *</span>}
           </span>
           {field.description && (
             <span className="text-2xs text-muted-foreground">
@@ -643,9 +639,7 @@ function FieldRenderer({
         >
           <span className="font-medium text-foreground text-xs">
             <InlineMarkdown>{field.label}</InlineMarkdown>
-            {field.required && (
-              <span className="text-destructive-solid"> *</span>
-            )}
+            {field.required && <span className="text-error-solid"> *</span>}
           </span>
           {field.description && (
             <span className="text-2xs text-muted-foreground">


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns error and status text colors in the browser app with the design system for better contrast and consistency. Covers downloads, history error messages, and chat form required markers.

- **Bug Fixes**
  - Downloads: "(Deleted)" label uses `text-muted-foreground` instead of `text-destructive`.
  - Downloads/History: error messages use `text-error-foreground` instead of `text-destructive`.
  - Agent chat form: required asterisk uses `text-error-solid` instead of `text-destructive-solid`.

<sup>Written for commit 1f3d30feda44a43b4d2ba8635193fa15372833fe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated visual styling for error and deleted-file indicators: destructive red text replaced with muted/error-foreground styles for downloads and history messages.
  * Adjusted required-field asterisk styling in form fields to use the updated error-solid appearance for consistent form validation visuals.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stagewise-io/stagewise/pull/1068)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->