### PR TITLE
style(stagewise): extract usage warnings and update notes into sideba…

### DIFF
--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/index.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/index.tsx
@@ -9,8 +9,6 @@ import {
 import { ChatHistory } from './chat-history';
 import { ChatPanelFooter } from './panel-footer';
 import { InternalAppFrame } from './internal-app-frame';
-import { UsageWarningBadge } from './usage-warning-badge';
-import { NotificationBanners } from './notification-banners';
 import { useKartonState } from '@ui/hooks/use-karton';
 import { cn } from '@ui/utils';
 import { useOpenAgent, OpenAgentContext } from '@ui/hooks/use-open-chat';
@@ -131,8 +129,6 @@ export function ChatPanel() {
           }}
         >
           <InternalAppFrame />
-          <NotificationBanners />
-          <UsageWarningBadge />
         </div>
         <ChatPanelFooter key={openAgent} />
       </div>

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/notification-banners.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/notification-banners.tsx
@@ -19,12 +19,12 @@ export function NotificationBanners() {
   if (notifications.length === 0) return null;
 
   return (
-    <div className="flex flex-col gap-2">
+    <div className="flex shrink-0 flex-col gap-2">
       {notifications.map((notification) => (
         <div
           key={notification.id}
           className={cn(
-            'relative flex shrink-0 flex-col gap-1.5 rounded-md bg-background p-2.5 shadow-elevation-1 ring-1 ring-derived-strong dark:bg-surface-1',
+            'relative flex shrink-0 flex-col gap-1.5 rounded-md bg-background/60 p-2.5 shadow-elevation-1 ring-1 ring-derived-strong backdrop-blur-xl dark:bg-surface-1/60',
           )}
         >
           <div className="flex flex-row items-start gap-2">

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/usage-warning-badge.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/usage-warning-badge.tsx
@@ -28,10 +28,16 @@ export function UsageWarningBadge() {
   // Scan all agents — not just the open one — so the warning is global.
   const instances = useKartonState((s) => s.agents.instances);
   const stateUsageWarning = useMemo(() => {
+    let highest:
+      | NonNullable<(typeof instances)[string]['state']['usageWarning']>
+      | undefined;
     for (const instance of Object.values(instances)) {
-      if (instance.state.usageWarning) return instance.state.usageWarning;
+      const warning = instance.state.usageWarning;
+      if (warning && (!highest || warning.usedPercent > highest.usedPercent)) {
+        highest = warning;
+      }
     }
-    return undefined;
+    return highest;
   }, [instances]);
 
   if (!stateUsageWarning) return null;

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/usage-warning-badge.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/usage-warning-badge.tsx
@@ -1,29 +1,53 @@
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
 import { useKartonState } from '@ui/hooks/use-karton';
-import { useOpenAgent } from '@ui/hooks/use-open-chat';
 import { Button } from '@stagewise/stage-ui/components/button';
 import { XIcon, TriangleAlertIcon } from 'lucide-react';
 
-let usageWarningDismissedThisSession = false;
+const THRESHOLDS = [80, 90, 100] as const;
+
+/** Highest threshold dismissed this app session. Resets on restart. */
+let lastDismissedThreshold = 0;
+
+/** Find the highest crossed threshold that hasn't been dismissed yet. */
+function findActiveThreshold(
+  usedPercent: number,
+  dismissed: number,
+): number | null {
+  for (let i = THRESHOLDS.length - 1; i >= 0; i--) {
+    const t = THRESHOLDS[i]!;
+    if (usedPercent >= t && t > dismissed) return t;
+  }
+  return null;
+}
 
 export function UsageWarningBadge() {
-  const [openAgent] = useOpenAgent();
-  const [dismissed, setDismissed] = useState(
-    () => usageWarningDismissedThisSession,
+  const [dismissedThreshold, setDismissedThreshold] = useState(
+    () => lastDismissedThreshold,
   );
 
-  const usageWarning = useKartonState((s) => {
-    if (!openAgent) return undefined;
-    return s.agents.instances[openAgent]?.state.usageWarning;
-  });
+  // Scan all agents — not just the open one — so the warning is global.
+  const instances = useKartonState((s) => s.agents.instances);
+  const stateUsageWarning = useMemo(() => {
+    for (const instance of Object.values(instances)) {
+      if (instance.state.usageWarning) return instance.state.usageWarning;
+    }
+    return undefined;
+  }, [instances]);
 
-  if (dismissed || !usageWarning) return null;
+  if (!stateUsageWarning) return null;
 
-  const pct = Math.round(usageWarning.usedPercent);
-  const window = usageWarning.windowType;
+  const activeThreshold = findActiveThreshold(
+    stateUsageWarning.usedPercent,
+    dismissedThreshold,
+  );
+
+  if (!activeThreshold) return null;
+
+  const pct = Math.round(stateUsageWarning.usedPercent);
+  const window = stateUsageWarning.windowType;
 
   return (
-    <div className="relative flex shrink-0 flex-row items-start gap-2 rounded-md bg-background p-2.5 shadow-elevation-1 ring-1 ring-derived-strong dark:bg-surface-1">
+    <div className="relative flex shrink-0 flex-row items-start gap-2 rounded-md bg-background/60 p-2.5 shadow-elevation-1 ring-1 ring-derived-strong backdrop-blur-xl dark:bg-surface-1/60">
       <TriangleAlertIcon className="mt-0.5 size-3.5 shrink-0 text-warning-foreground" />
       <span className="text-foreground text-xs">
         You&apos;ve used {pct}% of your {window} limit. Consider switching to a
@@ -35,8 +59,8 @@ export function UsageWarningBadge() {
         className="ml-auto shrink-0"
         aria-label="Dismiss usage warning"
         onClick={() => {
-          usageWarningDismissedThisSession = true;
-          setDismissed(true);
+          lastDismissedThreshold = activeThreshold;
+          setDismissedThreshold(activeThreshold);
         }}
       >
         <XIcon className="size-3" />

--- a/apps/browser/src/ui/screens/main/sidebar/index.tsx
+++ b/apps/browser/src/ui/screens/main/sidebar/index.tsx
@@ -23,6 +23,8 @@ import {
   readInitialSidebarCollapsed,
   useSidebarCollapsed,
 } from '../_components/sidebar-collapsed-context';
+import { NotificationBanners } from '../agent-chat/chat/_components/notification-banners';
+import { UsageWarningBadge } from '../agent-chat/chat/_components/usage-warning-badge';
 
 // Read the persisted collapsed state *once* at module eval so we can seed
 // `defaultSize` on first render. Without this the panel mounts expanded
@@ -98,8 +100,13 @@ export function Sidebar() {
         >
           <AgentsList />
 
+          <div className="mt-8 flex shrink-0 flex-col gap-2">
+            <NotificationBanners />
+            <UsageWarningBadge />
+          </div>
+
           {/* Bottom auth section */}
-          <div className="mt-8 flex flex-col gap-2">
+          <div className="mt-2 flex shrink-0 flex-col gap-2">
             <div className="flex flex-row items-center justify-between gap-2">
               {isAuthenticated ? (
                 <button


### PR DESCRIPTION
implements #1050


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved usage warnings and update banners into a dedicated sidebar section so they’re always visible and don’t overlay chat. Implements #1050 with global warnings and session-aware, threshold-aware dismissals.

- **Refactors**
  - Removed `NotificationBanners` and `UsageWarningBadge` from `ChatPanel`; added them to the sidebar above the auth section.
  - Usage warnings are global: scan all agent instances, show the highest crossed 80/90/100% threshold, and persist the highest dismissed threshold for the session.
  - Updated styles/layout: translucent `/60` backgrounds with `backdrop-blur-xl`, `shrink-0` containers, and tighter sidebar spacing.

<sup>Written for commit fae916a1e4d86f51fa7f5cbd306400043ea6daf0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Notification banners updated to a semi-transparent, blurred backdrop for improved visual appearance.

* **Refactor**
  * Notification banners and the usage warning were removed from the chat view and relocated to the sidebar; chat panel no longer displays them.

* **Bug Fixes**
  * Usage warning now evaluates thresholds across all agents and supports threshold-aware dismissal so higher warnings can reappear.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stagewise-io/stagewise/pull/1100)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->