### PR TITLE
fix(stagewise): fix searchbar-focus issue

### DIFF
--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/panel-footer.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/panel-footer.tsx
@@ -698,6 +698,11 @@ export const ChatPanelFooter = memo(function ChatPanelFooter() {
   // it, causing the chat input to steal focus on the next window 'focus'.
   const chatInputActiveRef = useRef(chatInputActive);
   chatInputActiveRef.current = chatInputActive;
+  // Natural/programmatic focus transfers already blur TipTap. Calling
+  // `editor.commands.blur()` again while another UI input is taking focus can
+  // race with that input's native focus, so the next inactive effect may skip
+  // the redundant blur. Explicit deactivation paths still blur normally.
+  const skipNextInactiveBlurRef = useRef(false);
   // Track if input was focused before app lost focus (for restoring on app regain)
   const wasActiveBeforeAppBlurRef = useRef(false);
 
@@ -711,6 +716,10 @@ export const ChatPanelFooter = memo(function ChatPanelFooter() {
       // Don't automatically deactivate element selection here
       // Element selection can be controlled by other components (inline edit mode)
       // It will be deactivated explicitly when needed (Escape key, send message, agent working, panel closed)
+      if (skipNextInactiveBlurRef.current) {
+        skipNextInactiveBlurRef.current = false;
+        return;
+      }
       chatInputRef.current?.blur();
     }
   }, [chatInputActive]);
@@ -744,8 +753,10 @@ export const ChatPanelFooter = memo(function ChatPanelFooter() {
       // earlier in the same event-loop turn (e.g. by
       // `omnibox-focus-requested`) are honoured before the programmatic blur
       // they trigger reaches us.
-      if (!target && chatInputActiveRef.current)
+      const wasChatInputActive = chatInputActiveRef.current;
+      if (!target && wasChatInputActive)
         wasActiveBeforeAppBlurRef.current = true;
+      if (target && wasChatInputActive) skipNextInactiveBlurRef.current = true;
 
       setChatInputActive(false);
     } else if (chatInputActiveRef.current) {
@@ -766,29 +777,35 @@ export const ChatPanelFooter = memo(function ChatPanelFooter() {
     window,
   );
 
-  // Clear focus restoration flag when omnibox takes focus (prevents chat from reclaiming focus)
-  useEventListener('omnibox-focus-requested', () => {
+  const deactivateChatInputForExternalFocus = useCallback(() => {
     wasActiveBeforeAppBlurRef.current = false;
-    // Synchronously mark the input as inactive so the blur fired by the
-    // omnibox's `focus()` chain (which blurs all contenteditable elements)
-    // doesn't re-arm `wasActiveBeforeAppBlurRef` via `onInputBlur` before the
-    // `setChatInputActive(false)` state update commits.
+    // Synchronously mark the input as inactive so focus chains that blur
+    // contenteditable elements cannot re-arm app-blur focus restoration before
+    // the `setChatInputActive(false)` state update commits.
+    const wasChatInputActive = chatInputActiveRef.current;
     chatInputActiveRef.current = false;
+    skipNextInactiveBlurRef.current = wasChatInputActive;
     setChatInputActive(false);
     // Also stop context selection to prevent its ESC handler from consuming the first ESC
     stopContextSelector();
-  });
+  }, [stopContextSelector]);
+
+  // Clear focus restoration flag when omnibox takes focus (prevents chat from reclaiming focus)
+  useEventListener(
+    'omnibox-focus-requested',
+    deactivateChatInputForExternalFocus,
+  );
 
   // Clear focus restoration flag when search bar takes focus (prevents chat from reclaiming focus)
-  useEventListener('search-bar-focus-requested', () => {
-    wasActiveBeforeAppBlurRef.current = false;
-    // See `omnibox-focus-requested` above for why we update the ref
-    // synchronously before the state setter.
-    chatInputActiveRef.current = false;
-    setChatInputActive(false);
-    // Also stop context selection to prevent its ESC handler from consuming the first ESC
-    stopContextSelector();
-  });
+  useEventListener(
+    'search-bar-focus-requested',
+    deactivateChatInputForExternalFocus,
+  );
+
+  useEventListener(
+    'sidebar-agent-search-focus-requested',
+    deactivateChatInputForExternalFocus,
+  );
 
   useHotKeyListener(
     useCallback(async () => {

--- a/apps/browser/src/ui/screens/main/sidebar/agents-list/index.tsx
+++ b/apps/browser/src/ui/screens/main/sidebar/agents-list/index.tsx
@@ -349,6 +349,9 @@ export function AgentsList() {
   const getAgentHistoryEntriesByIdsRef = useRef(getAgentHistoryEntriesByIds);
   getAgentHistoryEntriesByIdsRef.current = getAgentHistoryEntriesByIds;
   const updatePreferences = useKartonProcedure((p) => p.preferences.update);
+  const togglePanelKeyboardFocus = useKartonProcedure(
+    (p) => p.browser.layout.togglePanelKeyboardFocus,
+  );
   const pinnedAgentIds = useKartonState(
     useComparingSelector((s) => s.preferences.sidebar.pinnedAgentIds),
   );
@@ -1079,6 +1082,13 @@ export function AgentsList() {
             aria-label="Search agents"
             placeholder="Search agents…"
             value={searchQuery}
+            onPointerDown={(e) => {
+              if (!e.isPrimary || e.button !== 0) return;
+              window.dispatchEvent(
+                new Event('sidebar-agent-search-focus-requested'),
+              );
+              void togglePanelKeyboardFocus('stagewise-ui');
+            }}
             onChange={(e) => setSearchQuery(e.target.value)}
             className={cn(
               'w-full bg-transparent text-foreground text-sm placeholder:text-muted-foreground',


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes a focus bug where the chat input reclaimed focus when clicking the sidebar agent search. Focus now transfers cleanly to the search field (and the omnibox) without flicker or missed keystrokes.

- **Bug Fixes**
  - Deactivate chat input on `omnibox-focus-requested`, `search-bar-focus-requested`, and new `sidebar-agent-search-focus-requested`.
  - Add a `skipNextInactiveBlurRef` guard to avoid redundant TipTap blurs during native/programmatic focus changes.
  - Sidebar agent search dispatches `sidebar-agent-search-focus-requested` on pointer down and calls `togglePanelKeyboardFocus('stagewise-ui')` before focusing.
  - Stop context selection on external focus so ESC works as expected.

<sup>Written for commit fff947ec2f4768a527525160b11aabdc441d6982. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined focus/blur handling to prevent redundant operations when switching focus between the chat input and other UI elements like sidebar search.
  * Enhanced keyboard focus behavior coordination when interacting with the sidebar agent search feature.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stagewise-io/stagewise/pull/1107)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->