### PR TITLE
feat(stagewise): add gemini 3.5 flash

### DIFF
--- a/apps/browser/src/shared/available-models.ts
+++ b/apps/browser/src/shared/available-models.ts
@@ -90,6 +90,23 @@ const GOOGLE_INPUT_CONSTRAINTS: InputConstraints = {
   },
 };
 
+const GEMINI35_INPUT_CONSTRAINTS: InputConstraints = {
+  ...GOOGLE_INPUT_CONSTRAINTS,
+  audio: {
+    mimeTypes: [
+      'audio/aac',
+      'audio/aiff',
+      'audio/flac',
+      'audio/mp3',
+      'audio/mpeg',
+      'audio/ogg',
+      'audio/wav',
+      'audio/webm',
+    ],
+    maxBytes: 20_971_520, // 20 MB inline request limit
+  },
+};
+
 export const availableModels = [
   // Anthropic Models
   {
@@ -546,6 +563,46 @@ export const availableModels = [
         file: false,
       },
       inputConstraints: GPT54_INPUT_CONSTRAINTS,
+      toolCalling: true,
+    },
+  },
+  {
+    officialProvider: 'google',
+    modelId: 'gemini-3.5-flash',
+    modelDisplayName: 'Gemini 3.5 Flash',
+    modelDescription:
+      "Google's most intelligent model for sustained frontier performance on agentic and coding tasks.",
+    modelContext: '1m context',
+    modelContextRaw: 1_048_576,
+    headers: googleHeaders,
+    providerOptions: {
+      stagewise: { reasoning: { enabled: true, effort: 'medium' } },
+      google: {
+        thinkingConfig: { includeThoughts: true, thinkingLevel: 'medium' },
+      },
+    },
+    thinkingEnabled: true,
+    pricing: {
+      inputPerMillion: 1.5,
+      outputPerMillion: 9.0,
+      relativeMultiplier: 1.75,
+    },
+    capabilities: {
+      inputModalities: {
+        text: true,
+        audio: true,
+        image: true,
+        video: true,
+        file: true,
+      },
+      outputModalities: {
+        text: true,
+        audio: false,
+        image: false,
+        video: false,
+        file: false,
+      },
+      inputConstraints: GEMINI35_INPUT_CONSTRAINTS,
       toolCalling: true,
     },
   },

--- a/apps/browser/src/shared/karton-contracts/ui/shared-types.ts
+++ b/apps/browser/src/shared/karton-contracts/ui/shared-types.ts
@@ -580,7 +580,13 @@ export const defaultUserPreferences: UserPreferences = {
   sidebar: defaultSidebarPreferences,
   agent: {
     workspaceSettings: {},
-    disabledModelIds: ['claude-opus-4.6', 'kimi-k2.5', 'gpt-5.4', 'MiniMax-M2'],
+    disabledModelIds: [
+      'claude-opus-4.6',
+      'kimi-k2.5',
+      'gpt-5.4',
+      'MiniMax-M2',
+      'gemini-3-flash-preview',
+    ],
     disabledPluginIds: [],
   },
   providerConfigs: {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added Google Gemini 3.5 Flash as a new model with stagewise reasoning and multimodal input. Disabled the older `gemini-3-flash-preview` by default to guide users to the new model.

- **New Features**
  - New model: `gemini-3.5-flash` (1M context, tool calling, thinking enabled).
  - Provider config: stagewise reasoning (effort: medium); Google thinking (includeThoughts, medium).
  - Capabilities: input (text, image, video, file, audio), output (text).
  - Audio constraints: aac, aiff, flac, mp3, mpeg, ogg, wav, webm; 20 MB inline limit.
  - Pricing: input $1.5/M tokens, output $9.0/M tokens (relative 1.75).
  - Defaults: add `gemini-3-flash-preview` to disabled models.

<sup>Written for commit eba8778f2935199a829f61f0de21dbab40ab2a46. Summary will update on new commits. <a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1146?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Gemini-3.5-flash model with support for audio, image, video, and file inputs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stagewise-io/stagewise/pull/1146?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->