### PR TITLE
fix(browser): show server-unreachable notice on account page and fix error serialization

### DIFF
--- a/apps/browser/src/backend/services/auth/server-interop.ts
+++ b/apps/browser/src/backend/services/auth/server-interop.ts
@@ -72,7 +72,13 @@ export class AuthServerInterop {
     const SUBSCRIPTION_TIMEOUT_MS = 15_000;
     const subscriptionData = await Promise.race([
       client.v1.billing.plan.get().then(({ data, error }) => {
-        if (error) throw new Error(String(error));
+        if (error)
+          throw new Error(
+            typeof error === 'string'
+              ? error
+              : ((error as { message?: string }).message ??
+                JSON.stringify(error)),
+          );
         return data;
       }),
       new Promise<null>((_, reject) =>
@@ -124,7 +130,12 @@ export class AuthServerInterop {
     const { data, error } = await client.v1.usage.history.get({
       query: { days: String(days) },
     });
-    if (error) throw new Error(String(error));
+    if (error)
+      throw new Error(
+        typeof error === 'string'
+          ? error
+          : ((error as { message?: string }).message ?? JSON.stringify(error)),
+      );
     return data as UsageHistoryResponse;
   }
 }

--- a/apps/browser/src/pages/routes/_internal-app/account.tsx
+++ b/apps/browser/src/pages/routes/_internal-app/account.tsx
@@ -65,6 +65,9 @@ function Page() {
               email={userAccount.user?.email}
               subscription={userAccount.subscription}
               machineId={userAccount.machineId}
+              serverUnreachable={
+                userAccount.status === 'server_unreachable'
+              }
               onLogout={() => void logout()}
             />
           ) : (
@@ -80,6 +83,7 @@ function AuthenticatedView({
   email,
   subscription,
   machineId,
+  serverUnreachable,
   onLogout,
 }: {
   email?: string;
@@ -89,12 +93,20 @@ function AuthenticatedView({
     expiresAt?: string;
   };
   machineId?: string;
+  serverUnreachable?: boolean;
   onLogout: () => void;
 }) {
   const openTab = useKartonProcedure((p) => p.openTab);
 
   return (
     <>
+      {serverUnreachable && (
+        <p className="rounded-md bg-warning-background px-3 py-2 text-sm text-warning-foreground">
+          Unable to connect to the stagewise server. Showing cached account
+          data.
+        </p>
+      )}
+
       {/* User info */}
       <div className="flex flex-col gap-2">
         <h2 className="font-medium text-foreground text-lg">


### PR DESCRIPTION
## Problem

When the stagewise server cannot be reached, the Account page showed no clear indication of the connectivity problem. Additionally, two methods in `AuthServerInterop` (`getSubscription`, `getUsageHistory`) used `String(error)` to serialize API errors, which produces `[object Object]` for plain-object errors — the same class of issue reported in #1012.

## Solution

**1. Fix error serialization in `server-interop.ts`**

`getSubscription` and `getUsageHistory` now use the same extraction logic as `getUsageCurrent`:
```ts
typeof error === 'string'
  ? error
  : ((error as { message?: string }).message ?? JSON.stringify(error))
```
This returns a human-readable string instead of `[object Object]` when the API client returns an error object without a standard message property.

**2. Add server-unreachable notice on Account page**

When `userAccount.status === 'server_unreachable'`, a warning banner is now shown in `AuthenticatedView`:
> "Unable to connect to the stagewise server. Showing cached account data."

This makes the connectivity issue explicit, so users understand why usage data may be unavailable and that cached account information is being displayed.

## Testing

- Start the app with no network / after blocking the stagewise API host
- Open Account page
- Verify the yellow warning banner appears
- Verify no `[object Object]` string appears anywhere on the page

Closes #1012

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show a clear warning on the Account page when the server is unreachable and fix error serialization so users see readable messages instead of “[object Object]”.

- **Bug Fixes**
  - Account page displays a warning banner when `userAccount.status === 'server_unreachable'`: “Unable to connect to the stagewise server. Showing cached account data.”
  - Standardized error serialization in `AuthServerInterop.getSubscription` and `.getUsageHistory` to extract a message (or JSON) like `getUsageCurrent`, avoiding “[object Object]”.

<sup>Written for commit 859b01d4a7b90288537c605c871b719210120698. Summary will update on new commits. <a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1156?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for authentication and subscription-related operations to ensure more reliable API communication and clearer error reporting.

* **New Features**
  * Added a warning banner on the account page that appears when the server is unreachable, clearly informing users that the displayed account data is from cache.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stagewise-io/stagewise/pull/1156?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->