### PR TITLE
feat(stagewise): support agent-pinning

### DIFF
--- a/apps/browser/src/backend/services/agent-manager/agent-manager.ts
+++ b/apps/browser/src/backend/services/agent-manager/agent-manager.ts
@@ -454,6 +454,12 @@ export class AgentManagerService extends DisposableService {
       },
     );
     this.karton.registerServerProcedureHandler(
+      'agents.getAgentHistoryEntriesByIds',
+      async (_callingClientId: string, ids: string[]) => {
+        return await this.getAgentHistoryEntriesByIds(ids);
+      },
+    );
+    this.karton.registerServerProcedureHandler(
       'agents.updateInputState',
       async (
         _callingClientId: string,
@@ -1341,5 +1347,13 @@ export class AgentManagerService extends DisposableService {
         ? `%${searchString.trim()}%`
         : undefined,
     );
+  }
+
+  private async getAgentHistoryEntriesByIds(
+    ids: string[],
+  ): Promise<AgentHistoryEntry[]> {
+    const db = await this.ensureDBReady();
+    if (!db) return [];
+    return await db.getAgentHistoryEntriesByIds(ids);
   }
 }

--- a/apps/browser/src/backend/services/agent-manager/persistence/db.ts
+++ b/apps/browser/src/backend/services/agent-manager/persistence/db.ts
@@ -3,6 +3,7 @@ import * as schema from './schema';
 import {
   and,
   notInArray,
+  inArray,
   ilike,
   desc,
   isNull,
@@ -133,6 +134,39 @@ export class AgentPersistenceDB {
    *
    * @returns The stored agent instances
    */
+  public async getAgentHistoryEntriesByIds(
+    ids: string[],
+  ): Promise<AgentHistoryEntry[]> {
+    if (ids.length === 0) return [];
+
+    const results = await this._db
+      .select({
+        id: schema.agentInstances.id,
+        title: schema.agentInstances.title,
+        createdAt: schema.agentInstances.createdAt,
+        lastMessageAt: schema.agentInstances.lastMessageAt,
+        messageCount: sql<number>`(SELECT COUNT(*) FROM agentMessages WHERE agent_instance_id = ${schema.agentInstances.id})`,
+        parentAgentInstanceId: schema.agentInstances.parentAgentInstanceId,
+      })
+      .from(schema.agentInstances)
+      .where(
+        and(
+          inArray(schema.agentInstances.id, ids),
+          isNull(schema.agentInstances.parentAgentInstanceId),
+          eq(schema.agentInstances.type, AgentTypes.CHAT),
+        ),
+      );
+
+    this._logger.debug(
+      `[AgentPersistenceDB] Fetched agent history entries by ids`,
+    );
+
+    const resultById = new Map(results.map((entry) => [entry.id, entry]));
+    return ids
+      .map((id) => resultById.get(id))
+      .filter((entry): entry is AgentHistoryEntry => entry !== undefined);
+  }
+
   public async getStoredAgentInstanceById(
     id: string,
   ): Promise<schema.StoredAgentInstance | null> {

--- a/apps/browser/src/shared/karton-contracts/ui/index.ts
+++ b/apps/browser/src/shared/karton-contracts/ui/index.ts
@@ -691,6 +691,9 @@ export type KartonContract = {
         limit: number,
         searchString?: string,
       ) => Promise<AgentHistoryEntry[]>;
+      getAgentHistoryEntriesByIds: (
+        ids: string[],
+      ) => Promise<AgentHistoryEntry[]>;
       updateInputState: (agentId: string, inputState: string) => Promise<void>;
       sendUserMessage: (
         agentId: string,

--- a/apps/browser/src/shared/karton-contracts/ui/shared-types.test.ts
+++ b/apps/browser/src/shared/karton-contracts/ui/shared-types.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { userPreferencesSchema } from './shared-types';
+
+describe('userPreferencesSchema sidebar defaults', () => {
+  it('defaults sidebar preferences when sidebar is missing', () => {
+    const parsed = userPreferencesSchema.parse({});
+
+    expect(parsed.sidebar).toEqual({
+      showActiveAgents: true,
+      pinnedAgentIds: [],
+    });
+  });
+
+  it('defaults pinned agent ids for legacy sidebar preferences', () => {
+    const parsed = userPreferencesSchema.parse({
+      sidebar: { showActiveAgents: false },
+    });
+
+    expect(parsed.sidebar).toEqual({
+      showActiveAgents: false,
+      pinnedAgentIds: [],
+    });
+  });
+
+  it('defaults active agents visibility when only pinned ids exist', () => {
+    const parsed = userPreferencesSchema.parse({
+      sidebar: { pinnedAgentIds: ['agent-b', 'agent-a'] },
+    });
+
+    expect(parsed.sidebar).toEqual({
+      showActiveAgents: true,
+      pinnedAgentIds: ['agent-b', 'agent-a'],
+    });
+  });
+
+  it('preserves complete sidebar preferences', () => {
+    const parsed = userPreferencesSchema.parse({
+      sidebar: { showActiveAgents: false, pinnedAgentIds: ['agent-a'] },
+    });
+
+    expect(parsed.sidebar).toEqual({
+      showActiveAgents: false,
+      pinnedAgentIds: ['agent-a'],
+    });
+  });
+});

--- a/apps/browser/src/shared/karton-contracts/ui/shared-types.ts
+++ b/apps/browser/src/shared/karton-contracts/ui/shared-types.ts
@@ -405,6 +405,21 @@ export const DEFAULT_TOOL_APPROVAL_MODE: ToolApprovalMode = 'alwaysAsk';
 export const updateChannelSchema = z.enum(['alpha', 'beta']);
 export type UpdateChannel = z.infer<typeof updateChannelSchema>;
 
+const defaultSidebarPreferences = {
+  showActiveAgents: true,
+  pinnedAgentIds: [],
+};
+
+const sidebarPreferencesSchema = z
+  .object({
+    /** Whether to show the active agents grid in the sidebar */
+    showActiveAgents: z.boolean().default(true),
+    /** Ordered agent IDs pinned to the top of the sidebar */
+    pinnedAgentIds: z.array(z.string()).default([]),
+  })
+  .default(defaultSidebarPreferences)
+  .catch(defaultSidebarPreferences);
+
 export const userPreferencesSchema = z.object({
   privacy: z
     .object({
@@ -451,12 +466,7 @@ export const userPreferencesSchema = z.object({
       lastUsedOrigin: null,
     }),
   /** Sidebar display preferences */
-  sidebar: z
-    .object({
-      /** Whether to show the active agents grid in the sidebar */
-      showActiveAgents: z.boolean().default(true),
-    })
-    .default({ showActiveAgents: true }),
+  sidebar: sidebarPreferencesSchema,
   /** Per-workspace agent settings (keyed by workspace absolute path) */
   agent: z
     .object({
@@ -563,7 +573,7 @@ export const defaultUserPreferences: UserPreferences = {
   },
   permissions: defaultPermissionsForUserPrefs,
   devToolbar: defaultDevToolbarForUserPrefs,
-  sidebar: { showActiveAgents: true },
+  sidebar: defaultSidebarPreferences,
   agent: {
     workspaceSettings: {},
     disabledModelIds: ['claude-opus-4.6', 'kimi-k2.5', 'gpt-5.4', 'MiniMax-M2'],

--- a/apps/browser/src/ui/screens/main/_components/shared-agent-context-menu.tsx
+++ b/apps/browser/src/ui/screens/main/_components/shared-agent-context-menu.tsx
@@ -7,6 +7,8 @@ import {
   IconCopyIdOutline18,
   IconFolderOpenOutline18,
   IconPen2Outline18,
+  IconPinTackOutline18,
+  IconPinTackSlashOutline18,
 } from 'nucleo-ui-outline-18';
 import { useFloatingIsolation } from './use-floating-isolation';
 
@@ -33,6 +35,8 @@ export interface AgentContextMenuTarget {
    * when the user picks "Rename".
    */
   rename: () => void;
+  isPinned?: boolean;
+  togglePinned?: (id: string) => void;
 }
 
 export interface SharedAgentContextMenuState {
@@ -68,6 +72,8 @@ export function buildAgentContextMenuHandler(
   state: SharedAgentContextMenuState,
   agentId: string,
   rename: () => void,
+  isPinned?: boolean,
+  togglePinned?: (id: string) => void,
 ): (e: React.MouseEvent) => void {
   return (e) => {
     e.preventDefault();
@@ -78,6 +84,8 @@ export function buildAgentContextMenuHandler(
       y: e.clientY,
       showDev: e.shiftKey,
       rename,
+      isPinned,
+      togglePinned,
     });
   };
 }
@@ -158,7 +166,7 @@ export const SharedAgentContextMenuHost = memo(
     );
 
     if (!activeTarget) return null;
-    const { agentId, showDev, rename } = activeTarget;
+    const { agentId, showDev, rename, isPinned, togglePinned } = activeTarget;
 
     return (
       <MenuBase.Root open={open} onOpenChange={handleOpenChange}>
@@ -191,6 +199,21 @@ export const SharedAgentContextMenuHost = memo(
                 <IconPen2Outline18 className="size-3.5 shrink-0" />
                 <span>Rename</span>
               </AgentMenuItem>
+              {togglePinned && (
+                <AgentMenuItem
+                  onClick={() => {
+                    togglePinned(agentId);
+                    onClose();
+                  }}
+                >
+                  {isPinned ? (
+                    <IconPinTackSlashOutline18 className="size-3.5 shrink-0" />
+                  ) : (
+                    <IconPinTackOutline18 className="size-3.5 shrink-0" />
+                  )}
+                  <span>{isPinned ? 'Unpin' : 'Pin'}</span>
+                </AgentMenuItem>
+              )}
               <AgentMenuItem
                 onClick={() => {
                   onDeleteRequest(agentId, anchorX, anchorY);

--- a/apps/browser/src/ui/screens/main/sidebar/agents-list/_components/agent-card-with-preview.tsx
+++ b/apps/browser/src/ui/screens/main/sidebar/agents-list/_components/agent-card-with-preview.tsx
@@ -20,6 +20,8 @@ const MARGIN = 4;
 
 interface AgentCardWithPreviewProps extends AgentCardProps {
   cache: Map<string, CachedPreview>;
+  /** True when the agent is currently loaded in Karton state. */
+  isLiveAgent: boolean;
 }
 
 /**
@@ -37,6 +39,7 @@ interface AgentCardWithPreviewProps extends AgentCardProps {
  */
 export function AgentCardWithPreview({
   cache,
+  isLiveAgent,
   ...cardProps
 }: AgentCardWithPreviewProps) {
   const cardRef = useRef<HTMLDivElement>(null);
@@ -193,19 +196,16 @@ export function AgentCardWithPreview({
     // intent delay. By the time the timer fires the RPC is typically
     // already resolved and the cache is warm — the panel then mounts with
     // content on the very first frame, no skeleton flash.
-    // `isLiveAgent=true`: every card in `ActiveAgentsGrid` is sourced from
-    // `s.agents.instances`, so it is by construction a live (in-memory)
-    // agent — regardless of whether it's the currently-focused card
-    // (`cardProps.isActive`, which is pure visual state). Passing the
-    // visual flag here would cause prefetch to cache `{ data: null }` for
-    // non-focused live agents whose stored row hasn't been flushed yet,
-    // pinning their preview blank for the grid lifetime.
+    // `isLiveAgent` must describe the data source, not the visual open state
+    // (`cardProps.isActive`). Live agents can use Karton overlay data before
+    // their stored row has flushed; history-only pinned agents rely on the
+    // persisted preview data returned by `getStoredInstance`.
     const prefetchPromise = prefetchAgentPreview(
       cardProps.id,
       cache,
       getStoredInstanceRef.current,
       getTouchedFilesRef.current,
-      true,
+      isLiveAgent,
     );
     showTimerRef.current = setTimeout(async () => {
       showTimerRef.current = null;
@@ -235,7 +235,7 @@ export function AgentCardWithPreview({
     // Dep-array intentionally omits `getStoredInstance` / `getTouchedFiles`
     // — they're read via refs above, so reference changes should not
     // re-create the callback. See the comment where the refs are set up.
-  }, [cancelShowTimer, cancelExitTimer, cardProps.id, cache]);
+  }, [cancelShowTimer, cancelExitTimer, cardProps.id, cache, isLiveAgent]);
 
   // Measure-then-show: runs synchronously before paint so the panel never
   // renders at a stale position.
@@ -319,12 +319,12 @@ export function AgentCardWithPreview({
             <AgentPreviewPanel
               key={cardProps.id}
               agentId={cardProps.id}
-              // Always `true` in this surface — see the prefetch call above
-              // for the rationale. `cardProps.isActive` here would make the
-              // panel skip the Karton live-overlay (title / messageCount /
-              // workspaces) for non-focused live cards, rendering stale
-              // persisted values instead.
-              isActive={true}
+              // `isActive` here controls whether the preview overlays live
+              // Karton state. It intentionally uses data-source liveness,
+              // not `cardProps.isActive`, which is only the open-row visual
+              // state. History-only pinned agents should render persisted
+              // preview data instead of assuming a live instance exists.
+              isActive={isLiveAgent}
               cache={cache}
             />
           </div>,

--- a/apps/browser/src/ui/screens/main/sidebar/agents-list/_components/agent-card.tsx
+++ b/apps/browser/src/ui/screens/main/sidebar/agents-list/_components/agent-card.tsx
@@ -5,6 +5,10 @@ import {
   type SharedAgentContextMenuState,
   buildAgentContextMenuHandler,
 } from '../../../_components/shared-agent-context-menu';
+import {
+  IconPinTackOutline18,
+  IconPinTackSlashOutline18,
+} from 'nucleo-ui-outline-18';
 import { useInlineTitleEdit } from './use-inline-title-edit';
 
 function compactTimeAgo(timestamp: number): string {
@@ -38,6 +42,8 @@ export interface AgentCardProps {
   contextMenuState: SharedAgentContextMenuState;
   onClick: (id: string) => void;
   onRename: (id: string, newTitle: string) => void;
+  isPinned?: boolean;
+  onTogglePinned?: (id: string) => void;
   /** Optional hover/pointer callbacks — used by `AgentCardWithPreview` to
    *  drive the hover-preview without introducing a wrapping element that
    *  would disrupt the parent grid layout. */
@@ -73,6 +79,8 @@ export const AgentCard = memo(
       contextMenuState,
       onClick,
       onRename,
+      isPinned = false,
+      onTogglePinned,
       onMouseEnter,
       onMouseLeave,
       onMouseDown,
@@ -103,6 +111,8 @@ export const AgentCard = memo(
           contextMenuState,
           id,
           startEditing,
+          isPinned,
+          onTogglePinned,
         )}
         onClick={() => onClick(id)}
         onMouseEnter={onMouseEnter}
@@ -146,19 +156,49 @@ export const AgentCard = memo(
                   ? 'bg-success-solid'
                   : null;
           return (
-            <div className="flex size-4 shrink-0 items-center justify-center dark:brightness-125">
+            <div className="relative flex size-4 shrink-0 items-center justify-center dark:brightness-125">
               {dotColor ? (
-                <>
-                  <div
-                    className={cn('size-2 shrink-0 rounded-full', dotColor)}
-                  />
+                <div
+                  className={cn(
+                    'relative size-2 shrink-0 transition-opacity',
+                    onTogglePinned && 'group-hover/card:opacity-0',
+                  )}
+                >
+                  <div className={cn('size-full rounded-full', dotColor)} />
                   <div
                     className={cn(
-                      'absolute size-2 shrink-0 animate-ping rounded-full',
+                      'absolute inset-0 size-full animate-ping rounded-full',
                       dotColor,
                     )}
                   />
-                </>
+                </div>
+              ) : null}
+              {onTogglePinned ? (
+                <button
+                  type="button"
+                  data-no-dnd="true"
+                  aria-label={isPinned ? 'Unpin agent' : 'Pin agent'}
+                  title={isPinned ? 'Unpin agent' : 'Pin agent'}
+                  className={cn(
+                    'absolute inset-0 flex cursor-pointer items-center justify-center rounded-sm',
+                    'text-muted-foreground/60 opacity-0 outline-none transition-[color,opacity]',
+                    'hover:text-foreground focus-visible:text-foreground focus-visible:opacity-100 group-hover/card:opacity-100',
+                  )}
+                  onClick={(e) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    onTogglePinned(id);
+                  }}
+                  onPointerDown={(e) => {
+                    e.stopPropagation();
+                  }}
+                >
+                  {isPinned ? (
+                    <IconPinTackSlashOutline18 className="size-3.5" />
+                  ) : (
+                    <IconPinTackOutline18 className="size-3.5" />
+                  )}
+                </button>
               ) : null}
             </div>
           );
@@ -169,6 +209,7 @@ export const AgentCard = memo(
               ref={titleRef}
               role="textbox"
               contentEditable
+              data-no-dnd="true"
               suppressContentEditableWarning
               className="block min-w-0 flex-1 cursor-text overflow-x-clip truncate text-ellipsis whitespace-nowrap bg-transparent p-0 text-left text-sm leading-normal outline-none"
               onClick={(e) => e.stopPropagation()}
@@ -204,10 +245,6 @@ export const AgentCard = memo(
                 if (!isActive) return;
                 e.stopPropagation();
                 startEditing();
-              }}
-              onPointerDown={(e) => {
-                if (!isActive) return;
-                e.stopPropagation();
               }}
             >
               {displayTitle}
@@ -248,6 +285,8 @@ export const AgentCard = memo(
     prev.activityText === next.activityText &&
     prev.activityIsUserInput === next.activityIsUserInput &&
     prev.lastMessageAt === next.lastMessageAt &&
+    prev.isPinned === next.isPinned &&
+    prev.onTogglePinned === next.onTogglePinned &&
     prev.onMouseEnter === next.onMouseEnter &&
     prev.onMouseLeave === next.onMouseLeave &&
     prev.onMouseDown === next.onMouseDown,

--- a/apps/browser/src/ui/screens/main/sidebar/agents-list/index.tsx
+++ b/apps/browser/src/ui/screens/main/sidebar/agents-list/index.tsx
@@ -1,4 +1,38 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type CSSProperties,
+  type PointerEvent as ReactPointerEvent,
+} from 'react';
+import { enablePatches, type Patch } from 'immer';
+import {
+  DndContext,
+  DragOverlay,
+  KeyboardSensor,
+  PointerSensor,
+  closestCenter,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+  type DragStartEvent,
+  type PointerSensorOptions,
+} from '@dnd-kit/core';
+import {
+  arrayMove,
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+  type AnimateLayoutChanges,
+} from '@dnd-kit/sortable';
+import {
+  restrictToFirstScrollableAncestor,
+  restrictToVerticalAxis,
+} from '@dnd-kit/modifiers';
+import { CSS } from '@dnd-kit/utilities';
 import {
   useComparingSelector,
   useKartonProcedure,
@@ -22,7 +56,7 @@ import { extractTipTapText, firstWords } from '@ui/utils/text-utils';
 import { cn } from '@ui/utils';
 import { useEmptyAgentId } from '@ui/hooks/use-empty-agent';
 import { useTrack } from '@ui/hooks/use-track';
-import { AgentCardSkeleton } from './_components/agent-card';
+import { AgentCard, AgentCardSkeleton } from './_components/agent-card';
 import { AgentCardWithPreview } from './_components/agent-card-with-preview';
 import type { CachedPreview } from '../../_components/agent-preview-panel';
 import { getToolActivityLabel } from './_utils/tool-label';
@@ -33,6 +67,8 @@ import {
 import { DeleteConfirmPopover } from '../../_components/delete-confirm-popover';
 import { usePendingRemovals } from '@ui/hooks/use-pending-agent-removals';
 import { useScrollFadeMask } from '@ui/hooks/use-scroll-fade-mask';
+
+enablePatches();
 
 // ============================================================================
 // Types & helpers
@@ -57,6 +93,32 @@ type MergedAgentEntry = ActiveAgentCardData & {
   /** True when this agent is currently loaded in-memory (active instance). */
   isLive: boolean;
 };
+
+function stringArraysEqual(a: string[], b: string[]): boolean {
+  if (a.length !== b.length) return false;
+  return a.every((value, index) => value === b[index]);
+}
+
+function agentHistoryEntriesEqual(
+  a: AgentHistoryEntry[],
+  b: AgentHistoryEntry[],
+): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    const ai = a[i]!;
+    const bi = b[i]!;
+    if (
+      ai.id !== bi.id ||
+      ai.title !== bi.title ||
+      ai.createdAt !== bi.createdAt ||
+      ai.lastMessageAt !== bi.lastMessageAt ||
+      ai.messageCount !== bi.messageCount ||
+      ai.parentAgentInstanceId !== bi.parentAgentInstanceId
+    )
+      return false;
+  }
+  return true;
+}
 
 function activeAgentCardsEqual(
   a: ActiveAgentCardData[],
@@ -203,6 +265,106 @@ function insertGroupHeaders(agents: MergedAgentEntry[]): GroupedItem[] {
 }
 
 // ============================================================================
+// Sortable pinned rows
+// ============================================================================
+
+const disableSortableLayoutAnimation: AnimateLayoutChanges = () => false;
+
+function isPinnedDragBlockedTarget(target: EventTarget | null): boolean {
+  return (
+    target instanceof HTMLElement &&
+    !!target.closest('[data-no-dnd="true"], [contenteditable="true"]')
+  );
+}
+
+class PinnedPointerSensor extends PointerSensor {
+  static activators = [
+    {
+      eventName: 'onPointerDown' as const,
+      handler: (
+        event: ReactPointerEvent,
+        { onActivation }: PointerSensorOptions,
+      ) => {
+        const nativeEvent = event.nativeEvent;
+        if (
+          isPinnedDragBlockedTarget(nativeEvent.target) ||
+          !nativeEvent.isPrimary ||
+          nativeEvent.button !== 0
+        ) {
+          return false;
+        }
+
+        onActivation?.({ event: nativeEvent });
+        return true;
+      },
+    },
+  ];
+}
+
+function SortablePinnedAgentCard({
+  agent,
+  isOpen,
+  hasUnseen,
+  contextMenuState,
+  onClick,
+  onRename,
+  onTogglePinned,
+  cache,
+}: {
+  agent: MergedAgentEntry;
+  isOpen: boolean;
+  hasUnseen: boolean;
+  contextMenuState: ReturnType<typeof useSharedAgentContextMenu>[0];
+  onClick: (id: string) => void;
+  onRename: (id: string, newTitle: string) => void;
+  onTogglePinned: (id: string) => void;
+  cache: Map<string, CachedPreview>;
+}) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({
+    id: agent.id,
+    animateLayoutChanges: disableSortableLayoutAnimation,
+    transition: null,
+  });
+
+  const style: CSSProperties = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.35 : 1,
+  };
+
+  return (
+    <div ref={setNodeRef} style={style} {...attributes} {...listeners}>
+      <AgentCardWithPreview
+        id={agent.id}
+        title={agent.title}
+        isActive={isOpen}
+        isWorking={agent.isWorking}
+        isWaitingForUser={agent.isWaitingForUser}
+        hasError={agent.hasError}
+        hasUnseen={hasUnseen}
+        activityText={agent.activityText}
+        activityIsUserInput={agent.activityIsUserInput}
+        lastMessageAt={agent.lastMessageAt}
+        contextMenuState={contextMenuState}
+        onClick={onClick}
+        onRename={onRename}
+        isPinned
+        onTogglePinned={onTogglePinned}
+        cache={cache}
+        isLiveAgent={agent.isLive}
+      />
+    </div>
+  );
+}
+
+// ============================================================================
 // AgentsList
 // ============================================================================
 
@@ -216,6 +378,15 @@ export function AgentsList() {
   const markAsRead = useKartonProcedure((p) => p.agents.markAsRead);
   const getAgentsHistoryList = useKartonProcedure(
     (p) => p.agents.getAgentsHistoryList,
+  );
+  const getAgentHistoryEntriesByIds = useKartonProcedure(
+    (p) => p.agents.getAgentHistoryEntriesByIds,
+  );
+  const getAgentHistoryEntriesByIdsRef = useRef(getAgentHistoryEntriesByIds);
+  getAgentHistoryEntriesByIdsRef.current = getAgentHistoryEntriesByIds;
+  const updatePreferences = useKartonProcedure((p) => p.preferences.update);
+  const pinnedAgentIds = useKartonState(
+    useComparingSelector((s) => s.preferences.sidebar.pinnedAgentIds),
   );
 
   const [, emptyAgentIdRef] = useEmptyAgentId();
@@ -424,9 +595,15 @@ export function AgentsList() {
   // =========================================================================
 
   const [historyList, setHistoryList] = useState<AgentHistoryEntry[]>([]);
+  const [pinnedHistoryList, setPinnedHistoryList] = useState<
+    AgentHistoryEntry[]
+  >([]);
 
   const activeAgentIds = useKartonState(
-    useComparingSelector((s) => Object.keys(s.agents.instances)),
+    useComparingSelector(
+      (s) => Object.keys(s.agents.instances),
+      stringArraysEqual,
+    ),
   );
 
   // Tracks how many history entries have been fetched from the server.
@@ -496,11 +673,17 @@ export function AgentsList() {
     const activeById = new Map(agents.map((a) => [a.id, a]));
     const pendingSet = pendingRemovals;
 
-    // Index history entries by id for fallback lookups.
-    const historyById = new Map(historyList.map((e) => [e.id, e]));
+    // Index history entries by id for fallback lookups. Pinned-by-id
+    // entries come first so older pinned agents outside the paginated
+    // history slice can still be resolved.
+    const mergedHistoryList = [...pinnedHistoryList, ...historyList].filter(
+      (entry, index, entries) =>
+        entries.findIndex((candidate) => candidate.id === entry.id) === index,
+    );
+    const historyById = new Map(mergedHistoryList.map((e) => [e.id, e]));
 
     // History entries: exclude those that are already active or pending removal.
-    const historyEntries: MergedAgentEntry[] = historyList
+    const historyEntries: MergedAgentEntry[] = mergedHistoryList
       .filter((e) => !activeById.has(e.id) && !pendingSet.has(e.id))
       .map((e) => ({
         id: e.id,
@@ -562,7 +745,132 @@ export function AgentsList() {
     );
 
     return merged;
-  }, [agents, historyList, pendingRemovals]);
+  }, [agents, historyList, pendingRemovals, pinnedHistoryList]);
+
+  // =========================================================================
+  // Pinned agent preferences
+  // =========================================================================
+
+  const [optimisticPinnedAgentIds, setOptimisticPinnedAgentIds] = useState<
+    string[] | null
+  >(null);
+  const displayedPinnedAgentIds = optimisticPinnedAgentIds ?? pinnedAgentIds;
+
+  const updatePinnedAgentIds = useCallback(
+    async (
+      updater: (ids: string[]) => string[],
+      basePinnedAgentIds = displayedPinnedAgentIds,
+    ) => {
+      const nextIds = updater(basePinnedAgentIds).filter(
+        (id, index, ids) => ids.indexOf(id) === index,
+      );
+
+      if (stringArraysEqual(nextIds, basePinnedAgentIds)) return;
+
+      const patches: Patch[] = [
+        {
+          op: 'replace',
+          path: ['sidebar', 'pinnedAgentIds'],
+          value: nextIds,
+        },
+      ];
+
+      setOptimisticPinnedAgentIds(nextIds);
+      try {
+        await updatePreferences(patches);
+      } catch (err) {
+        setOptimisticPinnedAgentIds(null);
+        throw err;
+      }
+    },
+    [displayedPinnedAgentIds, updatePreferences],
+  );
+
+  const handlePinAgent = useCallback(
+    (id: string) =>
+      updatePinnedAgentIds((ids) => [
+        id,
+        ...ids.filter((value) => value !== id),
+      ]),
+    [updatePinnedAgentIds],
+  );
+
+  const handleUnpinAgent = useCallback(
+    (id: string) =>
+      updatePinnedAgentIds((ids) => ids.filter((value) => value !== id)),
+    [updatePinnedAgentIds],
+  );
+
+  const handleTogglePinned = useCallback(
+    (id: string) => {
+      if (displayedPinnedAgentIds.includes(id)) {
+        return handleUnpinAgent(id);
+      }
+      return handlePinAgent(id);
+    },
+    [displayedPinnedAgentIds, handlePinAgent, handleUnpinAgent],
+  );
+
+  const handleReorderPinnedAgents = useCallback(
+    (ids: string[]) => updatePinnedAgentIds(() => ids),
+    [updatePinnedAgentIds],
+  );
+
+  const updatePinnedAgentIdsRef = useRef(updatePinnedAgentIds);
+  updatePinnedAgentIdsRef.current = updatePinnedAgentIds;
+  const pinnedAgentIdsRef = useRef(pinnedAgentIds);
+  pinnedAgentIdsRef.current = pinnedAgentIds;
+
+  const activeAgentIdSet = useMemo(
+    () => new Set(activeAgentIds),
+    [activeAgentIds],
+  );
+
+  const historyPinnedAgentIds = useMemo(
+    () => pinnedAgentIds.filter((id) => !activeAgentIdSet.has(id)),
+    [activeAgentIdSet, pinnedAgentIds],
+  );
+  const historyPinnedAgentIdsKey = historyPinnedAgentIds.join('\0');
+
+  useEffect(() => {
+    let cancelled = false;
+
+    if (historyPinnedAgentIds.length === 0) {
+      setPinnedHistoryList((entries) => (entries.length === 0 ? entries : []));
+      return;
+    }
+
+    getAgentHistoryEntriesByIdsRef
+      .current(historyPinnedAgentIds)
+      .then((entries) => {
+        if (cancelled) return;
+        setPinnedHistoryList((currentEntries) =>
+          agentHistoryEntriesEqual(currentEntries, entries)
+            ? currentEntries
+            : entries,
+        );
+
+        const foundIds = new Set(entries.map((entry) => entry.id));
+        const missingIds = historyPinnedAgentIds.filter(
+          (id) => !foundIds.has(id),
+        );
+        if (missingIds.length > 0) {
+          void updatePinnedAgentIdsRef.current(
+            (ids) => ids.filter((id) => !missingIds.includes(id)),
+            pinnedAgentIdsRef.current,
+          );
+        }
+      })
+      .catch((err) => {
+        if (!cancelled) {
+          console.error('Failed to fetch pinned agent history:', err);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [historyPinnedAgentIdsKey]);
 
   // =========================================================================
   // Search
@@ -570,11 +878,117 @@ export function AgentsList() {
 
   const [searchQuery, setSearchQuery] = useState('');
 
-  const filteredAgents = useMemo(() => {
+  useEffect(() => {
+    if (!optimisticPinnedAgentIds) return;
+
+    if (stringArraysEqual(optimisticPinnedAgentIds, pinnedAgentIds)) {
+      setOptimisticPinnedAgentIds(null);
+      return;
+    }
+
+    const pinnedIdSet = new Set(pinnedAgentIds);
+    const hasSamePinnedIds =
+      optimisticPinnedAgentIds.length === pinnedAgentIds.length &&
+      optimisticPinnedAgentIds.every((id) => pinnedIdSet.has(id));
+
+    if (!hasSamePinnedIds) {
+      setOptimisticPinnedAgentIds(null);
+    }
+  }, [optimisticPinnedAgentIds, pinnedAgentIds]);
+
+  const pinnedAgentIdSet = useMemo(
+    () => new Set(displayedPinnedAgentIds),
+    [displayedPinnedAgentIds],
+  );
+
+  const allAgentsById = useMemo(
+    () => new Map(allAgents.map((agent) => [agent.id, agent])),
+    [allAgents],
+  );
+
+  const { filteredPinnedAgents, filteredUnpinnedAgents } = useMemo(() => {
     const q = searchQuery.trim().toLowerCase();
-    if (!q) return allAgents;
-    return allAgents.filter((a) => a.title.toLowerCase().includes(q));
-  }, [allAgents, searchQuery]);
+    const matchesSearch = (agent: MergedAgentEntry) =>
+      !q || agent.title.toLowerCase().includes(q);
+
+    return {
+      filteredPinnedAgents: displayedPinnedAgentIds
+        .map((id) => allAgentsById.get(id))
+        .filter(
+          (agent): agent is MergedAgentEntry => !!agent && matchesSearch(agent),
+        ),
+      filteredUnpinnedAgents: allAgents.filter(
+        (agent) => !pinnedAgentIdSet.has(agent.id) && matchesSearch(agent),
+      ),
+    };
+  }, [
+    allAgents,
+    allAgentsById,
+    displayedPinnedAgentIds,
+    pinnedAgentIdSet,
+    searchQuery,
+  ]);
+
+  const dndSensors = useSensors(
+    useSensor(PinnedPointerSensor, {
+      activationConstraint: { distance: 6 },
+    }),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    }),
+  );
+
+  const [activePinnedDragId, setActivePinnedDragId] = useState<string | null>(
+    null,
+  );
+
+  const activePinnedDragAgent = useMemo(
+    () =>
+      activePinnedDragId
+        ? (allAgentsById.get(activePinnedDragId) ?? null)
+        : null,
+    [activePinnedDragId, allAgentsById],
+  );
+
+  const handlePinnedDragStart = useCallback(({ active }: DragStartEvent) => {
+    setActivePinnedDragId(String(active.id));
+  }, []);
+
+  const handlePinnedDragEnd = useCallback(
+    ({ active, over }: DragEndEvent) => {
+      setActivePinnedDragId(null);
+      if (!over || active.id === over.id) return;
+
+      const visiblePinnedIds = filteredPinnedAgents.map((agent) => agent.id);
+      const oldVisibleIndex = visiblePinnedIds.indexOf(String(active.id));
+      const newVisibleIndex = visiblePinnedIds.indexOf(String(over.id));
+      if (oldVisibleIndex === -1 || newVisibleIndex === -1) return;
+
+      const reorderedVisibleIds = arrayMove(
+        visiblePinnedIds,
+        oldVisibleIndex,
+        newVisibleIndex,
+      );
+      const reorderedVisibleIdSet = new Set(reorderedVisibleIds);
+      let visibleIndex = 0;
+      const nextPinnedIds = displayedPinnedAgentIds.map((id) => {
+        if (!reorderedVisibleIdSet.has(id)) return id;
+        const nextVisibleId = reorderedVisibleIds[visibleIndex++];
+        return nextVisibleId ?? id;
+      });
+
+      if (!stringArraysEqual(nextPinnedIds, displayedPinnedAgentIds)) {
+        void handleReorderPinnedAgents(nextPinnedIds).catch(() => {
+          setOptimisticPinnedAgentIds(null);
+        });
+      }
+    },
+    [filteredPinnedAgents, handleReorderPinnedAgents, displayedPinnedAgentIds],
+  );
+
+  const handlePinnedDragCancel = useCallback(() => {
+    setActivePinnedDragId(null);
+  }, []);
 
   // =========================================================================
   // "Show more" pagination
@@ -585,8 +999,10 @@ export function AgentsList() {
   // Agents created during this session always show (floor = their count).
   const agentsCreatedThisSession = useMemo(
     () =>
-      allAgents.filter((a) => a.createdAt >= appStartTimeRef.current).length,
-    [allAgents],
+      filteredUnpinnedAgents.filter(
+        (a) => a.createdAt >= appStartTimeRef.current,
+      ).length,
+    [filteredUnpinnedAgents],
   );
 
   const effectiveVisible = useMemo(
@@ -594,17 +1010,17 @@ export function AgentsList() {
     [visibleCount, agentsCreatedThisSession],
   );
 
-  const visibleAgents = useMemo(
-    () => filteredAgents.slice(0, effectiveVisible),
-    [filteredAgents, effectiveVisible],
+  const visibleUnpinnedAgents = useMemo(
+    () => filteredUnpinnedAgents.slice(0, effectiveVisible),
+    [filteredUnpinnedAgents, effectiveVisible],
   );
 
   const groupedItems = useMemo(
-    () => insertGroupHeaders(visibleAgents),
-    [visibleAgents],
+    () => insertGroupHeaders(visibleUnpinnedAgents),
+    [visibleUnpinnedAgents],
   );
 
-  const hasMoreToShow = effectiveVisible < filteredAgents.length;
+  const hasMoreToShow = effectiveVisible < filteredUnpinnedAgents.length;
 
   const handleShowMore = useCallback(() => {
     setVisibleCount((c) => {
@@ -773,6 +1189,75 @@ export function AgentsList() {
         style={maskStyle}
         onViewportRef={setScrollViewport}
       >
+        {filteredPinnedAgents.length > 0 && (
+          <>
+            <div className="shrink-0 px-1.5 pt-0 pb-1 font-semibold text-subtle-foreground text-xs">
+              Pinned
+            </div>
+            <DndContext
+              sensors={dndSensors}
+              collisionDetection={closestCenter}
+              modifiers={[
+                restrictToVerticalAxis,
+                restrictToFirstScrollableAncestor,
+              ]}
+              onDragStart={handlePinnedDragStart}
+              onDragEnd={handlePinnedDragEnd}
+              onDragCancel={handlePinnedDragCancel}
+            >
+              <SortableContext
+                items={filteredPinnedAgents.map((agent) => agent.id)}
+                strategy={verticalListSortingStrategy}
+              >
+                {filteredPinnedAgents.map((agent) => {
+                  const isOpen = agent.id === openAgent;
+                  const hasUnseen = !isOpen && agent.unread;
+
+                  return (
+                    <SortablePinnedAgentCard
+                      key={agent.id}
+                      agent={agent}
+                      isOpen={isOpen}
+                      hasUnseen={hasUnseen}
+                      contextMenuState={ctxMenuState}
+                      onClick={handleClick}
+                      onRename={handleRename}
+                      onTogglePinned={handleTogglePinned}
+                      cache={previewCacheRef.current}
+                    />
+                  );
+                })}
+              </SortableContext>
+              <DragOverlay dropAnimation={null}>
+                {activePinnedDragAgent ? (
+                  <AgentCard
+                    id={activePinnedDragAgent.id}
+                    title={activePinnedDragAgent.title}
+                    isActive={activePinnedDragAgent.id === openAgent}
+                    isWorking={activePinnedDragAgent.isWorking}
+                    isWaitingForUser={activePinnedDragAgent.isWaitingForUser}
+                    hasError={activePinnedDragAgent.hasError}
+                    hasUnseen={
+                      activePinnedDragAgent.id !== openAgent &&
+                      activePinnedDragAgent.unread
+                    }
+                    activityText={activePinnedDragAgent.activityText}
+                    activityIsUserInput={
+                      activePinnedDragAgent.activityIsUserInput
+                    }
+                    lastMessageAt={activePinnedDragAgent.lastMessageAt}
+                    contextMenuState={ctxMenuState}
+                    onClick={handleClick}
+                    onRename={handleRename}
+                    isPinned
+                    onTogglePinned={handleTogglePinned}
+                  />
+                ) : null}
+              </DragOverlay>
+            </DndContext>
+          </>
+        )}
+
         {groupedItems.map((item) => {
           if (item.type === 'header') {
             return (
@@ -805,7 +1290,10 @@ export function AgentsList() {
               contextMenuState={ctxMenuState}
               onClick={handleClick}
               onRename={handleRename}
+              isPinned={false}
+              onTogglePinned={handleTogglePinned}
               cache={previewCacheRef.current}
+              isLiveAgent={agent.isLive}
             />
           );
         })}


### PR DESCRIPTION
implements #1095 


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds agent pinning to the sidebar with a persistent, user-defined order, drag-and-drop reordering, and a search-aware “Pinned” section. Hydrates pinned history entries by ID and ensures previews correctly handle live vs. history agents.

- New Features
  - Sidebar: Pin/unpin via card button or context menu; new “Pinned” section at the top; reorder pins via drag-and-drop (`@dnd-kit/core`, `@dnd-kit/sortable`, `@dnd-kit/modifiers`) with drag overlay; blocks drag on `[contenteditable]`/`[data-no-dnd]`; respects search when displaying and reordering.
  - Persistence: Adds `sidebar.pinnedAgentIds` to user preferences with safe defaults and legacy handling; optimistic updates via `preferences.update` Immer patches; prunes missing IDs after fetch; tests for schema defaults.
  - Backend/API: Adds `agents.getAgentHistoryEntriesByIds` RPC and DB query to return requested agents in the same order (chat, root-only); used to hydrate pinned agents not in the paginated history.
  - Previews: Passes `isLiveAgent` through preview components to use live Karton overlay only when appropriate; improves prefetch to avoid stale or empty previews for history-only pinned agents.

<sup>Written for commit 52881e5ba9861544a57015fdca4e72dbc3300ed9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pin and unpin agents in the sidebar (card button and context menu); pinned agents appear in a dedicated section above unpinned agents
  * Drag-and-drop reordering for pinned agents; pinned entries are fetched and reconciled into the history list

* **User Preferences**
  * Sidebar preferences now include pinnedAgentIds (defaults to empty) alongside active-agent visibility

* **Tests**
  * Added tests for sidebar preference defaults

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stagewise-io/stagewise/pull/1102)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->