### PR TITLE
Make Browing Tabs per-agent

### DIFF
--- a/apps/browser/src/backend/services/agent-manager/agent-manager.ts
+++ b/apps/browser/src/backend/services/agent-manager/agent-manager.ts
@@ -141,25 +141,10 @@ export class AgentManagerService extends DisposableService {
           this.logger.debug(
             `[AgentManager] Resumed last agent ${lastOpenAgentId} on startup`,
           );
-          // Mount last chat workspaces on the resumed agent
-          const lastWorkspaces =
-            await this.agentPersistenceDB.getLastChatWorkspacePaths();
-          if (lastWorkspaces) {
-            for (const ws of lastWorkspaces) {
-              try {
-                await this.toolbox.handleMountWorkspace(
-                  lastOpenAgentId,
-                  ws.path,
-                  ws.permissions,
-                );
-              } catch (error) {
-                this.logger.warn(
-                  `[AgentManager] Failed to mount workspace ${ws.path} on startup`,
-                  { error },
-                );
-              }
-            }
-          }
+          // resumeAgent already restores the agent's own mountedWorkspaces.
+          // Do NOT call getLastChatWorkspacePaths() here — it returns the
+          // most-recently-active chat agent's workspaces (by lastMessageAt),
+          // which may belong to a different agent.
           return;
         } catch (error) {
           this.logger.warn(

--- a/apps/browser/src/backend/services/agent-manager/agent-manager.ts
+++ b/apps/browser/src/backend/services/agent-manager/agent-manager.ts
@@ -19,6 +19,8 @@ import {
   type ToolApprovalMode,
 } from '@shared/karton-contracts/ui/shared-types';
 import type { z } from 'zod';
+import { z as zod } from 'zod';
+import { readPersistedDataSync } from '@/utils/persisted-data';
 import { AgentPersistenceDB } from './persistence/db';
 import type { AgentState } from '@shared/karton-contracts/ui/agent';
 import { writeBlob, deleteAgentBlobs } from '@/utils/attachment-blobs';
@@ -114,9 +116,60 @@ export class AgentManagerService extends DisposableService {
         return null;
       });
 
-    // Create an empty default agent only after the DB is ready
-    // This ensures that when there's an active agent, the DB is guaranteed to be initialized
+    // After the DB is ready, either restore the last-opened agent or
+    // create a new empty default agent if no persisted state exists.
     this.dbReadyPromise.then(async () => {
+      if (!this.agentPersistenceDB) {
+        // DB init failed — still create a default agent so the UI is usable
+        await this.createAgent(AgentTypes.CHAT, undefined);
+        return;
+      }
+
+      // Try to restore the last-opened agent
+      const state = readPersistedDataSync(
+        'tab-state',
+        zod.object({
+          lastOpenAgentId: zod.string().nullable().catch(null),
+        }),
+        { lastOpenAgentId: null },
+      );
+      const lastOpenAgentId = state.lastOpenAgentId;
+
+      if (lastOpenAgentId) {
+        try {
+          await this.resumeAgent(lastOpenAgentId);
+          this.logger.debug(
+            `[AgentManager] Resumed last agent ${lastOpenAgentId} on startup`,
+          );
+          // Mount last chat workspaces on the resumed agent
+          const lastWorkspaces =
+            await this.agentPersistenceDB.getLastChatWorkspacePaths();
+          if (lastWorkspaces) {
+            for (const ws of lastWorkspaces) {
+              try {
+                await this.toolbox.handleMountWorkspace(
+                  lastOpenAgentId,
+                  ws.path,
+                  ws.permissions,
+                );
+              } catch (error) {
+                this.logger.warn(
+                  `[AgentManager] Failed to mount workspace ${ws.path} on startup`,
+                  { error },
+                );
+              }
+            }
+          }
+          return;
+        } catch (error) {
+          this.logger.warn(
+            '[AgentManager] Failed to resume last agent, creating new one',
+            { error },
+          );
+        }
+      }
+
+      // No persisted agent or resume failed — create default
       const agent = await this.createAgent(AgentTypes.CHAT, undefined);
       const lastWorkspaces =
         await this.agentPersistenceDB?.getLastChatWorkspacePaths();

--- a/apps/browser/src/backend/services/toolbox/index.ts
+++ b/apps/browser/src/backend/services/toolbox/index.ts
@@ -1192,13 +1192,21 @@ export class ToolboxService extends DisposableService {
     this.shellService?.killSession(sessionId);
   }
 
-  public getBrowserSnapshot(): BrowserSnapshot {
+  public getBrowserSnapshot(agentInstanceId: string): BrowserSnapshot {
     const browser = this.uiKarton.state.browser;
-    const activeTab = browser.activeTabId
-      ? browser.tabs[browser.activeTabId]
-      : null;
 
-    const allTabs = Object.values(browser.tabs)
+    // Filter: only global tabs (null) and tabs assigned to this agent
+    const isTabVisible = (tab: { agentInstanceId: string | null }) =>
+      tab.agentInstanceId === null || tab.agentInstanceId === agentInstanceId;
+
+    const activeTab =
+      browser.activeTabId && browser.tabs[browser.activeTabId]
+        ? browser.tabs[browser.activeTabId]
+        : null;
+
+    const visibleTabs = Object.values(browser.tabs).filter(isTabVisible);
+
+    const allTabs = visibleTabs
       .sort((a, b) => b.lastFocusedAt - a.lastFocusedAt)
       .map((tab) => ({
         id: tab.id,
@@ -1210,29 +1218,35 @@ export class ToolboxService extends DisposableService {
         consoleLogCount: tab.consoleLogCount,
         consoleErrorCount: tab.consoleErrorCount,
         faviconUrl: tab.faviconUrls?.[0],
+        agentInstanceId: tab.agentInstanceId,
         lastFocusedAt: tab.lastFocusedAt,
       }));
 
+    // Only show active tab if it's visible to this agent
+    const activeTabVisible =
+      activeTab && isTabVisible(activeTab) ? activeTab : null;
+
     return {
-      activeTab: activeTab
+      activeTab: activeTabVisible
         ? {
-            id: activeTab.id,
-            title: activeTab.title,
-            url: activeTab.url,
-            error: activeTab.error,
-            consoleLogCount: activeTab.consoleLogCount,
-            consoleErrorCount: activeTab.consoleErrorCount,
+            id: activeTabVisible.id,
+            title: activeTabVisible.title,
+            url: activeTabVisible.url,
+            error: activeTabVisible.error,
+            consoleLogCount: activeTabVisible.consoleLogCount,
+            consoleErrorCount: activeTabVisible.consoleErrorCount,
+            agentInstanceId: activeTabVisible.agentInstanceId,
           }
         : null,
       tabs: allTabs,
-      totalTabCount: Object.keys(browser.tabs).length,
+      totalTabCount: visibleTabs.length,
     };
   }
 
   public async captureEnvironmentSnapshot(
     agentInstanceId: string,
   ): Promise<EnvironmentSnapshot> {
-    const browserState = this.getBrowserSnapshot();
+    const browserState = this.getBrowserSnapshot(agentInstanceId);
     const workspaceState =
       this.mountManagerService?.getWorkspaceSnapshot(agentInstanceId);
     const toolboxState = this.uiKarton.state.toolbox[agentInstanceId];

--- a/apps/browser/src/backend/services/toolbox/types.ts
+++ b/apps/browser/src/backend/services/toolbox/types.ts
@@ -17,6 +17,7 @@ export type BrowserTabInfo = {
   consoleLogCount: number;
   consoleErrorCount: number;
   faviconUrl?: string;
+  agentInstanceId: string | null;
 };
 
 /**

--- a/apps/browser/src/backend/services/window-layout/index.ts
+++ b/apps/browser/src/backend/services/window-layout/index.ts
@@ -906,7 +906,6 @@ export class WindowLayoutService extends DisposableService {
 
     // Create search utils instance for resolving navigation targets
     const searchUtils = createSearchUtils(searchUtilsConfig);
-
     const tab = new TabController(
       id,
       this.baseWindow!,
@@ -918,7 +917,9 @@ export class WindowLayoutService extends DisposableService {
       (target: NavigationTarget, setActive?: boolean) => {
         // Resolve the navigation target to a URL
         const resolvedUrl = searchUtils.resolveNavigationTarget(target);
-        void this.handleCreateTab(resolvedUrl, setActive, undefined, id);
+        // Inherit the parent tab's current agent scope (handles re-pinning).
+        const parentAgentId = this.tabs[id]?.getState().agentInstanceId ?? null;
+        void this.handleCreateTab(resolvedUrl, setActive, parentAgentId, id);
       },
       this.telemetryService ?? undefined,
     );
@@ -1640,13 +1641,23 @@ export class WindowLayoutService extends DisposableService {
       );
       return;
     }
+    // Capture old agent before reassignment so we can clean up the stale
+    // last-active-tab entry. The current code only cleaned up on unpin,
+    // which left dangling pointers when re-pinning tab A→B.
+    const oldAgentId = tab.getState().agentInstanceId;
     tab.setAgentInstance(agentInstanceId);
-    // If unpinning, remove stale last-active-tab entries for this tab
-    if (agentInstanceId === null) {
-      for (const [aid, tid] of Object.entries(this.lastActiveTabPerAgent)) {
-        if (tid === tabId) delete this.lastActiveTabPerAgent[aid];
-      }
+
+    // Remove old agent's last-active-tab entry if it points to this tab.
+    if (oldAgentId && this.lastActiveTabPerAgent[oldAgentId] === tabId) {
+      delete this.lastActiveTabPerAgent[oldAgentId];
     }
+
+    // When pinning to a new agent, record this tab as that agent's
+    // last-active tab so the agent has a valid entry immediately.
+    if (agentInstanceId) {
+      this.lastActiveTabPerAgent[agentInstanceId] = tabId;
+    }
+
     this.saveTabState();
   };
 

--- a/apps/browser/src/backend/services/window-layout/index.ts
+++ b/apps/browser/src/backend/services/window-layout/index.ts
@@ -55,6 +55,24 @@ const windowStateSchema = z.object({
 
 type WindowState = z.infer<typeof windowStateSchema>;
 
+const tabStateSchema = z.object({
+  /** Ordered list of tabs that were open */
+  tabs: z.array(
+    z.object({
+      url: z.string(),
+      agentInstanceId: z.string().nullable(),
+    }),
+  ),
+  /** Index into `tabs` of the active tab, or -1 if none */
+  activeTabIndex: z.number().int().min(-1),
+  /** Last active tab per agent instance */
+  lastActiveTabPerAgent: z.record(z.string(), z.string()),
+  /** ID of the agent instance that was last open, for restoration on restart */
+  lastOpenAgentId: z.string().nullable(),
+});
+
+type PersistedTabState = z.infer<typeof tabStateSchema>;
+
 /**
  * Anonymous URL classification for telemetry. Returns coarse booleans
  * (`isLocal`, `isHttps`) without exposing the host or path, so events can
@@ -99,6 +117,8 @@ export class WindowLayoutService extends DisposableService {
   private contentFullscreenTabId: string | null = null;
 
   private saveStateTimeout: NodeJS.Timeout | null = null;
+  /** Tracks the last active tab per agent instance for persistence & restore. */
+  private lastActiveTabPerAgent: Record<string, string> = {};
   private lastNonMaximizedBounds: {
     width: number;
     height: number;
@@ -291,6 +311,7 @@ export class WindowLayoutService extends DisposableService {
     });
     this.baseWindow.on('close', () => {
       this.saveWindowState();
+      this.saveTabState();
     });
 
     // Listen for OS theme changes and update window colors accordingly
@@ -321,6 +342,8 @@ export class WindowLayoutService extends DisposableService {
         selectedElements: [],
         hoveredElement: null,
         viewportSize: null,
+        lastActiveTabPerAgent: {},
+        lastOpenAgentId: null,
       };
       draft.appInfo.isFullScreen = this.baseWindow?.isFullScreen() ?? false;
       draft.appInfo.otherVersions = { ...process.versions, modules: undefined };
@@ -333,16 +356,8 @@ export class WindowLayoutService extends DisposableService {
       this.tabs,
     );
 
-    // Determine initial tab URL based on startup page preference
-    const preferences = this.preferencesService.get();
-    const startupPage = preferences.general.startupPage;
-    const initialUrl =
-      startupPage.type === 'custom' && startupPage.customUrl
-        ? startupPage.customUrl
-        : HOME_PAGE_URL;
-
-    // Create initial tab with the appropriate URL
-    this.createTab(initialUrl, true);
+    // Restore persisted tabs from previous session
+    await this.loadTabState();
 
     this.logger.debug('[WindowLayoutService] Service initialized');
   }
@@ -357,6 +372,8 @@ export class WindowLayoutService extends DisposableService {
 
   protected onTeardown() {
     this.logger.debug('[WindowLayoutService] Teardown called');
+
+    this.saveTabState();
 
     // Clean up session-level permission registry
     SessionPermissionRegistry.getInstance()?.destroy();
@@ -677,6 +694,8 @@ export class WindowLayoutService extends DisposableService {
     this.uiController.on('setColorScheme', this.handleSetColorScheme);
     this.uiController.on('cycleColorScheme', this.handleCycleColorScheme);
     this.uiController.on('setZoomPercentage', this.handleSetZoomPercentage);
+    this.uiController.on('setTabAgentInstance', this.handleSetTabAgentInstance);
+    this.uiController.on('setLastOpenAgentId', this.handleSetLastOpenAgentId);
     this.uiController.on(
       'setContextSelectionMode',
       this.handleSetContextSelectionMode,
@@ -814,6 +833,7 @@ export class WindowLayoutService extends DisposableService {
   private handleCreateTab = async (
     url?: string,
     setActive?: boolean,
+    agentInstanceId?: string | null,
     sourceTabId?: string,
   ) => {
     // If no URL is provided, check user's new tab page preference
@@ -851,13 +871,20 @@ export class WindowLayoutService extends DisposableService {
       }
     }
 
-    await this.createTab(targetUrl, setActive ?? true, sourceTabId);
+    await this.createTab(
+      targetUrl,
+      setActive ?? true,
+      sourceTabId,
+      agentInstanceId,
+    );
+    this.saveTabState();
   };
 
   private async createTab(
     url: string | undefined,
     setActive: boolean,
     sourceTabId?: string,
+    agentInstanceId?: string | null,
   ): Promise<string> {
     const id = generateTabId();
 
@@ -882,7 +909,7 @@ export class WindowLayoutService extends DisposableService {
       (target: NavigationTarget, setActive?: boolean) => {
         // Resolve the navigation target to a URL
         const resolvedUrl = searchUtils.resolveNavigationTarget(target);
-        void this.handleCreateTab(resolvedUrl, setActive, id);
+        void this.handleCreateTab(resolvedUrl, setActive, undefined, id);
       },
       this.telemetryService ?? undefined,
     );
@@ -1054,6 +1081,9 @@ export class WindowLayoutService extends DisposableService {
     // (or tab content if isWebContentInteractive is true)
     this.updateZOrder();
 
+    // Assign to agent instance (null = globally visible)
+    tab.setAgentInstance(agentInstanceId ?? null);
+
     // Only activate new tab if requested AND source tab is active (or no source tab)
     // This prevents background tabs from stealing focus when they open links
     const shouldActivate =
@@ -1111,16 +1141,20 @@ export class WindowLayoutService extends DisposableService {
         if (nextTabId) {
           await this.handleSwitchTab(nextTabId);
         } else {
-          // If no other tabs exist, create a new one
-          const preferences = this.preferencesService.get();
-          const newTabPage = preferences.general.newTabPage;
-          const initialUrl =
-            newTabPage.type === 'custom' && newTabPage.customUrl
-              ? newTabPage.customUrl
-              : HOME_PAGE_URL;
-          await this.createTab(initialUrl, true);
+          // No tabs left — clear active tab
+          this.activeTabId = null;
+          this.uiKarton.setState((draft) => {
+            draft.browser.activeTabId = null;
+          });
         }
       }
+
+      // Clean up stale lastActiveTabPerAgent entries for the closed tab
+      for (const [aid, tid] of Object.entries(this.lastActiveTabPerAgent)) {
+        if (tid === tabId) delete this.lastActiveTabPerAgent[aid];
+      }
+
+      this.saveTabState();
     }
   };
 
@@ -1171,12 +1205,20 @@ export class WindowLayoutService extends DisposableService {
 
     this.updateZOrder();
 
-    // Set viewport size to the new tab's current viewport size
-    // Don't set to null and wait for event - the event only fires on size CHANGE
+    const agentInstanceId = newTab.getState().agentInstanceId;
+    if (agentInstanceId) {
+      this.lastActiveTabPerAgent[agentInstanceId] = tabId;
+    }
+
     this.uiKarton.setState((draft) => {
       draft.browser.activeTabId = tabId;
       draft.browser.viewportSize = newTab.getViewportSize();
+      if (agentInstanceId) {
+        draft.browser.lastActiveTabPerAgent[agentInstanceId] = tabId;
+      }
     });
+
+    this.saveTabState();
   };
 
   private handleReorderTabs = async (tabIds: string[]) => {
@@ -1540,6 +1582,34 @@ export class WindowLayoutService extends DisposableService {
   ) => {
     const tab = tabId ? this.tabs[tabId] : this.activeTab;
     tab?.setZoomPercentage(percentage);
+  };
+
+  private handleSetTabAgentInstance = async (
+    tabId: string,
+    agentInstanceId: string | null,
+  ) => {
+    const tab = this.tabs[tabId];
+    if (!tab) {
+      this.logger.warn(
+        `[WindowLayoutService] setTabAgentInstance: tab ${tabId} not found`,
+      );
+      return;
+    }
+    tab.setAgentInstance(agentInstanceId);
+    // If unpinning, remove stale last-active-tab entries for this tab
+    if (agentInstanceId === null) {
+      for (const [aid, tid] of Object.entries(this.lastActiveTabPerAgent)) {
+        if (tid === tabId) delete this.lastActiveTabPerAgent[aid];
+      }
+    }
+    this.saveTabState();
+  };
+
+  private handleSetLastOpenAgentId = async (agentInstanceId: string | null) => {
+    this.uiKarton.setState((draft) => {
+      draft.browser.lastOpenAgentId = agentInstanceId;
+    });
+    this.saveTabState();
   };
 
   private handleSetContextSelectionMode = async (active: boolean) => {
@@ -1977,6 +2047,84 @@ export class WindowLayoutService extends DisposableService {
         '[WindowLayoutService] Failed to save window state',
         error,
       );
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Tab State Persistence
+  // -------------------------------------------------------------------------
+
+  /** Persist open tabs and agent-tab associations so they survive restart. */
+  private saveTabState() {
+    try {
+      // Sort global-first to match the UI display order
+      const sortedIds = [...Object.keys(this.tabs)].sort((a, b) => {
+        const aGlobal = this.tabs[a]!.getState().agentInstanceId === null;
+        const bGlobal = this.tabs[b]!.getState().agentInstanceId === null;
+        if (aGlobal && !bGlobal) return -1;
+        if (!aGlobal && bGlobal) return 1;
+        return 0;
+      });
+      const activeIndex = this.activeTabId
+        ? sortedIds.indexOf(this.activeTabId)
+        : -1;
+      const state: PersistedTabState = {
+        tabs: sortedIds.map((id) => {
+          const tabState = this.tabs[id]!.getState();
+          return {
+            url: tabState.url,
+            agentInstanceId: tabState.agentInstanceId,
+          };
+        }),
+        activeTabIndex: activeIndex,
+        lastActiveTabPerAgent: this.lastActiveTabPerAgent,
+        lastOpenAgentId: this.uiKarton.state.browser.lastOpenAgentId ?? null,
+      };
+      writePersistedDataSync('tab-state', tabStateSchema, state);
+    } catch (error) {
+      this.logger.error(
+        '[WindowLayoutService] Failed to save tab state',
+        error,
+      );
+    }
+  }
+
+  /** Restore tabs and agent associations from persisted state. */
+  private async loadTabState() {
+    const state = readPersistedDataSync(
+      'tab-state',
+      tabStateSchema,
+      null as unknown as PersistedTabState,
+    );
+    if (!state || state.tabs.length === 0) return;
+
+    this.logger.debug(
+      `[WindowLayoutService] Restoring ${state.tabs.length} persisted tabs`,
+    );
+
+    // Restore the last-active-tab-per-agent map first
+    this.lastActiveTabPerAgent = state.lastActiveTabPerAgent || {};
+    // Push to Karton state so the UI can use it
+    this.uiKarton.setState((draft) => {
+      draft.browser.lastActiveTabPerAgent = { ...this.lastActiveTabPerAgent };
+      draft.browser.lastOpenAgentId = state.lastOpenAgentId ?? null;
+    });
+
+    // Re-create tabs in saved order; tabs are appended so index is preserved.
+    for (const savedTab of state.tabs) {
+      await this.createTab(
+        savedTab.url,
+        false,
+        undefined,
+        savedTab.agentInstanceId,
+      );
+    }
+
+    // Activate the tab at the saved index
+    if (state.activeTabIndex >= 0 && state.activeTabIndex < state.tabs.length) {
+      const tabIds = Object.keys(this.tabs);
+      const targetId = tabIds[state.activeTabIndex];
+      if (targetId) await this.handleSwitchTab(targetId);
     }
   }
 

--- a/apps/browser/src/backend/services/window-layout/index.ts
+++ b/apps/browser/src/backend/services/window-layout/index.ts
@@ -856,13 +856,16 @@ export class WindowLayoutService extends DisposableService {
       }
     }
 
-    // For internal pages, check if a non-active tab with the same URL already exists
-    // If the active tab already has this URL, we still create a new tab (user explicitly wants another)
+    // For internal pages, check if a non-active tab with the same URL already
+    // exists AND is visible to the requesting agent (global or matching).
+    // If the active tab already has this URL, we still create a new tab.
     if (targetUrl?.startsWith('stagewise://')) {
-      const existingTab = Object.entries(this.tabs).find(
-        ([id, tab]) =>
-          id !== this.activeTabId && tab.getState().url === targetUrl,
-      );
+      const existingTab = Object.entries(this.tabs).find(([id, tab]) => {
+        if (id === this.activeTabId) return false;
+        if (tab.getState().url !== targetUrl) return false;
+        const tabAgent = tab.getState().agentInstanceId;
+        return tabAgent === null || tabAgent === (agentInstanceId ?? null);
+      });
 
       if (existingTab) {
         const [existingTabId] = existingTab;
@@ -1086,9 +1089,8 @@ export class WindowLayoutService extends DisposableService {
 
     // Only activate new tab if requested AND source tab is active (or no source tab)
     // This prevents background tabs from stealing focus when they open links
-    const shouldActivate =
-      setActive && (!sourceTabId || sourceTabId === this.activeTabId);
-    if (shouldActivate) await this.handleSwitchTab(id);
+    if (setActive && (!sourceTabId || sourceTabId === this.activeTabId))
+      await this.handleSwitchTab(id);
 
     return id;
   }
@@ -1100,6 +1102,7 @@ export class WindowLayoutService extends DisposableService {
       const tabIdsBeforeDeletion = Object.keys(this.tabs);
       const currentIndex = tabIdsBeforeDeletion.indexOf(tabId);
       const isActiveTab = this.activeTabId === tabId;
+      const closedAgentInstanceId = tab.getState().agentInstanceId;
 
       // Check if webContents is already destroyed (e.g., crash, external closure)
       const webContents = tab.getViewContainer().webContents;
@@ -1115,39 +1118,73 @@ export class WindowLayoutService extends DisposableService {
       // Update ChatStateController tabs reference
       this.chatStateController?.updateTabsReference(this.tabs);
 
-      // Clean up Karton state
-      this.uiKarton.setState((draft) => {
-        delete draft.browser.tabs[tabId];
-      });
-
       this.telemetryService?.capture('tab-destroyed', {
         tab_count_after: Object.keys(this.tabs).length,
       });
 
+      // Compute next tab BEFORE any Karton state update.
+      // Prefer tabs visible to the closed tab's agent (global + same-agent)
+      // so we don't switch to a tab the UI will hide, leaving empty content.
+      let nextTabId: string | undefined;
+      let nextTabAgentInstanceId: string | undefined;
       if (isActiveTab) {
-        // Get remaining tabs after deletion
         const remainingTabIds = Object.keys(this.tabs);
-
-        // Try next tab first
-        let nextTabId: string | undefined;
-        if (currentIndex < remainingTabIds.length) {
-          // Next tab is at the same index (since we removed current)
-          nextTabId = remainingTabIds[currentIndex];
-        } else if (currentIndex > 0) {
-          // If no next tab, try previous tab
-          nextTabId = remainingTabIds[currentIndex - 1];
+        // Filter to tabs visible from the closed tab's agent perspective
+        const visibleRemaining = remainingTabIds.filter((id) => {
+          const agentId = this.tabs[id]?.getState().agentInstanceId;
+          return agentId === null || agentId === closedAgentInstanceId;
+        });
+        if (visibleRemaining.length > 0) {
+          // Pick the next visible tab in positional order (prefer same index,
+          // fall back to last in filtered list)
+          const nextVisible =
+            visibleRemaining.find(
+              (id) => remainingTabIds.indexOf(id) >= currentIndex,
+            ) ?? visibleRemaining[visibleRemaining.length - 1];
+          nextTabId = nextVisible;
+        } else if (remainingTabIds.length > 0) {
+          // No visible tabs left — fall back to any remaining tab
+          if (currentIndex < remainingTabIds.length) {
+            nextTabId = remainingTabIds[currentIndex];
+          } else if (currentIndex > 0) {
+            nextTabId = remainingTabIds[currentIndex - 1];
+          }
         }
-
         if (nextTabId) {
-          await this.handleSwitchTab(nextTabId);
-        } else {
-          // No tabs left — clear active tab
-          this.activeTabId = null;
-          this.uiKarton.setState((draft) => {
-            draft.browser.activeTabId = null;
-          });
+          nextTabAgentInstanceId =
+            this.tabs[nextTabId]?.getState().agentInstanceId ?? undefined;
         }
       }
+
+      // Do internal tab switch (bounds, visibility, z-order) but skip its
+      // setState — we combine deletion + active-tab update below atomically.
+      if (isActiveTab) {
+        if (nextTabId) {
+          await this.handleSwitchTab(nextTabId, true);
+          this.activeTabId = nextTabId;
+          if (nextTabAgentInstanceId) {
+            this.lastActiveTabPerAgent[nextTabAgentInstanceId] = nextTabId;
+          }
+        } else {
+          this.activeTabId = null;
+        }
+      }
+
+      // Single atomic Karton state update: delete closed tab + set new active
+      const newTab = nextTabId ? this.tabs[nextTabId] : undefined;
+      this.uiKarton.setState((draft) => {
+        delete draft.browser.tabs[tabId];
+        if (isActiveTab) {
+          draft.browser.activeTabId = nextTabId ?? null;
+          if (newTab) {
+            draft.browser.viewportSize = newTab.getViewportSize();
+            if (nextTabAgentInstanceId) {
+              draft.browser.lastActiveTabPerAgent[nextTabAgentInstanceId] =
+                nextTabId!;
+            }
+          }
+        }
+      });
 
       // Clean up stale lastActiveTabPerAgent entries for the closed tab
       for (const [aid, tid] of Object.entries(this.lastActiveTabPerAgent)) {
@@ -1158,7 +1195,7 @@ export class WindowLayoutService extends DisposableService {
     }
   };
 
-  private handleSwitchTab = async (tabId: string) => {
+  private handleSwitchTab = async (tabId: string, skipSetState = false) => {
     if (!this.tabs[tabId]) return;
     if (this.activeTabId === tabId) return;
 
@@ -1210,15 +1247,17 @@ export class WindowLayoutService extends DisposableService {
       this.lastActiveTabPerAgent[agentInstanceId] = tabId;
     }
 
-    this.uiKarton.setState((draft) => {
-      draft.browser.activeTabId = tabId;
-      draft.browser.viewportSize = newTab.getViewportSize();
-      if (agentInstanceId) {
-        draft.browser.lastActiveTabPerAgent[agentInstanceId] = tabId;
-      }
-    });
+    if (!skipSetState) {
+      this.uiKarton.setState((draft) => {
+        draft.browser.activeTabId = tabId;
+        draft.browser.viewportSize = newTab.getViewportSize();
+        if (agentInstanceId) {
+          draft.browser.lastActiveTabPerAgent[agentInstanceId] = tabId;
+        }
+      });
 
-    this.saveTabState();
+      this.saveTabState();
+    }
   };
 
   private handleReorderTabs = async (tabIds: string[]) => {

--- a/apps/browser/src/backend/services/window-layout/index.ts
+++ b/apps/browser/src/backend/services/window-layout/index.ts
@@ -117,6 +117,12 @@ export class WindowLayoutService extends DisposableService {
   private contentFullscreenTabId: string | null = null;
 
   private saveStateTimeout: NodeJS.Timeout | null = null;
+  /** Tabs deferred at startup, grouped by agentInstanceId. Populated during
+   *  loadTabState(); consumed and cleared lazily by ensureAgentTabsCreated(). */
+  private deferredTabConfigs = new Map<
+    string | null,
+    { url: string; agentInstanceId: string | null }[]
+  >();
   /** Tracks the last active tab per agent instance for persistence & restore. */
   private lastActiveTabPerAgent: Record<string, string> = {};
   private lastNonMaximizedBounds: {
@@ -1644,7 +1650,27 @@ export class WindowLayoutService extends DisposableService {
     this.saveTabState();
   };
 
+  /** Lazily create persisted tabs for an agent when it is first selected.
+   *  Consumes from the snapshot stored at startup — never re-reads persisted
+   *  state, so tabs re-assigned after startup won't be duplicated. */
+  private async ensureAgentTabsCreated(agentInstanceId: string | null) {
+    const configs = this.deferredTabConfigs.get(agentInstanceId);
+    if (!configs || configs.length === 0) return;
+    this.deferredTabConfigs.delete(agentInstanceId);
+
+    this.logger.debug(
+      `[WindowLayoutService] Lazily creating ${configs.length} tabs for agent ${agentInstanceId}`,
+    );
+
+    for (const cfg of configs) {
+      await this.createTab(cfg.url, false, undefined, cfg.agentInstanceId);
+    }
+  }
+
   private handleSetLastOpenAgentId = async (agentInstanceId: string | null) => {
+    // Lazily create tabs when switching to a not-yet-activated agent.
+    await this.ensureAgentTabsCreated(agentInstanceId);
+
     this.uiKarton.setState((draft) => {
       draft.browser.lastOpenAgentId = agentInstanceId;
     });
@@ -2128,7 +2154,10 @@ export class WindowLayoutService extends DisposableService {
     }
   }
 
-  /** Restore tabs and agent associations from persisted state. */
+  /** Restore tabs and agent associations from persisted state.
+   *  Only global tabs and tabs belonging to the last-open agent are eagerly
+   *  created. Other agent tabs are stored in deferredTabConfigs and created
+   *  lazily when that agent is selected. */
   private async loadTabState() {
     const state = readPersistedDataSync(
       'tab-state',
@@ -2137,8 +2166,10 @@ export class WindowLayoutService extends DisposableService {
     );
     if (!state || state.tabs.length === 0) return;
 
+    const lastOpenAgentId = state.lastOpenAgentId;
+
     this.logger.debug(
-      `[WindowLayoutService] Restoring ${state.tabs.length} persisted tabs`,
+      `[WindowLayoutService] Restoring tabs (lastOpenAgentId=${lastOpenAgentId})`,
     );
 
     // Restore the last-active-tab-per-agent map first
@@ -2146,11 +2177,27 @@ export class WindowLayoutService extends DisposableService {
     // Push to Karton state so the UI can use it
     this.uiKarton.setState((draft) => {
       draft.browser.lastActiveTabPerAgent = { ...this.lastActiveTabPerAgent };
-      draft.browser.lastOpenAgentId = state.lastOpenAgentId ?? null;
+      draft.browser.lastOpenAgentId = lastOpenAgentId ?? null;
     });
 
-    // Re-create tabs in saved order; tabs are appended so index is preserved.
-    for (const savedTab of state.tabs) {
+    // Partition into eager (global + last-open agent) and deferred (the rest).
+    const visibleTabs: typeof state.tabs = [];
+    for (const t of state.tabs) {
+      if (!t.agentInstanceId || t.agentInstanceId === lastOpenAgentId) {
+        visibleTabs.push(t);
+      } else {
+        const group = this.deferredTabConfigs.get(t.agentInstanceId);
+        if (group) group.push(t);
+        else this.deferredTabConfigs.set(t.agentInstanceId, [t]);
+      }
+    }
+
+    const deferredCount = state.tabs.length - visibleTabs.length;
+    this.logger.debug(
+      `[WindowLayoutService] Eagerly creating ${visibleTabs.length} tabs, deferring ${deferredCount}`,
+    );
+
+    for (const savedTab of visibleTabs) {
       await this.createTab(
         savedTab.url,
         false,
@@ -2159,11 +2206,17 @@ export class WindowLayoutService extends DisposableService {
       );
     }
 
-    // Activate the tab at the saved index
+    // Activate the tab at the saved index (only if it was among the visible tabs)
     if (state.activeTabIndex >= 0 && state.activeTabIndex < state.tabs.length) {
-      const tabIds = Object.keys(this.tabs);
-      const targetId = tabIds[state.activeTabIndex];
-      if (targetId) await this.handleSwitchTab(targetId);
+      const targetTab = state.tabs[state.activeTabIndex]!;
+      if (
+        !targetTab.agentInstanceId ||
+        targetTab.agentInstanceId === lastOpenAgentId
+      ) {
+        const tabIds = Object.keys(this.tabs);
+        const targetId = tabIds[visibleTabs.indexOf(targetTab)];
+        if (targetId) await this.handleSwitchTab(targetId);
+      }
     }
   }
 

--- a/apps/browser/src/backend/services/window-layout/tab-controller.ts
+++ b/apps/browser/src/backend/services/window-layout/tab-controller.ts
@@ -56,6 +56,8 @@ import type {
 export interface TabState {
   title: string;
   url: string;
+  /** Agent instance this tab is attached to, or null if globally visible */
+  agentInstanceId: string | null;
   faviconUrls: string[];
   isLoading: boolean;
   isResponsive: boolean;
@@ -366,6 +368,7 @@ export class TabController extends EventEmitter<TabControllerEventMap> {
     this.currentState = {
       title: 'New tab',
       url: initialUrl || '',
+      agentInstanceId: null,
       isLoading: false,
       isResponsive: true,
       isPlayingAudio: this.webContentsView.webContents.isCurrentlyAudible(),
@@ -800,6 +803,11 @@ export class TabController extends EventEmitter<TabControllerEventMap> {
 
   public focus() {
     this.webContentsView.webContents.focus();
+  }
+
+  /** Set the agent instance this tab is attached to (null = globally visible) */
+  public setAgentInstance(agentInstanceId: string | null) {
+    this.updateState({ agentInstanceId });
   }
 
   public async setContextSelectionMode(active: boolean) {

--- a/apps/browser/src/backend/services/window-layout/ui-controller.ts
+++ b/apps/browser/src/backend/services/window-layout/ui-controller.ts
@@ -141,7 +141,11 @@ declare const MAIN_WINDOW_VITE_NAME: string;
 export interface UIControllerEventMap {
   uiReady: [];
   viewRecreated: [oldView: WebContentsView, newView: WebContentsView];
-  createTab: [url?: string, setActive?: boolean];
+  createTab: [
+    url?: string,
+    setActive?: boolean,
+    agentInstanceId?: string | null,
+  ];
   closeTab: [tabId: string];
   switchTab: [tabId: string];
   reorderTabs: [tabIds: string[]];
@@ -162,6 +166,8 @@ export interface UIControllerEventMap {
   setColorScheme: [scheme: ColorScheme, tabId?: string];
   cycleColorScheme: [tabId?: string];
   setZoomPercentage: [percentage: number, tabId?: string];
+  setTabAgentInstance: [tabId: string, agentInstanceId: string | null];
+  setLastOpenAgentId: [agentInstanceId: string | null];
   setContextSelectionMode: [active: boolean];
   setContextSelectionMouseCoordinates: [x: number, y: number];
   clearContextSelectionMouseCoordinates: [];
@@ -668,8 +674,13 @@ export class UIController extends EventEmitter<UIControllerEventMap> {
     );
     this.uiKarton.registerServerProcedureHandler(
       'browser.createTab',
-      async (_callingClientId: string, url?: string, setActive?: boolean) => {
-        this.emit('createTab', url, setActive);
+      async (
+        _callingClientId: string,
+        url?: string,
+        setActive?: boolean,
+        agentInstanceId?: string | null,
+      ) => {
+        this.emit('createTab', url, setActive, agentInstanceId);
       },
     );
     this.uiKarton.registerServerProcedureHandler(
@@ -787,6 +798,22 @@ export class UIController extends EventEmitter<UIControllerEventMap> {
       'browser.setZoomPercentage',
       async (_callingClientId: string, percentage: number, tabId?: string) => {
         this.emit('setZoomPercentage', percentage, tabId);
+      },
+    );
+    this.uiKarton.registerServerProcedureHandler(
+      'browser.setTabAgentInstance',
+      async (
+        _callingClientId: string,
+        tabId: string,
+        agentInstanceId: string | null,
+      ) => {
+        this.emit('setTabAgentInstance', tabId, agentInstanceId);
+      },
+    );
+    this.uiKarton.registerServerProcedureHandler(
+      'browser.setLastOpenAgentId',
+      async (_callingClientId: string, agentInstanceId: string | null) => {
+        this.emit('setLastOpenAgentId', agentInstanceId);
       },
     );
     this.uiKarton.registerServerProcedureHandler(
@@ -1113,6 +1140,7 @@ export class UIController extends EventEmitter<UIControllerEventMap> {
     this.uiKarton.removeServerProcedureHandler('browser.setColorScheme');
     this.uiKarton.removeServerProcedureHandler('browser.cycleColorScheme');
     this.uiKarton.removeServerProcedureHandler('browser.setZoomPercentage');
+    this.uiKarton.removeServerProcedureHandler('browser.setTabAgentInstance');
     this.uiKarton.removeServerProcedureHandler(
       'browser.contextSelection.setActive',
     );

--- a/apps/browser/src/backend/utils/paths.ts
+++ b/apps/browser/src/backend/utils/paths.ts
@@ -35,7 +35,8 @@ export type JsonName =
   | 'recently-opened-workspaces'
   | 'onboarding-state'
   | 'downloads-state'
-  | 'window-state';
+  | 'window-state'
+  | 'tab-state';
 
 export const getJsonPath = (name: JsonName): string =>
   path.join(getDataRoot(), `${name}.json`);

--- a/apps/browser/src/shared/karton-contracts/ui/index.ts
+++ b/apps/browser/src/shared/karton-contracts/ui/index.ts
@@ -350,6 +350,8 @@ export type TabState = {
   title: string;
   url: string;
   faviconUrls: string[];
+  /** Agent instance this tab is attached to, or null if globally visible */
+  agentInstanceId: string | null;
   isLoading: boolean;
   isResponsive: boolean;
   isPlayingAudio: boolean;
@@ -623,6 +625,10 @@ export type AppState = {
       height: number;
       scale: number;
     } | null;
+    /** Last active tab ID per agent instance. Key is agentInstanceId, value is tab ID. */
+    lastActiveTabPerAgent: Record<string, string>;
+    /** Agent instance ID that was open last, persisted across restarts. */
+    lastOpenAgentId: string | null;
   };
 
   // Downloads state for the control button
@@ -905,7 +911,11 @@ export type KartonContract = {
       ) => Promise<void>;
     };
     browser: {
-      createTab: (url?: string, setActive?: boolean) => Promise<void>;
+      createTab: (
+        url?: string,
+        setActive?: boolean,
+        agentInstanceId?: string | null,
+      ) => Promise<void>;
       closeTab: (tabId: string) => Promise<void>;
       switchTab: (tabId: string) => Promise<void>;
       reorderTabs: (tabIds: string[]) => Promise<void>;
@@ -985,6 +995,13 @@ export type KartonContract = {
       setColorScheme: (scheme: ColorScheme, tabId?: string) => Promise<void>;
       cycleColorScheme: (tabId?: string) => Promise<void>;
       setZoomPercentage: (percentage: number, tabId?: string) => Promise<void>;
+      /** Set the agent instance ID this tab is attached to (null = globally visible) */
+      setTabAgentInstance: (
+        tabId: string,
+        agentInstanceId: string | null,
+      ) => Promise<void>;
+      /** Persist the last-opened agent instance ID for restoration on restart. */
+      setLastOpenAgentId: (agentId: string | null) => Promise<void>;
       contextSelection: {
         setActive: (active: boolean) => Promise<void>;
         setMouseCoordinates: (x: number, y: number) => Promise<void>; // Used by the client to communicate where the mouse is currently located. Will be forwarded to the tab to check which element is at that point.
@@ -1228,6 +1245,8 @@ export const defaultState: KartonContract['state'] = {
     selectedElements: [],
     hoveredElement: null,
     viewportSize: null,
+    lastActiveTabPerAgent: {},
+    lastOpenAgentId: null,
   },
   downloads: {
     items: [],

--- a/apps/browser/src/ui/screens/main/_components/content-collapsed-context.tsx
+++ b/apps/browser/src/ui/screens/main/_components/content-collapsed-context.tsx
@@ -1,0 +1,81 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+  type ReactNode,
+} from 'react';
+
+const STORAGE_KEY = 'stagewise-content-collapsed';
+
+interface ContentCollapsedCtx {
+  collapsed: boolean;
+  setCollapsed: (value: boolean) => void;
+  toggle: () => void;
+}
+
+const ContentCollapsedContext = createContext<ContentCollapsedCtx | null>(null);
+
+function readInitialContentCollapsed(): boolean {
+  try {
+    return localStorage.getItem(STORAGE_KEY) === '1';
+  } catch {
+    return false;
+  }
+}
+
+function persist(value: boolean) {
+  try {
+    localStorage.setItem(STORAGE_KEY, value ? '1' : '0');
+  } catch {
+    // ignore
+  }
+}
+
+export function ContentCollapsedProvider({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  const [collapsed, setCollapsedState] = useState<boolean>(
+    readInitialContentCollapsed,
+  );
+
+  const setCollapsed = useCallback((value: boolean) => {
+    setCollapsedState((prev) => {
+      if (prev === value) return prev;
+      persist(value);
+      return value;
+    });
+  }, []);
+
+  const toggle = useCallback(() => {
+    setCollapsedState((prev) => {
+      const next = !prev;
+      persist(next);
+      return next;
+    });
+  }, []);
+
+  const value = useMemo<ContentCollapsedCtx>(
+    () => ({ collapsed, setCollapsed, toggle }),
+    [collapsed, setCollapsed, toggle],
+  );
+
+  return (
+    <ContentCollapsedContext.Provider value={value}>
+      {children}
+    </ContentCollapsedContext.Provider>
+  );
+}
+
+export function useContentCollapsed(): ContentCollapsedCtx {
+  const ctx = useContext(ContentCollapsedContext);
+  if (!ctx) {
+    throw new Error(
+      'useContentCollapsed must be used inside ContentCollapsedProvider',
+    );
+  }
+  return ctx;
+}

--- a/apps/browser/src/ui/screens/main/_components/content-toggle-button.tsx
+++ b/apps/browser/src/ui/screens/main/_components/content-toggle-button.tsx
@@ -1,0 +1,34 @@
+import { Button } from '@stagewise/stage-ui/components/button';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@stagewise/stage-ui/components/tooltip';
+import {
+  IconSidebarRightHideOutline18,
+  IconSidebarRightShowOutline18,
+} from 'nucleo-ui-outline-18';
+import { useContentCollapsed } from './content-collapsed-context';
+
+export function ContentToggleButton() {
+  const { collapsed, toggle } = useContentCollapsed();
+  const label = collapsed ? 'Show content panel' : 'Hide content panel';
+  const Icon = collapsed
+    ? IconSidebarRightShowOutline18
+    : IconSidebarRightHideOutline18;
+  return (
+    <Tooltip>
+      <TooltipTrigger>
+        <Button
+          variant="ghost"
+          size="icon-sm"
+          aria-label={label}
+          onClick={toggle}
+        >
+          <Icon className="size-4" />
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent>{label}</TooltipContent>
+    </Tooltip>
+  );
+}

--- a/apps/browser/src/ui/screens/main/_components/globe-plus-icon.tsx
+++ b/apps/browser/src/ui/screens/main/_components/globe-plus-icon.tsx
@@ -1,0 +1,46 @@
+import type { SVGProps } from 'react';
+
+export function GlobePlusIcon({
+  fill = 'currentColor',
+  secondaryfill,
+  ...props
+}: SVGProps<SVGSVGElement> & { secondaryfill?: string }) {
+  const sFill = secondaryfill || fill;
+  return (
+    <svg
+      height="18"
+      width="18"
+      viewBox="0 0 18 18"
+      xmlns="http://www.w3.org/2000/svg"
+      {...props}
+    >
+      <g fill="none" stroke={fill} strokeWidth="1.5" strokeLinecap="round">
+        {/* earth outline */}
+        <path d="M16.2392 9.3991C16.2464 9.267 16.25 9.1339 16.25 9C16.25 4.9959 13.0041 1.75 9 1.75C4.9959 1.75 1.75 4.9959 1.75 9C1.75 13.0041 4.9959 16.25 9 16.25C9.1307 16.25 9.2606 16.2465 9.3897 16.2397" />
+        {/* continents */}
+        <path d="M13.0008 2.98069L11.4893 2.9094C10.4948 2.8625 9.73551 3.7861 9.97371 4.7527L10.2457 5.8562C10.3051 6.0973 10.2086 6.3499 10.0036 6.4899C9.83801 6.603 9.62661 6.6251 9.44121 6.5487L8.51411 6.1666C7.78921 5.8678 6.96161 5.9623 6.32271 6.4169C5.75691 6.8194 5.40531 7.4578 5.36751 8.1511L5.29651 9.4532" />
+        <path d="M2.59167 5.7457C3.02037 6.8697 3.97027 8.6883 5.49667 9.6832C5.92257 9.9178 6.90037 10.6811 6.83237 11.8894C6.73917 13.5436 7.49188 13.4869 8.29058 14.0813C8.70068 14.3865 8.80518 15.3243 8.74518 16.0644" />
+        <path d="M5.75409 9.8474C6.41499 9.7081 7.1658 9.4986 7.9978 9.6495" />
+        {/* plus sign */}
+        <line
+          stroke={sFill}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          x1="14.25"
+          x2="14.25"
+          y1="11.75"
+          y2="16.75"
+        />
+        <line
+          stroke={sFill}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          x1="16.75"
+          x2="11.75"
+          y1="14.25"
+          y2="14.25"
+        />
+      </g>
+    </svg>
+  );
+}

--- a/apps/browser/src/ui/screens/main/_components/sidebar-titlebar-row.tsx
+++ b/apps/browser/src/ui/screens/main/_components/sidebar-titlebar-row.tsx
@@ -42,11 +42,6 @@ export function SidebarTitlebarRow({
     >
       <TrafficLightGutter />
       <SidebarToggleButton />
-      {/* Trailing drag region: fills the rest of the row so the area right
-          of the toggle button remains a window grab handle (matches the
-          pre-collapse sidebar behavior where the whole titlebar was
-          draggable). `shrink-0` + `flex-1` gives it all remaining width. */}
-      <div aria-hidden className="app-drag min-h-full flex-1" />
     </div>
   );
 }

--- a/apps/browser/src/ui/screens/main/_components/sidebar-toggle-button.tsx
+++ b/apps/browser/src/ui/screens/main/_components/sidebar-toggle-button.tsx
@@ -8,8 +8,10 @@ import {
 } from '@stagewise/stage-ui/components/tooltip';
 import { HotkeyComboText } from '@ui/components/hotkey-combo-text';
 import { useKartonState } from '@ui/hooks/use-karton';
-import { useUiZoomCounterScale } from '@ui/hooks/use-ui-zoom-counter-scale';
-import { IconSidebarLeftOutline18 } from 'nucleo-ui-outline-18';
+import {
+  IconSidebarLeftHideOutline18,
+  IconSidebarLeftShowOutline18,
+} from 'nucleo-ui-outline-18';
 import { useSidebarCollapsed } from './sidebar-collapsed-context';
 
 export function SidebarToggleButton() {
@@ -18,10 +20,11 @@ export function SidebarToggleButton() {
   // with the macOS traffic-light cluster. On Windows/Linux there are no
   // traffic lights to align against, so we skip the nudge and let the
   // icon sit on the flex-center of the titlebar row.
-  // Counter-scaled so the offset stays correct under UI zoom.
   const isMacOs = useKartonState((s) => s.appInfo.platform === 'darwin');
-  const counterScale = useUiZoomCounterScale();
   const label = collapsed ? 'Show sidebar' : 'Hide sidebar';
+  const Icon = collapsed
+    ? IconSidebarLeftShowOutline18
+    : IconSidebarLeftHideOutline18;
   return (
     <Tooltip>
       <TooltipTrigger>
@@ -31,13 +34,11 @@ export function SidebarToggleButton() {
           aria-label={label}
           className="app-no-drag shrink-0"
           style={
-            isMacOs
-              ? { marginTop: TITLEBAR_ICON_OPTICAL_OFFSET * counterScale }
-              : undefined
+            isMacOs ? { marginTop: TITLEBAR_ICON_OPTICAL_OFFSET } : undefined
           }
           onClick={toggle}
         >
-          <IconSidebarLeftOutline18 className="size-4" />
+          <Icon className="size-4" />
         </Button>
       </TooltipTrigger>
       <TooltipContent side="bottom">

--- a/apps/browser/src/ui/screens/main/agent-chat/index.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/index.tsx
@@ -4,9 +4,6 @@ import {
   type ImperativePanelHandle,
 } from '@stagewise/stage-ui/components/resizable';
 import { useRef } from 'react';
-import { TITLEBAR_HEIGHT } from '@shared/titlebar';
-import { useKartonState } from '@ui/hooks/use-karton';
-import { useUiZoomCounterScale } from '@ui/hooks/use-ui-zoom-counter-scale';
 import { useSidebarCollapsed } from '../_components/sidebar-collapsed-context';
 import { SidebarTitlebarRow } from '../_components/sidebar-titlebar-row';
 
@@ -14,8 +11,6 @@ export function AgentChat() {
   const panelRef = useRef<ImperativePanelHandle>(null);
   const previousSizeRef = useRef<number | null>(null);
 
-  const isMacOS = useKartonState((s) => s.appInfo.platform === 'darwin');
-  const counterScale = useUiZoomCounterScale();
   const { collapsed } = useSidebarCollapsed();
 
   return (
@@ -33,15 +28,6 @@ export function AgentChat() {
       }}
       className="@container group overflow-visible! relative z-10 flex h-full flex-col items-stretch justify-between bg-background"
     >
-      {/* Add a small draggable area for macOS hidden-titlebar windows.
-          Height is counter-scaled so it stays aligned with the native
-          traffic-light region regardless of UI zoom. */}
-      {isMacOS && (
-        <div
-          className="app-drag absolute top-0 left-0 -z-10 w-full"
-          style={{ height: TITLEBAR_HEIGHT * counterScale }}
-        />
-      )}
       {collapsed && <SidebarTitlebarRow absolute />}
       <div className="flex h-full flex-col items-stretch justify-between p-1">
         <Chat />

--- a/apps/browser/src/ui/screens/main/content/index.tsx
+++ b/apps/browser/src/ui/screens/main/content/index.tsx
@@ -14,8 +14,11 @@ import {
   type ReactElement,
 } from 'react';
 import { cn } from '@stagewise/stage-ui/lib/utils';
+import { useOpenAgent } from '@ui/hooks/use-open-chat';
 import { useEventListener } from '@ui/hooks/use-event-listener';
+import { useScrollFadeMask } from '@ui/hooks/use-scroll-fade-mask';
 import { useTrack } from '@ui/hooks/use-track';
+import { BackgroundWithCutout } from './_components/background-with-cutout';
 import { CoreHotkeyBindings } from './_components/core-hotkey-bindings';
 import {
   PerTabContent,
@@ -30,6 +33,10 @@ import {
 } from '@stagewise/stage-ui/components/sortable-tabs';
 import { Button } from '@stagewise/stage-ui/components/button';
 import { IconVolumeUpFill18, IconVolumeXmarkFill18 } from 'nucleo-ui-fill-18';
+import {
+  IconPinTackOutline18,
+  IconPinTackSlashOutline18,
+} from 'nucleo-ui-outline-18';
 import type { KartonContract, TabState } from '@shared/karton-contracts/ui';
 
 // ---------------------------------------------------------------------------
@@ -65,12 +72,71 @@ function AudioMuteButton({ tab }: { tab: TabState }) {
 }
 
 // ---------------------------------------------------------------------------
+// Pin-toggle icon overlay — replaces favicon on tab hover
+// ---------------------------------------------------------------------------
+function TabPinIcon({
+  tab,
+  openAgent,
+}: {
+  tab: TabState;
+  openAgent: string | null;
+}) {
+  const setTabAgentInstance = useKartonProcedure(
+    (p) => p.browser.setTabAgentInstance,
+  );
+
+  // No agent open → just show favicon, no pin toggle
+  if (!openAgent) return <TabFavicon tabState={tab} />;
+
+  const isAttachedToCurrentAgent = tab.agentInstanceId === openAgent;
+
+  const handleToggle = (e: React.MouseEvent | React.KeyboardEvent) => {
+    e.stopPropagation();
+    e.preventDefault();
+    const newValue = isAttachedToCurrentAgent ? null : openAgent;
+    setTabAgentInstance(tab.id, newValue);
+  };
+
+  return (
+    <div className="relative size-full">
+      {/* Favicon — hidden on group-hover */}
+      <span className="flex size-full items-center justify-center group-hover:opacity-0">
+        <TabFavicon tabState={tab} />
+      </span>
+      {/* Pin toggle — replaces favicon on group-hover */}
+      <span
+        role="button"
+        tabIndex={0}
+        title={isAttachedToCurrentAgent ? 'Unpin' : 'Pin globally'}
+        aria-label={
+          isAttachedToCurrentAgent
+            ? 'Unpin tab (make global)'
+            : 'Pin tab globally'
+        }
+        className="absolute inset-0 m-0 block flex size-full items-center justify-center p-0 text-muted-foreground opacity-0 hover:text-foreground group-hover:opacity-100"
+        onPointerDown={(e) => e.stopPropagation()}
+        onClick={handleToggle}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            handleToggle(e);
+          }
+        }}
+      >
+        {isAttachedToCurrentAgent ? (
+          <IconPinTackOutline18 className="size-3.5" />
+        ) : (
+          <IconPinTackSlashOutline18 className="size-3.5" />
+        )}
+      </span>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // MainSection
 // ---------------------------------------------------------------------------
 
 export function MainSection() {
-  const isMacOs = useKartonState((s) => s.appInfo.platform === 'darwin');
-  const isFullScreen = useKartonState((s) => s.appInfo.isFullScreen);
   const tabs = useKartonState((s) => s.browser.tabs);
   const activeTabId = useKartonState((s) => s.browser.activeTabId);
   const createTab = useKartonProcedure((p) => p.browser.createTab);
@@ -82,7 +148,71 @@ export function MainSection() {
   );
 
   const { setTabUiState, removeTabUiState } = useTabUIState();
+  const [openAgent] = useOpenAgent();
   const track = useTrack();
+
+  // ---------------------------------------------------------------------------
+  // Per-agent last-active-tab tracking + auto-switch on agent change
+  // ---------------------------------------------------------------------------
+  // Owned by the backend (persisted to tab-state.json), exposed via Karton state.
+  const lastActiveTabPerAgent = useKartonState(
+    (s) => s.browser.lastActiveTabPerAgent,
+  );
+
+  // When switching agents, move away from agent-exclusive tabs
+  const prevOpenAgentRef = useRef<string | null>(null);
+  useEffect(() => {
+    const prevAgent = prevOpenAgentRef.current;
+    prevOpenAgentRef.current = openAgent;
+
+    // Only react to actual agent changes
+    if (prevAgent === openAgent) return;
+    if (!openAgent) return;
+
+    // Bail only if the current tab is explicitly for this agent.
+    // A global tab is "visible" everywhere but we still want to
+    // switch to a remembered agent-specific tab when available.
+    if (activeTabId && tabs[activeTabId]) {
+      const currentTab = tabs[activeTabId];
+      if (currentTab.agentInstanceId === openAgent) return;
+    }
+
+    // Need to switch — collect visible tab IDs for the new agent
+    const visibleIds = Object.keys(tabs).filter((id) => {
+      const t = tabs[id];
+      return (
+        t && (t.agentInstanceId === null || t.agentInstanceId === openAgent)
+      );
+    });
+
+    // Prefer previously active tab for this agent
+    const prevActive = lastActiveTabPerAgent[openAgent];
+    if (prevActive && tabs[prevActive] && visibleIds.includes(prevActive)) {
+      switchTab(prevActive);
+      return;
+    }
+
+    // Prefer any agent-specific tab
+    const agentTab = visibleIds.find(
+      (id) => tabs[id]?.agentInstanceId === openAgent,
+    );
+    if (agentTab) {
+      switchTab(agentTab);
+      return;
+    }
+
+    // Prefer any global tab
+    const globalTab = visibleIds.find(
+      (id) => tabs[id]?.agentInstanceId === null,
+    );
+    if (globalTab) {
+      switchTab(globalTab);
+      return;
+    }
+
+    // No visible tabs for this agent — do nothing;
+    // effectiveActiveTabId derived below will show empty state.
+  }, [openAgent, activeTabId, tabs, switchTab]);
 
   // ---------------------------------------------------------------------------
   // Optimistic tab order
@@ -97,51 +227,135 @@ export function MainSection() {
   const [optimisticTabIds, setOptimisticTabIds] =
     useState<string[]>(serverTabIds);
 
-  // Sync when the server adds/removes tabs
+  // Sync when the server adds/removes tabs — sort global tabs first
   useEffect(() => {
-    setOptimisticTabIds(serverTabIds);
+    const sorted = [...serverTabIds].sort((a, b) => {
+      const aGlobal = tabs[a]?.agentInstanceId === null;
+      const bGlobal = tabs[b]?.agentInstanceId === null;
+      if (aGlobal && !bGlobal) return -1;
+      if (!aGlobal && bGlobal) return 1;
+      return 0;
+    });
+    setOptimisticTabIds(sorted);
+    // tabs omitted from deps intentionally — only re-sort on add/remove
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [serverTabIds]);
 
-  const handleReorder = useCallback(
+  // Effective active tab ID: null when the real activeTabId belongs to a
+  // tab that isn't visible under the current agent (prevents showing content
+  // for another agent's tab after switching agents).
+  const effectiveActiveTabId = useMemo(() => {
+    if (!activeTabId) return null;
+    const tab = tabs[activeTabId];
+    if (!tab) return null;
+    if (tab.agentInstanceId === null || tab.agentInstanceId === openAgent) {
+      return activeTabId;
+    }
+    return null;
+  }, [activeTabId, tabs, openAgent]);
+
+  // Visible tab IDs filtered to current agent (global + this agent's tabs)
+  const visibleTabIds = useMemo(() => {
+    return optimisticTabIds.filter((id) => {
+      const tab = tabs[id];
+      if (!tab) return false;
+      return tab.agentInstanceId === null || tab.agentInstanceId === openAgent;
+    });
+  }, [optimisticTabIds, tabs, openAgent]);
+
+  // ---------------------------------------------------------------------------
+  // Detect new tabs and agentInstanceId changes — move to end of their group
+  // ---------------------------------------------------------------------------
+  const prevTabsRef = useRef(tabs);
+  useEffect(() => {
+    const prev = prevTabsRef.current;
+    const idsToMove = new Set<string>();
+
+    for (const id of Object.keys(tabs)) {
+      if (!prev[id]) {
+        // New tab — move to end of its group
+        idsToMove.add(id);
+      } else if (prev[id]?.agentInstanceId !== tabs[id]?.agentInstanceId) {
+        // Pin/unpin toggled — move to end of its new group
+        idsToMove.add(id);
+      }
+    }
+
+    prevTabsRef.current = tabs;
+
+    if (idsToMove.size === 0) return;
+
+    setOptimisticTabIds((prevIds) => {
+      // Preserve existing order for non-moved tabs, split by group
+      const globalIds = prevIds.filter(
+        (id) => tabs[id]?.agentInstanceId === null && !idsToMove.has(id),
+      );
+      const agentIds = prevIds.filter(
+        (id) => tabs[id]?.agentInstanceId !== null && !idsToMove.has(id),
+      );
+      // Moved items at end of their respective groups
+      const movedGlobal: string[] = [];
+      const movedAgent: string[] = [];
+      idsToMove.forEach((id) => {
+        if (tabs[id]?.agentInstanceId === null) {
+          movedGlobal.push(id);
+        } else {
+          movedAgent.push(id);
+        }
+      });
+      return [...globalIds, ...movedGlobal, ...agentIds, ...movedAgent];
+    });
+  }, [tabs]);
+
+  // Per-group reorder handlers — each DndContext isolated, no cross-group drag
+  const handleReorderGlobal = useCallback(
     (newItems: SortableTabItem[]) => {
-      const newIds = newItems.map((t) => t.id);
-      setOptimisticTabIds(newIds);
-      reorderTabs(newIds);
+      const newOrder = newItems.map((t) => t.id);
+      const agentIds = optimisticTabIds.filter(
+        (id) => tabs[id]?.agentInstanceId !== null,
+      );
+      const newFullIds = [...newOrder, ...agentIds];
+      setOptimisticTabIds(newFullIds);
+      reorderTabs(newFullIds);
     },
-    [reorderTabs],
+    [optimisticTabIds, tabs, reorderTabs],
+  );
+
+  const handleReorderAgent = useCallback(
+    (newItems: SortableTabItem[]) => {
+      const newOrder = newItems.map((t) => t.id);
+      const globalIds = optimisticTabIds.filter(
+        (id) => tabs[id]?.agentInstanceId === null,
+      );
+      const newFullIds = [...globalIds, ...newOrder];
+      setOptimisticTabIds(newFullIds);
+      reorderTabs(newFullIds);
+    },
+    [optimisticTabIds, tabs, reorderTabs],
   );
 
   // ---------------------------------------------------------------------------
   // Build SortableTabItem[] from optimistic order + Karton tab state
   // ---------------------------------------------------------------------------
   const tabItems = useMemo<SortableTabItem[]>(() => {
-    const isOnlyTab = Object.keys(tabs).length === 1;
-    return optimisticTabIds
+    return visibleTabIds
       .map((id): SortableTabItem | null => {
         const tab = tabs[id];
         if (!tab) return null;
-        const isInternalPage =
-          tab.url?.startsWith('stagewise://internal/') ?? false;
-        const hideClose = isOnlyTab && isInternalPage;
         return {
           id,
           label: tab.title,
-          icon: <TabFavicon tabState={tab} />,
-          closeable: !hideClose,
-          onClose: hideClose
-            ? undefined
-            : () => {
-                void closeTab(id);
-                removeTabUiState(id);
-              },
-          onAuxClick: hideClose
-            ? undefined
-            : (e: React.MouseEvent) => {
-                if (e.button !== 1) return;
-                e.preventDefault();
-                void closeTab(id);
-                removeTabUiState(id);
-              },
+          icon: <TabPinIcon tab={tab} openAgent={openAgent} />,
+          onClose: () => {
+            void closeTab(id);
+            removeTabUiState(id);
+          },
+          onAuxClick: (e: React.MouseEvent) => {
+            if (e.button !== 1) return;
+            e.preventDefault();
+            void closeTab(id);
+            removeTabUiState(id);
+          },
           actions:
             tab.isPlayingAudio || tab.isMuted ? (
               <AudioMuteButton tab={tab} />
@@ -154,7 +368,17 @@ export function MainSection() {
         };
       })
       .filter((item): item is SortableTabItem => item !== null);
-  }, [optimisticTabIds, tabs, activeTabId, closeTab, removeTabUiState]);
+  }, [visibleTabIds, tabs, activeTabId, openAgent, closeTab, removeTabUiState]);
+
+  // Split into global and agent groups for separate sortable lists
+  const globalTabItems = useMemo(
+    () => tabItems.filter((t) => tabs[t.id]?.agentInstanceId === null),
+    [tabItems, tabs],
+  );
+  const agentTabItems = useMemo(
+    () => tabItems.filter((t) => tabs[t.id]?.agentInstanceId !== null),
+    [tabItems, tabs],
+  );
 
   // ---------------------------------------------------------------------------
   // Omnibox focus plumbing (unchanged)
@@ -189,8 +413,8 @@ export function MainSection() {
 
   const handleCreateTab = useCallback(() => {
     pendingOmniboxFocusFromTabIdRef.current = activeTabId;
-    createTab();
-  }, [createTab, activeTabId]);
+    createTab(undefined, undefined, openAgent);
+  }, [createTab, activeTabId, openAgent]);
 
   const handleCleanAllTabs = useCallback(() => {
     const tabIdsToClose = Object.keys(tabs).filter(
@@ -239,6 +463,28 @@ export function MainSection() {
     [activeTabId, setTabUiState],
   );
 
+  const tabBarScrollRef = useRef<HTMLDivElement>(null);
+
+  const { maskStyle } = useScrollFadeMask(tabBarScrollRef, {
+    axis: 'horizontal',
+    fadeDistance: 8,
+  });
+
+  // Redirect vertical mouse-wheel to horizontal scroll on the tab bar.
+  // Must be a non-passive listener so we can call preventDefault().
+  useEffect(() => {
+    const el = tabBarScrollRef.current;
+    if (!el) return;
+    const onWheel = (e: WheelEvent) => {
+      if (e.deltaX !== 0) return; // already horizontal — leave it alone
+      if (e.deltaY === 0) return;
+      e.preventDefault();
+      el.scrollLeft += e.deltaY;
+    };
+    el.addEventListener('wheel', onWheel, { passive: false });
+    return () => el.removeEventListener('wheel', onWheel);
+  }, []);
+
   useEventListener('focus', handleUIFocused, undefined, window);
   useEventListener(
     'stagewise-tab-focused',
@@ -262,44 +508,64 @@ export function MainSection() {
       />
       <div className="flex h-full w-full flex-col">
         {/* Tab bar */}
-        <div className="flex shrink-0 flex-row items-stretch bg-background">
+        <div className="flex shrink-0 flex-row items-stretch bg-background py-1.5 pr-9 pl-1">
           <SortableTabs
-            value={activeTabId ?? ''}
+            value={effectiveActiveTabId ?? ''}
             onValueChange={(id) => {
               if (id) void switchTab(id);
             }}
-            // Override default `w-full` so the tab list shrinks to content
-            // width, leaving the trailing draggable strip room to grow into
-            // the empty space.
-            className="w-auto min-w-0 shrink"
+            ref={tabBarScrollRef}
+            style={maskStyle}
+            className="w-auto min-w-0 shrink gap-1 overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
           >
-            <SortableTabsList
-              variant="bar"
-              items={tabItems}
-              onReorder={handleReorder}
-              activeValue={activeTabId ?? ''}
-              onAddItem={handleCreateTab}
-            />
+            {/* Global (pinned) tabs — shrinks independently, inner scroll handles overflow */}
+            {globalTabItems.length > 0 && (
+              <SortableTabsList
+                variant="bar"
+                items={globalTabItems}
+                onReorder={handleReorderGlobal}
+                activeValue={effectiveActiveTabId ?? ''}
+                className="min-w-0 shrink"
+              />
+            )}
+            {/* Separator */}
+            {globalTabItems.length > 0 && agentTabItems.length > 0 && (
+              <div className="h-full w-px shrink-0 bg-border-subtle" />
+            )}
+            {/* Agent-specific (unpinned) tabs — shrinks independently */}
+            {agentTabItems.length > 0 && (
+              <SortableTabsList
+                variant="bar"
+                items={agentTabItems}
+                onReorder={handleReorderAgent}
+                activeValue={effectiveActiveTabId ?? ''}
+                className="min-w-0 shrink"
+              />
+            )}
           </SortableTabs>
-          {/* Trailing drag strip for macOS hidden-titlebar windows — fills
-              the empty row space so users can drag the window. */}
-          {isMacOs && !isFullScreen && (
-            <div className="app-drag h-8 grow" aria-hidden="true" />
-          )}
         </div>
         {/* Content area with per-tab UI */}
         <div className="relative flex size-full flex-col">
           {/* Inner container with overflow clipping */}
           <div className="flex size-full flex-col overflow-hidden">
-            {/* Per-tab content instances */}
-            {Object.keys(tabs).map((tabId) => (
+            {/* Background with mask for the web-content */}
+            <BackgroundWithCutout
+              className="z-0"
+              targetElementId={
+                effectiveActiveTabId
+                  ? `dev-app-preview-container-${effectiveActiveTabId}`
+                  : undefined
+              }
+            />
+            {/* Per-tab content instances — only visible tabs */}
+            {visibleTabIds.map((tabId) => (
               <PerTabContent
                 key={tabId}
                 ref={(ref) => {
                   tabContentRefs.current[tabId] = ref;
                 }}
                 tabId={tabId}
-                isActive={tabId === activeTabId}
+                isActive={tabId === effectiveActiveTabId}
               />
             ))}
           </div>

--- a/apps/browser/src/ui/screens/main/content/index.tsx
+++ b/apps/browser/src/ui/screens/main/content/index.tsx
@@ -21,7 +21,7 @@ import { useOpenAgent } from '@ui/hooks/use-open-chat';
 import { useEventListener } from '@ui/hooks/use-event-listener';
 import { useScrollFadeMask } from '@ui/hooks/use-scroll-fade-mask';
 import { useTrack } from '@ui/hooks/use-track';
-import { BackgroundWithCutout } from './_components/background-with-cutout';
+
 import { CoreHotkeyBindings } from './_components/core-hotkey-bindings';
 import {
   PerTabContent,
@@ -637,15 +637,6 @@ export function MainSection() {
         <div className="relative flex size-full flex-col">
           {/* Inner container with overflow clipping */}
           <div className="flex size-full flex-col overflow-hidden">
-            {/* Background with mask for the web-content */}
-            <BackgroundWithCutout
-              className="z-0"
-              targetElementId={
-                effectiveActiveTabId
-                  ? `dev-app-preview-container-${effectiveActiveTabId}`
-                  : undefined
-              }
-            />
             {/* Per-tab content instances — only visible tabs */}
             {visibleTabIds.map((tabId) => (
               <PerTabContent

--- a/apps/browser/src/ui/screens/main/content/index.tsx
+++ b/apps/browser/src/ui/screens/main/content/index.tsx
@@ -116,11 +116,11 @@ function TabPinIcon({
       <span
         role="button"
         tabIndex={0}
-        title={isAttachedToCurrentAgent ? 'Unpin' : 'Pin globally'}
+        title={isAttachedToCurrentAgent ? 'Unpin' : 'Pin to agent'}
         aria-label={
           isAttachedToCurrentAgent
             ? 'Unpin tab (make global)'
-            : 'Pin tab globally'
+            : 'Pin tab to current agent'
         }
         className="absolute inset-0 m-0 block flex size-full items-center justify-center p-0 text-muted-foreground opacity-0 hover:text-foreground group-hover:opacity-100"
         onPointerDown={(e) => e.stopPropagation()}
@@ -150,7 +150,9 @@ const CONTENT_SIZE_KEY = 'stagewise-content-panel-size';
 function readContentSize(): number {
   try {
     const stored = localStorage.getItem(CONTENT_SIZE_KEY);
-    return stored ? Number.parseFloat(stored) : 70;
+    if (!stored) return 70;
+    const parsed = Number.parseFloat(stored);
+    return Number.isFinite(parsed) && parsed >= 20 ? parsed : 70;
   } catch {
     return 70;
   }
@@ -191,13 +193,19 @@ export function MainSection() {
     const panel = panelRef.current;
     if (!panel) return;
     const saved = storedSizeRef.current;
-    requestAnimationFrame(() => {
+    const rafId = requestAnimationFrame(() => {
       panel.resize(saved);
       const tid = setTimeout(() => {
         isRestoringRef.current = false;
       }, 150);
-      return () => clearTimeout(tid);
+      // If the effect unmounts during this RAF, cancel the timeout.
+      timeoutId = tid;
     });
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+    return () => {
+      cancelAnimationFrame(rafId);
+      if (timeoutId !== undefined) clearTimeout(timeoutId);
+    };
   }, []);
 
   // ---------------------------------------------------------------------------
@@ -374,10 +382,15 @@ export function MainSection() {
   const handleReorderAgent = useCallback(
     (newItems: SortableTabItem[]) => {
       const newOrder = newItems.map((t) => t.id);
+      const newAgentSet = new Set(newOrder);
       const globalIds = optimisticTabIds.filter(
         (id) => tabs[id]?.agentInstanceId === null,
       );
-      const newFullIds = [...globalIds, ...newOrder];
+      // Preserve other agents' tabs that weren't part of this reorder.
+      const otherAgentIds = optimisticTabIds.filter(
+        (id) => tabs[id]?.agentInstanceId !== null && !newAgentSet.has(id),
+      );
+      const newFullIds = [...globalIds, ...otherAgentIds, ...newOrder];
       setOptimisticTabIds(newFullIds);
       reorderTabs(newFullIds);
     },

--- a/apps/browser/src/ui/screens/main/content/index.tsx
+++ b/apps/browser/src/ui/screens/main/content/index.tsx
@@ -1,4 +1,7 @@
-import { ResizablePanel } from '@stagewise/stage-ui/components/resizable';
+import {
+  ResizablePanel,
+  type ImperativePanelHandle,
+} from '@stagewise/stage-ui/components/resizable';
 import { useTabUIState } from '@ui/hooks/use-tab-ui-state';
 import {
   useComparingSelector,
@@ -32,11 +35,17 @@ import {
   type SortableTabItem,
 } from '@stagewise/stage-ui/components/sortable-tabs';
 import { Button } from '@stagewise/stage-ui/components/button';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@stagewise/stage-ui/components/tooltip';
 import { IconVolumeUpFill18, IconVolumeXmarkFill18 } from 'nucleo-ui-fill-18';
 import {
   IconPinTackOutline18,
   IconPinTackSlashOutline18,
 } from 'nucleo-ui-outline-18';
+import { GlobePlusIcon } from '../_components/globe-plus-icon';
 import type { KartonContract, TabState } from '@shared/karton-contracts/ui';
 
 // ---------------------------------------------------------------------------
@@ -136,7 +145,27 @@ function TabPinIcon({
 // MainSection
 // ---------------------------------------------------------------------------
 
+const CONTENT_SIZE_KEY = 'stagewise-content-panel-size';
+
+function readContentSize(): number {
+  try {
+    const stored = localStorage.getItem(CONTENT_SIZE_KEY);
+    return stored ? Number.parseFloat(stored) : 70;
+  } catch {
+    return 70;
+  }
+}
+
+function persistContentSize(size: number) {
+  try {
+    localStorage.setItem(CONTENT_SIZE_KEY, String(size));
+  } catch {
+    // ignore
+  }
+}
+
 export function MainSection() {
+  const panelRef = useRef<ImperativePanelHandle>(null);
   const tabs = useKartonState((s) => s.browser.tabs);
   const activeTabId = useKartonState((s) => s.browser.activeTabId);
   const createTab = useKartonProcedure((p) => p.browser.createTab);
@@ -150,6 +179,26 @@ export function MainSection() {
   const { setTabUiState, removeTabUiState } = useTabUIState();
   const [openAgent] = useOpenAgent();
   const track = useTrack();
+
+  // Persisted panel size survives mount/unmount (conditional rendering).
+  const storedSizeRef = useRef(readContentSize());
+  // Block onResize→persist during mount-time layout and programmatic restore.
+  // Starts true: onResize fires BEFORE useEffect, and the panel group's
+  // auto-layout size must not leak into localStorage.
+  const isRestoringRef = useRef(true);
+
+  useEffect(() => {
+    const panel = panelRef.current;
+    if (!panel) return;
+    const saved = storedSizeRef.current;
+    requestAnimationFrame(() => {
+      panel.resize(saved);
+      const tid = setTimeout(() => {
+        isRestoringRef.current = false;
+      }, 150);
+      return () => clearTimeout(tid);
+    });
+  }, []);
 
   // ---------------------------------------------------------------------------
   // Per-agent last-active-tab tracking + auto-switch on agent change
@@ -219,6 +268,7 @@ export function MainSection() {
   // useComparingSelector prevents a new array reference on every tab property
   // mutation (title / URL / loading state) — only the set/order of IDs matters.
   // ---------------------------------------------------------------------------
+
   const tabIdsSelector = useComparingSelector<KartonContract, string[]>(
     (s) => Object.keys(s.browser.tabs),
     (a, b) => a.length === b.length && a.every((id, i) => id === b[i]),
@@ -416,6 +466,10 @@ export function MainSection() {
     createTab(undefined, undefined, openAgent);
   }, [createTab, activeTabId, openAgent]);
 
+  const handleGlobeClick = useCallback(() => {
+    createTab(undefined, undefined, openAgent);
+  }, [createTab, openAgent]);
+
   const handleCleanAllTabs = useCallback(() => {
     const tabIdsToClose = Object.keys(tabs).filter(
       (tabId) => tabId !== activeTabId,
@@ -495,9 +549,17 @@ export function MainSection() {
 
   return (
     <ResizablePanel
+      ref={panelRef}
       id="opened-content-panel"
       order={2}
-      defaultSize={70}
+      defaultSize={storedSizeRef.current}
+      minSize={20}
+      onResize={(size) => {
+        if (size > 0 && !isRestoringRef.current) {
+          storedSizeRef.current = size;
+          persistContentSize(size);
+        }
+      }}
       className="@container overflow-visible! flex h-full flex-1 flex-col items-start justify-between"
     >
       <CoreHotkeyBindings
@@ -508,7 +570,7 @@ export function MainSection() {
       />
       <div className="flex h-full w-full flex-col">
         {/* Tab bar */}
-        <div className="flex shrink-0 flex-row items-stretch bg-background py-1.5 pr-9 pl-1">
+        <div className="flex shrink-0 flex-row items-stretch gap-1 bg-background py-1.5 pl-1">
           <SortableTabs
             value={effectiveActiveTabId ?? ''}
             onValueChange={(id) => {
@@ -543,6 +605,20 @@ export function MainSection() {
               />
             )}
           </SortableTabs>
+          <Tooltip>
+            <TooltipTrigger>
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                aria-label="Open new browser tab"
+                className="size-7 rounded-md"
+                onClick={handleGlobeClick}
+              >
+                <GlobePlusIcon className="size-4" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>Open browsing tab</TooltipContent>
+          </Tooltip>
         </div>
         {/* Content area with per-tab UI */}
         <div className="relative flex size-full flex-col">

--- a/apps/browser/src/ui/screens/main/content/index.tsx
+++ b/apps/browser/src/ui/screens/main/content/index.tsx
@@ -269,7 +269,7 @@ export function MainSection() {
 
     // No visible tabs for this agent — do nothing;
     // effectiveActiveTabId derived below will show empty state.
-  }, [openAgent, activeTabId, tabs, switchTab]);
+  }, [openAgent]);
 
   // ---------------------------------------------------------------------------
   // Optimistic tab order

--- a/apps/browser/src/ui/screens/main/index.tsx
+++ b/apps/browser/src/ui/screens/main/index.tsx
@@ -9,9 +9,11 @@ import { AgentChat } from './agent-chat';
 import { MainSection } from './content';
 import { cn } from '@ui/utils';
 import { Sidebar } from './sidebar';
-import { useKartonState } from '@ui/hooks/use-karton';
-import { useUiZoomCounterScale } from '@ui/hooks/use-ui-zoom-counter-scale';
-import { OpenAgentProvider } from '@ui/hooks/use-open-chat';
+import { useKartonState, useKartonProcedure } from '@ui/hooks/use-karton';
+import { OpenAgentProvider, useOpenAgent } from '@ui/hooks/use-open-chat';
+import { useCallback, useMemo } from 'react';
+import { Button } from '@stagewise/stage-ui/components/button';
+import { IconGlobePointerOutline18 } from 'nucleo-ui-outline-18';
 import { ChatDraftProvider } from '@ui/hooks/use-chat-draft';
 import { PendingRemovalsProvider } from '@ui/hooks/use-pending-agent-removals';
 import { useAutoSelectFirstAgent } from '@ui/hooks/use-auto-select-agent';
@@ -41,8 +43,22 @@ export function DefaultLayout({ show }: { show: boolean }) {
 function DefaultLayoutInner({ show }: { show: boolean }) {
   const isMacOs = useKartonState((s) => s.appInfo.platform === 'darwin');
   const isFullScreen = useKartonState((s) => s.appInfo.isFullScreen);
+  const tabs = useKartonState((s) => s.browser.tabs);
+  const [openAgent] = useOpenAgent();
   const { collapsed } = useSidebarCollapsed();
-  const counterScale = useUiZoomCounterScale();
+
+  const hasVisibleTabs = useMemo(() => {
+    return Object.values(tabs).some(
+      (tab) =>
+        tab.agentInstanceId === null || tab.agentInstanceId === openAgent,
+    );
+  }, [tabs, openAgent]);
+
+  const createTab = useKartonProcedure((p) => p.browser.createTab);
+
+  const handleOpenTab = useCallback(() => {
+    createTab(undefined, undefined, openAgent);
+  }, [createTab, openAgent]);
 
   // Headless: keeps `openAgent` valid regardless of whether the sidebar
   // (which used to own this effect) is mounted.
@@ -53,18 +69,13 @@ function DefaultLayoutInner({ show }: { show: boolean }) {
       {show && <AgentHotkeyBindings />}
       <div
         className={cn(
-          'root pointer-events-auto inset-0 flex size-full flex-row items-stretch justify-between transition-[opacity,filter] delay-150 duration-300 ease-out',
+          'root pointer-events-auto relative inset-0 flex size-full flex-row items-stretch justify-between transition-[opacity,filter] delay-150 duration-300 ease-out',
           !show && 'pointer-events-none opacity-0 blur-lg',
         )}
       >
-        {/* Thin draggable strip at the very top for macOS hidden-titlebar
-            windows. Height is counter-scaled so it stays aligned with the
-            native traffic-light region regardless of UI zoom. */}
+        {/* Single global drag zone for macOS titlebar — sits behind everything */}
         {isMacOs && !isFullScreen && (
-          <div
-            className="app-drag fixed top-0 right-0 left-0"
-            style={{ height: 8 * counterScale }}
-          />
+          <div className="app-drag absolute top-0 left-0 -z-10 h-8 w-full" />
         )}
         <ResizablePanelGroup
           direction="horizontal"
@@ -80,10 +91,21 @@ function DefaultLayoutInner({ show }: { show: boolean }) {
             order={1}
             defaultSize={65}
             className={cn(
-              'h-full overflow-hidden rounded-l-xl ring-1 ring-derived-subtle',
+              'relative h-full overflow-hidden rounded-l-xl ring-1 ring-derived-subtle',
               !isMacOs && 'mt-px',
             )}
           >
+            {/* Globe button — always visible top-right for creating new tabs */}
+            <div className="app-no-drag absolute top-1 right-1 z-20">
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                aria-label="Open new browser tab"
+                onClick={handleOpenTab}
+              >
+                <IconGlobePointerOutline18 className="size-4" />
+              </Button>
+            </div>
             <ResizablePanelGroup
               direction="horizontal"
               autoSaveId={layoutStorageKey}
@@ -91,9 +113,8 @@ function DefaultLayoutInner({ show }: { show: boolean }) {
             >
               <AgentChat />
 
-              <ResizableHandle />
-
-              <MainSection />
+              {hasVisibleTabs && <ResizableHandle />}
+              {hasVisibleTabs && <MainSection />}
             </ResizablePanelGroup>
           </ResizablePanel>
         </ResizablePanelGroup>

--- a/apps/browser/src/ui/screens/main/index.tsx
+++ b/apps/browser/src/ui/screens/main/index.tsx
@@ -13,7 +13,12 @@ import { useKartonState, useKartonProcedure } from '@ui/hooks/use-karton';
 import { OpenAgentProvider, useOpenAgent } from '@ui/hooks/use-open-chat';
 import { useCallback, useMemo } from 'react';
 import { Button } from '@stagewise/stage-ui/components/button';
-import { IconGlobePointerOutline18 } from 'nucleo-ui-outline-18';
+import {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+} from '@stagewise/stage-ui/components/tooltip';
+import { GlobePlusIcon } from './_components/globe-plus-icon';
 import { ChatDraftProvider } from '@ui/hooks/use-chat-draft';
 import { PendingRemovalsProvider } from '@ui/hooks/use-pending-agent-removals';
 import { useAutoSelectFirstAgent } from '@ui/hooks/use-auto-select-agent';
@@ -21,19 +26,25 @@ import {
   SidebarCollapsedProvider,
   useSidebarCollapsed,
 } from './_components/sidebar-collapsed-context';
+import {
+  ContentCollapsedProvider,
+  useContentCollapsed,
+} from './_components/content-collapsed-context';
+import { ContentToggleButton } from './_components/content-toggle-button';
 import { AgentHotkeyBindings } from './_components/agent-hotkey-bindings';
 
 const rootLayoutStorageKey = 'stagewise-panel-layout-root';
-const layoutStorageKey = 'stagewise-panel-layout';
 
 export function DefaultLayout({ show }: { show: boolean }) {
   return (
     <OpenAgentProvider>
       <ChatDraftProvider>
         <SidebarCollapsedProvider>
-          <PendingRemovalsProvider>
-            <DefaultLayoutInner show={show} />
-          </PendingRemovalsProvider>
+          <ContentCollapsedProvider>
+            <PendingRemovalsProvider>
+              <DefaultLayoutInner show={show} />
+            </PendingRemovalsProvider>
+          </ContentCollapsedProvider>
         </SidebarCollapsedProvider>
       </ChatDraftProvider>
     </OpenAgentProvider>
@@ -45,7 +56,9 @@ function DefaultLayoutInner({ show }: { show: boolean }) {
   const isFullScreen = useKartonState((s) => s.appInfo.isFullScreen);
   const tabs = useKartonState((s) => s.browser.tabs);
   const [openAgent] = useOpenAgent();
-  const { collapsed } = useSidebarCollapsed();
+  const { collapsed: sidebarCollapsed } = useSidebarCollapsed();
+  const { collapsed: contentCollapsed, setCollapsed: setContentCollapsed } =
+    useContentCollapsed();
 
   const hasVisibleTabs = useMemo(() => {
     return Object.values(tabs).some(
@@ -55,10 +68,13 @@ function DefaultLayoutInner({ show }: { show: boolean }) {
   }, [tabs, openAgent]);
 
   const createTab = useKartonProcedure((p) => p.browser.createTab);
+  // content panel visible when there are visible tabs AND it's not collapsed
+  const showContent = hasVisibleTabs && !contentCollapsed;
 
   const handleOpenTab = useCallback(() => {
+    if (contentCollapsed) setContentCollapsed(false);
     createTab(undefined, undefined, openAgent);
-  }, [createTab, openAgent]);
+  }, [createTab, openAgent, contentCollapsed, setContentCollapsed]);
 
   // Headless: keeps `openAgent` valid regardless of whether the sidebar
   // (which used to own this effect) is mounted.
@@ -84,7 +100,7 @@ function DefaultLayoutInner({ show }: { show: boolean }) {
         >
           <Sidebar />
 
-          {!collapsed && <ResizableHandle />}
+          {!sidebarCollapsed && <ResizableHandle />}
 
           <ResizablePanel
             id="content-panel"
@@ -95,26 +111,34 @@ function DefaultLayoutInner({ show }: { show: boolean }) {
               !isMacOs && 'mt-px',
             )}
           >
-            {/* Globe button — always visible top-right for creating new tabs */}
+            {/* Top-right action button: content toggle when tabs visible, globe when none */}
             <div className="app-no-drag absolute top-1 right-1 z-20">
-              <Button
-                variant="ghost"
-                size="icon-sm"
-                aria-label="Open new browser tab"
-                onClick={handleOpenTab}
-              >
-                <IconGlobePointerOutline18 className="size-4" />
-              </Button>
+              {hasVisibleTabs ? (
+                <ContentToggleButton />
+              ) : (
+                <Tooltip>
+                  <TooltipTrigger>
+                    <Button
+                      variant="ghost"
+                      size="icon-sm"
+                      aria-label="Open new browser tab"
+                      onClick={handleOpenTab}
+                    >
+                      <GlobePlusIcon className="size-4" />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>Open browsing tab</TooltipContent>
+                </Tooltip>
+              )}
             </div>
             <ResizablePanelGroup
               direction="horizontal"
-              autoSaveId={layoutStorageKey}
               className="h-full divide-x divide-surface-1"
             >
               <AgentChat />
 
-              {hasVisibleTabs && <ResizableHandle />}
-              {hasVisibleTabs && <MainSection />}
+              <ResizableHandle />
+              {showContent && <MainSection />}
             </ResizablePanelGroup>
           </ResizablePanel>
         </ResizablePanelGroup>

--- a/apps/browser/src/ui/screens/main/index.tsx
+++ b/apps/browser/src/ui/screens/main/index.tsx
@@ -137,8 +137,12 @@ function DefaultLayoutInner({ show }: { show: boolean }) {
             >
               <AgentChat />
 
-              <ResizableHandle />
-              {showContent && <MainSection />}
+              {showContent && (
+                <>
+                  <ResizableHandle />
+                  <MainSection />
+                </>
+              )}
             </ResizablePanelGroup>
           </ResizablePanel>
         </ResizablePanelGroup>

--- a/apps/browser/src/ui/screens/main/sidebar/agents-list/index.tsx
+++ b/apps/browser/src/ui/screens/main/sidebar/agents-list/index.tsx
@@ -339,6 +339,9 @@ export function AgentsList() {
   const { previewAgentId } = useAgentSwitcher();
   const createAgent = useKartonProcedure((p) => p.agents.create);
   const resumeAgent = useKartonProcedure((p) => p.agents.resume);
+  const setLastOpenAgentId = useKartonProcedure(
+    (p) => p.browser.setLastOpenAgentId,
+  );
   const deleteAgent = useKartonProcedure((p) => p.agents.delete);
   const setAgentTitle = useKartonProcedure((p) => p.agents.setTitle);
   const markAsRead = useKartonProcedure((p) => p.agents.markAsRead);
@@ -486,6 +489,7 @@ export function AgentsList() {
     const existingEmpty = emptyAgentIdRef.current;
     if (existingEmpty && !pendingRemovalsRef.current.has(existingEmpty)) {
       setOpenAgent(existingEmpty);
+      void setLastOpenAgentId(existingEmpty);
       window.dispatchEvent(new Event('sidebar-chat-panel-opened'));
       return;
     }
@@ -505,6 +509,7 @@ export function AgentsList() {
     ).then((id) => {
       setOpenAgent(id);
       setPendingCreate(false);
+      void setLastOpenAgentId(id);
     });
   }, [agents.length, createAgent, emptyAgentIdRef, setOpenAgent, track]);
 
@@ -517,8 +522,9 @@ export function AgentsList() {
       // Optimistic: update the open agent immediately, don't wait for the RPC.
       setOpenAgent(id);
       void resumeAgent(id);
+      void setLastOpenAgentId(id);
     },
-    [resumeAgent, setOpenAgent],
+    [resumeAgent, setOpenAgent, setLastOpenAgentId],
   );
 
   const handleDelete = useCallback(

--- a/apps/browser/src/ui/screens/main/sidebar/index.tsx
+++ b/apps/browser/src/ui/screens/main/sidebar/index.tsx
@@ -32,7 +32,7 @@ import { UsageWarningBadge } from '../agent-chat/chat/_components/usage-warning-
 // (`defaultSize={12}`) and then collapses via effect on the next frame,
 // producing a visible flash when the user last left the sidebar collapsed.
 const INITIAL_COLLAPSED = readInitialSidebarCollapsed();
-const DEFAULT_EXPANDED_SIZE = 12;
+const DEFAULT_EXPANDED_SIZE = 6;
 
 function getPlanLabel(plan: string | undefined): string {
   if (!plan) return 'Free';
@@ -41,6 +41,7 @@ function getPlanLabel(plan: string | undefined): string {
 
 export function Sidebar() {
   const panelRef = useRef<ImperativePanelHandle>(null);
+  const preCollapseSizeRef = useRef<number>(DEFAULT_EXPANDED_SIZE);
 
   const track = useTrack();
   const createTab = useKartonProcedure((p) => p.browser.createTab);
@@ -74,9 +75,19 @@ export function Sidebar() {
     if (!panel) return;
     const isPanelCollapsed = panel.isCollapsed();
     if (collapsed && !isPanelCollapsed) {
+      const currentSize = panel.getSize();
+      if (currentSize > 0) preCollapseSizeRef.current = currentSize;
       panel.collapse();
     } else if (!collapsed && isPanelCollapsed) {
       panel.expand();
+      // Restore the pre-collapse size instead of defaultSize.
+      // `panel.expand()` may set defaultSize; override with the
+      // remembered size so user-resized widths survive collapse cycles.
+      const restoreSize = preCollapseSizeRef.current;
+      if (restoreSize !== DEFAULT_EXPANDED_SIZE) {
+        // Delay one tick so expand() has settled.
+        requestAnimationFrame(() => panel.resize(restoreSize));
+      }
     }
   }, [collapsed]);
 
@@ -86,7 +97,7 @@ export function Sidebar() {
       id="new-sidebar-panel"
       order={0}
       defaultSize={INITIAL_COLLAPSED ? 0 : DEFAULT_EXPANDED_SIZE}
-      minSize={DEFAULT_EXPANDED_SIZE}
+      minSize={6}
       maxSize={50}
       collapsible
       collapsedSize={0}

--- a/packages/stage-ui/src/components/sortable-tabs.tsx
+++ b/packages/stage-ui/src/components/sortable-tabs.tsx
@@ -69,13 +69,11 @@ import { CSS } from '@dnd-kit/utilities';
 import { Tabs as TabsBase } from '@base-ui/react/tabs';
 import {
   useCallback,
-  useEffect,
-  useRef,
   useState,
   type ReactElement,
   type ReactNode,
 } from 'react';
-import { PlusIcon, XIcon } from 'lucide-react';
+import { XIcon } from 'lucide-react';
 import { cn } from '../lib/utils';
 
 // ---------------------------------------------------------------------------
@@ -138,7 +136,7 @@ export type SortableTabsProps = React.ComponentProps<typeof TabsBase.Root>;
 export const SortableTabs = ({ className, ...props }: SortableTabsProps) => (
   <TabsBase.Root
     {...props}
-    className={cn('flex w-full flex-col items-start gap-2', className)}
+    className={cn('flex w-full flex-row items-stretch', className)}
   />
 );
 
@@ -191,10 +189,8 @@ function BarTriggerContent({
     <div
       onAuxClick={item.onAuxClick}
       className={cn(
-        'group flex h-8 flex-row items-stretch ring-1 transition-colors duration-150 ease-out',
-        isActive
-          ? 'bg-surface-1 ring-derived-subtle'
-          : 'bg-transparent ring-transparent hover:bg-surface-1',
+        'group relative flex h-7 flex-row items-stretch rounded-md transition-colors duration-150 ease-out',
+        isActive ? 'bg-surface-1' : 'bg-transparent hover:bg-surface-1',
       )}
     >
       {/* Trigger — fills remaining width, handles tab activation */}
@@ -202,7 +198,7 @@ function BarTriggerContent({
         value={item.id}
         disabled={item.disabled}
         className={cn(
-          'flex min-w-0 flex-1 select-none flex-row items-center gap-1.5 bg-transparent py-1 pr-1 pl-2.5 text-xs',
+          'flex min-w-0 flex-1 select-none flex-row items-center gap-1.5 bg-transparent py-0.5 pr-3 pl-2 text-xs',
           item.disabled && 'cursor-not-allowed opacity-50',
         )}
       >
@@ -210,9 +206,9 @@ function BarTriggerContent({
           <span className="size-4 shrink-0 [&>*]:size-full">{item.icon}</span>
         )}
         <span
+          data-active={isActive}
           className={cn(
-            'flex-1 truncate text-left font-regular',
-            isActive ? 'text-foreground' : 'text-muted-foreground',
+            'mask-alpha mask-l-from-black mask-l-to-black group-hover:mask-l-from-transparent mask-l-from-3 mask-l-to-6 flex-1 truncate text-left font-regular text-muted-foreground data-[active=true]:text-foreground',
           )}
         >
           {item.label}
@@ -222,7 +218,7 @@ function BarTriggerContent({
       {/* Extra actions (e.g. audio mute toggle) — sibling to Tabs.Tab */}
       {item.actions}
 
-      {/* Close button — sibling to Tabs.Tab, never causes nested <button> */}
+      {/* Close button — absolute overlay on the right, fades in on hover/active */}
       {showClose && (
         <button
           type="button"
@@ -231,9 +227,7 @@ function BarTriggerContent({
           onPointerDown={(e) => e.stopPropagation()}
           onClick={item.onClose}
           className={cn(
-            'flex shrink-0 items-center justify-center pr-2 pl-0.5 text-muted-foreground transition-colors hover:text-foreground',
-            // Only show on hover for inactive tabs (matches browser behaviour)
-            !isActive && 'opacity-0 group-hover:opacity-100',
+            'absolute top-1/2 right-0.5 flex shrink-0 -translate-y-1/2 items-center justify-center p-1 text-muted-foreground opacity-0 transition-colors hover:text-foreground group-hover:opacity-100',
           )}
         >
           <XIcon className="size-3" />
@@ -269,17 +263,10 @@ function BarOverlayContent({
   const showClose = item.closeable !== false && !!item.onClose;
 
   return (
-    <div
-      className={cn(
-        'flex h-8 flex-row items-stretch shadow-elevation-1 ring-1',
-        isActive
-          ? 'bg-surface-1 ring-derived-subtle'
-          : 'bg-surface-1 ring-derived',
-      )}
-    >
-      <div className="flex min-w-0 flex-1 items-center gap-1.5 px-2.5 py-1 text-xs">
+    <div className="relative flex h-7 flex-row items-stretch bg-surface-1 shadow-elevation-1">
+      <div className="flex min-w-0 flex-1 items-center gap-1.5 px-2.5 py-0.5 text-xs">
         {item.icon && (
-          <span className="size-4 shrink-0 [&>*]:size-full">{item.icon}</span>
+          <span className="size-6 shrink-0 [&>*]:size-full">{item.icon}</span>
         )}
         <span
           className={cn(
@@ -291,7 +278,7 @@ function BarOverlayContent({
         </span>
       </div>
       {showClose && (
-        <div className="flex shrink-0 items-center justify-center px-1 text-muted-foreground">
+        <div className="absolute top-1/2 right-0.5 flex shrink-0 -translate-y-1/2 items-center justify-center p-1 text-muted-foreground">
           <XIcon className="size-3" />
         </div>
       )}
@@ -336,9 +323,10 @@ function SortableTrigger({
     return (
       <div
         ref={setNodeRef}
+        className="app-no-drag"
         style={{
           ...style,
-          minWidth: '6rem',
+          minWidth: '5rem',
           maxWidth: '11rem',
         }}
         {...attributes}
@@ -400,27 +388,9 @@ export const SortableTabsList = ({
   onReorder,
   variant = 'pill',
   activeValue,
-  onAddItem,
   className,
 }: SortableTabsListProps) => {
   const [activeId, setActiveId] = useState<string | null>(null);
-  const barScrollRef = useRef<HTMLDivElement>(null);
-
-  // Redirect vertical mouse-wheel to horizontal scroll on the tab bar.
-  // Must be a non-passive listener so we can call preventDefault().
-  useEffect(() => {
-    if (variant !== 'bar') return;
-    const el = barScrollRef.current;
-    if (!el) return;
-    const onWheel = (e: WheelEvent) => {
-      if (e.deltaX !== 0) return; // already horizontal — leave it alone
-      if (e.deltaY === 0) return;
-      e.preventDefault();
-      el.scrollLeft += e.deltaY;
-    };
-    el.addEventListener('wheel', onWheel, { passive: false });
-    return () => el.removeEventListener('wheel', onWheel);
-  }, [variant]);
 
   const sensors = useSensors(
     useSensor(PointerSensor, {
@@ -471,38 +441,16 @@ export const SortableTabsList = ({
           // runs out of space the tabs compress proportionally. Once every tab
           // hits its minWidth floor the container overflows and scrolls.
           // min-w-full on the List keeps tabs filling the container width.
-          <div
-            className={cn(
-              'flex w-full min-w-0 flex-row items-stretch',
-              className,
-            )}
-          >
-            <div
-              ref={barScrollRef}
-              className="min-w-0 overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
-            >
-              <TabsBase.List className="flex h-full w-fit flex-row items-stretch divide-x divide-surface-2">
-                {items.map((item) => (
-                  <SortableTrigger
-                    key={item.id}
-                    item={item}
-                    variant="bar"
-                    activeValue={activeValue}
-                  />
-                ))}
-              </TabsBase.List>
-            </div>
-            {onAddItem && (
-              <button
-                type="button"
-                aria-label="Add tab"
-                onClick={onAddItem}
-                className="flex h-8 shrink-0 cursor-pointer items-center justify-center border-surface-2 border-l bg-background px-2 text-muted-foreground transition-colors hover:bg-surface-1 hover:text-foreground"
-              >
-                <PlusIcon className="size-3" />
-              </button>
-            )}
-          </div>
+          <TabsBase.List className="flex h-full w-fit flex-row items-stretch gap-1">
+            {items.map((item) => (
+              <SortableTrigger
+                key={item.id}
+                item={item}
+                variant="bar"
+                activeValue={activeValue}
+              />
+            ))}
+          </TabsBase.List>
         ) : (
           // Pill: equal-width grid in a rounded container
           <TabsBase.List

--- a/packages/stage-ui/src/components/sortable-tabs.tsx
+++ b/packages/stage-ui/src/components/sortable-tabs.tsx
@@ -14,7 +14,8 @@
  * For the `"bar"` variant, pass `activeValue` matching the `value` you
  * pass to `SortableTabs` so active-tab styling is applied correctly to
  * the outer wrapper (which covers both the trigger text area and the close
- * button).
+ * button). Any "add tab" UI belongs outside `SortableTabsList` — render
+ * it as a sibling after the component.
  *
  * ## Persistence
  * Callers own persistence. `onReorder` fires with the new item array and
@@ -36,7 +37,6 @@
  *     items={items}
  *     onReorder={setItems}
  *     activeValue={active}
- *     onAddItem={handleAddTab}
  *   />
  *   <TabsContent value="a">…</TabsContent>
  * </SortableTabs>
@@ -375,11 +375,6 @@ export interface SortableTabsListProps {
    * Pass the same value you pass to `SortableTabs value={...}`.
    */
   activeValue?: string;
-  /**
-   * Rendered as an "add" button after the last tab in the `"bar"` variant.
-   * Not shown in the `"pill"` variant.
-   */
-  onAddItem?: () => void;
   className?: string;
 }
 

--- a/packages/stage-ui/src/stories/SortableTabs.stories.tsx
+++ b/packages/stage-ui/src/stories/SortableTabs.stories.tsx
@@ -91,20 +91,6 @@ export const BarVariant: Story = {
     );
     const [active, setActive] = useState('home');
 
-    const handleAdd = () => {
-      const id = `tab-${Date.now()}`;
-      setItems((prev) => [
-        ...prev,
-        {
-          id,
-          label: 'New tab',
-          icon: <GlobeIcon />,
-          onClose: () => setItems((p) => p.filter((t) => t.id !== id)),
-        },
-      ]);
-      setActive(id);
-    };
-
     return (
       <div className="flex flex-col overflow-hidden rounded-lg border border-border/20">
         {/* Tab bar — sits at the top like a browser chrome */}
@@ -115,7 +101,6 @@ export const BarVariant: Story = {
               items={items}
               onReorder={setItems}
               activeValue={active}
-              onAddItem={handleAdd}
             />
             {items.map((item) => (
               <TabsContent key={item.id} value={item.id} className="p-4">


### PR DESCRIPTION
implements #1046 

Also adds remembering of content panel size, collapse state, tabs per agent and global tabs, as well as auto-reopens last agent on start

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make browsing tabs per-agent so each agent sees its own tabs plus global tabs. Restores tabs and the last-open agent on startup and speeds up launch with lazy tab creation. Implements #1046.

- New Features
  - Per-agent tabs with pin/unpin: tab bar shows global first, then agent tabs; hover shows a pin toggle; new tabs open in the current agent’s scope.
  - Tab state persistence: restores tab URLs, ordering, active index, last-active tab per agent, and last-open agent; auto-resumes the last agent on launch.
  - API updates: `TabState.agentInstanceId`; `browser.createTab(url?, setActive?, agentInstanceId?)`; new procedures `browser.setTabAgentInstance` and `browser.setLastOpenAgentId`; `getBrowserSnapshot(agentInstanceId)` returns only visible tabs and includes `agentInstanceId`; Karton adds `lastActiveTabPerAgent` and `lastOpenAgentId`.
  - Content panel UX: collapsible with a toggle, remembers width, hides when no visible tabs, plus a globe button to open a browsing tab; sidebar width restores after collapse.
  - UI polish: tab bar split into global and agent groups with a separator and scroll mask; updated `@stagewise/stage-ui` `SortableTabs` (removed `onAddItem`).

- Performance
  - Lazy tab creation: only creates web views for global tabs and the last-open agent at startup; other agents’ tabs are created on first selection.
  - Smarter tab switching: respects per-agent visibility, restores each agent’s last-active tab, and on close selects the next visible tab.
  - Toolbox scope: `getBrowserSnapshot(agentInstanceId)` and totals only include tabs visible to the agent.
  - Fix: agent resume no longer cross-contaminates workspaces.

<sup>Written for commit 194d0f5d872d411d8881732da772f421ef7187a3. Summary will update on new commits. <a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1119?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-agent tab persistence and restore across restarts, including automatic restore of the last-opened agent.
  * Pin/unpin tabs to agents (agent-scoped visibility), agent-aware browser snapshots, and UI actions to assign tabs and record last-opened agent.
  * Content collapsed state provider and toggle; new Globe+ icon.

* **Bug Fixes & Improvements**
  * Better tab ordering, activation, closing/switch behavior, and deferred tab restoration.
  * Sidebar sizing/restore improvements and refined tab-bar visuals, grouping and drag interactions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stagewise-io/stagewise/pull/1119?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->