### PR TITLE
feat(stagewise): support tabbing through agents

### DIFF
--- a/apps/browser/src/shared/hotkeys.ts
+++ b/apps/browser/src/shared/hotkeys.ts
@@ -28,22 +28,26 @@ export enum HotkeyActions {
   NEW_CHAT = 'new_chat',
   DOWNLOADS = 'downloads',
 
-  // Tab & window navigation
+  // Tab & window navigation (browser tabs only)
   NEW_TAB = 'new_tab',
   RESTORE_TAB = 'restore_tab',
   CLOSE_TAB = 'close_tab',
   CLOSE_WINDOW = 'close_window',
   NEXT_TAB = 'next_tab',
   PREV_TAB = 'prev_tab',
-  FOCUS_TAB_1 = 'focus_tab_1',
-  FOCUS_TAB_2 = 'focus_tab_2',
-  FOCUS_TAB_3 = 'focus_tab_3',
-  FOCUS_TAB_4 = 'focus_tab_4',
-  FOCUS_TAB_5 = 'focus_tab_5',
-  FOCUS_TAB_6 = 'focus_tab_6',
-  FOCUS_TAB_7 = 'focus_tab_7',
-  FOCUS_TAB_8 = 'focus_tab_8',
-  FOCUS_TAB_LAST = 'focus_tab_last',
+
+  // Agent switching (sidebar agents — independent of browser tabs)
+  NEXT_AGENT = 'next_agent',
+  PREV_AGENT = 'prev_agent',
+  FOCUS_AGENT_1 = 'focus_agent_1',
+  FOCUS_AGENT_2 = 'focus_agent_2',
+  FOCUS_AGENT_3 = 'focus_agent_3',
+  FOCUS_AGENT_4 = 'focus_agent_4',
+  FOCUS_AGENT_5 = 'focus_agent_5',
+  FOCUS_AGENT_6 = 'focus_agent_6',
+  FOCUS_AGENT_7 = 'focus_agent_7',
+  FOCUS_AGENT_8 = 'focus_agent_8',
+  FOCUS_AGENT_LAST = 'focus_agent_last',
 
   // History navigation
   HISTORY_BACK = 'history_back',
@@ -119,54 +123,65 @@ export const hotkeyDefinitions: Record<HotkeyActions, HotkeyDefinition> = {
     accelerator: 'Mod+Shift+W',
     captureDominantly: true,
   },
+  // Browser-tab navigation. Ctrl+Tab is intentionally NOT bound here —
+  // those keys drive agent switching via NEXT_AGENT / PREV_AGENT.
   [HotkeyActions.NEXT_TAB]: {
-    // Ctrl+Tab works on all platforms (explicit Ctrl, not Mod)
-    accelerator: 'Ctrl+Tab',
-    aliases: ['Mod+PageDown'],
+    accelerator: 'Mod+PageDown',
     mac: 'Mod+Alt+ArrowRight',
-    macAliases: ['Ctrl+Tab', 'Mod+PageDown'],
+    macAliases: ['Mod+PageDown'],
     captureDominantly: true,
   },
   [HotkeyActions.PREV_TAB]: {
-    accelerator: 'Ctrl+Shift+Tab',
-    aliases: ['Mod+PageUp'],
+    accelerator: 'Mod+PageUp',
     mac: 'Mod+Alt+ArrowLeft',
-    macAliases: ['Ctrl+Shift+Tab', 'Mod+PageUp'],
+    macAliases: ['Mod+PageUp'],
     captureDominantly: true,
   },
-  [HotkeyActions.FOCUS_TAB_1]: {
+
+  // Agent switching. Ctrl+Tab works on all platforms (explicit Ctrl, not
+  // Mod) — Cmd+Tab on macOS is reserved by the OS app switcher and cannot
+  // be intercepted reliably.
+  [HotkeyActions.NEXT_AGENT]: {
+    accelerator: 'Ctrl+Tab',
+    captureDominantly: true,
+  },
+  [HotkeyActions.PREV_AGENT]: {
+    accelerator: 'Ctrl+Shift+Tab',
+    captureDominantly: true,
+  },
+  [HotkeyActions.FOCUS_AGENT_1]: {
     accelerator: 'Mod+1',
     captureDominantly: true,
   },
-  [HotkeyActions.FOCUS_TAB_2]: {
+  [HotkeyActions.FOCUS_AGENT_2]: {
     accelerator: 'Mod+2',
     captureDominantly: true,
   },
-  [HotkeyActions.FOCUS_TAB_3]: {
+  [HotkeyActions.FOCUS_AGENT_3]: {
     accelerator: 'Mod+3',
     captureDominantly: true,
   },
-  [HotkeyActions.FOCUS_TAB_4]: {
+  [HotkeyActions.FOCUS_AGENT_4]: {
     accelerator: 'Mod+4',
     captureDominantly: true,
   },
-  [HotkeyActions.FOCUS_TAB_5]: {
+  [HotkeyActions.FOCUS_AGENT_5]: {
     accelerator: 'Mod+5',
     captureDominantly: true,
   },
-  [HotkeyActions.FOCUS_TAB_6]: {
+  [HotkeyActions.FOCUS_AGENT_6]: {
     accelerator: 'Mod+6',
     captureDominantly: true,
   },
-  [HotkeyActions.FOCUS_TAB_7]: {
+  [HotkeyActions.FOCUS_AGENT_7]: {
     accelerator: 'Mod+7',
     captureDominantly: true,
   },
-  [HotkeyActions.FOCUS_TAB_8]: {
+  [HotkeyActions.FOCUS_AGENT_8]: {
     accelerator: 'Mod+8',
     captureDominantly: true,
   },
-  [HotkeyActions.FOCUS_TAB_LAST]: {
+  [HotkeyActions.FOCUS_AGENT_LAST]: {
     accelerator: 'Mod+9',
     captureDominantly: true,
   },

--- a/apps/browser/src/ui/hooks/use-open-chat.tsx
+++ b/apps/browser/src/ui/hooks/use-open-chat.tsx
@@ -17,19 +17,83 @@ type OpenAgentState = [
   (id: string, fallback?: string | null) => void,
 ];
 
-export const OpenAgentContext = createContext<OpenAgentState>([
-  null,
-  () => {},
-  () => {},
-]);
+export type AgentCycleStepDirection = 'next' | 'previous';
+
+export type AgentCycleResult = {
+  id: string | null;
+  committed: boolean;
+};
+
+export type AgentCycleState = {
+  previewAgentId: string | null;
+  isCyclingAgents: boolean;
+  beginAgentCycle: (
+    orderedAgentIds: string[],
+    direction: AgentCycleStepDirection,
+  ) => string | null;
+  stepAgentCycle: (
+    orderedAgentIds: string[],
+    direction: AgentCycleStepDirection,
+  ) => string | null;
+  commitAgentCycle: () => AgentCycleResult;
+  cancelAgentCycle: () => void;
+  focusAgentFromHotkey: (id: string | null) => void;
+};
+
+type OpenAgentContextValue = {
+  tuple: OpenAgentState;
+  switcher: AgentCycleState;
+};
+
+const noopOpenAgentTuple: OpenAgentState = [null, () => {}, () => {}];
+
+export const noopAgentSwitcher: AgentCycleState = {
+  previewAgentId: null,
+  isCyclingAgents: false,
+  beginAgentCycle: () => null,
+  stepAgentCycle: () => null,
+  commitAgentCycle: () => ({ id: null, committed: false }),
+  cancelAgentCycle: () => {},
+  focusAgentFromHotkey: () => {},
+};
+
+export const OpenAgentContext = createContext<OpenAgentContextValue>({
+  tuple: noopOpenAgentTuple,
+  switcher: noopAgentSwitcher,
+});
 
 export const useOpenAgent = () => {
   const context = useContext(OpenAgentContext);
   if (!context) {
     throw new Error('useOpenAgent must be used within a OpenAgentProvider');
   }
-  return context;
+  return context.tuple;
 };
+
+export const useAgentSwitcher = () => {
+  const context = useContext(OpenAgentContext);
+  if (!context) {
+    throw new Error('useAgentSwitcher must be used within a OpenAgentProvider');
+  }
+  return context.switcher;
+};
+
+function dedupeIds(ids: string[]): string[] {
+  return Array.from(new Set(ids));
+}
+
+function getSteppedIndex({
+  currentIndex,
+  count,
+  direction,
+}: {
+  currentIndex: number;
+  count: number;
+  direction: AgentCycleStepDirection;
+}): number {
+  if (direction === 'next') return (currentIndex + 1) % count;
+  return (currentIndex - 1 + count) % count;
+}
 
 export const OpenAgentProvider = ({
   children,
@@ -40,7 +104,19 @@ export const OpenAgentProvider = ({
   // Stored as a ref so mutations don't trigger extra renders — the
   // derived `openAgent` state is the single source of truth for React.
   const stackRef = useRef<string[]>([]);
+  const cycleSnapshotRef = useRef<string[] | null>(null);
+  const cycleStartAgentRef = useRef<string | null>(null);
+  const cycleCursorRef = useRef<number>(-1);
+  const cyclePreviewRef = useRef<string | null>(null);
+
   const [openAgent, setOpenAgentRaw] = useState<string | null>(null);
+  const [previewAgentId, setPreviewAgentId] = useState<string | null>(null);
+  const [isCyclingAgents, setIsCyclingAgents] = useState(false);
+
+  const setPreview = useCallback((id: string | null) => {
+    cyclePreviewRef.current = id;
+    setPreviewAgentId(id);
+  }, []);
 
   const setOpenAgent = useCallback((id: string | null) => {
     const stack = stackRef.current;
@@ -55,6 +131,19 @@ export const OpenAgentProvider = ({
     setOpenAgentRaw(id);
   }, []);
 
+  const focusAgentFromHotkey = useCallback(
+    (id: string | null) => {
+      if (!id) return;
+      cycleSnapshotRef.current = null;
+      cycleStartAgentRef.current = null;
+      cycleCursorRef.current = -1;
+      setIsCyclingAgents(false);
+      setPreview(null);
+      setOpenAgent(id);
+    },
+    [setOpenAgent, setPreview],
+  );
+
   const removeFromHistory = useCallback(
     (id: string, fallback?: string | null) => {
       const stack = stackRef.current;
@@ -67,13 +156,128 @@ export const OpenAgentProvider = ({
         stack.push(next);
       }
       setOpenAgentRaw((prev) => (prev === id ? next : prev));
+
+      if (cyclePreviewRef.current === id) setPreview(null);
+    },
+    [setPreview],
+  );
+
+  const buildCycleSnapshot = useCallback(
+    (orderedAgentIds: string[]): string[] => {
+      const orderedIds = dedupeIds(orderedAgentIds);
+      const available = new Set(orderedIds);
+      const mruIds = stackRef.current.filter((id) => available.has(id));
+      const snapshot = [
+        ...mruIds.slice().reverse(),
+        ...orderedIds.filter((id) => !mruIds.includes(id)),
+      ];
+
+      return snapshot;
     },
     [],
   );
 
-  const value = useMemo<OpenAgentState>(
+  const beginAgentCycle = useCallback(
+    (orderedAgentIds: string[], direction: AgentCycleStepDirection) => {
+      const snapshot = buildCycleSnapshot(orderedAgentIds);
+      if (snapshot.length === 0) return null;
+
+      cycleSnapshotRef.current = snapshot;
+      cycleStartAgentRef.current = openAgent;
+      setIsCyclingAgents(true);
+
+      const startIndex = openAgent ? snapshot.indexOf(openAgent) : -1;
+      const currentIndex =
+        startIndex !== -1 ? startIndex : direction === 'next' ? -1 : 0;
+      const nextIndex = getSteppedIndex({
+        currentIndex,
+        count: snapshot.length,
+        direction,
+      });
+      const nextId = snapshot[nextIndex] ?? null;
+
+      cycleCursorRef.current = nextIndex;
+      setPreview(nextId);
+      return nextId;
+    },
+    [buildCycleSnapshot, openAgent, setPreview],
+  );
+
+  const stepAgentCycle = useCallback(
+    (orderedAgentIds: string[], direction: AgentCycleStepDirection) => {
+      const snapshot = cycleSnapshotRef.current;
+      if (!snapshot) return beginAgentCycle(orderedAgentIds, direction);
+      if (snapshot.length === 0) return null;
+
+      const nextIndex = getSteppedIndex({
+        currentIndex: cycleCursorRef.current,
+        count: snapshot.length,
+        direction,
+      });
+      const nextId = snapshot[nextIndex] ?? null;
+
+      cycleCursorRef.current = nextIndex;
+      setPreview(nextId);
+      return nextId;
+    },
+    [beginAgentCycle, setPreview],
+  );
+
+  const commitAgentCycle = useCallback((): AgentCycleResult => {
+    const id = cyclePreviewRef.current;
+    const wasCycling = cycleSnapshotRef.current !== null || isCyclingAgents;
+
+    cycleSnapshotRef.current = null;
+    cycleStartAgentRef.current = null;
+    cycleCursorRef.current = -1;
+    setIsCyclingAgents(false);
+    setPreview(null);
+
+    if (!id) return { id: null, committed: false };
+
+    const alreadyOpen = id === openAgent;
+    setOpenAgent(id);
+
+    return { id, committed: wasCycling && !alreadyOpen };
+  }, [isCyclingAgents, openAgent, setOpenAgent, setPreview]);
+
+  const cancelAgentCycle = useCallback(() => {
+    cycleSnapshotRef.current = null;
+    cycleStartAgentRef.current = null;
+    cycleCursorRef.current = -1;
+    setIsCyclingAgents(false);
+    setPreview(null);
+  }, [setPreview]);
+
+  const tuple = useMemo<OpenAgentState>(
     () => [openAgent, setOpenAgent, removeFromHistory],
     [openAgent, setOpenAgent, removeFromHistory],
+  );
+
+  const switcher = useMemo<AgentCycleState>(
+    () => ({
+      previewAgentId,
+      isCyclingAgents,
+      beginAgentCycle,
+      stepAgentCycle,
+      commitAgentCycle,
+      cancelAgentCycle,
+      focusAgentFromHotkey,
+    }),
+    [
+      previewAgentId,
+      isCyclingAgents,
+      beginAgentCycle,
+      stepAgentCycle,
+      commitAgentCycle,
+      cancelAgentCycle,
+      focusAgentFromHotkey,
+    ],
+  );
+
+  const value = useMemo<OpenAgentContextValue>(
+    () => ({ tuple, switcher }),
+    [tuple, switcher],
   );
 
   return (

--- a/apps/browser/src/ui/screens/main/_components/agent-hotkey-bindings.tsx
+++ b/apps/browser/src/ui/screens/main/_components/agent-hotkey-bindings.tsx
@@ -1,0 +1,323 @@
+import {
+  getCurrentPlatform,
+  hotkeyDefinitions,
+  HotkeyActions,
+  isEventMatch,
+} from '@shared/hotkeys';
+import { AgentTypes } from '@shared/karton-contracts/ui/agent';
+import type { AgentHistoryEntry } from '@shared/karton-contracts/ui/agent';
+import { useHotKeyListener } from '@ui/hooks/use-hotkey-listener';
+import {
+  useComparingSelector,
+  useKartonProcedure,
+  useKartonState,
+} from '@ui/hooks/use-karton';
+import { useAgentSwitcher } from '@ui/hooks/use-open-chat';
+import { usePendingRemovals } from '@ui/hooks/use-pending-agent-removals';
+import { extractTipTapText, firstWords } from '@ui/utils/text-utils';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  activeAgentCardsEqual,
+  getOrderedAgentIds,
+  mergeAgentEntries,
+  type ActiveAgentCardData,
+} from '../sidebar/agents-list/agent-list-model';
+import { getToolActivityLabel } from '../sidebar/agents-list/_utils/tool-label';
+
+const HOTKEY_HISTORY_FETCH_LIMIT = 100;
+
+function getVisibleAgentIds() {
+  return Array.from(
+    document.querySelectorAll<HTMLElement>('[data-agent-id]'),
+    (element) => element.dataset.agentId,
+  ).filter((id): id is string => !!id);
+}
+
+function deriveActivityText(
+  history: { role: string; parts: { type: string; text?: string }[] }[],
+  inputState: string,
+): { text: string; isUserInput: boolean } {
+  for (let i = history.length - 1; i >= 0; i--) {
+    const msg = history[i]!;
+    if (msg.role !== 'assistant') continue;
+    const parts = msg.parts;
+    for (let j = parts.length - 1; j >= 0; j--) {
+      const part = parts[j]!;
+      if (part.type === 'reasoning')
+        return { text: 'Thinking…', isUserInput: false };
+      if (part.type === 'text') {
+        const snippet = firstWords(part.text ?? '', 10);
+        if (snippet) return { text: snippet, isUserInput: false };
+        continue;
+      }
+      if (part.type.startsWith('tool-')) {
+        return { text: getToolActivityLabel(part.type), isUserInput: false };
+      }
+    }
+    break;
+  }
+
+  if (inputState) {
+    const draftText = extractTipTapText(inputState).trim();
+    if (draftText) {
+      const snippet = firstWords(draftText, 10, false);
+      if (snippet) return { text: snippet, isUserInput: true };
+    }
+  }
+
+  for (let i = history.length - 1; i >= 0; i--) {
+    const msg = history[i]!;
+    if (msg.role !== 'user') continue;
+    for (let j = msg.parts.length - 1; j >= 0; j--) {
+      const part = msg.parts[j]!;
+      if (part.type === 'text') {
+        const snippet = firstWords(part.text ?? '', 10);
+        if (snippet) return { text: snippet, isUserInput: true };
+      }
+    }
+    break;
+  }
+
+  return { text: '', isUserInput: false };
+}
+
+function useOrderedAgentIds() {
+  const [historyList, setHistoryList] = useState<AgentHistoryEntry[]>([]);
+  const getAgentsHistoryList = useKartonProcedure(
+    (p) => p.agents.getAgentsHistoryList,
+  );
+  const getAgentsHistoryListRef = useRef(getAgentsHistoryList);
+  const fetchedHistoryKeyRef = useRef<string | null>(null);
+  const activeAgentIds = useKartonState(
+    useComparingSelector((s) => Object.keys(s.agents.instances)),
+  );
+  const activeAgentIdsKey = useMemo(
+    () => activeAgentIds.join(','),
+    [activeAgentIds],
+  );
+
+  useEffect(() => {
+    getAgentsHistoryListRef.current = getAgentsHistoryList;
+  }, [getAgentsHistoryList]);
+
+  useEffect(() => {
+    if (activeAgentIds.length === 0) {
+      fetchedHistoryKeyRef.current = null;
+      setHistoryList([]);
+      return;
+    }
+
+    if (fetchedHistoryKeyRef.current === activeAgentIdsKey) return;
+
+    fetchedHistoryKeyRef.current = activeAgentIdsKey;
+    let cancelled = false;
+    getAgentsHistoryListRef
+      .current(0, HOTKEY_HISTORY_FETCH_LIMIT)
+      .then((entries) => {
+        if (!cancelled) setHistoryList(entries);
+      })
+      .catch((err) => {
+        if (!cancelled) fetchedHistoryKeyRef.current = null;
+        console.error('Failed to fetch agent history for hotkeys:', err);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [activeAgentIds.length, activeAgentIdsKey]);
+
+  const agents = useKartonState(
+    useComparingSelector(
+      (s): ActiveAgentCardData[] =>
+        Object.entries(s.agents.instances)
+          .filter(([_, agent]) => agent.type === AgentTypes.CHAT)
+          .map(([id, agent]) => {
+            const history = agent.state.history;
+            const lastMsg = history[history.length - 1]!;
+            const hasPendingQuestion = !!s.toolbox[id]?.pendingUserQuestion;
+            const hasPendingToolApproval = (() => {
+              const h = agent.state.history;
+              for (let i = h.length - 1; i >= 0; i--) {
+                const msg = h[i]!;
+                if (msg.role !== 'assistant') continue;
+                return msg.parts.some(
+                  (p: { type: string; state?: string }) =>
+                    p.state === 'approval-requested',
+                );
+              }
+              return false;
+            })();
+            const isWorking = agent.state.isWorking;
+            const rawActivity = hasPendingQuestion
+              ? { text: 'Waiting for response...', isUserInput: false }
+              : deriveActivityText(
+                  history as {
+                    role: string;
+                    parts: { type: string; text?: string }[];
+                  }[],
+                  agent.state.inputState,
+                );
+            const activity =
+              isWorking && rawActivity.isUserInput
+                ? { text: 'Working…', isUserInput: false }
+                : rawActivity;
+            return {
+              id,
+              title: agent.state.title,
+              isWorking: agent.state.isWorking,
+              isWaitingForUser: hasPendingQuestion || hasPendingToolApproval,
+              activityText: activity.text,
+              activityIsUserInput: activity.isUserInput,
+              hasError:
+                !!agent.state.error &&
+                agent.state.error.kind !== 'plan-limit-exceeded',
+              unread: !!agent.state.unread,
+              lastMessageAt: lastMsg?.metadata?.createdAt
+                ? new Date(lastMsg.metadata.createdAt).getTime()
+                : 0,
+              createdAt: agent.state.history[0]?.metadata?.createdAt
+                ? new Date(agent.state.history[0].metadata.createdAt).getTime()
+                : 0,
+              messageCount: history.length,
+            };
+          }),
+      activeAgentCardsEqual,
+    ),
+  );
+
+  const { pending } = usePendingRemovals();
+
+  return useMemo(
+    () =>
+      getOrderedAgentIds(
+        mergeAgentEntries({
+          activeAgents: agents,
+          historyList,
+          pendingRemovals: pending,
+        }),
+      ),
+    [agents, historyList, pending],
+  );
+}
+
+export function AgentHotkeyBindings() {
+  const orderedAgentIds = useOrderedAgentIds();
+  const orderedAgentIdsRef = useRef(orderedAgentIds);
+  orderedAgentIdsRef.current = orderedAgentIds;
+
+  const resumeAgent = useKartonProcedure((p) => p.agents.resume);
+  const resumeAgentRef = useRef(resumeAgent);
+  resumeAgentRef.current = resumeAgent;
+
+  const platform = useMemo(() => getCurrentPlatform(), []);
+  const {
+    stepAgentCycle,
+    commitAgentCycle,
+    cancelAgentCycle,
+    focusAgentFromHotkey,
+    isCyclingAgents,
+  } = useAgentSwitcher();
+  const isCyclingAgentsRef = useRef(isCyclingAgents);
+  isCyclingAgentsRef.current = isCyclingAgents;
+  const hasActiveCycleRef = useRef(false);
+
+  const handleAgentCycle = useCallback(
+    (direction: 'next' | 'previous') => {
+      const previewId = stepAgentCycle(getVisibleAgentIds(), direction);
+      if (previewId) hasActiveCycleRef.current = true;
+    },
+    [stepAgentCycle],
+  );
+
+  useEffect(() => {
+    const nextAgentDefinition = hotkeyDefinitions[HotkeyActions.NEXT_AGENT];
+    const prevAgentDefinition = hotkeyDefinitions[HotkeyActions.PREV_AGENT];
+
+    const handleCycleKeyDown = (event: KeyboardEvent) => {
+      const direction = isEventMatch(event, prevAgentDefinition, platform)
+        ? 'previous'
+        : isEventMatch(event, nextAgentDefinition, platform)
+          ? 'next'
+          : null;
+
+      if (!direction) return;
+      event.preventDefault();
+      event.stopPropagation();
+
+      // A held Tab key should not race through the stack. Only deliberate
+      // repeated key presses while Ctrl remains held should step the cycle.
+      if (event.repeat) return;
+      handleAgentCycle(direction);
+    };
+
+    window.addEventListener('keydown', handleCycleKeyDown, true);
+    return () => {
+      window.removeEventListener('keydown', handleCycleKeyDown, true);
+    };
+  }, [handleAgentCycle, platform]);
+
+  const commitCycle = useCallback(() => {
+    hasActiveCycleRef.current = false;
+    const { id, committed } = commitAgentCycle();
+    if (id && committed) void resumeAgentRef.current(id);
+  }, [commitAgentCycle]);
+
+  const cancelCycle = useCallback(() => {
+    hasActiveCycleRef.current = false;
+    cancelAgentCycle();
+  }, [cancelAgentCycle]);
+
+  useEffect(() => {
+    const handleKeyUp = (event: KeyboardEvent) => {
+      if (event.key !== 'Control') return;
+      if (!hasActiveCycleRef.current && !isCyclingAgentsRef.current) return;
+      event.preventDefault();
+      event.stopPropagation();
+      commitCycle();
+    };
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== 'Escape') return;
+      if (!hasActiveCycleRef.current && !isCyclingAgentsRef.current) return;
+      event.preventDefault();
+      event.stopPropagation();
+      cancelCycle();
+    };
+
+    const handleBlur = () => {
+      if (hasActiveCycleRef.current || isCyclingAgentsRef.current)
+        commitCycle();
+    };
+
+    window.addEventListener('keyup', handleKeyUp, true);
+    window.addEventListener('keydown', handleKeyDown, true);
+    window.addEventListener('blur', handleBlur);
+    return () => {
+      window.removeEventListener('keyup', handleKeyUp, true);
+      window.removeEventListener('keydown', handleKeyDown, true);
+      window.removeEventListener('blur', handleBlur);
+    };
+  }, [cancelCycle, commitCycle]);
+
+  const focusAgentByIndex = useCallback(
+    (index: number) => {
+      const visibleAgentIds = getVisibleAgentIds();
+      const id = index === 8 ? visibleAgentIds.at(-1) : visibleAgentIds[index];
+      if (!id) return;
+      focusAgentFromHotkey(id);
+      void resumeAgentRef.current(id);
+    },
+    [focusAgentFromHotkey],
+  );
+
+  useHotKeyListener(() => focusAgentByIndex(0), HotkeyActions.FOCUS_AGENT_1);
+  useHotKeyListener(() => focusAgentByIndex(1), HotkeyActions.FOCUS_AGENT_2);
+  useHotKeyListener(() => focusAgentByIndex(2), HotkeyActions.FOCUS_AGENT_3);
+  useHotKeyListener(() => focusAgentByIndex(3), HotkeyActions.FOCUS_AGENT_4);
+  useHotKeyListener(() => focusAgentByIndex(4), HotkeyActions.FOCUS_AGENT_5);
+  useHotKeyListener(() => focusAgentByIndex(5), HotkeyActions.FOCUS_AGENT_6);
+  useHotKeyListener(() => focusAgentByIndex(6), HotkeyActions.FOCUS_AGENT_7);
+  useHotKeyListener(() => focusAgentByIndex(7), HotkeyActions.FOCUS_AGENT_8);
+  useHotKeyListener(() => focusAgentByIndex(8), HotkeyActions.FOCUS_AGENT_LAST);
+
+  return null;
+}

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/index.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/index.tsx
@@ -11,7 +11,11 @@ import { ChatPanelFooter } from './panel-footer';
 import { InternalAppFrame } from './internal-app-frame';
 import { useKartonState } from '@ui/hooks/use-karton';
 import { cn } from '@ui/utils';
-import { useOpenAgent, OpenAgentContext } from '@ui/hooks/use-open-chat';
+import {
+  useOpenAgent,
+  OpenAgentContext,
+  noopAgentSwitcher,
+} from '@ui/hooks/use-open-chat';
 
 export function ChatPanel() {
   const { forwardDropEvent } = useMessageEditState();
@@ -85,12 +89,15 @@ export function ChatPanel() {
 
   // Context override: ChatHistory reads openAgent from context, so we provide
   // the deferred value so React can schedule the heavy render as interruptible.
-  const deferredContext: [
-    string | null,
-    (id: string | null) => void,
-    (id: string) => void,
-  ] = useMemo(
-    () => [deferredAgent, setOpenAgent, removeFromHistory],
+  const deferredContext = useMemo(
+    () => ({
+      tuple: [deferredAgent, setOpenAgent, removeFromHistory] as [
+        string | null,
+        (id: string | null) => void,
+        (id: string, fallback?: string | null) => void,
+      ],
+      switcher: noopAgentSwitcher,
+    }),
     [deferredAgent, setOpenAgent, removeFromHistory],
   );
 

--- a/apps/browser/src/ui/screens/main/content/_components/core-hotkey-bindings.tsx
+++ b/apps/browser/src/ui/screens/main/content/_components/core-hotkey-bindings.tsx
@@ -84,7 +84,9 @@ export function CoreHotkeyBindings({
     onCleanAllTabs();
   }, HotkeyActions.CLOSE_WINDOW);
 
-  // Switch to next tab (aliases handled in definition: Ctrl+Tab, Mod+PageDown, Mod+Alt+Arrow on Mac)
+  // Switch to next browser tab (Mod+PageDown / Mac Cmd+Alt+ArrowRight).
+  // Ctrl+Tab is no longer bound here — it now drives agent switching
+  // (see `agent-hotkey-bindings.tsx`).
   const handleNextTab = useCallback(async () => {
     if (!tabNeighborsToActiveTab?.next) return;
     await handleSwitchTab(tabNeighborsToActiveTab.next);
@@ -92,7 +94,7 @@ export function CoreHotkeyBindings({
 
   useHotKeyListener(handleNextTab, HotkeyActions.NEXT_TAB);
 
-  // Switch to previous tab (aliases handled in definition)
+  // Switch to previous browser tab (Mod+PageUp / Mac Cmd+Alt+ArrowLeft).
   const handlePreviousTab = useCallback(() => {
     if (!tabNeighborsToActiveTab?.previous) return;
     handleSwitchTab(tabNeighborsToActiveTab.previous);
@@ -100,34 +102,8 @@ export function CoreHotkeyBindings({
 
   useHotKeyListener(handlePreviousTab, HotkeyActions.PREV_TAB);
 
-  // Focus specific tabs (Mod+1 through Mod+9)
-  const createTabIndexHandler = useCallback(
-    (index: number) => {
-      return () => {
-        if (index === 9) {
-          // Mod+9 focuses last tab
-          if (tabCount === 0) return;
-          const lastTabId = tabIds[tabCount - 1]!;
-          handleSwitchTab(lastTabId);
-        } else {
-          // Mod+1-8 focus tabs by index (0-based)
-          if (index >= tabCount) return;
-          handleSwitchTab(tabIds[index]!);
-        }
-      };
-    },
-    [tabIds, tabCount, handleSwitchTab],
-  );
-
-  useHotKeyListener(createTabIndexHandler(0), HotkeyActions.FOCUS_TAB_1);
-  useHotKeyListener(createTabIndexHandler(1), HotkeyActions.FOCUS_TAB_2);
-  useHotKeyListener(createTabIndexHandler(2), HotkeyActions.FOCUS_TAB_3);
-  useHotKeyListener(createTabIndexHandler(3), HotkeyActions.FOCUS_TAB_4);
-  useHotKeyListener(createTabIndexHandler(4), HotkeyActions.FOCUS_TAB_5);
-  useHotKeyListener(createTabIndexHandler(5), HotkeyActions.FOCUS_TAB_6);
-  useHotKeyListener(createTabIndexHandler(6), HotkeyActions.FOCUS_TAB_7);
-  useHotKeyListener(createTabIndexHandler(7), HotkeyActions.FOCUS_TAB_8);
-  useHotKeyListener(createTabIndexHandler(9), HotkeyActions.FOCUS_TAB_LAST);
+  // Mod+1…9 are no longer browser-tab index jumps — they focus agents now
+  // (see `agent-hotkey-bindings.tsx`).
 
   // HISTORY NAVIGATION
 

--- a/apps/browser/src/ui/screens/main/index.tsx
+++ b/apps/browser/src/ui/screens/main/index.tsx
@@ -18,6 +18,7 @@ import {
   SidebarCollapsedProvider,
   useSidebarCollapsed,
 } from './_components/sidebar-collapsed-context';
+import { AgentHotkeyBindings } from './_components/agent-hotkey-bindings';
 
 const rootLayoutStorageKey = 'stagewise-panel-layout-root';
 const layoutStorageKey = 'stagewise-panel-layout';
@@ -46,47 +47,50 @@ function DefaultLayoutInner({ show }: { show: boolean }) {
   useAutoSelectFirstAgent();
 
   return (
-    <div
-      className={cn(
-        'root pointer-events-auto inset-0 flex size-full flex-row items-stretch justify-between transition-[opacity,filter] delay-150 duration-300 ease-out',
-        !show && 'pointer-events-none opacity-0 blur-lg',
-      )}
-    >
-      {/* Thin draggable strip at the very top for macOS hidden-titlebar windows */}
-      {isMacOs && !isFullScreen && (
-        <div className="app-drag fixed top-0 right-0 left-0 h-2" />
-      )}
-      <ResizablePanelGroup
-        direction="horizontal"
-        autoSaveId={rootLayoutStorageKey}
-        className="overflow-visible! h-full w-full"
+    <>
+      {show && <AgentHotkeyBindings />}
+      <div
+        className={cn(
+          'root pointer-events-auto inset-0 flex size-full flex-row items-stretch justify-between transition-[opacity,filter] delay-150 duration-300 ease-out',
+          !show && 'pointer-events-none opacity-0 blur-lg',
+        )}
       >
-        <Sidebar />
-
-        {!collapsed && <ResizableHandle />}
-
-        <ResizablePanel
-          id="content-panel"
-          order={1}
-          defaultSize={65}
-          className={cn(
-            'h-full overflow-hidden rounded-l-xl ring-1 ring-derived-subtle',
-            !isMacOs && 'mt-px',
-          )}
+        {/* Thin draggable strip at the very top for macOS hidden-titlebar windows */}
+        {isMacOs && !isFullScreen && (
+          <div className="app-drag fixed top-0 right-0 left-0 h-2" />
+        )}
+        <ResizablePanelGroup
+          direction="horizontal"
+          autoSaveId={rootLayoutStorageKey}
+          className="overflow-visible! h-full w-full"
         >
-          <ResizablePanelGroup
-            direction="horizontal"
-            autoSaveId={layoutStorageKey}
-            className="h-full divide-x divide-surface-1"
+          <Sidebar />
+
+          {!collapsed && <ResizableHandle />}
+
+          <ResizablePanel
+            id="content-panel"
+            order={1}
+            defaultSize={65}
+            className={cn(
+              'h-full overflow-hidden rounded-l-xl ring-1 ring-derived-subtle',
+              !isMacOs && 'mt-px',
+            )}
           >
-            <AgentChat />
+            <ResizablePanelGroup
+              direction="horizontal"
+              autoSaveId={layoutStorageKey}
+              className="h-full divide-x divide-surface-1"
+            >
+              <AgentChat />
 
-            <ResizableHandle />
+              <ResizableHandle />
 
-            <MainSection />
-          </ResizablePanelGroup>
-        </ResizablePanel>
-      </ResizablePanelGroup>
-    </div>
+              <MainSection />
+            </ResizablePanelGroup>
+          </ResizablePanel>
+        </ResizablePanelGroup>
+      </div>
+    </>
   );
 }

--- a/apps/browser/src/ui/screens/main/sidebar/agents-list/_components/agent-card.tsx
+++ b/apps/browser/src/ui/screens/main/sidebar/agents-list/_components/agent-card.tsx
@@ -31,6 +31,7 @@ export interface AgentCardProps {
   id: string;
   title: string;
   isActive: boolean;
+  isPreviewActive?: boolean;
   isWorking: boolean;
   isWaitingForUser: boolean;
   hasError: boolean;
@@ -71,6 +72,7 @@ export const AgentCard = memo(
       id,
       title,
       isActive,
+      isPreviewActive = false,
       isWorking,
       isWaitingForUser,
       hasError,
@@ -141,6 +143,7 @@ export const AgentCard = memo(
         className={cn(
           buttonVariants({ variant: 'ghost', size: 'sm' }),
           'group/card relative justify-start pl-1.5 text-start text-muted-foreground hover:bg-foreground/8',
+          isPreviewActive && !isActive && 'bg-foreground/8 text-foreground',
           isActive && 'bg-foreground/5 text-foreground',
         )}
       >
@@ -278,6 +281,7 @@ export const AgentCard = memo(
     prev.id === next.id &&
     prev.title === next.title &&
     prev.isActive === next.isActive &&
+    prev.isPreviewActive === next.isPreviewActive &&
     prev.isWorking === next.isWorking &&
     prev.isWaitingForUser === next.isWaitingForUser &&
     prev.hasError === next.hasError &&

--- a/apps/browser/src/ui/screens/main/sidebar/agents-list/agent-list-model.ts
+++ b/apps/browser/src/ui/screens/main/sidebar/agents-list/agent-list-model.ts
@@ -1,0 +1,119 @@
+import type { AgentHistoryEntry } from '@shared/karton-contracts/ui/agent';
+
+export type ActiveAgentCardData = {
+  id: string;
+  title: string;
+  isWorking: boolean;
+  isWaitingForUser: boolean;
+  activityText: string;
+  activityIsUserInput: boolean;
+  hasError: boolean;
+  lastMessageAt: number;
+  createdAt: number;
+  messageCount: number;
+  unread: boolean;
+};
+
+/** Unified entry for the merged active + history list. */
+export type MergedAgentEntry = ActiveAgentCardData & {
+  /** True when this agent is currently loaded in-memory (active instance). */
+  isLive: boolean;
+};
+
+export function activeAgentCardsEqual(
+  a: ActiveAgentCardData[],
+  b: ActiveAgentCardData[],
+): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    const ai = a[i]!;
+    const bi = b[i]!;
+    if (
+      ai.id !== bi.id ||
+      ai.title !== bi.title ||
+      ai.isWorking !== bi.isWorking ||
+      ai.isWaitingForUser !== bi.isWaitingForUser ||
+      ai.activityText !== bi.activityText ||
+      ai.activityIsUserInput !== bi.activityIsUserInput ||
+      ai.hasError !== bi.hasError ||
+      ai.lastMessageAt !== bi.lastMessageAt ||
+      ai.createdAt !== bi.createdAt ||
+      ai.messageCount !== bi.messageCount ||
+      ai.unread !== bi.unread
+    )
+      return false;
+  }
+  return true;
+}
+
+export function mergeAgentEntries({
+  activeAgents,
+  historyList,
+  pendingRemovals,
+  now = Date.now(),
+}: {
+  activeAgents: ActiveAgentCardData[];
+  historyList: AgentHistoryEntry[];
+  pendingRemovals: ReadonlySet<string>;
+  now?: number;
+}): MergedAgentEntry[] {
+  const activeById = new Map(activeAgents.map((a) => [a.id, a]));
+  const historyById = new Map(historyList.map((e) => [e.id, e]));
+
+  const historyEntries: MergedAgentEntry[] = historyList
+    .filter((e) => !activeById.has(e.id) && !pendingRemovals.has(e.id))
+    .map((e) => ({
+      id: e.id,
+      title: e.title,
+      isWorking: false,
+      isWaitingForUser: false,
+      activityText: '',
+      activityIsUserInput: false,
+      hasError: false,
+      unread: false,
+      lastMessageAt: new Date(e.lastMessageAt).getTime(),
+      createdAt: new Date(e.createdAt).getTime(),
+      messageCount: e.messageCount,
+      isLive: false,
+    }));
+
+  const activeEntries: MergedAgentEntry[] = activeAgents
+    .filter((a) => !pendingRemovals.has(a.id))
+    .map((a) => {
+      const h = historyById.get(a.id);
+      const createdAt =
+        a.createdAt > 0
+          ? a.createdAt
+          : h
+            ? new Date(h.createdAt).getTime()
+            : now;
+      return {
+        ...a,
+        title: a.title || h?.title || a.title,
+        isLive: true,
+        lastMessageAt:
+          a.lastMessageAt > 0
+            ? a.lastMessageAt
+            : h
+              ? new Date(h.lastMessageAt).getTime()
+              : 0,
+        createdAt,
+      };
+    });
+
+  return sortAgentEntriesNewestFirst([...activeEntries, ...historyEntries]);
+}
+
+export function sortAgentEntriesNewestFirst(
+  entries: MergedAgentEntry[],
+): MergedAgentEntry[] {
+  return entries.sort(
+    (a, b) =>
+      Math.max(b.lastMessageAt, b.createdAt) -
+      Math.max(a.lastMessageAt, a.createdAt),
+  );
+}
+
+export function getOrderedAgentIds(entries: MergedAgentEntry[]): string[] {
+  return entries.map((agent) => agent.id);
+}

--- a/apps/browser/src/ui/screens/main/sidebar/agents-list/index.tsx
+++ b/apps/browser/src/ui/screens/main/sidebar/agents-list/index.tsx
@@ -38,9 +38,15 @@ import {
   useKartonProcedure,
   useKartonState,
 } from '@ui/hooks/use-karton';
-import { useOpenAgent } from '@ui/hooks/use-open-chat';
+import { useAgentSwitcher, useOpenAgent } from '@ui/hooks/use-open-chat';
 import { AgentTypes } from '@shared/karton-contracts/ui/agent';
 import type { AgentHistoryEntry } from '@shared/karton-contracts/ui/agent';
+import {
+  activeAgentCardsEqual,
+  mergeAgentEntries,
+  type ActiveAgentCardData,
+  type MergedAgentEntry,
+} from './agent-list-model';
 import { EMPTY_MOUNTS } from '@shared/karton-contracts/ui';
 import type { ToolApprovalMode } from '@shared/karton-contracts/ui/shared-types';
 import { Button } from '@stagewise/stage-ui/components/button';
@@ -74,26 +80,6 @@ enablePatches();
 // Types & helpers
 // ============================================================================
 
-type ActiveAgentCardData = {
-  id: string;
-  title: string;
-  isWorking: boolean;
-  isWaitingForUser: boolean;
-  activityText: string;
-  activityIsUserInput: boolean;
-  hasError: boolean;
-  lastMessageAt: number;
-  createdAt: number;
-  messageCount: number;
-  unread: boolean;
-};
-
-/** Unified entry for the merged active + history list. */
-type MergedAgentEntry = ActiveAgentCardData & {
-  /** True when this agent is currently loaded in-memory (active instance). */
-  isLive: boolean;
-};
-
 function stringArraysEqual(a: string[], b: string[]): boolean {
   if (a.length !== b.length) return false;
   return a.every((value, index) => value === b[index]);
@@ -114,32 +100,6 @@ function agentHistoryEntriesEqual(
       ai.lastMessageAt !== bi.lastMessageAt ||
       ai.messageCount !== bi.messageCount ||
       ai.parentAgentInstanceId !== bi.parentAgentInstanceId
-    )
-      return false;
-  }
-  return true;
-}
-
-function activeAgentCardsEqual(
-  a: ActiveAgentCardData[],
-  b: ActiveAgentCardData[],
-): boolean {
-  if (a.length !== b.length) return false;
-  for (let i = 0; i < a.length; i++) {
-    const ai = a[i]!;
-    const bi = b[i]!;
-    if (
-      ai.id !== bi.id ||
-      ai.title !== bi.title ||
-      ai.isWorking !== bi.isWorking ||
-      ai.isWaitingForUser !== bi.isWaitingForUser ||
-      ai.activityText !== bi.activityText ||
-      ai.activityIsUserInput !== bi.activityIsUserInput ||
-      ai.hasError !== bi.hasError ||
-      ai.lastMessageAt !== bi.lastMessageAt ||
-      ai.createdAt !== bi.createdAt ||
-      ai.messageCount !== bi.messageCount ||
-      ai.unread !== bi.unread
     )
       return false;
   }
@@ -371,6 +331,7 @@ function SortablePinnedAgentCard({
 export function AgentsList() {
   const isMacOs = useKartonState((s) => s.appInfo.platform === 'darwin');
   const [openAgent, setOpenAgent] = useOpenAgent();
+  const { previewAgentId } = useAgentSwitcher();
   const createAgent = useKartonProcedure((p) => p.agents.create);
   const resumeAgent = useKartonProcedure((p) => p.agents.resume);
   const deleteAgent = useKartonProcedure((p) => p.agents.delete);
@@ -669,83 +630,24 @@ export function AgentsList() {
   // Merged list: active + history, sorted newest-first by lastMessageAt.
   // =========================================================================
 
-  const allAgents = useMemo((): MergedAgentEntry[] => {
-    const activeById = new Map(agents.map((a) => [a.id, a]));
-    const pendingSet = pendingRemovals;
+  const mergedHistoryList = useMemo(
+    () =>
+      [...pinnedHistoryList, ...historyList].filter(
+        (entry, index, entries) =>
+          entries.findIndex((candidate) => candidate.id === entry.id) === index,
+      ),
+    [pinnedHistoryList, historyList],
+  );
 
-    // Index history entries by id for fallback lookups. Pinned-by-id
-    // entries come first so older pinned agents outside the paginated
-    // history slice can still be resolved.
-    const mergedHistoryList = [...pinnedHistoryList, ...historyList].filter(
-      (entry, index, entries) =>
-        entries.findIndex((candidate) => candidate.id === entry.id) === index,
-    );
-    const historyById = new Map(mergedHistoryList.map((e) => [e.id, e]));
-
-    // History entries: exclude those that are already active or pending removal.
-    const historyEntries: MergedAgentEntry[] = mergedHistoryList
-      .filter((e) => !activeById.has(e.id) && !pendingSet.has(e.id))
-      .map((e) => ({
-        id: e.id,
-        title: e.title,
-        isWorking: false,
-        isWaitingForUser: false,
-        activityText: '',
-        activityIsUserInput: false,
-        hasError: false,
-        unread: false,
-        lastMessageAt: new Date(e.lastMessageAt).getTime(),
-        createdAt: new Date(e.createdAt).getTime(),
-        messageCount: e.messageCount,
-        isLive: false,
-      }));
-
-    // Active entries: exclude those pending removal.
-    // When an agent was just resumed, its active state may still be loading
-    // — fall back to the persisted history entry for title and timestamps
-    // so the card doesn't flicker or jump position.
-    // For brand-new agents (no history entry, no messages), use Date.now()
-    // so they sort to the top instead of being hidden at the bottom.
-    const now = Date.now();
-    const activeEntries: MergedAgentEntry[] = agents
-      .filter((a) => !pendingSet.has(a.id))
-      .map((a) => {
-        const h = historyById.get(a.id);
-        const createdAt =
-          a.createdAt > 0
-            ? a.createdAt
-            : h
-              ? new Date(h.createdAt).getTime()
-              : now;
-        return {
-          ...a,
-          title: a.title || h?.title || a.title,
-          isLive: true,
-          lastMessageAt:
-            a.lastMessageAt > 0
-              ? a.lastMessageAt
-              : h
-                ? new Date(h.lastMessageAt).getTime()
-                : 0,
-          createdAt,
-        };
-      });
-
-    // Sort by the higher of lastMessageAt and createdAt so new agents
-    // (no messages yet, createdAt = now) appear at the top.
-    // NOTE: This must stay aligned with `getAgentHistoryEntries` on the
-    // backend, which paginates ordered by lastMessageAt. If the two
-    // diverge, paginated fetches return a different slice than the one
-    // the UI sorts/groups by, and agents go missing from time-bucket
-    // sections until the user clicks "Show more".
-    const merged = [...activeEntries, ...historyEntries].sort(
-      (a, b) =>
-        Math.max(b.lastMessageAt, b.createdAt) -
-        Math.max(a.lastMessageAt, a.createdAt),
-    );
-
-    return merged;
-  }, [agents, historyList, pendingRemovals, pinnedHistoryList]);
+  const allAgents = useMemo(
+    (): MergedAgentEntry[] =>
+      mergeAgentEntries({
+        activeAgents: agents,
+        historyList: mergedHistoryList,
+        pendingRemovals,
+      }),
+    [agents, mergedHistoryList, pendingRemovals],
+  );
 
   // =========================================================================
   // Pinned agent preferences
@@ -1087,6 +989,12 @@ export function AgentsList() {
     if (openAgent) scrollCardIntoView(openAgent);
   }, [openAgent, scrollCardIntoView]);
 
+  // During Ctrl+Tab cycling, keep the preview-highlighted card visible without
+  // committing the chat-panel switch.
+  useEffect(() => {
+    if (previewAgentId) scrollCardIntoView(previewAgentId);
+  }, [previewAgentId, scrollCardIntoView]);
+
   // Clear the unread dot when the user opens an agent.
   useEffect(() => {
     if (openAgent) {
@@ -1272,6 +1180,7 @@ export function AgentsList() {
 
           const agent = item.agent;
           const isOpen = agent.id === openAgent;
+          const isPreviewOpen = agent.id === previewAgentId;
           const hasUnseen = !isOpen && agent.unread;
 
           return (
@@ -1280,6 +1189,7 @@ export function AgentsList() {
               id={agent.id}
               title={agent.title}
               isActive={isOpen}
+              isPreviewActive={isPreviewOpen}
               isWorking={agent.isWorking}
               isWaitingForUser={agent.isWaitingForUser}
               hasError={agent.hasError}


### PR DESCRIPTION
implement #1097 


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add agent switching with Ctrl+Tab, including a live sidebar preview, commit-on-release, and auto-resume on switch. Browser tab shortcuts are remapped, and Mod+1…9 now jump to visible agents for faster navigation.

- New Features
  - Cycle agents with Ctrl+Tab / Ctrl+Shift+Tab; preview is highlighted; release Ctrl to commit; Esc to cancel; window blur commits; discrete Tab presses only (no key-repeat); uses Ctrl+Tab on all platforms (Cmd+Tab remains OS-level).
  - Mod+1…8 focus agents 1–8; Mod+9 focuses the last visible agent; focusing or committing resumes the agent.
  - Sidebar auto-scrolls preview/open agents into view and shows a preview highlight state.
  - Cycling order merges active + history, sorted by recency with MRU weighting for predictable cycling.

- Migration
  - Ctrl+Tab / Ctrl+Shift+Tab → next/previous agent (no longer switches browser tabs).
  - Mod+PageDown / Mod+PageUp → next/previous browser tab (Mac: Cmd+Alt+Right/Left).
  - Mod+1…9 → focus agents (9 = last visible).

<sup>Written for commit 330a3e72a6812042d6ba5936fb26020b33e0aedb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Global shortcuts to cycle agents (Ctrl+Tab / Ctrl+Shift+Tab) and jump to specific agents with Mod+1–Mod+8 (Mod+9 = last).
  * Live preview while cycling: agent card preview highlight with auto-scroll; commit on key release, cancel with Escape or blur.
  * Platform-aware tab navigation now uses Mod+PageDown / Mod+PageUp (with macOS-specific aliases).

* **Changes**
  * Numeric Mod+ shortcuts repurposed to focus agents instead of browser tabs.
  * Agent list ordering and merge logic improved for consistent previewing and cycling behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stagewise-io/stagewise/pull/1099)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->