### PR TITLE
1080 reuse permission mode

### DIFF
--- a/apps/browser/src/backend/services/agent-manager/agent-manager.ts
+++ b/apps/browser/src/backend/services/agent-manager/agent-manager.ts
@@ -176,16 +176,20 @@ export class AgentManagerService extends DisposableService {
       ) => {
         const normalizedToolApprovalMode =
           toolApprovalMode === 'alwaysAllow' ? 'smart' : toolApprovalMode;
+        const explicitInitialState =
+          modelId || normalizedToolApprovalMode
+            ? {
+                ...(modelId ? { activeModelId: modelId } : {}),
+                ...(normalizedToolApprovalMode
+                  ? { toolApprovalMode: normalizedToolApprovalMode }
+                  : {}),
+              }
+            : undefined;
         const agent = await this.createAgent(
           AgentTypes.CHAT,
           undefined,
           undefined,
-          {
-            ...(modelId ? { activeModelId: modelId } : {}),
-            ...(normalizedToolApprovalMode
-              ? { toolApprovalMode: normalizedToolApprovalMode }
-              : {}),
-          },
+          explicitInitialState,
           undefined,
           initialInputState,
         );
@@ -722,13 +726,20 @@ export class AgentManagerService extends DisposableService {
       // @ts-ignore - The onFinish handler returns outputs with the configured schema of the agent. dunno why ts doesn't get this right.
       parent?.onFinish,
       parent?.onError,
-      initialState ?? {
+      {
+        ...(initialState ?? {}),
         activeModelId:
-          lastModelValid && type === AgentTypes.CHAT
-            ? lastChatModelId
-            : undefined,
+          initialState && 'activeModelId' in initialState
+            ? initialState.activeModelId
+            : lastModelValid && type === AgentTypes.CHAT
+              ? lastChatModelId
+              : undefined,
         toolApprovalMode:
-          type === AgentTypes.CHAT ? inheritedToolApprovalMode : undefined,
+          initialState && 'toolApprovalMode' in initialState
+            ? initialState.toolApprovalMode
+            : type === AgentTypes.CHAT
+              ? inheritedToolApprovalMode
+              : undefined,
       },
       this.assetCacheService,
       this.processedImageCacheService,

--- a/apps/browser/src/backend/services/agent-manager/agent-manager.ts
+++ b/apps/browser/src/backend/services/agent-manager/agent-manager.ts
@@ -171,13 +171,17 @@ export class AgentManagerService extends DisposableService {
         _callingClientId: string,
         initialInputState?: string,
         modelId?: ModelId,
+        toolApprovalMode?: ToolApprovalMode,
         workspacePaths?: string[],
       ) => {
         const agent = await this.createAgent(
           AgentTypes.CHAT,
           undefined,
           undefined,
-          modelId ? { activeModelId: modelId } : undefined,
+          {
+            ...(modelId ? { activeModelId: modelId } : {}),
+            ...(toolApprovalMode ? { toolApprovalMode } : {}),
+          },
           undefined,
           initialInputState,
         );
@@ -638,11 +642,17 @@ export class AgentManagerService extends DisposableService {
   > {
     const agentInstanceId = instanceId ?? randomUUID();
 
-    // For new chat agents (not resumed), use the model from the last persisted chat
-    // Validate the model still exists (it may have been a deleted custom model)
+    // For new chat agents (not resumed), reuse settings from the most recent chat.
+    // Validate the model still exists (it may have been a deleted custom model).
     const lastChatModelId = await this.agentPersistenceDB?.getLastChatModelId();
+    const lastChatToolApprovalMode =
+      await this.agentPersistenceDB?.getLastChatToolApprovalMode();
     const lastModelValid =
       lastChatModelId && this.modelProviderService.modelExists(lastChatModelId);
+    const inheritedToolApprovalMode =
+      lastChatToolApprovalMode === 'alwaysAllow'
+        ? 'smart'
+        : (lastChatToolApprovalMode ?? DEFAULT_TOOL_APPROVAL_MODE);
 
     // Build state object outside setState to avoid "Type instantiation is excessively deep" error
     // caused by complex Draft<[]> inference from the 'ai' package's UIMessage type
@@ -713,6 +723,8 @@ export class AgentManagerService extends DisposableService {
           lastModelValid && type === AgentTypes.CHAT
             ? lastChatModelId
             : undefined,
+        toolApprovalMode:
+          type === AgentTypes.CHAT ? inheritedToolApprovalMode : undefined,
       },
       this.assetCacheService,
       this.processedImageCacheService,

--- a/apps/browser/src/backend/services/agent-manager/agent-manager.ts
+++ b/apps/browser/src/backend/services/agent-manager/agent-manager.ts
@@ -174,13 +174,17 @@ export class AgentManagerService extends DisposableService {
         toolApprovalMode?: ToolApprovalMode,
         workspacePaths?: string[],
       ) => {
+        const normalizedToolApprovalMode =
+          toolApprovalMode === 'alwaysAllow' ? 'smart' : toolApprovalMode;
         const agent = await this.createAgent(
           AgentTypes.CHAT,
           undefined,
           undefined,
           {
             ...(modelId ? { activeModelId: modelId } : {}),
-            ...(toolApprovalMode ? { toolApprovalMode } : {}),
+            ...(normalizedToolApprovalMode
+              ? { toolApprovalMode: normalizedToolApprovalMode }
+              : {}),
           },
           undefined,
           initialInputState,

--- a/apps/browser/src/backend/services/agent-manager/persistence/db.ts
+++ b/apps/browser/src/backend/services/agent-manager/persistence/db.ts
@@ -338,6 +338,34 @@ export class AgentPersistenceDB {
   }
 
   /**
+   * Returns the toolApprovalMode of the most recently persisted chat agent,
+   * or null if no chat agents exist.
+   */
+  public async getLastChatToolApprovalMode(): Promise<
+    schema.StoredAgentInstance['toolApprovalMode'] | null
+  > {
+    const results = await this._db
+      .select({ toolApprovalMode: schema.agentInstances.toolApprovalMode })
+      .from(schema.agentInstances)
+      .where(
+        and(
+          isNull(schema.agentInstances.parentAgentInstanceId),
+          eq(schema.agentInstances.type, AgentTypes.CHAT),
+        ),
+      )
+      .orderBy(desc(schema.agentInstances.lastMessageAt))
+      .limit(1)
+      .catch((error) => {
+        this._logger.error(
+          `[AgentPersistenceDB] Failed to fetch last chat tool approval mode: ${error}`,
+        );
+        return null;
+      });
+
+    return results?.[0]?.toolApprovalMode ?? null;
+  }
+
+  /**
    * Returns the mountedWorkspaces of the most recently persisted chat agent,
    * or null if no chat agents exist.
    */

--- a/apps/browser/src/shared/karton-contracts/ui/index.ts
+++ b/apps/browser/src/shared/karton-contracts/ui/index.ts
@@ -680,6 +680,7 @@ export type KartonContract = {
       create: (
         initialInputState?: string,
         modelId?: ModelId,
+        toolApprovalMode?: ToolApprovalMode,
         workspacePaths?: string[],
       ) => Promise<string>;
       resume: (agentId: string) => Promise<void>;

--- a/apps/browser/src/ui/screens/main/sidebar/agents-list/index.tsx
+++ b/apps/browser/src/ui/screens/main/sidebar/agents-list/index.tsx
@@ -8,6 +8,7 @@ import { useOpenAgent } from '@ui/hooks/use-open-chat';
 import { AgentTypes } from '@shared/karton-contracts/ui/agent';
 import type { AgentHistoryEntry } from '@shared/karton-contracts/ui/agent';
 import { EMPTY_MOUNTS } from '@shared/karton-contracts/ui';
+import type { ToolApprovalMode } from '@shared/karton-contracts/ui/shared-types';
 import { Button } from '@stagewise/stage-ui/components/button';
 import {
   OverlayScrollbar,
@@ -233,6 +234,11 @@ export function AgentsList() {
       ? (s.agents.instances[openAgent]?.state.activeModelId ?? null)
       : null,
   );
+  const openAgentToolApprovalMode = useKartonState((s) =>
+    openAgent
+      ? (s.agents.instances[openAgent]?.state.toolApprovalMode ?? null)
+      : null,
+  );
   const currentMounts = useKartonState((s) =>
     openAgent
       ? (s.toolbox[openAgent]?.workspace?.mounts ?? EMPTY_MOUNTS)
@@ -240,6 +246,10 @@ export function AgentsList() {
   );
   const openAgentModelIdRef = useRef(openAgentModelId);
   openAgentModelIdRef.current = openAgentModelId;
+  const openAgentToolApprovalModeRef = useRef<ToolApprovalMode | null>(
+    openAgentToolApprovalMode,
+  );
+  openAgentToolApprovalModeRef.current = openAgentToolApprovalMode;
   const currentMountPathsRef = useRef(currentMounts.map((m) => m.path));
   currentMountPathsRef.current = currentMounts.map((m) => m.path);
 
@@ -344,10 +354,13 @@ export function AgentsList() {
     setPendingCreate(true);
     window.dispatchEvent(new Event('sidebar-chat-panel-opened'));
     const currentModelId = openAgentModelIdRef.current ?? undefined;
+    const currentToolApprovalMode =
+      openAgentToolApprovalModeRef.current ?? undefined;
     const paths = currentMountPathsRef.current;
     void createAgent(
       undefined,
       currentModelId,
+      currentToolApprovalMode,
       paths.length > 0 ? paths : undefined,
     ).then((id) => {
       setOpenAgent(id);


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
New chats now reuse the current tool call permission mode, matching your last or open chat. This keeps approvals consistent when starting or duplicating chats.

- **New Features**
  - Sidebar chat creation passes the open chat’s `toolApprovalMode` into `create()`.
  - Backend accepts an explicit `toolApprovalMode`, normalizes `alwaysAllow` to `smart`, and for chat agents without an explicit mode inherits the most recent chat’s mode (else falls back to default); non‑chat agents leave it unset.
  - `@shared/karton-contracts/ui` adds a `toolApprovalMode` param to `create()` so callers can seed the new agent’s permission mode.

<sup>Written for commit 4a73265687a5be4cf1cf42a1accc5c53dab8ba14. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Agents now automatically inherit the tool approval mode from your most recently active agent when creating new ones, reducing setup time.
  * You can explicitly set the tool approval mode when creating new agents for additional control.
  * Legacy 'alwaysAllow' settings are automatically converted to 'smart' for consistency across your workspace.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stagewise-io/stagewise/pull/1085)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->