### PR TITLE
fix(stagewise): fix app-focus-behaviour on webcontents

### DIFF
--- a/apps/browser/src/backend/services/window-layout/index.ts
+++ b/apps/browser/src/backend/services/window-layout/index.ts
@@ -4,6 +4,7 @@ import type { SelectedElement } from '@shared/karton-contracts/ui';
 import { getHotkeyDefinitionForEvent } from '@shared/hotkeys';
 import { generateTabId, resetTabIdCounter } from './tab-id';
 import { getBrowserSessionId } from './browser-session';
+import { getElectronHotkeyPlatform } from '@/utils/electron-platform';
 import type { KartonService } from '../karton';
 import type { Logger } from '../logger';
 import type { TelemetryService } from '../telemetry';
@@ -841,7 +842,8 @@ export class WindowLayoutService extends DisposableService {
     setActive?: boolean,
     agentInstanceId?: string | null,
     sourceTabId?: string,
-  ) => {
+    onCreated?: (tabId: string | undefined) => void,
+  ): Promise<string | undefined> => {
     // If no URL is provided, check user's new tab page preference
     let targetUrl = url;
 
@@ -862,31 +864,40 @@ export class WindowLayoutService extends DisposableService {
       }
     }
 
-    // For internal pages, check if a non-active tab with the same URL already
-    // exists AND is visible to the requesting agent (global or matching).
-    // If the active tab already has this URL, we still create a new tab.
-    if (targetUrl?.startsWith('stagewise://')) {
-      const existingTab = Object.entries(this.tabs).find(([id, tab]) => {
-        if (id === this.activeTabId) return false;
-        if (tab.getState().url !== targetUrl) return false;
-        const tabAgent = tab.getState().agentInstanceId;
-        return tabAgent === null || tabAgent === (agentInstanceId ?? null);
-      });
+    let createdTabId: string | undefined;
 
-      if (existingTab) {
-        const [existingTabId] = existingTab;
-        await this.handleSwitchTab(existingTabId);
-        return;
+    try {
+      // For internal pages, check if a non-active tab with the same URL already
+      // exists AND is visible to the requesting agent (global or matching).
+      // If the active tab already has this URL, we still create a new tab.
+      if (targetUrl?.startsWith('stagewise://')) {
+        const existingTab = Object.entries(this.tabs).find(([id, tab]) => {
+          if (id === this.activeTabId) return false;
+          if (tab.getState().url !== targetUrl) return false;
+          const tabAgent = tab.getState().agentInstanceId;
+          return tabAgent === null || tabAgent === (agentInstanceId ?? null);
+        });
+
+        if (existingTab) {
+          const [existingTabId] = existingTab;
+          if (setActive ?? true) await this.handleSwitchTab(existingTabId);
+          createdTabId = existingTabId;
+          return existingTabId;
+        }
       }
-    }
 
-    await this.createTab(
-      targetUrl,
-      setActive ?? true,
-      sourceTabId,
-      agentInstanceId,
-    );
-    this.saveTabState();
+      const tabId = await this.createTab(
+        targetUrl,
+        setActive ?? true,
+        sourceTabId,
+        agentInstanceId,
+      );
+      this.saveTabState();
+      createdTabId = tabId;
+      return tabId;
+    } finally {
+      onCreated?.(createdTabId);
+    }
   };
 
   private async createTab(
@@ -940,7 +951,10 @@ export class WindowLayoutService extends DisposableService {
 
     tab.on('handleKeyDown', (keyDownEvent) => {
       if (id !== this.activeTabId) return;
-      const def = getHotkeyDefinitionForEvent(keyDownEvent as KeyboardEvent);
+      const def = getHotkeyDefinitionForEvent(
+        keyDownEvent as KeyboardEvent,
+        getElectronHotkeyPlatform(),
+      );
       if (def) this.uiController?.forwardKeyDownEvent(keyDownEvent);
     });
 

--- a/apps/browser/src/backend/services/window-layout/tab-controller.ts
+++ b/apps/browser/src/backend/services/window-layout/tab-controller.ts
@@ -24,6 +24,7 @@ import type { ColorScheme } from '@shared/karton-contracts/ui';
 import type { SelectedElement } from '@shared/selected-elements';
 import { SelectedElementTracker } from './selected-element-tracker';
 import { electronInputToDomKeyboardEvent } from '@/utils/electron-input-to-dom-keyboard-event';
+import { getElectronHotkeyPlatform } from '@/utils/electron-platform';
 import { fileURLToPath } from 'node:url';
 import {
   PageTransition,
@@ -1511,7 +1512,10 @@ export class TabController extends EventEmitter<TabControllerEventMap> {
       wc.devToolsWebContents?.addListener('input-event', (_e, input) => {
         const domEvent = electronInputToDomKeyboardEvent(input as Input);
         if (input.type === 'keyDown' || input.type === 'rawKeyDown') {
-          const hotkeyDef = getHotkeyDefinitionForEvent(domEvent);
+          const hotkeyDef = getHotkeyDefinitionForEvent(
+            domEvent,
+            getElectronHotkeyPlatform(),
+          );
           if (hotkeyDef?.captureDominantly)
             this.emit('handleKeyDown', domEvent);
         }

--- a/apps/browser/src/backend/services/window-layout/ui-controller.ts
+++ b/apps/browser/src/backend/services/window-layout/ui-controller.ts
@@ -145,6 +145,8 @@ export interface UIControllerEventMap {
     url?: string,
     setActive?: boolean,
     agentInstanceId?: string | null,
+    sourceTabId?: string,
+    onCreated?: (tabId: string | undefined) => void,
   ];
   closeTab: [tabId: string];
   switchTab: [tabId: string];
@@ -679,8 +681,33 @@ export class UIController extends EventEmitter<UIControllerEventMap> {
         url?: string,
         setActive?: boolean,
         agentInstanceId?: string | null,
-      ) => {
-        this.emit('createTab', url, setActive, agentInstanceId);
+      ): Promise<string | undefined> => {
+        return await new Promise((resolve) => {
+          let settled = false;
+          let timeoutId: ReturnType<typeof setTimeout> | undefined;
+          const finish = (tabId: string | undefined) => {
+            if (settled) return;
+            settled = true;
+            if (timeoutId !== undefined) clearTimeout(timeoutId);
+            resolve(tabId);
+          };
+
+          timeoutId = setTimeout(() => finish(undefined), 5000);
+
+          try {
+            const handled = this.emit(
+              'createTab',
+              url,
+              setActive,
+              agentInstanceId,
+              undefined,
+              finish,
+            );
+            if (!handled) finish(undefined);
+          } catch {
+            finish(undefined);
+          }
+        });
       },
     );
     this.uiKarton.registerServerProcedureHandler(

--- a/apps/browser/src/backend/utils/dom-code-to-electron-key-code.ts
+++ b/apps/browser/src/backend/utils/dom-code-to-electron-key-code.ts
@@ -58,8 +58,17 @@ export function domCodeToElectronKeyCode(code: string, key: string): string {
   // Check if it's a special key
   if (specialKeys[code]) return specialKeys[code];
 
-  // For regular character keys (KeyA, KeyB, etc.), use the key property
-  // which gives us the actual character
+  // Hotkeys are defined against physical DOM codes (KeyA, Digit1, etc.).
+  // With Alt/Option, `key` can become a layout-specific symbol (e.g.
+  // Option+L => "¬", Option+B => "∫"), which would synthesize the wrong
+  // KeyboardEvent code in the UI process. Prefer the physical code for
+  // letter/digit keys so tunneled app shortcuts still match.
+  if (code.startsWith('Key')) return code.substring(3);
+  if (code.startsWith('Digit')) return code.substring(5);
+
+  // For regular character keys that are not represented by a physical
+  // letter/digit code, use the key property which gives us the actual
+  // character.
   if (key.length === 1) return key;
 
   // For modifier keys, we don't need to send them as keyCode
@@ -71,9 +80,6 @@ export function domCodeToElectronKeyCode(code: string, key: string): string {
     code.startsWith('Shift')
   )
     return key;
-
-  // Fallback: try to extract from code (e.g., "KeyA" -> "A")
-  if (code.startsWith('Key')) return code.substring(3);
 
   // Last resort: use the key as-is
   return key;

--- a/apps/browser/src/backend/utils/electron-platform.ts
+++ b/apps/browser/src/backend/utils/electron-platform.ts
@@ -1,0 +1,7 @@
+import type { Platform } from '@shared/hotkeys';
+
+export function getElectronHotkeyPlatform(): Platform {
+  if (process.platform === 'darwin') return 'mac';
+  if (process.platform === 'win32') return 'windows';
+  return 'linux';
+}

--- a/apps/browser/src/shared/hotkeys.ts
+++ b/apps/browser/src/shared/hotkeys.ts
@@ -25,7 +25,7 @@ export enum HotkeyActions {
   // Stagewise specific
   TOGGLE_CONTEXT_SELECTOR = 'toggle_context_selector',
   TOGGLE_SIDEBAR = 'toggle_sidebar',
-  TOGGLE_CHAT_FOCUS = 'toggle_chat_focus',
+  FOCUS_CHAT_INPUT = 'focus_chat_input',
   NEW_CHAT = 'new_chat',
   DOWNLOADS = 'downloads',
 
@@ -102,7 +102,8 @@ export const hotkeyDefinitions: Record<HotkeyActions, HotkeyDefinition> = {
     accelerator: 'Mod+B',
     captureDominantly: true,
   },
-  [HotkeyActions.TOGGLE_CHAT_FOCUS]: {
+  // Focus the chat input. One-way focus command; does not toggle away.
+  [HotkeyActions.FOCUS_CHAT_INPUT]: {
     accelerator: 'Mod+L',
     captureDominantly: true,
   },

--- a/apps/browser/src/shared/karton-contracts/ui/index.ts
+++ b/apps/browser/src/shared/karton-contracts/ui/index.ts
@@ -915,7 +915,7 @@ export type KartonContract = {
         url?: string,
         setActive?: boolean,
         agentInstanceId?: string | null,
-      ) => Promise<void>;
+      ) => Promise<string | undefined>;
       closeTab: (tabId: string) => Promise<void>;
       switchTab: (tabId: string) => Promise<void>;
       reorderTabs: (tabIds: string[]) => Promise<void>;

--- a/apps/browser/src/ui/screens/main/_components/agent-hotkey-bindings.tsx
+++ b/apps/browser/src/ui/screens/main/_components/agent-hotkey-bindings.tsx
@@ -11,7 +11,11 @@ import { useOpenAgent } from '@ui/hooks/use-open-chat';
  * to the current agent and content-panel toggling. Handlers are no-ops
  * when there is no active browser tab.
  */
-export function AgentHotkeyBindings() {
+export function AgentHotkeyBindings({
+  onCreateTab,
+}: {
+  onCreateTab: () => void;
+}) {
   // -- Content panel toggle (Mod+Alt+B) ----------------------------------
   const { collapsed: contentCollapsed, setCollapsed: setContentCollapsed } =
     useContentCollapsed();
@@ -23,7 +27,6 @@ export function AgentHotkeyBindings() {
   // -- Tab management (per-agent) ---------------------------------------
   const activeTabId = useKartonState((s) => s.browser.activeTabId);
   const tabs = useKartonState((s) => s.browser.tabs);
-  const createTab = useKartonProcedure((p) => p.browser.createTab);
   const closeTab = useKartonProcedure((p) => p.browser.closeTab);
   const switchTab = useKartonProcedure((p) => p.browser.switchTab);
   const { removeTabUiState } = useTabUIState();
@@ -32,7 +35,7 @@ export function AgentHotkeyBindings() {
   const [openAgent] = useOpenAgent();
   useHotKeyListener(() => {
     if (contentCollapsed) setContentCollapsed(false);
-    createTab(undefined, undefined, openAgent);
+    onCreateTab();
   }, HotkeyActions.NEW_TAB);
 
   // Mod+W: close active tab

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/panel-footer.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/panel-footer.tsx
@@ -710,20 +710,24 @@ export const ChatPanelFooter = memo(function ChatPanelFooter() {
 
   useEffect(() => {
     if (chatInputActive) {
-      // Wait for the next tick to ensure the input is mounted
-      setTimeout(() => {
+      // Wait for the next tick to ensure the input is mounted. Guard against
+      // stale scheduled focus calls: external focus handoffs (omnibox/search)
+      // can deactivate the chat before this timeout runs.
+      const timeoutId = setTimeout(() => {
+        if (!chatInputActiveRef.current) return;
         chatInputRef.current?.focus();
       }, 0);
-    } else {
-      // Don't automatically deactivate element selection here
-      // Element selection can be controlled by other components (inline edit mode)
-      // It will be deactivated explicitly when needed (Escape key, send message, agent working, panel closed)
-      if (skipNextInactiveBlurRef.current) {
-        skipNextInactiveBlurRef.current = false;
-        return;
-      }
-      chatInputRef.current?.blur();
+      return () => clearTimeout(timeoutId);
     }
+
+    // Don't automatically deactivate element selection here
+    // Element selection can be controlled by other components (inline edit mode)
+    // It will be deactivated explicitly when needed (Escape key, send message, agent working, panel closed)
+    if (skipNextInactiveBlurRef.current) {
+      skipNextInactiveBlurRef.current = false;
+      return;
+    }
+    chatInputRef.current?.blur();
   }, [chatInputActive]);
 
   const onInputFocus = useCallback(() => {
@@ -836,16 +840,21 @@ export const ChatPanelFooter = memo(function ChatPanelFooter() {
     HotkeyActions.TOGGLE_CONTEXT_SELECTOR,
   );
 
-  // Cmd+L: toggle chat input focus.
+  // Cmd+L: focus chat input. One-way command; Escape/external focus
+  // paths handle deactivation.
   useHotKeyListener(
-    useCallback(() => {
-      if (chatInputActive) {
-        window.dispatchEvent(new Event('sidebar-chat-panel-closed'));
-      } else {
-        window.dispatchEvent(new Event('sidebar-chat-panel-opened'));
+    useCallback(async () => {
+      chatInputActiveRef.current = true;
+      if (!chatInputActive) setChatInputActive(true);
+      try {
+        await togglePanelKeyboardFocus('stagewise-ui');
+      } catch {
+        // Still focus the chat input if the panel-focus handoff fails.
       }
-    }, [chatInputActive]),
-    HotkeyActions.TOGGLE_CHAT_FOCUS,
+      if (!chatInputActiveRef.current) return;
+      chatInputRef.current?.focus();
+    }, [chatInputActive, setChatInputActive, togglePanelKeyboardFocus]),
+    HotkeyActions.FOCUS_CHAT_INPUT,
   );
 
   useEventListener(

--- a/apps/browser/src/ui/screens/main/content/_components/browser-tab-hotkeys.tsx
+++ b/apps/browser/src/ui/screens/main/content/_components/browser-tab-hotkeys.tsx
@@ -3,6 +3,7 @@ import { HotkeyActions } from '@shared/hotkeys';
 import { useKartonState, useKartonProcedure } from '@ui/hooks/use-karton';
 import { useTabUIState } from '@ui/hooks/use-tab-ui-state';
 import { produceWithPatches, enablePatches } from 'immer';
+import { useEffect, useRef } from 'react';
 
 enablePatches();
 
@@ -19,6 +20,7 @@ export function BrowserTabHotkeys({
   onFocusSearchBar: () => void;
 }) {
   const activeTabId = useKartonState((s) => s.browser.activeTabId);
+  const activeTabIdRef = useRef(activeTabId);
   const { tabUiState } = useTabUIState();
   const focusedPanel = activeTabId
     ? (tabUiState[activeTabId]?.focusedPanel ?? 'stagewise-ui')
@@ -45,6 +47,10 @@ export function BrowserTabHotkeys({
   const currentZoomPercentage = useKartonState((s) =>
     activeTabId ? s.browser.tabs[activeTabId]?.zoomPercentage : 100,
   );
+
+  useEffect(() => {
+    activeTabIdRef.current = activeTabId;
+  }, [activeTabId]);
 
   // Zoom helpers
   useHotKeyListener(() => {
@@ -88,14 +94,16 @@ export function BrowserTabHotkeys({
     }
   }, HotkeyActions.ZOOM_RESET);
 
-  // URL bar (Mod+Alt+L): toggle between omnibox focus and tab content.
-  useHotKeyListener(() => {
-    if (focusedPanel === 'stagewise-ui') {
-      togglePanelKeyboardFocus('tab-content');
-    } else {
-      togglePanelKeyboardFocus('stagewise-ui');
-      onFocusUrlBar();
+  // URL bar (Mod+Alt+L): always focus the omnibox.
+  useHotKeyListener(async () => {
+    const targetTabId = activeTabId;
+    try {
+      await togglePanelKeyboardFocus('stagewise-ui');
+    } catch {
+      // Still focus the omnibox if the panel-focus handoff fails.
     }
+    if (activeTabIdRef.current !== targetTabId) return;
+    onFocusUrlBar();
   }, HotkeyActions.FOCUS_URL_BAR);
 
   // Search bar

--- a/apps/browser/src/ui/screens/main/content/_components/omnibox/index.tsx
+++ b/apps/browser/src/ui/screens/main/content/_components/omnibox/index.tsx
@@ -67,7 +67,7 @@ export const Omnibox = ({
   //   keeps UI in foreground until the URL actually changes
   const [navigationPending, setNavigationPending] = useState(false);
 
-  // Expose focus method via ref (called by hotkey CMD+L)
+  // Expose focus method via ref (called by hotkey Cmd+Option+L)
   useImperativeHandle(
     ref,
     () => ({

--- a/apps/browser/src/ui/screens/main/content/index.tsx
+++ b/apps/browser/src/ui/screens/main/content/index.tsx
@@ -165,17 +165,36 @@ function persistContentSize(size: number) {
   }
 }
 
-export function MainSection() {
+export function MainSection({
+  onCreateTab,
+  pendingOmniboxFocusRequest,
+  onPendingOmniboxFocusHandled,
+}: {
+  onCreateTab: () => void;
+  pendingOmniboxFocusRequest: {
+    id: number;
+    fromTabId: string | null;
+    targetTabId: string;
+  } | null;
+  onPendingOmniboxFocusHandled: (requestId: number) => void;
+}) {
   const panelRef = useRef<ImperativePanelHandle>(null);
   const tabs = useKartonState((s) => s.browser.tabs);
   const activeTabId = useKartonState((s) => s.browser.activeTabId);
-  const createTab = useKartonProcedure((p) => p.browser.createTab);
+  const activeTabIdRef = useRef(activeTabId);
   const closeTab = useKartonProcedure((p) => p.browser.closeTab);
   const switchTab = useKartonProcedure((p) => p.browser.switchTab);
   const reorderTabs = useKartonProcedure((p) => p.browser.reorderTabs);
+  const togglePanelKeyboardFocus = useKartonProcedure(
+    (p) => p.browser.layout.togglePanelKeyboardFocus,
+  );
 
   const { setTabUiState, removeTabUiState } = useTabUIState();
   const [openAgent] = useOpenAgent();
+
+  useEffect(() => {
+    activeTabIdRef.current = activeTabId;
+  }, [activeTabId]);
   // Persisted panel size survives mount/unmount (conditional rendering).
   const storedSizeRef = useRef(readContentSize());
   // Block onResize→persist during mount-time layout and programmatic restore.
@@ -442,10 +461,6 @@ export function MainSection() {
   // ---------------------------------------------------------------------------
   const tabContentRefs = useRef<Record<string, PerTabContentRef | null>>({});
 
-  const handleGlobeClick = useCallback(() => {
-    createTab(undefined, undefined, openAgent);
-  }, [createTab, openAgent]);
-
   const handleFocusUrlBar = useCallback(() => {
     if (activeTabId) {
       tabContentRefs.current[activeTabId]?.focusOmnibox();
@@ -457,6 +472,63 @@ export function MainSection() {
       tabContentRefs.current[activeTabId]?.focusSearchBar();
     }
   }, [activeTabId]);
+
+  useEffect(() => {
+    if (!pendingOmniboxFocusRequest || !activeTabId) return;
+
+    const { id: requestId, targetTabId } = pendingOmniboxFocusRequest;
+    if (activeTabId !== targetTabId) return;
+
+    let cancelled = false;
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+    const tryFocus = async () => {
+      if (cancelled) return true;
+
+      const ref = tabContentRefs.current[activeTabId];
+      if (!ref) return false;
+
+      // Ensure the UI view owns keyboard focus before the omnibox focuses its
+      // DOM input. If the chat input was focused, focusing the omnibox first can
+      // race with the async panel-focus handoff and let TipTap reclaim focus.
+      try {
+        await togglePanelKeyboardFocus('stagewise-ui');
+      } catch {
+        // Still focus the omnibox if the panel-focus handoff fails.
+      }
+      if (cancelled) return true;
+      if (activeTabIdRef.current !== targetTabId) return false;
+      if (tabContentRefs.current[targetTabId] !== ref) return false;
+
+      ref.focusOmnibox();
+      onPendingOmniboxFocusHandled(requestId);
+      return true;
+    };
+
+    const scheduleRetry = () => {
+      timeoutId = setTimeout(() => {
+        void tryFocus().then((focused) => {
+          if (focused || cancelled) return;
+          scheduleRetry();
+        });
+      }, 50);
+    };
+
+    void tryFocus().then((focused) => {
+      if (focused || cancelled) return;
+      scheduleRetry();
+    });
+
+    return () => {
+      cancelled = true;
+      if (timeoutId !== undefined) clearTimeout(timeoutId);
+    };
+  }, [
+    activeTabId,
+    pendingOmniboxFocusRequest,
+    togglePanelKeyboardFocus,
+    onPendingOmniboxFocusHandled,
+  ]);
 
   const handleTabFocused = useCallback(
     (event: CustomEvent<string>) => {
@@ -570,7 +642,7 @@ export function MainSection() {
                 size="icon-sm"
                 aria-label="Open new browser tab"
                 className="size-7 shrink-0 rounded-md"
-                onClick={handleGlobeClick}
+                onClick={onCreateTab}
               >
                 <GlobePlusIcon className="size-4" />
               </Button>

--- a/apps/browser/src/ui/screens/main/index.tsx
+++ b/apps/browser/src/ui/screens/main/index.tsx
@@ -11,7 +11,7 @@ import { cn } from '@ui/utils';
 import { Sidebar } from './sidebar';
 import { useKartonState, useKartonProcedure } from '@ui/hooks/use-karton';
 import { OpenAgentProvider, useOpenAgent } from '@ui/hooks/use-open-chat';
-import { useCallback, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Button } from '@stagewise/stage-ui/components/button';
 import {
   Tooltip,
@@ -56,6 +56,7 @@ function DefaultLayoutInner({ show }: { show: boolean }) {
   const isMacOs = useKartonState((s) => s.appInfo.platform === 'darwin');
   const isFullScreen = useKartonState((s) => s.appInfo.isFullScreen);
   const tabs = useKartonState((s) => s.browser.tabs);
+  const activeTabId = useKartonState((s) => s.browser.activeTabId);
   const [openAgent] = useOpenAgent();
   const { collapsed: sidebarCollapsed } = useSidebarCollapsed();
   const { collapsed: contentCollapsed, setCollapsed: setContentCollapsed } =
@@ -72,10 +73,78 @@ function DefaultLayoutInner({ show }: { show: boolean }) {
   // content panel visible when there are visible tabs AND it's not collapsed
   const showContent = hasVisibleTabs && !contentCollapsed;
 
-  const handleOpenTab = useCallback(() => {
+  const pendingOmniboxFocusRequestIdRef = useRef(0);
+  const pendingOmniboxFocusExpiryRef = useRef<ReturnType<
+    typeof setTimeout
+  > | null>(null);
+  const pendingOmniboxFocusRequestRef = useRef<{
+    id: number;
+    fromTabId: string | null;
+    targetTabId: string;
+  } | null>(null);
+  const [pendingOmniboxFocusRequest, setPendingOmniboxFocusRequest] = useState<{
+    id: number;
+    fromTabId: string | null;
+    targetTabId: string;
+  } | null>(null);
+
+  useEffect(() => {
+    pendingOmniboxFocusRequestRef.current = pendingOmniboxFocusRequest;
+  }, [pendingOmniboxFocusRequest]);
+
+  useEffect(() => {
+    return () => {
+      if (pendingOmniboxFocusExpiryRef.current !== null)
+        clearTimeout(pendingOmniboxFocusExpiryRef.current);
+    };
+  }, []);
+
+  const handleCreateTab = useCallback(() => {
     if (contentCollapsed) setContentCollapsed(false);
-    createTab(undefined, undefined, openAgent);
-  }, [createTab, openAgent, contentCollapsed, setContentCollapsed]);
+
+    const requestId = ++pendingOmniboxFocusRequestIdRef.current;
+    if (pendingOmniboxFocusExpiryRef.current !== null) {
+      clearTimeout(pendingOmniboxFocusExpiryRef.current);
+      pendingOmniboxFocusExpiryRef.current = null;
+    }
+    setPendingOmniboxFocusRequest(null);
+
+    void createTab(undefined, undefined, openAgent).then((targetTabId) => {
+      if (requestId !== pendingOmniboxFocusRequestIdRef.current) return;
+      if (!targetTabId) return;
+
+      setPendingOmniboxFocusRequest({
+        id: requestId,
+        fromTabId: activeTabId ?? null,
+        targetTabId,
+      });
+
+      pendingOmniboxFocusExpiryRef.current = setTimeout(() => {
+        setPendingOmniboxFocusRequest((request) =>
+          request?.id === requestId ? null : request,
+        );
+        pendingOmniboxFocusExpiryRef.current = null;
+      }, 5000);
+    });
+  }, [
+    activeTabId,
+    createTab,
+    openAgent,
+    contentCollapsed,
+    setContentCollapsed,
+  ]);
+
+  const handlePendingOmniboxFocusHandled = useCallback((requestId: number) => {
+    if (pendingOmniboxFocusRequestRef.current?.id !== requestId) return;
+
+    if (pendingOmniboxFocusExpiryRef.current !== null) {
+      clearTimeout(pendingOmniboxFocusExpiryRef.current);
+      pendingOmniboxFocusExpiryRef.current = null;
+    }
+
+    pendingOmniboxFocusRequestRef.current = null;
+    setPendingOmniboxFocusRequest(null);
+  }, []);
 
   // Headless: keeps `openAgent` valid regardless of whether the sidebar
   // (which used to own this effect) is mounted.
@@ -84,7 +153,7 @@ function DefaultLayoutInner({ show }: { show: boolean }) {
   return (
     <>
       {show && <GlobalHotkeyBindings />}
-      {show && <AgentHotkeyBindings />}
+      {show && <AgentHotkeyBindings onCreateTab={handleCreateTab} />}
       <div
         className={cn(
           'root pointer-events-auto relative inset-0 flex size-full flex-row items-stretch justify-between transition-[opacity,filter] delay-150 duration-300 ease-out',
@@ -124,7 +193,7 @@ function DefaultLayoutInner({ show }: { show: boolean }) {
                       variant="ghost"
                       size="icon-sm"
                       aria-label="Open new browser tab"
-                      onClick={handleOpenTab}
+                      onClick={handleCreateTab}
                     >
                       <GlobePlusIcon className="size-4" />
                     </Button>
@@ -142,7 +211,13 @@ function DefaultLayoutInner({ show }: { show: boolean }) {
               {showContent && (
                 <>
                   <ResizableHandle />
-                  <MainSection />
+                  <MainSection
+                    onCreateTab={handleCreateTab}
+                    pendingOmniboxFocusRequest={pendingOmniboxFocusRequest}
+                    onPendingOmniboxFocusHandled={
+                      handlePendingOmniboxFocusHandled
+                    }
+                  />
                 </>
               )}
             </ResizablePanelGroup>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes inconsistent keyboard focus between the UI and tab webcontents. Hotkeys are platform-aware, and focusing the omnibox or chat input is reliable, including right after creating new tabs.

- **Bug Fixes**
  - Platform-aware hotkey parsing via `getElectronHotkeyPlatform()` in window/layout and tab webcontents; DOM→Electron key mapping prefers physical `Key*`/`Digit*` codes.
  - Deterministic focus handoff: the UI panel gets focus before omnibox/chat; a retryable omnibox-focus request is queued on tab create with a 5s expiry, aborts if the active tab changes, and falls back to focusing inputs even if panel handoff fails.
  - Hotkeys: Mod+Alt+L always focuses the omnibox; Mod+L is now `FOCUS_CHAT_INPUT` (one-way).
  - New tab: switching/creating tabs reuses matching internal `stagewise://` tabs when appropriate.

- **Refactors**
  - `browser.createTab` now returns the created/reused `tabId` and supports an `onCreated` callback; the UI’s create-tab procedure returns the `tabId` and uses an `onCreateTab` pathway with a transient pending-focus request (5s safety timeout) to reliably focus the omnibox.

<sup>Written for commit 22bd8b51c8f8ee8d02b6b3cb6e52e18c3209b700. Summary will update on new commits. <a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1158?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Platform-aware hotkey handling for more accurate shortcuts across OSes.
  * Mod+L/Cmd+L changed to a one-way “focus chat input” action.
  * New-tab flow now returns a created or reused tab id; internal stagewise:// tabs may be reused.
  * Components accept external tab-creation callbacks and coordinate omnibox-focus requests with retries and timeouts.

* **Bug Fixes**
  * More reliable keyboard focus transfer when opening, switching, or focusing the omnibox.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stagewise-io/stagewise/pull/1158?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->