### PR TITLE
fix(stagewise): fix omnibox-focus-loss

### DIFF
--- a/apps/browser/src/backend/services/window-layout/index.ts
+++ b/apps/browser/src/backend/services/window-layout/index.ts
@@ -915,15 +915,20 @@ export class WindowLayoutService extends DisposableService {
     });
 
     tab.on('tabFocused', (id) => {
-      // FIX: On Win32, webContents may auto-focus multiple times during page load
+      // FIX: webContents may auto-focus multiple times during page load
       // (wc.on('focus') fires on visibility, DOM load, script execution, etc.).
       // When isWebContentInteractive is false, the UI should have focus priority.
       // Reclaim it immediately to prevent the tab from stealing keyboard input.
-      if (
-        process.platform === 'win32' &&
-        !this.isWebContentInteractive &&
-        id === this.activeTabId
-      ) {
+      //
+      // Originally scoped to Win32, but macOS exhibits the same behavior:
+      // during CMD+T new-tab creation the tab's webContents grabs native OS
+      // focus while still loading (url='', isLoading=true), which moves focus
+      // away from the renderer's BrowserWindow. The omnibox INPUT remains
+      // document.activeElement but document.hasFocus() returns false —
+      // typing goes nowhere. UIController.focus() calls webContents.focus()
+      // on the UI view; it does NOT change z-order, so it is safe on all
+      // platforms (see Invariant #2 in focus-handling.md).
+      if (!this.isWebContentInteractive && id === this.activeTabId) {
         this.uiController?.focus();
       }
       this.uiController?.forwardFocusEvent(id);

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/panel-footer.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/panel-footer.tsx
@@ -689,6 +689,15 @@ export const ChatPanelFooter = memo(function ChatPanelFooter() {
   }, [flushQueue, openAgent]);
 
   const [chatInputActive, setChatInputActive] = useState<boolean>(false);
+  // Mirror `chatInputActive` into a ref so synchronous handlers
+  // (`omnibox-focus-requested`, `search-bar-focus-requested`, `onInputBlur`)
+  // can read the up-to-date value within the same event-loop turn instead of
+  // a stale `useCallback` closure value. Without this, programmatic blurs
+  // triggered by the omnibox/search-bar focus chain re-arm
+  // `wasActiveBeforeAppBlurRef` against the very listener that just cleared
+  // it, causing the chat input to steal focus on the next window 'focus'.
+  const chatInputActiveRef = useRef(chatInputActive);
+  chatInputActiveRef.current = chatInputActive;
   // Track if input was focused before app lost focus (for restoring on app regain)
   const wasActiveBeforeAppBlurRef = useRef(false);
 
@@ -714,34 +723,35 @@ export const ChatPanelFooter = memo(function ChatPanelFooter() {
     wasActiveBeforeAppBlurRef.current = false;
   }, [chatInputActive]);
 
-  const onInputBlur = useCallback(
-    (ev: FocusEvent) => {
-      const target = ev.relatedTarget as HTMLElement;
-      // We should only allow chat blur if the user clicked outside the chat box or the context selector element tree. Otherwise, we should keep the input active by refocusing it.
-      if (target?.closest('#chat-file-attachment-menu-content')) {
-        return;
-      }
-      // Let focus move naturally into status card inputs (e.g. user question form)
-      if (target?.closest('[data-status-card]')) {
-        return;
-      }
-      if (
-        !target ||
-        (!target.closest('#chat-input-container-box') &&
-          !target.closest('#element-selector-element-canvas'))
-      ) {
-        // If relatedTarget is null, the app might be losing focus (e.g., CMD+tab)
-        // Track this so we can restore focus when the app regains focus
-        if (!target && chatInputActive)
-          wasActiveBeforeAppBlurRef.current = true;
+  const onInputBlur = useCallback((ev: FocusEvent) => {
+    const target = ev.relatedTarget as HTMLElement;
+    // We should only allow chat blur if the user clicked outside the chat box or the context selector element tree. Otherwise, we should keep the input active by refocusing it.
+    if (target?.closest('#chat-file-attachment-menu-content')) {
+      return;
+    }
+    // Let focus move naturally into status card inputs (e.g. user question form)
+    if (target?.closest('[data-status-card]')) {
+      return;
+    }
+    if (
+      !target ||
+      (!target.closest('#chat-input-container-box') &&
+        !target.closest('#element-selector-element-canvas'))
+    ) {
+      // If relatedTarget is null, the app might be losing focus (e.g., CMD+tab)
+      // Track this so we can restore focus when the app regains focus.
+      // Read from the ref (not the closure) so synchronous resets dispatched
+      // earlier in the same event-loop turn (e.g. by
+      // `omnibox-focus-requested`) are honoured before the programmatic blur
+      // they trigger reaches us.
+      if (!target && chatInputActiveRef.current)
+        wasActiveBeforeAppBlurRef.current = true;
 
-        setChatInputActive(false);
-      } else if (chatInputActive) {
-        chatInputRef.current?.focus();
-      }
-    },
-    [chatInputActive],
-  );
+      setChatInputActive(false);
+    } else if (chatInputActiveRef.current) {
+      chatInputRef.current?.focus();
+    }
+  }, []);
 
   // Restore focus when the app regains focus (e.g., after CMD+tab back)
   useEventListener(
@@ -759,6 +769,11 @@ export const ChatPanelFooter = memo(function ChatPanelFooter() {
   // Clear focus restoration flag when omnibox takes focus (prevents chat from reclaiming focus)
   useEventListener('omnibox-focus-requested', () => {
     wasActiveBeforeAppBlurRef.current = false;
+    // Synchronously mark the input as inactive so the blur fired by the
+    // omnibox's `focus()` chain (which blurs all contenteditable elements)
+    // doesn't re-arm `wasActiveBeforeAppBlurRef` via `onInputBlur` before the
+    // `setChatInputActive(false)` state update commits.
+    chatInputActiveRef.current = false;
     setChatInputActive(false);
     // Also stop context selection to prevent its ESC handler from consuming the first ESC
     stopContextSelector();
@@ -767,6 +782,9 @@ export const ChatPanelFooter = memo(function ChatPanelFooter() {
   // Clear focus restoration flag when search bar takes focus (prevents chat from reclaiming focus)
   useEventListener('search-bar-focus-requested', () => {
     wasActiveBeforeAppBlurRef.current = false;
+    // See `omnibox-focus-requested` above for why we update the ref
+    // synchronously before the state setter.
+    chatInputActiveRef.current = false;
     setChatInputActive(false);
     // Also stop context selection to prevent its ESC handler from consuming the first ESC
     stopContextSelector();


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes omnibox focus loss by preventing loading tabs and the chat input from stealing focus. The omnibox now keeps focus when opening a new tab (incl. macOS CMD+T), switching to search, or returning to the app.

- **Bug Fixes**
  - Window layout: reclaim UI focus whenever the active tab’s `webContents` isn’t interactive (no longer Win32-only).
  - Chat panel: mirror `chatInputActive` into a ref for synchronous blur/focus handlers to avoid stale closures.
  - `onInputBlur`: read from the ref and stop re-arming focus-restore during programmatic blurs.
  - On `omnibox-focus-requested` and `search-bar-focus-requested`: clear restore flags and set the ref inactive before state updates to prevent the blur chain from re-arming focus.

<sup>Written for commit ac7f9541d61a4ab8cf4b1c2c529a03b2dfe2e2ad. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cross-platform focus behavior when switching between tabs.
  * Fixed chat input focus handling to prevent unintended deactivation and refocus cycles during programmatic focus changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stagewise-io/stagewise/pull/1098)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->