### PR TITLE
feat(stagewise): decrease history compression threshold

### DIFF
--- a/.agents/skills/history-compression/SKILL.md
+++ b/.agents/skills/history-compression/SKILL.md
@@ -21,10 +21,10 @@ All paths are repo-root-relative.
 
 After every step → `handlePostStep` checks:
 
-`usedTokens > min(compactionThreshold × contextWindow, 100k)`
+`usedTokens > min(compactionThreshold × contextWindow, 200k)`
 
 - `compactionThreshold` default **0.65**; chat agent overrides to **0.5**.
-- `100k` hard cap (`HISTORY_COMPRESSION_HARD_CAP_TOKENS`) = 1M-ctx models trigger at same absolute count as 200k models.
+- `200k` hard cap (`HISTORY_COMPRESSION_HARD_CAP_TOKENS`) = 1M-ctx models trigger at the same absolute count as a 200k-context model running near its full window.
 - Runs via `void` (async, non-blocking). Guarded by `_isCompressingHistory` flag → no concurrent runs.
 - Silent failure — agent keeps going, context overflow later surfaces normal model error.
 
@@ -97,7 +97,7 @@ Input to LLM is XML-ish:
 | Knob | Where | Default | Effect |
 |---|---|---|---|
 | `compactionThreshold` | `config.historyCompressionThreshold` | 0.65 (chat: 0.5) | Trigger fraction of ctx window |
-| `HISTORY_COMPRESSION_HARD_CAP_TOKENS` | `base-agent.ts` const | 100_000 | Absolute trigger cap |
+| `HISTORY_COMPRESSION_HARD_CAP_TOKENS` | `base-agent.ts` const | 200_000 | Absolute trigger cap |
 | `KEPT_BUDGET_FRACTION` | `base-agent.ts` const | 0.2 | Fraction kept uncompressed |
 | `KEPT_BUDGET_HARD_CAP_TOKENS` | `base-agent.ts` const | 40_000 | Absolute kept cap |
 | `minUncompressedMessages` | `config` | 10 | Floor on kept msg count |

--- a/apps/browser/src/backend/agents/shared/base-agent/base-agent.ts
+++ b/apps/browser/src/backend/agents/shared/base-agent/base-agent.ts
@@ -1921,10 +1921,11 @@ export abstract class BaseAgent<
    * Absolute maximum (in tokens) for the compression trigger threshold.
    * Used via `Math.min(fraction * contextWindowSize, HARD_CAP)` so
    * large-context models (e.g. 1M) compress at the same absolute token
-   * count as the 200k-model sweet spot. Calibrated to `0.5 × 200_000`
-   * matching the chat agent's `historyCompressionThreshold = 0.5`.
+   * count as a 200k-context model running near its full window. The cap
+   * is intentionally a hard ceiling on input size, independent of
+   * `historyCompressionThreshold`.
    */
-  private static readonly HISTORY_COMPRESSION_HARD_CAP_TOKENS = 100_000;
+  private static readonly HISTORY_COMPRESSION_HARD_CAP_TOKENS = 200_000;
 
   /**
    * Absolute maximum (in tokens) for the kept-uncompressed budget after


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Raised the history compression hard cap from 100k to 200k tokens so large-context models compress later, while 200k-context models keep the same trigger point. Updated docs to match and clarified that the cap is independent of `historyCompressionThreshold`.

<sup>Written for commit 0023650ecd7a2715e448313164e49e2882446665. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Increased the history compression hard cap from 100,000 to 200,000 tokens, improving handling of extended conversation contexts and large-context models.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stagewise-io/stagewise/pull/1105)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->