### PR TITLE
fix(stagewise): enable cmd-b sidebar toggle when chat focused

### DIFF
--- a/apps/browser/src/shared/hotkeys.ts
+++ b/apps/browser/src/shared/hotkeys.ts
@@ -85,11 +85,13 @@ export const hotkeyDefinitions: Record<HotkeyActions, HotkeyDefinition> = {
   },
   [HotkeyActions.TOGGLE_SIDEBAR]: {
     // Matches Codex / VS Code / GitHub Desktop convention.
-    // NOT capture-dominant: Cmd/Ctrl+B is the universal "bold" shortcut
-    // inside rich-text editors (TipTap), so we let native editable
-    // elements consume the event first via `shouldNativeInputConsumeEvent`.
+    // Capture-dominant: the chat composer (TipTap) is configured as
+    // plain-text only (no bold/italic/underline marks), so there is no
+    // formatting shortcut to protect. Running in the capture phase makes
+    // Cmd/Ctrl+B reliably toggle the sidebar even when the chat input
+    // (a contentEditable element) is focused.
     accelerator: 'Mod+B',
-    captureDominantly: false,
+    captureDominantly: true,
   },
   [HotkeyActions.NEW_CHAT]: {
     accelerator: 'Mod+N',


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enable Cmd/Ctrl+B to toggle the sidebar even when the chat input is focused. Prevents the shortcut from being swallowed by the contentEditable composer.

- **Bug Fixes**
  - Made `TOGGLE_SIDEBAR` (`Mod+B`) capture-dominant so it works when the TipTap chat composer is focused; safe because the composer is plain-text (no bold formatting).

<sup>Written for commit 02f457fb3ccc26cdbca01c74ddbe86c5f96cf0ed. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Improved Toggle Sidebar hotkey to work more reliably by preventing interference from native editor hotkey handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stagewise-io/stagewise/pull/1096)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->