### PR TITLE
feat(stagewise): carry tool-approval-mode to new agents

### DIFF
--- a/apps/browser/src/backend/services/agent-manager/agent-manager.ts
+++ b/apps/browser/src/backend/services/agent-manager/agent-manager.ts
@@ -638,11 +638,27 @@ export class AgentManagerService extends DisposableService {
   > {
     const agentInstanceId = instanceId ?? randomUUID();
 
-    // For new chat agents (not resumed), use the model from the last persisted chat
-    // Validate the model still exists (it may have been a deleted custom model)
-    const lastChatModelId = await this.agentPersistenceDB?.getLastChatModelId();
+    // For new chat agents (not resumed), carry forward preferences from the
+    // most recently persisted chat agent so the UI feels stateful. Values
+    // are merged as defaults — an explicit `initialState` field (e.g. the
+    // UI passing a user-picked modelId) always wins.
+    const [lastChatModelId, lastChatToolApprovalMode] = await Promise.all([
+      this.agentPersistenceDB?.getLastChatModelId() ?? null,
+      this.agentPersistenceDB?.getLastChatToolApprovalMode() ?? null,
+    ]);
+    // Validate modelId — the referenced BYOK model may have been deleted.
+    // toolApprovalMode is a fixed enum, so no runtime validation is needed.
     const lastModelValid =
       lastChatModelId && this.modelProviderService.modelExists(lastChatModelId);
+    const inheritedState: Partial<AgentState> =
+      type === AgentTypes.CHAT
+        ? {
+            ...(lastModelValid ? { activeModelId: lastChatModelId } : {}),
+            ...(lastChatToolApprovalMode
+              ? { toolApprovalMode: lastChatToolApprovalMode }
+              : {}),
+          }
+        : {};
 
     // Build state object outside setState to avoid "Type instantiation is excessively deep" error
     // caused by complex Draft<[]> inference from the 'ai' package's UIMessage type
@@ -708,12 +724,9 @@ export class AgentManagerService extends DisposableService {
       // @ts-ignore - The onFinish handler returns outputs with the configured schema of the agent. dunno why ts doesn't get this right.
       parent?.onFinish,
       parent?.onError,
-      initialState ?? {
-        activeModelId:
-          lastModelValid && type === AgentTypes.CHAT
-            ? lastChatModelId
-            : undefined,
-      },
+      // Merge inherited defaults under any explicit initialState so
+      // caller-provided values (resume path, UI-picked modelId) win.
+      { ...inheritedState, ...initialState },
       this.assetCacheService,
       this.processedImageCacheService,
     );
@@ -726,6 +739,9 @@ export class AgentManagerService extends DisposableService {
       model_id:
         this.karton.state.agents.instances[agentInstanceId]?.state
           .activeModelId ?? 'unknown',
+      tool_approval_mode:
+        this.karton.state.agents.instances[agentInstanceId]?.state
+          .toolApprovalMode ?? 'unknown',
     });
 
     return agent as BaseAgent<

--- a/apps/browser/src/backend/services/agent-manager/persistence/db.ts
+++ b/apps/browser/src/backend/services/agent-manager/persistence/db.ts
@@ -338,6 +338,36 @@ export class AgentPersistenceDB {
   }
 
   /**
+   * Returns the toolApprovalMode of the most recently persisted chat agent,
+   * or null if no chat agents exist. Used by AgentManager to carry the
+   * user's approval-policy preference forward into newly created chat
+   * agents (mirrors getLastChatModelId).
+   */
+  public async getLastChatToolApprovalMode(): Promise<
+    schema.StoredAgentInstance['toolApprovalMode'] | null
+  > {
+    const results = await this._db
+      .select({ toolApprovalMode: schema.agentInstances.toolApprovalMode })
+      .from(schema.agentInstances)
+      .where(
+        and(
+          isNull(schema.agentInstances.parentAgentInstanceId),
+          eq(schema.agentInstances.type, AgentTypes.CHAT),
+        ),
+      )
+      .orderBy(desc(schema.agentInstances.lastMessageAt))
+      .limit(1)
+      .catch((error) => {
+        this._logger.error(
+          `[AgentPersistenceDB] Failed to fetch last chat tool approval mode: ${error}`,
+        );
+        return null;
+      });
+
+    return results?.[0]?.toolApprovalMode ?? null;
+  }
+
+  /**
    * Returns the mountedWorkspaces of the most recently persisted chat agent,
    * or null if no chat agents exist.
    */

--- a/apps/browser/src/backend/services/telemetry.ts
+++ b/apps/browser/src/backend/services/telemetry.ts
@@ -115,6 +115,7 @@ export type EventProperties = {
     agent_type: string;
     agent_instance_id: string;
     model_id: string;
+    tool_approval_mode: string;
   };
   'agent-message-sent': {
     agent_type: string;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
New chat agents now inherit the previous chat’s tool approval mode so preferences persist across sessions. Also adds `tool_approval_mode` to the agent-created telemetry event.

- **New Features**
  - New chat agents default to the last chat’s `toolApprovalMode` (and validated `activeModelId`); explicit `initialState` still overrides.
  - Agent Manager reads both values from persistence and merges them as defaults; only applies to non-resumed chat agents.
  - Persistence DB adds a method to fetch the last chat’s `toolApprovalMode`.
  - Telemetry: `agent-created` now includes `tool_approval_mode`.

<sup>Written for commit b01c0260e1bf3ec97de745ba4d1bf992882f41bb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New chat agents now inherit model and tool approval settings from previously created agents, with the ability to override these defaults when needed.

* **Improvements**
  * Enhanced telemetry tracking to capture tool approval mode when creating agents.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stagewise-io/stagewise/pull/1084)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->