### PR TITLE
fix(stagewise): save and send missing reasoning signatures

### DIFF
--- a/apps/browser/src/backend/agents/shared/base-agent/base-agent.ts
+++ b/apps/browser/src/backend/agents/shared/base-agent/base-agent.ts
@@ -59,6 +59,7 @@ import { deriveMaxReadChars } from './file-read-transformer/format-utils';
 import { clearPendingApproval } from './pending-approvals-cleanup';
 import type { StagewiseToolSet } from '@shared/karton-contracts/ui/agent/tools/types';
 import { stripStrictFromToolSet } from './strip-strict-from-tools';
+import type { StagewiseProviderMetadata } from '../../stagewise-provider';
 import type { AgentToolUIPart } from '@shared/karton-contracts/ui/agent';
 import { AgentsMap } from '../../agents-map';
 
@@ -1464,12 +1465,7 @@ export abstract class BaseAgent<
       this.state.set((draft) => {
         draft.title = newTitle;
       });
-      // Persist immediately — the fire-and-forget updateTitle call races
-      // with the step's saveState at the tail of runStep, and if the LLM
-      // title generation hasn't returned by then, the old title gets
-      // written. Explicit saveState here ensures the auto-title lands in
-      // the DB regardless of timing.
-      await this.saveState();
+      // We don't do persistence here, since that happens after a step is finished
     } catch (e) {
       const error = e as Error;
       this.logger.error(
@@ -1493,6 +1489,12 @@ export abstract class BaseAgent<
     // Reset continuation flag at the start of every step so a leftover
     // value from a prior aborted step cannot leak into the tail.
     this._pendingContinue = null;
+
+    // Holds the `onFinish` result for use in the tail AFTER the UI
+    // stream has drained. Used to populate reasoning_details onto the
+    // assistant message at a point where it is guaranteed to exist in
+    // `state.history` — see the tail block below for the race rationale.
+    let finishedResult: StepResult<StagewiseToolSet> | null = null;
 
     let queueFlushIndex = -1;
     this.state.set((draft) => {
@@ -1616,6 +1618,13 @@ export abstract class BaseAgent<
       onFinish: async (result) => {
         // Guard: ignore if a newer step has started (e.g. queue flush)
         if (this._stepGeneration !== stepGen) return;
+
+        // Capture the result for the runStep tail. We do NOT extract
+        // reasoning_details here because onFinish fires before the UI
+        // stream has drained, and the assistant message may not yet be
+        // in `state.history`. The tail applies it safely after
+        // Promise.all resolves. See populateReasoningDetailsOnAssistantMessage.
+        finishedResult = result;
 
         // Log step completion details
         this.logger.debug(
@@ -1793,6 +1802,26 @@ export abstract class BaseAgent<
         ),
         stream.consumeStream(),
       ]);
+
+      // ─── Populate reasoning_details on the assistant message ───────
+      // MUST run AFTER Promise.all resolves for the same reason as
+      // populatePathReferences below: onFinish fires before the UI
+      // stream has drained, and handleUiStream() is the only code path
+      // that pushes the assistant message into state.history. Running
+      // this inside the callback would silently drop signatures for
+      // short steps / slow consumers, which would regress the B2 fix
+      // and re-introduce Bedrock "thinking blocks cannot be modified"
+      // rejections on the next turn. See
+      // populateReasoningDetailsOnAssistantMessage for details.
+      if (finishedResult && this._stepGeneration === stepGen) {
+        try {
+          this.populateReasoningDetailsOnAssistantMessage(finishedResult);
+        } catch (err) {
+          this.logger.debug(
+            `[BaseAgent:${this.instanceId}] Failed to populate reasoningDetails: ${this.formatError(err as Error)}`,
+          );
+        }
+      }
 
       // ─── Populate pathReferences on the assistant message ───────────
       // MUST run AFTER Promise.all resolves so the UI stream has fully
@@ -2472,6 +2501,59 @@ export abstract class BaseAgent<
         };
       });
     }
+  }
+
+  /**
+   * Persist the provider's signed `reasoning_details` array into the
+   * last assistant message's metadata so it can be re-injected on
+   * subsequent requests.
+   *
+   * Context: OpenRouter / Bedrock-hosted Claude refuses to extend a
+   * thinking process when the conversation carries unsigned reasoning
+   * blocks. We capture the per-step signatures here (extracted by the
+   * stagewise metadata extractor under
+   * `providerMetadata.openaiCompatible.reasoningDetails`) and later
+   * spread them back onto the outbound assistant message via
+   * `providerOptions.openaiCompatible.reasoning_details`.
+   *
+   * Multi-step continuations append to the existing array so the full
+   * thinking history stays intact across tool-call rounds.
+   *
+   * Must be called AFTER `handleUiStream` has drained. `handleUiStream`
+   * is the only site that pushes the assistant message into
+   * `state.history` (see `draft.history.push(uiMessage)` in the UI
+   * stream loop), and it runs concurrently with `onFinish`. Invoking
+   * this function from inside `onFinish`/`onStepFinish` therefore
+   * races with the history push and can silently no-op (the early
+   * return below triggers, no signatures are persisted, and the next
+   * turn ships unsigned `reasoning_content` to Bedrock → rejection).
+   * The safe site is the `runStep` tail after
+   * `Promise.all([handleUiStream, consumeStream])` resolves.
+   */
+  private populateReasoningDetailsOnAssistantMessage(
+    step: StepResult<StagewiseToolSet>,
+  ): void {
+    const meta = step.providerMetadata as StagewiseProviderMetadata | undefined;
+    const details = meta?.openaiCompatible?.reasoningDetails;
+    if (!Array.isArray(details) || details.length === 0) return;
+
+    const targetIdx = this.state.get().history.length - 1;
+    const lastMsg = this.state.get().history[targetIdx];
+    if (!lastMsg || lastMsg.role !== 'assistant') return;
+
+    this.state.set((draft) => {
+      const target = draft.history[targetIdx];
+      if (!target || target.role !== 'assistant') return;
+      target.metadata ??= {
+        createdAt: new Date(),
+        partsMetadata: [],
+      };
+      const existing = target.metadata.reasoningDetails ?? [];
+      target.metadata.reasoningDetails = [
+        ...existing,
+        ...(details as Record<string, unknown>[]),
+      ];
+    });
   }
 
   /**

--- a/apps/browser/src/backend/agents/shared/base-agent/utils.ts
+++ b/apps/browser/src/backend/agents/shared/base-agent/utils.ts
@@ -736,52 +736,221 @@ function buildCompressedHistoryPart(
  * Convert an assistant UI message into model messages.
  * Returns only the assistant-role message(s). Sandbox file attachments
  * are handled by the main loop alongside env-changes.
+ *
+ * Also round-trips signed `reasoning_details` through the outbound
+ * `providerOptions.openaiCompatible.reasoning_details` hook that the
+ * SDK spreads onto the OpenAI-compatible request body. Without this,
+ * Bedrock-hosted Claude silently refuses to extend the thinking
+ * process because the history carries unsigned `reasoning_content`
+ * strings. See `plans/rehydrate-reasoning-signatures-openrouter.md`.
  */
 async function convertAssistantMessage(
   message: AgentMessage,
   tools: ToolSet,
 ): Promise<ModelMessage[]> {
+  const signedDetails = message.metadata?.reasoningDetails ?? [];
+  const hasSignatures = signedDetails.length > 0;
+
   const cleanedMessage = {
     ...message,
-    parts: message.parts.map((part) => {
-      const isToolPart =
-        part.type.startsWith('tool-') || part.type === 'dynamic-tool';
-      if (!isToolPart) return part;
+    parts: message.parts
+      // Drop `reasoning` UI parts from the outbound conversion ONLY
+      // when we have signed `reasoning_details` to replace them with
+      // (the stagewise / OpenRouter path).
+      //
+      // Rationale: for the openai-compatible SDK path,
+      // `convertToOpenAICompatibleChatMessages` concatenates reasoning
+      // parts into a top-level `reasoning_content` string. That string
+      // is UI-derived and not byte-identical to what the provider
+      // originally signed. Shipping it alongside our signed
+      // `reasoning_details` array causes Anthropic/Bedrock to reject
+      // the turn with `thinking blocks ... cannot be modified`.
+      //
+      // When signatures ARE present, we rely purely on
+      // `providerOptions.openaiCompatible.reasoning_details` (attached
+      // below) to round-trip signed reasoning. OpenRouter reconstructs
+      // Anthropic `thinking` / Gemini `thought` blocks from that
+      // structured array.
+      //
+      // When signatures are NOT present we leave reasoning parts
+      // alone. This matters for BYOK with native SDKs
+      // (@ai-sdk/anthropic, @ai-sdk/google) which consume reasoning
+      // parts via their own signature mechanism
+      // (`providerMetadata.anthropic.signature`,
+      // `providerMetadata.google.thoughtSignature`) and would
+      // otherwise lose cross-turn chain-of-thought. It also preserves
+      // pre-fix stagewise messages' reasoning text in outbound history
+      // — no worse than before.
+      //
+      // UI visibility is unaffected — this filter only touches the
+      // throwaway copy used for model conversion; persisted UI parts
+      // still carry reasoning for transcript display.
+      .filter((part) => !(hasSignatures && part.type === 'reasoning'))
+      .map((part) => {
+        const isToolPart =
+          part.type.startsWith('tool-') || part.type === 'dynamic-tool';
+        if (!isToolPart) return part;
 
-      let cleaned = { ...part };
+        let cleaned = { ...part };
 
-      // Sanitize tool input: providers reject non-object input in
-      // tool-call content blocks (e.g. raw strings from failed
-      // repair). Replace with empty object so the conversation
-      // stays recoverable — the tool result/error already carries
-      // enough context for the LLM.
-      if (
-        'input' in cleaned &&
-        (typeof cleaned.input !== 'object' ||
-          cleaned.input === null ||
-          Array.isArray(cleaned.input))
-      )
-        cleaned = { ...cleaned, input: {} } as typeof cleaned;
+        // Sanitize tool input: providers reject non-object input in
+        // tool-call content blocks (e.g. raw strings from failed
+        // repair). Replace with empty object so the conversation
+        // stays recoverable — the tool result/error already carries
+        // enough context for the LLM.
+        if (
+          'input' in cleaned &&
+          (typeof cleaned.input !== 'object' ||
+            cleaned.input === null ||
+            Array.isArray(cleaned.input))
+        )
+          cleaned = { ...cleaned, input: {} } as typeof cleaned;
 
-      // Strip internal underscore properties from tool output.
-      if (
-        'output' in cleaned &&
-        cleaned.output &&
-        typeof cleaned.output === 'object'
-      ) {
-        cleaned = {
-          ...cleaned,
-          output: stripUnderscoreProperties(
-            cleaned.output as Record<string, unknown>,
-          ),
-        } as typeof cleaned;
-      }
+        // Strip internal underscore properties from tool output.
+        if (
+          'output' in cleaned &&
+          cleaned.output &&
+          typeof cleaned.output === 'object'
+        ) {
+          cleaned = {
+            ...cleaned,
+            output: stripUnderscoreProperties(
+              cleaned.output as Record<string, unknown>,
+            ),
+          } as typeof cleaned;
+        }
 
-      return cleaned;
-    }),
+        return cleaned;
+      }),
   };
 
-  return convertToModelMessages([cleanedMessage], { tools });
+  const modelMessages = await convertToModelMessages([cleanedMessage], {
+    tools,
+  });
+
+  // ── Distribute signed reasoning_details per step ─────────────────
+  //
+  // `convertToModelMessages` splits a multi-step assistant UI message
+  // into one assistant ModelMessage per `step-start` boundary (see
+  // `ai/dist/index.js` — `processBlock` flush at each step-start).
+  // Each step originally carried its own thinking block(s); we must
+  // attach each step's reasoning_details to the ModelMessage that
+  // represents that step, not dump them all onto the first one.
+  //
+  // Putting every signature on the first assistant ModelMessage makes
+  // OpenRouter reconstruct `[thinking_A, thinking_B, text, tool_use]`
+  // for step 1 while step 2 is sent without any thinking block.
+  // Anthropic's validator then rejects the turn with:
+  //   `thinking blocks in the latest assistant message cannot be
+  //    modified. These blocks must remain as they were in the
+  //    original response.`
+  //
+  // The UI parts and the accumulated `reasoningDetails` array are both
+  // ordered by (step, position-in-step), so counting reasoning parts
+  // per step block and slicing the details array the same way keeps
+  // them aligned.
+  if (hasSignatures) {
+    const reasoningCountsPerStep = countReasoningPartsPerStep(message.parts);
+    const totalReasoningParts = reasoningCountsPerStep.reduce(
+      (a, b) => a + b,
+      0,
+    );
+
+    // Slice `signedDetails` into per-step chunks. Only when the UI
+    // reasoning-part count matches the captured-details count (the
+    // normal, post-fix case) do we trust the segmentation. Otherwise
+    // fall back to attaching the whole array to the first assistant
+    // ModelMessage — which is wrong for multi-step turns but preserves
+    // the pre-existing behaviour and is safer than shuffling unsigned
+    // content across steps.
+    const detailsPerStep: Record<string, unknown>[][] = [];
+    if (
+      totalReasoningParts === signedDetails.length &&
+      reasoningCountsPerStep.length > 0
+    ) {
+      let cursor = 0;
+      for (const count of reasoningCountsPerStep) {
+        detailsPerStep.push(signedDetails.slice(cursor, cursor + count));
+        cursor += count;
+      }
+    }
+
+    let stepIdx = 0;
+    let usedFallback = detailsPerStep.length === 0;
+    for (const modelMessage of modelMessages) {
+      if (modelMessage.role !== 'assistant') continue;
+
+      let stepDetails: Record<string, unknown>[];
+      if (usedFallback) {
+        // Legacy behaviour: everything on the first assistant message.
+        stepDetails = signedDetails;
+        usedFallback = false;
+      } else {
+        stepDetails = detailsPerStep[stepIdx] ?? [];
+        stepIdx++;
+      }
+
+      if (stepDetails.length === 0) continue;
+
+      // `providerOptions` is typed as `JSONValue`, but the SDK reads
+      // `message.providerOptions.openaiCompatible` verbatim and spreads
+      // it onto the outbound assistant message body. `reasoning_details`
+      // entries are provider-shaped records and are JSON-serialisable
+      // at runtime; the cast is needed because TS's `JSONObject` forbids
+      // `unknown` values even though the wire format is plain JSON.
+      const prior = (modelMessage.providerOptions ?? {}) as Record<
+        string,
+        Record<string, unknown>
+      >;
+      const priorOC = (prior.openaiCompatible ?? {}) as Record<string, unknown>;
+      modelMessage.providerOptions = {
+        ...prior,
+        openaiCompatible: {
+          ...priorOC,
+          reasoning_details: stepDetails,
+        },
+      } as unknown as typeof modelMessage.providerOptions;
+    }
+  }
+
+  return modelMessages;
+}
+
+/**
+ * Count how many `reasoning` UI parts fall inside each step block of
+ * an assistant UI message. A step block is delimited by `step-start`
+ * parts (matching the segmentation that `convertToModelMessages`
+ * performs in its `processBlock` loop).
+ *
+ * Examples:
+ *   `[step-start, reasoning, text, tool, step-start, reasoning, tool]`
+ *   → `[1, 1]` (one reasoning in each of the two step blocks)
+ *
+ *   `[text, tool]` (no step-start at all)
+ *   → `[0]` (single implicit block with no reasoning)
+ *
+ *   `[step-start, tool]` (step with no reasoning)
+ *   → `[0]`
+ */
+function countReasoningPartsPerStep(parts: AgentMessage['parts']): number[] {
+  const counts: number[] = [];
+  let current = 0;
+  let inStep = false;
+  for (const part of parts) {
+    if (part.type === 'step-start') {
+      if (inStep) counts.push(current);
+      current = 0;
+      inStep = true;
+    } else if (part.type === 'reasoning') {
+      current++;
+    }
+  }
+  if (inStep) counts.push(current);
+  // If the message had no step-start at all (unlikely but possible for
+  // legacy / synthetic messages), return a single implicit block so the
+  // caller still has one bucket to attach details to.
+  if (counts.length === 0) counts.push(current);
+  return counts;
 }
 
 /**

--- a/apps/browser/src/backend/agents/stagewise-provider.ts
+++ b/apps/browser/src/backend/agents/stagewise-provider.ts
@@ -21,55 +21,204 @@ function createClientFetch(): typeof globalThis.fetch {
 }
 
 /**
- * Metadata extractor that captures the full response body as provider
- * metadata, preserving all keys from the API response as-is.
+ * One reasoning-details entry as emitted by OpenRouter.
+ * The exact field set is provider-defined — we keep the shape loose so
+ * unknown keys are preserved verbatim for forward compatibility
+ * (new Anthropic/Google fields, etc.).
+ *
+ * Common fields we round-trip today:
+ *  - Anthropic: `{ type: 'reasoning.text', text, signature }`
+ *  - Google:    `{ type: 'reasoning.text' | 'reasoning.encrypted',
+ *                  text?, format?, thought_signature? }`
+ */
+export type StagewiseReasoningDetail = Record<string, unknown>;
+
+/**
+ * Typed shape of the `providerMetadata` the stagewise extractor emits.
+ * Kept in sync with what `base-agent` consumes in
+ * `populateReasoningDetailsOnAssistantMessage`.
+ */
+export type StagewiseProviderMetadata = {
+  openaiCompatible?: {
+    reasoningDetails?: StagewiseReasoningDetail[];
+  };
+  stagewise?: Record<string, unknown>;
+};
+
+type RecordOrUndefined = Record<string, unknown> | undefined;
+
+/**
+ * Merge a single incoming reasoning-details chunk into the accumulated
+ * entry at the same index.
+ *
+ *  - `text` is concatenated (streaming deltas arrive split into chunks).
+ *  - Every other field (`type`, `signature`, `thought_signature`,
+ *    `format`, and any unknown keys) is overwritten with the incoming
+ *    value if it is non-null/non-undefined; otherwise the existing value
+ *    is kept. This matches how OR streams the fields: the signature
+ *    arrives once on a terminal chunk while earlier chunks carry only
+ *    text deltas.
+ *
+ * Exported so it can be unit-tested independently of the streaming
+ * extractor and re-used elsewhere if needed.
+ */
+export function mergeReasoningDetailChunk(
+  acc: StagewiseReasoningDetail | undefined,
+  incoming: Record<string, unknown>,
+): StagewiseReasoningDetail {
+  const base: StagewiseReasoningDetail = { ...(acc ?? {}) };
+  for (const [key, value] of Object.entries(incoming)) {
+    if (key === 'index') continue;
+    if (key === 'text') {
+      if (typeof value === 'string' && value.length > 0) {
+        const prev = typeof base.text === 'string' ? base.text : '';
+        base.text = prev + value;
+      }
+      continue;
+    }
+    if (value != null) {
+      base[key] = value;
+    }
+  }
+  return base;
+}
+
+/**
+ * Read reasoning_details array from a non-streaming response message.
+ * Tolerant of the field being absent or a non-array value.
+ */
+function extractReasoningDetailsFromMessage(
+  message: RecordOrUndefined,
+): StagewiseReasoningDetail[] | undefined {
+  const details = message?.reasoning_details;
+  if (!Array.isArray(details) || details.length === 0) return undefined;
+  return details.filter(
+    (entry): entry is StagewiseReasoningDetail =>
+      entry != null && typeof entry === 'object' && !Array.isArray(entry),
+  );
+}
+
+/**
+ * Metadata extractor for the stagewise / OpenRouter gateway.
+ *
+ * Captures two things:
+ *
+ *  1. `openaiCompatible.reasoningDetails` — the provider-signed
+ *     reasoning details array OR returns on the response. Required for
+ *     Anthropic (Bedrock) and Google models to validate chain-of-thought
+ *     signatures on subsequent turns. The SDK does not map this field
+ *     natively (see vercel/ai#11342), so we capture it here and
+ *     `base-agent` re-injects it via `providerOptions.openaiCompatible`
+ *     on each outgoing assistant message.
+ *
+ *  2. `stagewise` — any `provider_metadata` riding on the response
+ *     message/delta. Preserved as-is for existing usage-limit/plan
+ *     metadata flows that read from this key.
  */
 const stagewiseMetadataExtractor: MetadataExtractor = {
   extractMetadata: async ({ parsedBody }) => {
-    const body = parsedBody as Record<string, unknown> | undefined;
+    const body = parsedBody as RecordOrUndefined;
     const choices = body?.choices as unknown[] | undefined;
-    const message = (choices?.[0] as Record<string, unknown>)?.message as
+    const firstChoice = choices?.[0] as RecordOrUndefined;
+    const message = firstChoice?.message as RecordOrUndefined;
+
+    const out: SharedV3ProviderMetadata = {};
+
+    const reasoningDetails = extractReasoningDetailsFromMessage(message);
+    if (reasoningDetails && reasoningDetails.length > 0) {
+      out.openaiCompatible = {
+        reasoningDetails: reasoningDetails as unknown as JSONObject[],
+      } as JSONObject;
+    }
+
+    // Spread `provider_metadata` keys at the root — the gateway already
+    // emits `{ stagewise: {...} }` (and potentially other provider keys),
+    // so the SharedV3ProviderMetadata shape is identical to what the
+    // server sends. The streaming path does the same; any asymmetry
+    // between the two would quietly break consumers that read
+    // `providerMetadata.stagewise.<...>` on non-streaming responses.
+    const stagewisePassthrough = message?.provider_metadata as
       | Record<string, unknown>
       | undefined;
-    const providerMetadata = message?.provider_metadata as
-      | SharedV3ProviderMetadata
-      | undefined;
-    return providerMetadata;
+    if (stagewisePassthrough != null) {
+      for (const [key, value] of Object.entries(stagewisePassthrough)) {
+        if (value != null) out[key] = value as JSONObject;
+      }
+    }
+
+    return Object.keys(out).length > 0 ? out : undefined;
   },
   createStreamExtractor: () => {
-    const accumulated: SharedV3ProviderMetadata = {};
+    const byIndex = new Map<number, StagewiseReasoningDetail>();
+    const stagewisePassthrough: SharedV3ProviderMetadata = {};
+
     return {
       processChunk(parsedChunk: unknown) {
-        const chunk = parsedChunk as Record<string, unknown> | undefined;
+        const chunk = parsedChunk as RecordOrUndefined;
         const choices = chunk?.choices as unknown[] | undefined;
-        const delta = (choices?.[0] as Record<string, unknown>)?.delta as
+        const firstChoice = choices?.[0] as RecordOrUndefined;
+        const delta = firstChoice?.delta as RecordOrUndefined;
+        if (!delta) return;
+
+        // ── 1. reasoning_details[] accumulation ───────────────────────
+        const reasoningDetails = delta.reasoning_details as
+          | unknown[]
+          | undefined;
+        if (Array.isArray(reasoningDetails)) {
+          for (const entry of reasoningDetails) {
+            if (entry == null || typeof entry !== 'object') continue;
+            const record = entry as Record<string, unknown>;
+            const idx = record.index;
+            if (typeof idx !== 'number') continue;
+            byIndex.set(
+              idx,
+              mergeReasoningDetailChunk(byIndex.get(idx), record),
+            );
+          }
+        }
+
+        // ── 2. `stagewise` passthrough (deep-merged) ──────────────────
+        const chunkStagewise = delta.provider_metadata as
           | Record<string, unknown>
           | undefined;
-        const chunkProviderMetadata = delta?.provider_metadata as
-          | SharedV3ProviderMetadata
-          | undefined;
-
-        if (!chunkProviderMetadata) return;
-
-        for (const [key, value] of Object.entries(chunkProviderMetadata)) {
-          const currentValue = accumulated[key];
-          if (
-            value != null &&
-            typeof value === 'object' &&
-            typeof currentValue === 'object'
-          ) {
-            accumulated[key] = deepMergeProviderOptions(
-              currentValue as JSONObject,
-              value as JSONObject,
-            ) as JSONObject;
-          } else if (value != null) {
-            accumulated[key] = value;
-          } else if (value == null) {
-            delete accumulated[key];
+        if (chunkStagewise) {
+          for (const [key, value] of Object.entries(chunkStagewise)) {
+            const current = stagewisePassthrough[key];
+            if (
+              value != null &&
+              typeof value === 'object' &&
+              typeof current === 'object'
+            ) {
+              stagewisePassthrough[key] = deepMergeProviderOptions(
+                current as JSONObject,
+                value as JSONObject,
+              ) as JSONObject;
+            } else if (value != null) {
+              stagewisePassthrough[key] = value as JSONObject;
+            } else if (value == null) {
+              delete stagewisePassthrough[key];
+            }
           }
         }
       },
-      buildMetadata: () => accumulated,
+      buildMetadata: () => {
+        const out: SharedV3ProviderMetadata = {};
+
+        if (byIndex.size > 0) {
+          const sorted = [...byIndex.entries()]
+            .sort((a, b) => a[0] - b[0])
+            .map(([, value]) => value);
+          out.openaiCompatible = {
+            reasoningDetails: sorted as unknown as JSONObject[],
+          } as JSONObject;
+        }
+
+        for (const [key, value] of Object.entries(stagewisePassthrough)) {
+          out[key] = value;
+        }
+
+        return out;
+      },
     };
   },
 };
@@ -86,9 +235,10 @@ export type StagewiseProviderSettings = {
  * Provider options are forwarded under the `stagewise` key and
  * response metadata is extracted under the same key.
  *
- * Message-level metadata (e.g. `cache_control`) is forwarded via the
- * built-in `openaiCompatible` providerOptions key which the SDK
- * spreads directly onto each message in the request body.
+ * Message-level metadata (e.g. `cache_control`, signed
+ * `reasoning_details`) is forwarded via the built-in
+ * `openaiCompatible` providerOptions key which the SDK spreads
+ * directly onto each message in the request body.
  */
 export function createStagewise(
   settings: StagewiseProviderSettings,

--- a/apps/browser/src/shared/karton-contracts/ui/agent/metadata.ts
+++ b/apps/browser/src/shared/karton-contracts/ui/agent/metadata.ts
@@ -340,6 +340,22 @@ const metadataSchema = z.object({
    * once across the conversation unless the hash changes.
    */
   pathReferences: z.record(z.string(), z.string()).optional(),
+  /**
+   * Signed `reasoning_details` captured from the provider response.
+   * Re-injected into outbound assistant messages on subsequent requests
+   * so providers (Anthropic via Bedrock/OpenRouter, Google) can verify
+   * chain-of-thought signatures and keep extending the thinking process.
+   *
+   * Shape is provider-defined (`reasoning.text`, `reasoning.encrypted`,
+   * `reasoning.summary`, etc., each carrying `signature` /
+   * `thought_signature` / `format`). We store entries verbatim so
+   * forward-compat is preserved — do NOT tighten this schema.
+   *
+   * Populated by `populateReasoningDetailsOnAssistantMessage` at step end.
+   * Consumed by `convertAssistantMessage` when building ModelMessages
+   * (attached under `providerOptions.openaiCompatible.reasoning_details`).
+   */
+  reasoningDetails: z.array(z.record(z.string(), z.unknown())).optional(),
 });
 
 export type UserMessageMetadata = z.infer<typeof metadataSchema>;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist and round‑trip provider‑signed `reasoning_details` so Anthropic (Bedrock/OpenRouter) and Google models keep the thinking process across steps without rejections. We save per‑step signatures after the UI stream drains and reattach them to the exact assistant step on subsequent requests.

- **Bug Fixes**
  - Stagewise extractor records `reasoning_details` from streaming and non‑streaming responses, merges deltas by index, and exposes them under `providerMetadata.openaiCompatible.reasoningDetails` while preserving `stagewise` passthrough.
  - `BaseAgent` persists signed details onto the last assistant message in the `runStep` tail (after the UI stream drains) to avoid races; appends across multi‑step turns; metadata schema adds `metadata.reasoningDetails`.
  - Model conversion attaches per‑step signatures to the matching assistant model message via `providerOptions.openaiCompatible.reasoning_details`, aligning by step boundaries and falling back safely when counts don’t match.
  - Outbound conversion filters `reasoning` UI parts only when signatures are present to prevent unsigned `reasoning_content` mismatches; leaves them when signatures are absent.

<sup>Written for commit 762f151668c9868c781408b4bde80630222bd736. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Persist signed LLM reasoning details across multi-step agent conversations so assistant messages retain per-step reasoning.
  * Carry signed reasoning details through outbound model requests while excluding unsigned UI reasoning content.
  * Add streaming-aware stagewise reasoning metadata with merging so streamed reasoning chunks accumulate reliably and round-trip via a model-compatible metadata shape.
* **Documentation**
  * Message metadata schema extended to include optional per-message reasoningDetails.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stagewise-io/stagewise/pull/1083)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->