### PR TITLE
chore(stagewise): update gemini 3-1 flash lite model id

### DIFF
--- a/.agents/skills/history-compression/SKILL.md
+++ b/.agents/skills/history-compression/SKILL.md
@@ -34,6 +34,7 @@ Kept-budget = `min(0.2 × contextWindow, 40k tokens)` (`KEPT_BUDGET_FRACTION`, `
 Preferred floor = `max(5, config.minUncompressedMessages ?? 10)`.
 
 Walk backward from history end:
+
 1. Accumulate `estimateMessageTokens(msg)` until next msg would bust budget → boundary there.
 2. Else stop once kept-count ≥ floor.
 3. Edge: single last msg > budget → keep just that one, warn.
@@ -44,6 +45,7 @@ Then: `messagesToCompact = history.slice(0, boundary)` → compress → write re
 ### Token estimation quirks
 
 `estimateMessageTokens` = `ceil(chars / 4)`. Includes:
+
 - Text parts.
 - Tool-call `toolName` + JSON-stringified `input` + `output`.
 - Metadata overhead: env-snapshot, compressedHistory, mentions, attachments.
@@ -65,10 +67,11 @@ When `messagesToCompact` already contains a prior `compressedHistory`:
 ## Serialization format
 
 Input to LLM is XML-ish:
+
 - `<user>` — text + `[attached: ...]`, `[mentioned: ...]` metadata annotations.
 - `<assistant>` — text + one-liner tool markers: `[read: path]`, `[edited: path (N edits)]`, `[shell: label → ✓ / exit N / timed out]`, `[lint: paths → clean / N errors, M warnings]`, `[asked user: title → field: answer; ...]`, `[searched: "query"]`, `[created: path]`, `[wrote: path]`.
 - `<previous-chat-history>` — inlined prior briefing (see above).
-- Error state on any tool → ` ✗ <msg>` suffix.
+- Error state on any tool → `✗ <msg>` suffix.
 - Unknown tool types → `[tool-xxx]` generic marker (never silently dropped).
 
 ## Prompt design (`apps/browser/src/backend/agents/shared/base-agent/history-compression/prompt.ts`)
@@ -82,7 +85,8 @@ Input to LLM is XML-ish:
 
 ## Model cascade (`apps/browser/src/backend/agents/shared/base-agent/history-compression/index.ts`)
 
-1. `gemini-3.1-flash-lite-preview` → 2. `gpt-5.4-nano` → 3. `claude-haiku-4.5`.
+1. `gemini-3.1-flash-lite` → 2. `gpt-5.4-nano` → 3. `claude-haiku-4.5`.
+
 - Each 30s abort timeout, `temperature: 0.1`, `maxOutputTokens: 20000`.
 - Min valid output: 30 chars (shorter → fallback).
 - Final fallback: active chat model (only if not already tried).
@@ -116,6 +120,7 @@ npx tsx scripts/experiments/extract-compression-test-data.ts --channel dev --min
 Channels map to `<appData>/{stagewise | stagewise-prerelease | stagewise-dev}/stagewise/agents/instances.sqlite`.
 
 Per chat, for each boundary message (every real compression event):
+
 - Slices `messages[0..boundary)`.
 - Runs **real** `convertAgentMessagesToCompactMessageHistoryString` + `buildCompressionUserMessage` (imported from app source → fidelity guaranteed).
 - Writes to `experiments-data/history-compression/<channel>/NNN-title/compression-NNN/`:

--- a/README.de.md
+++ b/README.de.md
@@ -57,7 +57,7 @@ Enthaltene Modelle:
 
 - **Anthropic**: Opus 4.7, Opus 4.6, Sonnet 4.6, Haiku 4.5
 - **OpenAI**: GPT-5.5, GPT-5.4, GPT-5.3 Codex, GPT-5.3 Instant, GPT-5.4 mini, GPT-5.4 nano
-- **Google**: Gemini 3.1 Pro (Preview), Gemini 3 Flash, Gemini 3.1 Flash Lite (Preview)
+- **Google**: Gemini 3.1 Pro (Preview), Gemini 3 Flash, Gemini 3.1 Flash Lite
 - **Moonshot AI**: Kimi K2.6, Kimi K2.5
 - **Alibaba**: Qwen 3-32B, Qwen 3-Coder 30B-A3B
 - **DeepSeek**: DeepSeek V4 Pro, DeepSeek V4 Flash

--- a/README.es.md
+++ b/README.es.md
@@ -57,7 +57,7 @@ Modelos incluidos:
 
 - **Anthropic**: Opus 4.7, Opus 4.6, Sonnet 4.6, Haiku 4.5
 - **OpenAI**: GPT-5.5, GPT-5.4, GPT-5.3 Codex, GPT-5.3 Instant, GPT-5.4 mini, GPT-5.4 nano
-- **Google**: Gemini 3.1 Pro (Preview), Gemini 3 Flash, Gemini 3.1 Flash Lite (Preview)
+- **Google**: Gemini 3.1 Pro (Preview), Gemini 3 Flash, Gemini 3.1 Flash Lite
 - **Moonshot AI**: Kimi K2.6, Kimi K2.5
 - **Alibaba**: Qwen 3-32B, Qwen 3-Coder 30B-A3B
 - **DeepSeek**: DeepSeek V4 Pro, DeepSeek V4 Flash

--- a/README.ja.md
+++ b/README.ja.md
@@ -57,7 +57,7 @@
 
 - **Anthropic**: Opus 4.7, Opus 4.6, Sonnet 4.6, Haiku 4.5
 - **OpenAI**: GPT-5.5, GPT-5.4, GPT-5.3 Codex, GPT-5.3 Instant, GPT-5.4 mini, GPT-5.4 nano
-- **Google**: Gemini 3.1 Pro (Preview), Gemini 3 Flash, Gemini 3.1 Flash Lite (Preview)
+- **Google**: Gemini 3.1 Pro (Preview), Gemini 3 Flash, Gemini 3.1 Flash Lite
 - **Moonshot AI**: Kimi K2.6, Kimi K2.5
 - **Alibaba**: Qwen 3-32B, Qwen 3-Coder 30B-A3B
 - **DeepSeek**: DeepSeek V4 Pro, DeepSeek V4 Flash

--- a/README.ko.md
+++ b/README.ko.md
@@ -57,7 +57,7 @@
 
 - **Anthropic**: Opus 4.7, Opus 4.6, Sonnet 4.6, Haiku 4.5
 - **OpenAI**: GPT-5.5, GPT-5.4, GPT-5.3 Codex, GPT-5.3 Instant, GPT-5.4 mini, GPT-5.4 nano
-- **Google**: Gemini 3.1 Pro (Preview), Gemini 3 Flash, Gemini 3.1 Flash Lite (Preview)
+- **Google**: Gemini 3.1 Pro (Preview), Gemini 3 Flash, Gemini 3.1 Flash Lite
 - **Moonshot AI**: Kimi K2.6, Kimi K2.5
 - **Alibaba**: Qwen 3-32B, Qwen 3-Coder 30B-A3B
 - **DeepSeek**: DeepSeek V4 Pro, DeepSeek V4 Flash

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Included models:
 
 - **Anthropic**: Opus 4.7, Opus 4.6, Sonnet 4.6, Haiku 4.5
 - **OpenAI**: GPT-5.5, GPT-5.4, GPT-5.3 Codex, GPT-5.3 Instant, GPT-5.4 mini, GPT-5.4 nano
-- **Google**: Gemini 3.1 Pro (Preview), Gemini 3 Flash, Gemini 3.1 Flash Lite (Preview)
+- **Google**: Gemini 3.1 Pro (Preview), Gemini 3 Flash, Gemini 3.1 Flash Lite
 - **Moonshot AI**: Kimi K2.6, Kimi K2.5
 - **Alibaba**: Qwen 3-32B, Qwen 3-Coder 30B-A3B
 - **DeepSeek**: DeepSeek V4 Pro, DeepSeek V4 Flash

--- a/apps/browser/src/backend/agents/shared/base-agent/history-compression/index.test.ts
+++ b/apps/browser/src/backend/agents/shared/base-agent/history-compression/index.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { AgentMessage } from '@shared/karton-contracts/ui/agent';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ModelProviderService } from '@/agents/model-provider';
 
 // ---------------------------------------------------------------------------
@@ -26,13 +26,13 @@ vi.mock(
   },
 );
 
+import type { SkillDefinition } from '@shared/skills';
 import { generateText } from 'ai';
 import { resolveSlashSkill } from '@/agents/shared/prompts/utils/metadata-converter/slash-items';
-import type { SkillDefinition } from '@shared/skills';
 import {
-  generateSimpleCompressedHistory,
   convertAgentMessagesToCompactMessageHistoryString,
   estimateMessageTokens,
+  generateSimpleCompressedHistory,
 } from '.';
 
 const resolveSlashSkillMock = vi.mocked(resolveSlashSkill);
@@ -959,7 +959,7 @@ describe('generateSimpleCompressedHistory', () => {
     expect(result).toBe('The user asked the assistant to help with a task.');
     expect(generateTextMock).toHaveBeenCalledTimes(1);
     expect(mps.getModelWithOptions).toHaveBeenCalledWith(
-      'gemini-3.1-flash-lite-preview',
+      'gemini-3.1-flash-lite',
       'agent-1',
       expect.objectContaining({ $ai_span_name: 'history-compression' }),
     );
@@ -1078,7 +1078,7 @@ describe('generateSimpleCompressedHistory', () => {
     expect(generateTextMock).toHaveBeenCalledTimes(2);
     expect(mps.getModelWithOptions).toHaveBeenNthCalledWith(
       1,
-      'gemini-3.1-flash-lite-preview',
+      'gemini-3.1-flash-lite',
       'agent-1',
       expect.any(Object),
     );
@@ -1107,7 +1107,7 @@ describe('generateSimpleCompressedHistory', () => {
     expect(generateTextMock).toHaveBeenCalledTimes(3);
     expect(mps.getModelWithOptions).toHaveBeenNthCalledWith(
       1,
-      'gemini-3.1-flash-lite-preview',
+      'gemini-3.1-flash-lite',
       'agent-1',
       expect.any(Object),
     );
@@ -1333,7 +1333,7 @@ describe('generateSimpleCompressedHistory', () => {
     expect(generateTextMock).toHaveBeenCalledTimes(1);
     expect(mps.getModelWithOptions).toHaveBeenCalledTimes(1);
     expect(mps.getModelWithOptions).toHaveBeenCalledWith(
-      'gemini-3.1-flash-lite-preview',
+      'gemini-3.1-flash-lite',
       'agent-1',
       expect.any(Object),
     );

--- a/apps/browser/src/backend/agents/shared/base-agent/history-compression/index.ts
+++ b/apps/browser/src/backend/agents/shared/base-agent/history-compression/index.ts
@@ -1,12 +1,12 @@
-import { generateText } from 'ai';
-import type { AgentMessage } from '@shared/karton-contracts/ui/agent';
-import type { ModelProviderService } from '@/agents/model-provider';
 import type { ModelId } from '@shared/available-models';
+import type { AgentMessage } from '@shared/karton-contracts/ui/agent';
 import type { SkillDefinition } from '@shared/skills';
+import { generateText } from 'ai';
+import type { ModelProviderService } from '@/agents/model-provider';
 import {
   extractSlashIdsFromText,
-  resolveSlashSkill,
   type ResolvedSlashCommand,
+  resolveSlashSkill,
 } from '@/agents/shared/prompts/utils/metadata-converter/slash-items';
 
 // Import for local use + re-export so existing imports keep working.
@@ -21,9 +21,9 @@ export {
 
 // Re-export prompt pieces so existing imports from this module keep working.
 import {
+  buildCompressionUserMessage,
   COMPRESSION_SYSTEM_PROMPT,
   COMPRESSION_TARGET_CHARS,
-  buildCompressionUserMessage,
 } from './prompt';
 export {
   COMPRESSION_SYSTEM_PROMPT,
@@ -37,7 +37,7 @@ export {
  * tried in order when the previous one fails or times out.
  */
 const HISTORY_COMPRESSION_MODELS = [
-  'gemini-3.1-flash-lite-preview',
+  'gemini-3.1-flash-lite',
   'gpt-5.4-nano',
   'claude-haiku-4.5',
 ] as const;

--- a/apps/browser/src/backend/agents/shared/base-agent/title-generation.test.ts
+++ b/apps/browser/src/backend/agents/shared/base-agent/title-generation.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { AgentMessage } from '@shared/karton-contracts/ui/agent';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ModelProviderService } from '@/agents/model-provider';
 
 // ---------------------------------------------------------------------------
@@ -70,7 +70,7 @@ describe('generateSimpleTitle', () => {
     expect(generateTextMock).toHaveBeenCalledTimes(1);
     // Should use the primary model
     expect(mps.getModelWithOptions).toHaveBeenCalledWith(
-      'gemini-3.1-flash-lite-preview',
+      'gemini-3.1-flash-lite',
       'agent-1',
       expect.objectContaining({ $ai_span_name: 'title-generation' }),
     );
@@ -202,7 +202,7 @@ describe('generateSimpleTitle', () => {
     // First model attempted, then fallback
     expect(mps.getModelWithOptions).toHaveBeenNthCalledWith(
       1,
-      'gemini-3.1-flash-lite-preview',
+      'gemini-3.1-flash-lite',
       'agent-1',
       expect.any(Object),
     );
@@ -233,7 +233,7 @@ describe('generateSimpleTitle', () => {
     // Verify all three model IDs were attempted in order
     expect(mps.getModelWithOptions).toHaveBeenNthCalledWith(
       1,
-      'gemini-3.1-flash-lite-preview',
+      'gemini-3.1-flash-lite',
       'agent-1',
       expect.any(Object),
     );

--- a/apps/browser/src/backend/agents/shared/base-agent/title-generation/index.ts
+++ b/apps/browser/src/backend/agents/shared/base-agent/title-generation/index.ts
@@ -1,8 +1,8 @@
-import { generateText } from 'ai';
 import type { AgentMessage } from '@shared/karton-contracts/ui/agent';
+import { generateText } from 'ai';
 import {
-  type ModelProviderService,
   deepMergeProviderOptions,
+  type ModelProviderService,
 } from '@/agents/model-provider';
 import { TITLE_GENERATION_SYSTEM_PROMPT } from './prompt';
 
@@ -12,7 +12,7 @@ import { TITLE_GENERATION_SYSTEM_PROMPT } from './prompt';
  * tried in order when the previous one fails or times out.
  */
 const TITLE_GENERATION_MODELS = [
-  'gemini-3.1-flash-lite-preview',
+  'gemini-3.1-flash-lite',
   'gpt-5.4-nano',
   'claude-haiku-4.5',
 ] as const;

--- a/apps/browser/src/backend/services/toolbox/tools/shell/smart-approval/index.test.ts
+++ b/apps/browser/src/backend/services/toolbox/tools/shell/smart-approval/index.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ModelProviderService } from '@/agents/model-provider';
 import type { TelemetryService } from '@/services/telemetry';
 
@@ -11,7 +11,7 @@ vi.mock('ai', () => ({
 
 // We import *after* vi.mock so vitest can intercept
 import { generateObject } from 'ai';
-import { classifyShellCommand, type ClassifyShellCommandInput } from './index';
+import { type ClassifyShellCommandInput, classifyShellCommand } from './index';
 
 const generateObjectMock = vi.mocked(generateObject);
 
@@ -82,7 +82,7 @@ describe('classifyShellCommand', () => {
     });
     expect(generateObjectMock).toHaveBeenCalledTimes(1);
     expect(mps.getModelWithOptions).toHaveBeenCalledWith(
-      'gemini-3.1-flash-lite-preview',
+      'gemini-3.1-flash-lite',
       'agent-1',
       expect.objectContaining({
         $ai_span_name: 'smart-approval-classification',
@@ -92,7 +92,7 @@ describe('classifyShellCommand', () => {
       'smart-approval-classified',
       expect.objectContaining({
         needs_approval: false,
-        model_id: 'gemini-3.1-flash-lite-preview',
+        model_id: 'gemini-3.1-flash-lite',
         fallback_index: 0,
       }),
     );

--- a/apps/browser/src/backend/services/toolbox/tools/shell/smart-approval/index.ts
+++ b/apps/browser/src/backend/services/toolbox/tools/shell/smart-approval/index.ts
@@ -1,9 +1,9 @@
+import type { ModelId } from '@shared/available-models';
 import { generateObject } from 'ai';
 import { z } from 'zod';
-import type { ModelId } from '@shared/available-models';
 import {
-  type ModelProviderService,
   deepMergeProviderOptions,
+  type ModelProviderService,
 } from '@/agents/model-provider';
 import type { TelemetryService } from '@/services/telemetry';
 import { SMART_APPROVAL_SYSTEM_PROMPT } from './prompt';
@@ -16,7 +16,7 @@ import { SMART_APPROVAL_SYSTEM_PROMPT } from './prompt';
  * of which provider they have configured.
  */
 export const SMART_APPROVAL_MODELS: readonly ModelId[] = [
-  'gemini-3.1-flash-lite-preview',
+  'gemini-3.1-flash-lite',
   'gpt-5.4-nano',
   'claude-haiku-4.5',
 ];

--- a/apps/browser/src/shared/available-models.ts
+++ b/apps/browser/src/shared/available-models.ts
@@ -627,8 +627,8 @@ export const availableModels = [
   },
   {
     officialProvider: 'google',
-    modelId: 'gemini-3.1-flash-lite-preview',
-    modelDisplayName: 'Gemini 3.1 Flash Lite (Preview)',
+    modelId: 'gemini-3.1-flash-lite',
+    modelDisplayName: 'Gemini 3.1 Flash Lite',
     modelDescription:
       "Google's workhorse model for high-speed and high-volume use, with improvements across translation, data extraction, and code completion.",
     modelContext: '1m context',


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Promotes Google Gemini 3.1 Flash Lite from preview to GA by switching all references to `gemini-3.1-flash-lite`. Updates model lists, agent cascades, tests, and docs; no behavior changes.

- **Refactors**
  - Switched `HISTORY_COMPRESSION_MODELS`, `TITLE_GENERATION_MODELS`, and `SMART_APPROVAL_MODELS` to `gemini-3.1-flash-lite`.
  - Updated `available-models` (ID + display name) and the history-compression SKILL cascade; removed “(Preview)” from READMEs (EN/DE/ES/JA/KO).
  - Adjusted tests and telemetry expectations; minor import/order cleanup.

- **Migration**
  - Replace any stored or configured `gemini-3.1-flash-lite-preview` references with `gemini-3.1-flash-lite`.

<sup>Written for commit 51f96ddf7880ffed2715e7adf901d73893e6884e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated README files across all languages to reflect Gemini 3.1 Flash Lite model naming changes.
  * Updated skill documentation with revised model cascade.

* **Updates**
  * Changed model references from `gemini-3.1-flash-lite-preview` to `gemini-3.1-flash-lite` in model fallback chains and available models list.
  * Updated test expectations to reflect updated model identifiers across multiple test suites.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stagewise-io/stagewise/pull/1090)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->