### PR TITLE
chore(website): seo improvements

### DIFF
--- a/apps/website/src/app/(home)/(legal)/legal-notice/page.tsx
+++ b/apps/website/src/app/(home)/(legal)/legal-notice/page.tsx
@@ -1,6 +1,26 @@
+import type { Metadata } from 'next';
 import { getLegalPage } from '@/lib/source';
 import { notFound } from 'next/navigation';
 import { compileMDX } from 'next-mdx-remote/rsc';
+
+export const metadata: Metadata = {
+  title: 'Legal Notice · stagewise',
+  description:
+    'Read the legal notice for stagewise, including company information and legal disclosures.',
+  openGraph: {
+    title: 'Legal Notice · stagewise',
+    description:
+      'Read the legal notice for stagewise, including company information and legal disclosures.',
+    type: 'website',
+  },
+  twitter: {
+    title: 'Legal Notice · stagewise',
+    description:
+      'Read the legal notice for stagewise, including company information and legal disclosures.',
+    creator: '@stagewise_io',
+  },
+  category: 'legal',
+};
 
 export default async function LegalNoticePage() {
   const page = getLegalPage('legal-notice');

--- a/apps/website/src/app/(home)/(legal)/privacy/page.tsx
+++ b/apps/website/src/app/(home)/(legal)/privacy/page.tsx
@@ -1,6 +1,26 @@
+import type { Metadata } from 'next';
 import { getLegalPage } from '@/lib/source';
 import { notFound } from 'next/navigation';
 import { compileMDX } from 'next-mdx-remote/rsc';
+
+export const metadata: Metadata = {
+  title: 'Privacy Policy · stagewise',
+  description:
+    'Read the stagewise Privacy Policy and learn how we collect, use, and protect your data.',
+  openGraph: {
+    title: 'Privacy Policy · stagewise',
+    description:
+      'Read the stagewise Privacy Policy and learn how we collect, use, and protect your data.',
+    type: 'website',
+  },
+  twitter: {
+    title: 'Privacy Policy · stagewise',
+    description:
+      'Read the stagewise Privacy Policy and learn how we collect, use, and protect your data.',
+    creator: '@stagewise_io',
+  },
+  category: 'legal',
+};
 
 export default async function PrivacyPolicyPage() {
   const page = getLegalPage('privacy');

--- a/apps/website/src/app/(home)/(legal)/terms/page.tsx
+++ b/apps/website/src/app/(home)/(legal)/terms/page.tsx
@@ -1,6 +1,26 @@
+import type { Metadata } from 'next';
 import { getLegalPage } from '@/lib/source';
 import { notFound } from 'next/navigation';
 import { compileMDX } from 'next-mdx-remote/rsc';
+
+export const metadata: Metadata = {
+  title: 'Terms of Service · stagewise',
+  description:
+    'Read the stagewise Terms of Service for using the website, product, and related services.',
+  openGraph: {
+    title: 'Terms of Service · stagewise',
+    description:
+      'Read the stagewise Terms of Service for using the website, product, and related services.',
+    type: 'website',
+  },
+  twitter: {
+    title: 'Terms of Service · stagewise',
+    description:
+      'Read the stagewise Terms of Service for using the website, product, and related services.',
+    creator: '@stagewise_io',
+  },
+  category: 'legal',
+};
 
 export default async function TermsPage() {
   const page = getLegalPage('terms');

--- a/apps/website/src/app/(home)/(legal)/trademark-policy/page.tsx
+++ b/apps/website/src/app/(home)/(legal)/trademark-policy/page.tsx
@@ -1,6 +1,26 @@
+import type { Metadata } from 'next';
 import { getLegalPage } from '@/lib/source';
 import { notFound } from 'next/navigation';
 import { compileMDX } from 'next-mdx-remote/rsc';
+
+export const metadata: Metadata = {
+  title: 'Trademark Policy · stagewise',
+  description:
+    'Read the stagewise Trademark Policy for guidance on using the stagewise name, brand, and assets.',
+  openGraph: {
+    title: 'Trademark Policy · stagewise',
+    description:
+      'Read the stagewise Trademark Policy for guidance on using the stagewise name, brand, and assets.',
+    type: 'website',
+  },
+  twitter: {
+    title: 'Trademark Policy · stagewise',
+    description:
+      'Read the stagewise Trademark Policy for guidance on using the stagewise name, brand, and assets.',
+    creator: '@stagewise_io',
+  },
+  category: 'legal',
+};
 
 export default async function TrademarkPolicyPage() {
   const page = getLegalPage('trademark-policy');

--- a/apps/website/src/app/(home)/_components/home-client.tsx
+++ b/apps/website/src/app/(home)/_components/home-client.tsx
@@ -2,6 +2,7 @@
 import { IconGithub } from 'nucleo-social-media';
 import { Button, buttonVariants } from '@stagewise/stage-ui/components/button';
 import { IconDownload4FillDuo18 } from 'nucleo-ui-fill-duo-18';
+import { IconArrowRightFill18 } from 'nucleo-ui-fill-18';
 import { ScrollReveal } from '@/components/landing/scroll-reveal';
 import type { NewsType } from '@/lib/news';
 import { usePostHog } from 'posthog-js/react';
@@ -407,7 +408,7 @@ export function HomeClient({ newsPosts }: { newsPosts: NewsPost[] }) {
         <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
           <ScrollReveal>
             <div className="flex flex-col items-start justify-between gap-6 rounded-lg bg-surface-1 p-6 md:flex-row-reverse md:items-center md:gap-12">
-              <div className="space-y-2">
+              <div className="space-y-3">
                 <h3 className="font-medium text-2xl">
                   Open-Source and extensible
                 </h3>
@@ -416,6 +417,16 @@ export function HomeClient({ newsPosts }: { newsPosts: NewsPost[] }) {
                   compatible with your favorite models — including the ones you
                   run locally.
                 </p>
+                <a
+                  href="https://github.com/stagewise-io/stagewise"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex w-fit items-center gap-2 text-primary-foreground hover:text-hover-derived active:text-active-derived"
+                >
+                  <IconGithub className="size-4" />
+                  View on GitHub
+                  <IconArrowRightFill18 className="inline size-4" />
+                </a>
               </div>
               <div
                 className="relative w-full shrink-0 overflow-hidden rounded-md md:max-w-[45%]"

--- a/apps/website/src/app/(home)/mission/layout.tsx
+++ b/apps/website/src/app/(home)/mission/layout.tsx
@@ -2,7 +2,22 @@ import type { Metadata } from 'next';
 import type { ReactNode } from 'react';
 
 export const metadata: Metadata = {
-  title: 'Our Mission',
+  title: 'Our Mission · stagewise',
+  description:
+    "We're building the software engineering environment of the future.",
+  openGraph: {
+    title: 'Our Mission · stagewise',
+    description:
+      "We're building the software engineering environment of the future.",
+    type: 'website',
+  },
+  twitter: {
+    title: 'Our Mission · stagewise',
+    description:
+      "We're building the software engineering environment of the future.",
+    creator: '@stagewise_io',
+  },
+  category: 'technology',
 };
 
 export default function TeamLayout({ children }: { children: ReactNode }) {

--- a/apps/website/src/app/(home)/page.tsx
+++ b/apps/website/src/app/(home)/page.tsx
@@ -1,5 +1,25 @@
+import type { Metadata } from 'next';
 import { getAllNewsPosts } from '@/lib/source';
 import { HomeClient } from './_components/home-client';
+
+export const metadata: Metadata = {
+  title: 'The Open Source Agentic IDE · stagewise',
+  description:
+    'Create and orchestrate coding agents, show app previews and run git workflows. Use your favorite models across all providers.',
+  openGraph: {
+    title: 'The Open Source Agentic IDE · stagewise',
+    description:
+      'Create and orchestrate coding agents, show app previews and run git workflows. Use your favorite models across all providers.',
+    type: 'website',
+  },
+  twitter: {
+    title: 'The Open Source Agentic IDE · stagewise',
+    description:
+      'Create and orchestrate coding agents, show app previews and run git workflows. Use your favorite models across all providers.',
+    creator: '@stagewise_io',
+  },
+  category: 'technology',
+};
 
 export default function Home() {
   const posts = getAllNewsPosts()

--- a/apps/website/src/app/download/layout.tsx
+++ b/apps/website/src/app/download/layout.tsx
@@ -1,0 +1,22 @@
+import type { Metadata } from 'next';
+import type { ReactNode } from 'react';
+
+export const metadata: Metadata = {
+  title: 'Download stagewise · The Open Source Agentic IDE',
+  description: 'Download stagewise for macOS, Windows, and Linux.',
+  openGraph: {
+    title: 'Download stagewise · The Open Source Agentic IDE',
+    description: 'Download stagewise for macOS, Windows, and Linux.',
+    type: 'website',
+  },
+  twitter: {
+    title: 'Download stagewise · The Open Source Agentic IDE',
+    description: 'Download stagewise for macOS, Windows, and Linux.',
+    creator: '@stagewise_io',
+  },
+  category: 'technology',
+};
+
+export default function DownloadLayout({ children }: { children: ReactNode }) {
+  return children;
+}

--- a/apps/website/src/app/layout.tsx
+++ b/apps/website/src/app/layout.tsx
@@ -15,7 +15,7 @@ export const metadata: Metadata = {
     apple: [{ url: '/apple-touch-icon.png', type: 'image/png' }],
   },
   metadataBase: new URL('https://stagewise.io'),
-  title: 'stagewise',
+  title: 'stagewise · The Open Source Agentic IDE',
   description:
     'The Open Source Agentic IDE. stagewise is a purpose-built browser for developers with a coding agent built right in.',
   openGraph: {

--- a/apps/website/src/app/vscode-extension/migrate-to-cli/layout.tsx
+++ b/apps/website/src/app/vscode-extension/migrate-to-cli/layout.tsx
@@ -1,0 +1,29 @@
+import type { Metadata } from 'next';
+import type { ReactNode } from 'react';
+
+export const metadata: Metadata = {
+  title: 'Upgrade to the new stagewise · stagewise',
+  description:
+    'Your stagewise setup needs an upgrade. Download the standalone stagewise IDE for a more powerful experience — no extension required.',
+  openGraph: {
+    title: 'Upgrade to the new stagewise · stagewise',
+    description:
+      'Your stagewise setup needs an upgrade. Download the standalone stagewise IDE for a more powerful experience — no extension required.',
+    type: 'website',
+  },
+  twitter: {
+    title: 'Upgrade to the new stagewise · stagewise',
+    description:
+      'Your stagewise setup needs an upgrade. Download the standalone stagewise IDE for a more powerful experience — no extension required.',
+    creator: '@stagewise_io',
+  },
+  category: 'technology',
+};
+
+export default function MigrateToCliLayout({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  return children;
+}

--- a/apps/website/src/app/vscode-extension/welcome/layout.tsx
+++ b/apps/website/src/app/vscode-extension/welcome/layout.tsx
@@ -1,0 +1,25 @@
+import type { Metadata } from 'next';
+import type { ReactNode } from 'react';
+
+export const metadata: Metadata = {
+  title: 'Meet the new stagewise · stagewise',
+  description:
+    'The stagewise extension is retired. Download the standalone stagewise IDE for a more powerful experience — no extension required.',
+  openGraph: {
+    title: 'Meet the new stagewise · stagewise',
+    description:
+      'The stagewise extension is retired. Download the standalone stagewise IDE for a more powerful experience — no extension required.',
+    type: 'website',
+  },
+  twitter: {
+    title: 'Meet the new stagewise · stagewise',
+    description:
+      'The stagewise extension is retired. Download the standalone stagewise IDE for a more powerful experience — no extension required.',
+    creator: '@stagewise_io',
+  },
+  category: 'technology',
+};
+
+export default function WelcomeLayout({ children }: { children: ReactNode }) {
+  return children;
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improved SEO and social cards by adding explicit page metadata across key pages and standardizing site titles. Also adds a GitHub CTA on the homepage and layout shells for download and VS Code extension routes.

- **New Features**
  - Added Next.js page `metadata` (title, description, Open Graph/Twitter, `category`) to Home, Mission, legal pages (Privacy, Terms, Trademark Policy, Legal Notice), `/download`, and VS Code extension pages; added layout shells for `/download`, `/vscode-extension/welcome`, and `/vscode-extension/migrate-to-cli`.
  - Standardized titles: root set to `stagewise · The Open Source Agentic IDE`; Home set to `The Open Source Agentic IDE · stagewise`. Added a “View on GitHub” link with icon and arrow on the homepage.

<sup>Written for commit 105dc291689e52c6e8cbfea6a1d8c9f15ed37f88. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "View on GitHub" link in the home page open-source section.
  * Added Download page layout and VSCode migration/welcome layouts.

* **Documentation**
  * Updated metadata and social (Open Graph/Twitter) cards across home, mission, download, VSCode, and legal pages.
  * Updated global site title branding to "stagewise · The Open Source Agentic IDE."

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stagewise-io/stagewise/pull/1088)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->