### PR TITLE
fix(stagewise): remove backdrop blur to prevent flickering during scroll

### DIFF
--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/chat-input.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/chat-input.tsx
@@ -806,7 +806,7 @@ export const ChatInputActions = memo(function ChatInputActions({
                 onClick={onStop}
                 aria-label="Stop agent"
                 variant="secondary"
-                className="group z-10 size-8 shrink-0 cursor-pointer rounded-full p-1 opacity-100! shadow-md backdrop-blur-lg"
+                className="group z-10 size-8 shrink-0 cursor-pointer rounded-full p-1 opacity-100! shadow-md"
               >
                 <SquareIcon className="size-3 fill-current" />
               </Button>
@@ -822,7 +822,7 @@ export const ChatInputActions = memo(function ChatInputActions({
                 onClick={onSubmit}
                 aria-label="Send message"
                 variant="primary"
-                className="z-10 size-8 shrink-0 cursor-pointer rounded-full p-1 shadow-md backdrop-blur-lg transition-all disabled:opacity-50"
+                className="z-10 size-8 shrink-0 cursor-pointer rounded-full p-1 shadow-md transition-all disabled:opacity-50"
               >
                 <ArrowUpIcon className="size-4 stroke-3" />
               </Button>

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/footer-status-card/shared.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/footer-status-card/shared.tsx
@@ -141,7 +141,7 @@ export function StatusCardComponent({
     <div
       ref={ref}
       data-status-card
-      className="-z-10 absolute right-2 bottom-[calc(100%+1px)] left-2 flex flex-col items-center justify-between rounded-t-lg border-derived border-t border-r border-l bg-background p-1 backdrop-blur-lg"
+      className="-z-10 absolute right-2 bottom-[calc(100%+1px)] left-2 flex flex-col items-center justify-between rounded-t-lg border-derived border-t border-r border-l bg-background p-1"
     >
       {items.map((item, index) => (
         <StatusCardSectionComponent


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed backdrop blur from chat input actions and the status card to stop flickering during scroll. This reduces repaints and stabilizes the UI while scrolling.

- **Bug Fixes**
  - Dropped `backdrop-blur-lg` from Stop/Send buttons in `chat-input.tsx`.
  - Dropped `backdrop-blur-lg` from the status card container in `footer-status-card/shared.tsx`.

<sup>Written for commit 1f12af0d71e4220737ea1611413bde510f1439d0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Removed backdrop blur visual effects from interface elements to create a cleaner, more refined appearance across the application. This styling update improves visual clarity and design consistency while maintaining all existing functionality and interactive behavior. The refinement provides a crisper, more polished interface that enhances the overall user experience.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stagewise-io/stagewise/pull/1072)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->