### PR TITLE
fix(stagewise): fix cmd-n

### DIFF
--- a/apps/browser/src/ui/screens/main/sidebar/agents-list/index.tsx
+++ b/apps/browser/src/ui/screens/main/sidebar/agents-list/index.tsx
@@ -39,6 +39,8 @@ import {
   useKartonState,
 } from '@ui/hooks/use-karton';
 import { useAgentSwitcher, useOpenAgent } from '@ui/hooks/use-open-chat';
+import { useHotKeyListener } from '@ui/hooks/use-hotkey-listener';
+import { HotkeyActions } from '@shared/hotkeys';
 import { AgentTypes } from '@shared/karton-contracts/ui/agent';
 import type { AgentHistoryEntry } from '@shared/karton-contracts/ui/agent';
 import {
@@ -505,6 +507,10 @@ export function AgentsList() {
       setPendingCreate(false);
     });
   }, [agents.length, createAgent, emptyAgentIdRef, setOpenAgent, track]);
+
+  // Cmd/Ctrl+N: create (or focus an existing empty) agent from the keyboard.
+  // Mirrors the click handler on the "new agent" button.
+  useHotKeyListener(handleCreateAgent, HotkeyActions.NEW_CHAT);
 
   const handleClick = useCallback(
     (id: string) => {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes the Cmd/Ctrl+N shortcut so it creates a new chat (or focuses the empty agent) from the sidebar. Adds a `useHotKeyListener` bound to `HotkeyActions.NEW_CHAT` to mirror the “New agent” button behavior.

<sup>Written for commit 99d830cb67b5953e0f1f986d59aceb0a85648030. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a keyboard shortcut (Cmd/Ctrl+N) in the agents sidebar to quickly create a new agent/chat, matching the existing "New Agent" button behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stagewise-io/stagewise/pull/1112)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->