### PR TITLE
fix(stagewise): fix sorting in agents-sidebar

### DIFF
--- a/apps/browser/src/backend/services/agent-manager/persistence/db.ts
+++ b/apps/browser/src/backend/services/agent-manager/persistence/db.ts
@@ -98,7 +98,14 @@ export class AgentPersistenceDB {
         parentAgentInstanceId: schema.agentInstances.parentAgentInstanceId,
       })
       .from(schema.agentInstances)
-      .orderBy(desc(schema.agentInstances.createdAt))
+      // Order by lastMessageAt so the sidebar's time-bucket grouping
+      // (Today / Yesterday / Last 7 days / ...) — which is keyed on
+      // lastMessageAt — sees a contiguous, correctly-ordered page.
+      // Ordering by createdAt here let agents whose latest activity was
+      // recent but whose creation is older drop out of the initial page,
+      // making them silently missing from groups like "Yesterday" until
+      // the user clicked "Show more".
+      .orderBy(desc(schema.agentInstances.lastMessageAt))
       .limit(limit)
       .offset(offset)
       .where(

--- a/apps/browser/src/ui/screens/main/sidebar/agents-list/index.tsx
+++ b/apps/browser/src/ui/screens/main/sidebar/agents-list/index.tsx
@@ -550,6 +550,11 @@ export function AgentsList() {
 
     // Sort by the higher of lastMessageAt and createdAt so new agents
     // (no messages yet, createdAt = now) appear at the top.
+    // NOTE: This must stay aligned with `getAgentHistoryEntries` on the
+    // backend, which paginates ordered by lastMessageAt. If the two
+    // diverge, paginated fetches return a different slice than the one
+    // the UI sorts/groups by, and agents go missing from time-bucket
+    // sections until the user clicks "Show more".
     const merged = [...activeEntries, ...historyEntries].sort(
       (a, b) =>
         Math.max(b.lastMessageAt, b.createdAt) -


### PR DESCRIPTION
closes #1092 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes inconsistent agent sorting by aligning backend pagination with the sidebar’s time buckets. Recently active agents now appear in the correct Today/Yesterday buckets on first load without clicking “Show more” (Linear #1092).

- **Bug Fixes**
  - Backend: paginate agent history ordered by `lastMessageAt` to match time-bucket grouping.
  - Frontend: keep sorting by `max(lastMessageAt, createdAt)` so new agents surface correctly; added notes to keep backend/UI aligned.

<sup>Written for commit 760a3275b1330373893e1a1a0b24e5731fabfdae. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed sidebar agent sorting to prioritize latest activity, aligning grouping and pagination so agents appear in the correct time-based sections.
  * Prevented agents from being hidden from time-bucket sections until "Show more" is clicked by ensuring consistent ordering between backend and UI.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stagewise-io/stagewise/pull/1093)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->