### PR TITLE
feat(stagewise): add more shortcut-controls and align design

### DIFF
--- a/apps/browser/src/shared/hotkeys.ts
+++ b/apps/browser/src/shared/hotkeys.ts
@@ -46,12 +46,18 @@ export enum HotkeyActions {
   TOGGLE_CONTEXT_SELECTOR = 'toggle_context_selector',
   TOGGLE_SIDEBAR = 'toggle_sidebar',
   FOCUS_CHAT_INPUT = 'focus_chat_input',
+  OPEN_SETTINGS = 'open_settings',
+  EDIT_NEAREST_USER_MESSAGE = 'edit_nearest_user_message',
+  OPEN_WORKSPACE_SELECT = 'open_workspace_select',
+  OPEN_MODEL_SELECT = 'open_model_select',
   OPEN_COMMAND_CENTER = 'open_command_center',
   COMMAND_CENTER_RENAME_AGENT = 'command_center_rename_agent',
   COMMAND_CENTER_TOGGLE_AGENT_PIN = 'command_center_toggle_agent_pin',
   COMMAND_CENTER_COPY_TAB_URL = 'command_center_copy_tab_url',
   COMMAND_CENTER_DELETE_AGENT = 'command_center_delete_agent',
   NEW_CHAT = 'new_chat',
+  IMPLEMENT_CREATED_PLAN = 'implement_created_plan',
+  STOP_AGENT = 'stop_agent',
   DOWNLOADS = 'downloads',
 
   // Tab & window navigation
@@ -132,6 +138,23 @@ export const hotkeyDefinitions: Record<HotkeyActions, HotkeyDefinition> = {
     accelerator: 'Mod+L',
     captureDominantly: true,
   },
+  [HotkeyActions.OPEN_SETTINGS]: {
+    accelerator: 'Mod+Comma',
+    captureDominantly: true,
+  },
+  [HotkeyActions.EDIT_NEAREST_USER_MESSAGE]: {
+    accelerator: 'Ctrl+Shift+E',
+    mac: 'Mod+Shift+I',
+    captureDominantly: true,
+  },
+  [HotkeyActions.OPEN_WORKSPACE_SELECT]: {
+    accelerator: 'Mod+O',
+    captureDominantly: true,
+  },
+  [HotkeyActions.OPEN_MODEL_SELECT]: {
+    accelerator: 'Mod+Slash',
+    captureDominantly: true,
+  },
   [HotkeyActions.OPEN_COMMAND_CENTER]: {
     accelerator: 'Mod+K',
     captureDominantly: false,
@@ -157,6 +180,14 @@ export const hotkeyDefinitions: Record<HotkeyActions, HotkeyDefinition> = {
   [HotkeyActions.NEW_CHAT]: {
     accelerator: 'Mod+N',
     captureDominantly: false,
+  },
+  [HotkeyActions.IMPLEMENT_CREATED_PLAN]: {
+    accelerator: 'Mod+Enter',
+    captureDominantly: true,
+  },
+  [HotkeyActions.STOP_AGENT]: {
+    accelerator: 'Ctrl+C',
+    captureDominantly: true,
   },
   [HotkeyActions.DOWNLOADS]: {
     accelerator: 'Mod+J',
@@ -327,9 +358,9 @@ export const hotkeyDefinitions: Record<HotkeyActions, HotkeyDefinition> = {
 
   // Dev tools
   [HotkeyActions.DEV_TOOLS]: {
-    accelerator: 'Ctrl+Shift+I', // Windows/Linux: Ctrl+Shift+I
+    accelerator: 'Ctrl+Shift+I',
     aliases: ['F12', 'Ctrl+Shift+J'],
-    mac: 'Mod+Alt+I', // Mac: Cmd+Opt+I
+    mac: 'Mod+Alt+I',
     macAliases: ['F12'],
     captureDominantly: true,
   },
@@ -597,6 +628,13 @@ const KEY_DISPLAY_NAMES: Record<string, { mac: string; default: string }> = {
   MINUS: { mac: '-', default: '-' },
   BRACKETLEFT: { mac: '[', default: '[' },
   BRACKETRIGHT: { mac: ']', default: ']' },
+  SEMICOLON: { mac: ';', default: ';' },
+  QUOTE: { mac: "'", default: "'" },
+  BACKQUOTE: { mac: '`', default: '`' },
+  BACKSLASH: { mac: '\\', default: '\\' },
+  COMMA: { mac: ',', default: ',' },
+  PERIOD: { mac: '.', default: '.' },
+  SLASH: { mac: '/', default: '/' },
 };
 
 /**

--- a/apps/browser/src/ui/hooks/use-hotkey-listener.tsx
+++ b/apps/browser/src/ui/hooks/use-hotkey-listener.tsx
@@ -19,7 +19,7 @@ function isEventFromCommandCenter(event: KeyboardEvent) {
 }
 
 export function useHotKeyListener(
-  action: () => void,
+  action: (event: KeyboardEvent) => unknown,
   hotKeyAction: HotkeyActions,
   enabled = true,
 ) {
@@ -34,12 +34,10 @@ export function useHotKeyListener(
         hotKeyAction !== HotkeyActions.OPEN_COMMAND_CENTER &&
         document.body.hasAttribute(commandCenterModalActiveAttribute)
       ) {
-        if (isMatchingHotkey) {
+        if (isMatchingHotkey && !isEventFromCommandCenter(ev)) {
           ev.preventDefault();
-          if (!isEventFromCommandCenter(ev)) {
-            ev.stopPropagation();
-            ev.stopImmediatePropagation();
-          }
+          ev.stopPropagation();
+          ev.stopImmediatePropagation();
         }
         return;
       }
@@ -53,8 +51,11 @@ export function useHotKeyListener(
 
       // The first matching hotkey action will be executed and abort further processing of other hotkey actions.
       if (isMatchingHotkey) {
-        action();
+        const handled = action(ev) !== false;
+        if (!handled) return;
+
         ev.stopPropagation();
+        ev.stopImmediatePropagation();
         ev.preventDefault();
       }
     },

--- a/apps/browser/src/ui/screens/main/_components/content-toggle-button.tsx
+++ b/apps/browser/src/ui/screens/main/_components/content-toggle-button.tsx
@@ -1,3 +1,4 @@
+import { HotkeyActions } from '@shared/hotkeys';
 import { Button } from '@stagewise/stage-ui/components/button';
 import {
   Tooltip,
@@ -8,6 +9,7 @@ import {
   IconSidebarRightHideOutline18,
   IconSidebarRightShowOutline18,
 } from 'nucleo-ui-outline-18';
+import { HotkeyCombo } from '@ui/components/hotkey-combo';
 import { useContentCollapsed } from './content-collapsed-context';
 
 export function ContentToggleButton() {
@@ -28,7 +30,12 @@ export function ContentToggleButton() {
           <Icon className="size-4" />
         </Button>
       </TooltipTrigger>
-      <TooltipContent>{label}</TooltipContent>
+      <TooltipContent>
+        <span className="flex items-center gap-1.5">
+          <span>{label}</span>
+          <HotkeyCombo action={HotkeyActions.TOGGLE_CONTENT_PANEL} size="xs" />
+        </span>
+      </TooltipContent>
     </Tooltip>
   );
 }

--- a/apps/browser/src/ui/screens/main/_components/global-hotkey-bindings.tsx
+++ b/apps/browser/src/ui/screens/main/_components/global-hotkey-bindings.tsx
@@ -4,6 +4,7 @@ import {
   HotkeyActions,
   isEventMatch,
 } from '@shared/hotkeys';
+import { SETTINGS_PAGE_URL } from '@shared/internal-urls';
 import { useHotKeyListener } from '@ui/hooks/use-hotkey-listener';
 import { useKartonProcedure, useKartonState } from '@ui/hooks/use-karton';
 import { useAgentSwitcher } from '@ui/hooks/use-open-chat';
@@ -204,6 +205,14 @@ export function GlobalHotkeyBindings() {
   useHotKeyListener(
     () => focusAgentByIndex(8),
     HotkeyActions.FOCUS_AGENT_LAST,
+    globalHotkeysEnabled,
+  );
+
+  // -- Settings (Mod+,) --------------------------------------------------
+  const createTab = useKartonProcedure((p) => p.browser.createTab);
+  useHotKeyListener(
+    () => createTab(SETTINGS_PAGE_URL, true),
+    HotkeyActions.OPEN_SETTINGS,
     globalHotkeysEnabled,
   );
 

--- a/apps/browser/src/ui/screens/main/_components/sidebar-toggle-button.tsx
+++ b/apps/browser/src/ui/screens/main/_components/sidebar-toggle-button.tsx
@@ -6,7 +6,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from '@stagewise/stage-ui/components/tooltip';
-import { HotkeyComboText } from '@ui/components/hotkey-combo-text';
+import { HotkeyCombo } from '@ui/components/hotkey-combo';
 import { useKartonState } from '@ui/hooks/use-karton';
 import {
   IconSidebarLeftHideOutline18,
@@ -42,7 +42,10 @@ export function SidebarToggleButton() {
         </Button>
       </TooltipTrigger>
       <TooltipContent side="bottom">
-        {label} (<HotkeyComboText action={HotkeyActions.TOGGLE_SIDEBAR} />)
+        <span className="flex items-center gap-1.5">
+          <span>{label}</span>
+          <HotkeyCombo action={HotkeyActions.TOGGLE_SIDEBAR} size="xs" />
+        </span>
       </TooltipContent>
     </Tooltip>
   );

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/chat-history.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/chat-history.tsx
@@ -30,6 +30,14 @@ import type {
 import { isEmptyAssistantMessage, areAllPartsSettled } from './message-utils';
 import { useOpenAgent } from '@ui/hooks/use-open-chat';
 import { calculateChatItemHeights } from '@ui/utils/calculate-chat-item-height';
+import { shouldNativeInputConsumeEvent } from '@shared/native-input-events';
+import { HotkeyActions } from '@shared/hotkeys';
+import { useHotKeyListener } from '@ui/hooks/use-hotkey-listener';
+import {
+  CHAT_HISTORY_SCROLL_EVENT,
+  type ChatHistoryScrollDirection,
+} from '../_lib/chat-history-scroll-event';
+import { CHAT_EDIT_USER_MESSAGE_REQUESTED_EVENT } from '../_lib/chat-edit-user-message-event';
 
 // Top inset reserved for titlebar-level chrome (sidebar toggle, future
 // top-right buttons). Sits as a sibling spacer ABOVE Virtuoso so items can
@@ -43,6 +51,8 @@ const CHAT_TOP_INSET = 32;
 // first message stays fully crisp at scrollTop=0 and only starts fading
 // once the user actually scrolls.
 const CHAT_FADE = 16;
+const CHAT_PAGE_SCROLL_FACTOR = 0.6;
+const CHAT_PAGE_SCROLL_MIN = 120;
 
 // Stable empty array to avoid infinite re-renders with useSyncExternalStore
 const EMPTY_HISTORY: AgentMessage[] = [];
@@ -138,6 +148,34 @@ function isOptimisticMessageConfirmed(
   return (
     optimisticMessage._serverUserCountAtSend !== undefined &&
     serverUserMessages.length > optimisticMessage._serverUserCountAtSend
+  );
+}
+
+function getChatHistoryScrollDirectionFromEvent(
+  event: KeyboardEvent,
+): ChatHistoryScrollDirection | null {
+  if (!event.metaKey && !event.ctrlKey && !event.altKey && !event.shiftKey) {
+    if (event.key === 'PageUp') return 'up';
+    if (event.key === 'PageDown') return 'down';
+  }
+
+  if (!event.ctrlKey || event.metaKey || event.altKey || event.shiftKey)
+    return null;
+
+  const key = event.key.toLowerCase();
+  if (key === 'u') return 'up';
+  if (key === 'd') return 'down';
+
+  return null;
+}
+
+function isEventFromEditableTarget(event: KeyboardEvent) {
+  const target = event.target;
+  if (!(target instanceof HTMLElement)) return false;
+
+  return (
+    target.isContentEditable ||
+    target.closest('input, textarea, select, [contenteditable="true"]') !== null
   );
 }
 
@@ -237,6 +275,55 @@ export const ChatHistory = () => {
     },
     [autoScrollRef],
   );
+
+  const scrollChatHistoryByPage = useCallback(
+    (direction: ChatHistoryScrollDirection) => {
+      if (!scroller) return;
+
+      const amount = Math.max(
+        CHAT_PAGE_SCROLL_MIN,
+        scroller.clientHeight * CHAT_PAGE_SCROLL_FACTOR,
+      );
+      scroller.scrollBy({
+        top: direction === 'up' ? -amount : amount,
+        behavior: 'smooth',
+      });
+    },
+    [scroller],
+  );
+
+  useEffect(() => {
+    const handleChatHistoryScroll = (
+      event: WindowEventMap[typeof CHAT_HISTORY_SCROLL_EVENT],
+    ) => {
+      scrollChatHistoryByPage(event.detail.direction);
+    };
+
+    window.addEventListener(CHAT_HISTORY_SCROLL_EVENT, handleChatHistoryScroll);
+    return () => {
+      window.removeEventListener(
+        CHAT_HISTORY_SCROLL_EVENT,
+        handleChatHistoryScroll,
+      );
+    };
+  }, [scrollChatHistoryByPage]);
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.defaultPrevented) return;
+
+      const direction = getChatHistoryScrollDirectionFromEvent(event);
+      if (!direction) return;
+      if (isEventFromEditableTarget(event)) return;
+      if (shouldNativeInputConsumeEvent(event)) return;
+
+      event.preventDefault();
+      scrollChatHistoryByPage(direction);
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [scrollChatHistoryByPage]);
 
   const { activeEditMessageId } = useMessageEditState();
   const track = useTrack();
@@ -807,6 +894,49 @@ export const ChatHistory = () => {
 
     return -1;
   }, [filteredMessages]);
+
+  useHotKeyListener(
+    useCallback(() => {
+      if (isWorking) return;
+      const editableMessages = Array.from(
+        document.querySelectorAll<HTMLElement>(
+          '[data-editable-user-message-id]',
+        ),
+      );
+      if (!scroller) return;
+      const scrollerRect = scroller.getBoundingClientRect();
+      const visibleTop = scrollerRect.top;
+      const visibleBottom = scrollerRect.bottom;
+
+      let nearestMessageId: string | undefined;
+      let nearestDistance = Number.POSITIVE_INFINITY;
+
+      for (const element of editableMessages) {
+        const rect = element.getBoundingClientRect();
+        if (
+          rect.bottom > visibleBottom ||
+          rect.bottom <= visibleTop ||
+          rect.top >= visibleBottom
+        )
+          continue;
+        const distance = visibleBottom - rect.bottom;
+        if (distance < nearestDistance) {
+          nearestDistance = distance;
+          nearestMessageId = element.dataset.editableUserMessageId;
+        }
+      }
+
+      if (!nearestMessageId) return;
+
+      window.dispatchEvent(
+        new CustomEvent(CHAT_EDIT_USER_MESSAGE_REQUESTED_EVENT, {
+          detail: { messageId: nearestMessageId },
+        }),
+      );
+    }, [isWorking, scroller]),
+    HotkeyActions.EDIT_NEAREST_USER_MESSAGE,
+    !activeEditMessageId,
+  );
 
   // --- Refs for itemContent stabilisation ---
   // These mirror frequently-changing derived values so that the

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/chat-input.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/chat-input.tsx
@@ -1,4 +1,6 @@
 import { useEditor, EditorContent, type Content } from '@tiptap/react';
+import { Fragment, type Node as ProseMirrorNode } from '@tiptap/pm/model';
+import type { EditorView } from '@tiptap/pm/view';
 import StarterKit from '@tiptap/starter-kit';
 import Placeholder from '@tiptap/extension-placeholder';
 import { ModelSelect } from './model-select';
@@ -26,7 +28,8 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from '@stagewise/stage-ui/components/tooltip';
-import { HotkeyComboText } from '@ui/components/hotkey-combo-text';
+import { ShortcutCombo } from '@stagewise/stage-ui/components/shortcut-key';
+import { HotkeyCombo } from '@ui/components/hotkey-combo';
 import {
   configureAttachmentExtensions,
   ALL_ATTACHMENT_NODE_NAMES,
@@ -41,11 +44,151 @@ import {
 import { SlashExtension, slashSkillsRef } from './rich-text/slash';
 import type { SkillDefinitionUI } from '@shared/skills';
 import { useState, memo } from 'react';
+import { useIsContainerScrollable } from '@ui/hooks/use-is-container-scrollable';
+import {
+  dispatchChatHistoryScroll,
+  type ChatHistoryScrollDirection,
+} from '../_lib/chat-history-scroll-event';
 // Re-export types for convenience
 export type { AttachmentAttributes, AttachmentType };
 
 /** Minimum paste length to auto-convert into a `.textclip` file attachment */
 const TEXT_CLIP_THRESHOLD = 100;
+const CHAT_INPUT_PAGE_SCROLL_FACTOR = 0.6;
+const CHAT_INPUT_PAGE_SCROLL_MIN = 120;
+const SLASH_CYCLE_BUILTIN_IDS = new Set([
+  'command:plan',
+  'command:preview',
+  'command:debug',
+  'command:learn',
+]);
+
+function isCtrlPageScrollEvent(event: KeyboardEvent) {
+  if (!event.ctrlKey || event.metaKey || event.altKey || event.shiftKey)
+    return false;
+
+  const key = event.key.toLowerCase();
+  return key === 'u' || key === 'd';
+}
+
+function getChatHistoryScrollDirectionFromEvent(
+  event: KeyboardEvent,
+): ChatHistoryScrollDirection | null {
+  if (!event.ctrlKey || event.metaKey || event.altKey || event.shiftKey)
+    return null;
+
+  const key = event.key.toLowerCase();
+  if (key === 'u') return 'up';
+  if (key === 'd') return 'down';
+
+  return null;
+}
+
+function isShiftTabSlashCycleEvent(event: KeyboardEvent) {
+  return (
+    event.key === 'Tab' &&
+    event.shiftKey &&
+    !event.metaKey &&
+    !event.ctrlKey &&
+    !event.altKey
+  );
+}
+
+type SlashCycleItem = {
+  id: string;
+  label: string;
+};
+
+type LeadingSlashNode = {
+  from: number;
+  to: number;
+  deleteTo: number;
+  id: string;
+};
+
+function getSlashCycleItems(): SlashCycleItem[] {
+  return slashSkillsRef.current
+    .filter((skill) => SLASH_CYCLE_BUILTIN_IDS.has(skill.id))
+    .map((skill) => ({
+      id: skill.id,
+      label: skill.displayName,
+    }));
+}
+
+function isZeroWidthTextNode(node: ProseMirrorNode) {
+  if (!node.isText) return false;
+  return (node.text ?? '').replaceAll('\u200B', '').length === 0;
+}
+
+function findLeadingSlashNode(doc: ProseMirrorNode): LeadingSlashNode | null {
+  const firstBlock = doc.firstChild;
+  if (!firstBlock?.isTextblock) return null;
+
+  let offset = 0;
+  for (let i = 0; i < firstBlock.childCount; i++) {
+    const node = firstBlock.child(i);
+    const from = 1 + offset;
+
+    if (isZeroWidthTextNode(node)) {
+      offset += node.nodeSize;
+      continue;
+    }
+
+    if (node.type.name !== 'slash') return null;
+
+    const to = from + node.nodeSize;
+    const next = i + 1 < firstBlock.childCount ? firstBlock.child(i + 1) : null;
+    const deleteTo = next?.isText && next.text?.startsWith(' ') ? to + 1 : to;
+
+    return {
+      from,
+      to,
+      deleteTo,
+      id: String(node.attrs.id ?? ''),
+    };
+  }
+
+  return null;
+}
+
+function createSlashCycleFragment(
+  view: EditorView,
+  item: SlashCycleItem,
+): Fragment | null {
+  const slashType = view.state.schema.nodes.slash;
+  if (!slashType) return null;
+
+  return Fragment.fromArray([
+    slashType.create({ id: item.id, label: item.label }),
+    view.state.schema.text(' '),
+  ]);
+}
+
+function cycleLeadingSlashCommand(view: EditorView) {
+  const items = getSlashCycleItems();
+  const firstBlock = view.state.doc.firstChild;
+  if (items.length === 0 || !firstBlock?.isTextblock) return false;
+
+  const leadingSlash = findLeadingSlashNode(view.state.doc);
+  const currentIndex = leadingSlash
+    ? items.findIndex((item) => item.id === leadingSlash.id)
+    : -1;
+  const nextIndex = leadingSlash
+    ? (Math.max(0, currentIndex) + 1) % items.length
+    : 0;
+
+  const nextItem = items[nextIndex];
+  if (!nextItem) return false;
+
+  const fragment = createSlashCycleFragment(view, nextItem);
+  if (!fragment) return false;
+
+  const from = leadingSlash?.from ?? 1;
+  const to = leadingSlash?.deleteTo ?? from;
+  view.dispatch(view.state.tr.replaceWith(from, to, fragment).scrollIntoView());
+  view.focus();
+  return true;
+}
 
 export interface ChatInputProps {
   // Core controlled input
@@ -158,16 +301,12 @@ export const ChatInput = memo(function ChatInput({
   className,
   ref,
 }: ChatInputProps) {
-  const focusChatHotkeyText = HotkeyComboText({
-    action: HotkeyActions.TOGGLE_CONTEXT_SELECTOR,
-  });
-
   const shownPlaceholder = useRef('');
   useEffect(() => {
     shownPlaceholder.current =
       placeholder ??
       `Use / to plan and run commands. Use @ for context. ${hasQueuedMessages ? 'Press ↵ to send now' : ''}`;
-  }, [placeholder, focusChatHotkeyText, hasQueuedMessages]);
+  }, [placeholder, hasQueuedMessages]);
   const staticPlaceholderRef = useRef(() => shownPlaceholder.current);
 
   const [textContent, setTextContent] = useState<string>('');
@@ -184,6 +323,15 @@ export const ChatInput = memo(function ChatInput({
       setInternalValue(value);
     }
   }, [value]);
+
+  const inputScrollContainerRef = useRef<HTMLDivElement>(null);
+  const { canScrollUp, canScrollDown } = useIsContainerScrollable(
+    inputScrollContainerRef,
+  );
+  const canScrollUpRef = useRef(canScrollUp);
+  const canScrollDownRef = useRef(canScrollDown);
+  canScrollUpRef.current = canScrollUp;
+  canScrollDownRef.current = canScrollDown;
 
   // TipTap editor setup
   const editor = useEditor({
@@ -230,6 +378,47 @@ export const ChatInput = memo(function ChatInput({
         ),
       },
       handleKeyDown: (view, event) => {
+        if (isShiftTabSlashCycleEvent(event)) {
+          const hasSuggestionPopup = document.querySelector(
+            '.mention-suggestion-container, .slash-suggestion-container',
+          );
+          if (hasSuggestionPopup) return false;
+
+          if (cycleLeadingSlashCommand(view)) {
+            event.preventDefault();
+            return true;
+          }
+        }
+
+        const scrollDirection = getChatHistoryScrollDirectionFromEvent(event);
+        if (scrollDirection) {
+          const canInputScroll =
+            scrollDirection === 'up'
+              ? canScrollUpRef.current
+              : canScrollDownRef.current;
+          if (canInputScroll) {
+            if (!isCtrlPageScrollEvent(event)) return false;
+
+            const scroller = inputScrollContainerRef.current;
+            if (!scroller) return false;
+
+            const amount = Math.max(
+              CHAT_INPUT_PAGE_SCROLL_MIN,
+              scroller.clientHeight * CHAT_INPUT_PAGE_SCROLL_FACTOR,
+            );
+            scroller.scrollBy({
+              top: scrollDirection === 'up' ? -amount : amount,
+              behavior: 'smooth',
+            });
+            event.preventDefault();
+            return true;
+          }
+
+          event.preventDefault();
+          dispatchChatHistoryScroll(scrollDirection);
+          return true;
+        }
+
         // Handle Enter without Shift for submit
         if (event.key === 'Enter' && !event.shiftKey) {
           // Check DOM for actual popup presence — the boolean flags
@@ -567,6 +756,7 @@ export const ChatInput = memo(function ChatInput({
         )}
       >
         <EditorContent
+          ref={inputScrollContainerRef}
           editor={editor}
           className={cn(
             'h-full w-full',
@@ -721,17 +911,21 @@ export const ChatInputActions = memo(function ChatInputActions({
             </Button>
           </TooltipTrigger>
           <TooltipContent>
-            {elementSelectionActive ? (
-              'Stop selecting elements (Esc)'
-            ) : (
-              <>
-                Add reference elements (
-                <HotkeyComboText
+            <span className="flex items-center gap-1.5">
+              <span>
+                {elementSelectionActive
+                  ? 'Stop selecting elements'
+                  : 'Add reference elements'}
+              </span>
+              {elementSelectionActive ? (
+                <ShortcutCombo value="Esc" size="xs" />
+              ) : (
+                <HotkeyCombo
                   action={HotkeyActions.TOGGLE_CONTEXT_SELECTOR}
+                  size="xs"
                 />
-                )
-              </>
-            )}
+              )}
+            </span>
           </TooltipContent>
         </Tooltip>
       )}
@@ -787,7 +981,12 @@ export const ChatInputActions = memo(function ChatInputActions({
                 <SquareIcon className="size-3 fill-current" />
               </Button>
             </TooltipTrigger>
-            <TooltipContent>Stop agent</TooltipContent>
+            <TooltipContent>
+              <span className="flex items-center gap-1.5">
+                <span>Stop agent</span>
+                <HotkeyCombo action={HotkeyActions.STOP_AGENT} size="xs" />
+              </span>
+            </TooltipContent>
           </Tooltip>
         )}
         {showSendButton && (

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/message-part-ui/tools/execute-shell-command.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/message-part-ui/tools/execute-shell-command.tsx
@@ -19,6 +19,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from '@stagewise/stage-ui/components/tooltip';
+import { ShortcutCombo } from '@stagewise/stage-ui/components/shortcut-key';
 
 export const ExecuteShellCommandToolPart = ({
   part,
@@ -339,7 +340,7 @@ export const ExecuteShellCommandToolPart = ({
           {isStdin ? (
             <>
               <span className="select-none text-subtle-foreground">→ </span>
-              {humanizeStdin(part.input?.stdin ?? '')}
+              <HumanizedStdin value={part.input?.stdin ?? ''} />
             </>
           ) : isKill ? (
             <>
@@ -483,10 +484,12 @@ const STDIN_SEQUENCES: [string, string][] = [
   ['\t', 'Tab'],
 ];
 
-const CONTROL_LABELS = new Set(STDIN_SEQUENCES.map(([, label]) => label));
+type StdinToken =
+  | { type: 'control'; value: string }
+  | { type: 'text'; value: string };
 
-function humanizeStdin(raw: string): string {
-  const tokens: string[] = [];
+function tokenizeStdin(raw: string): StdinToken[] {
+  const tokens: StdinToken[] = [];
   let printable = '';
   let i = 0;
 
@@ -495,10 +498,10 @@ function humanizeStdin(raw: string): string {
     for (const [pattern, label] of STDIN_SEQUENCES) {
       if (raw.startsWith(pattern, i)) {
         if (printable) {
-          tokens.push(printable);
+          tokens.push({ type: 'text', value: printable });
           printable = '';
         }
-        tokens.push(label);
+        tokens.push({ type: 'control', value: label });
         i += pattern.length;
         matched = true;
         break;
@@ -509,11 +512,32 @@ function humanizeStdin(raw: string): string {
       i++;
     }
   }
-  if (printable) tokens.push(printable);
-  if (tokens.length === 0) return raw || '(empty)';
+  if (printable) tokens.push({ type: 'text', value: printable });
+  return tokens;
+}
 
-  const allControl = tokens.every((t) => CONTROL_LABELS.has(t));
-  return allControl ? tokens.join(' ') : tokens.join('');
+function HumanizedStdin({ value }: { value: string }) {
+  const tokens = tokenizeStdin(value);
+  if (tokens.length === 0) return value || '(empty)';
+
+  return (
+    <span className="inline-flex flex-wrap items-center gap-0.5 align-middle">
+      {tokens.map((token, index) =>
+        token.type === 'control' ? (
+          <ShortcutCombo
+            key={`${token.value}-${index}`}
+            value={token.value}
+            size="xs"
+            variant="subtle"
+          />
+        ) : (
+          <span key={`${token.value}-${index}`} className="whitespace-pre-wrap">
+            {token.value}
+          </span>
+        ),
+      )}
+    </span>
+  );
 }
 
 function TruncatedCommandText({

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/message-part-ui/tools/get-linting-diagnostics.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/message-part-ui/tools/get-linting-diagnostics.tsx
@@ -98,9 +98,9 @@ export const GetLintingDiagnosticsToolPart = ({
       content={
         <>
           {streaming && (
-            <pre className="overflow-x-hidden whitespace-pre font-mono text-muted-foreground text-xs opacity-75">
+            <div className="overflow-x-hidden text-muted-foreground text-xs opacity-75">
               Checking for issues...
-            </pre>
+            </div>
           )}
           {state === 'success' && hasDiagnostics && files.length > 0 && (
             <div className="flex flex-col gap-1">

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/message-part-ui/tools/write/create-plan.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/message-part-ui/tools/write/create-plan.tsx
@@ -10,6 +10,7 @@ import {
 } from '@shared/plan-parsing';
 import { getBaseName } from '@shared/path-utils';
 import { stripMountPrefix } from '@ui/utils';
+import { HotkeyActions } from '@shared/hotkeys';
 import { useKartonProcedure } from '@ui/hooks/use-karton';
 import { useKartonState } from '@ui/hooks/use-karton';
 import { memo, useMemo, useCallback, useState } from 'react';
@@ -20,6 +21,8 @@ import { cn } from '@ui/utils';
 import { IconClipboardOutline18 } from 'nucleo-ui-outline-18';
 import { usePlanPhase } from '@ui/hooks/use-plan-phase';
 import { useSendImplement } from '@ui/hooks/use-send-implement';
+import { HotkeyCombo } from '@ui/components/hotkey-combo';
+import { useHotKeyListener } from '@ui/hooks/use-hotkey-listener';
 import {
   Tooltip,
   TooltipContent,
@@ -143,6 +146,12 @@ function CreatePlanSettledCard({ part }: { part: WritePart }) {
   // Implement: send a synthetic /implement message to the agent
   const handleImplement = useSendImplement();
 
+  useHotKeyListener(
+    handleImplement,
+    HotkeyActions.IMPLEMENT_CREATED_PLAN,
+    phase === 'just-created',
+  );
+
   const handleOpenPlan = useCallback(() => {
     const baseUrl = `stagewise://internal/plan/${encodeURIComponent(filename)}`;
     const existingTab = Object.values(tabs).find((tab) =>
@@ -209,8 +218,20 @@ function CreatePlanSettledCard({ part }: { part: WritePart }) {
           Open Plan
         </Button>
         {phase === 'just-created' && (
-          <Button variant="primary" size="xs" onClick={handleImplement}>
-            Implement
+          <Button
+            variant="primary"
+            size="xs"
+            className="pr-1"
+            onClick={handleImplement}
+          >
+            <span className="flex items-center gap-1.5">
+              <span>Implement</span>
+              <HotkeyCombo
+                action={HotkeyActions.IMPLEMENT_CREATED_PLAN}
+                size="xs"
+                variant="solid"
+              />
+            </span>
           </Button>
         )}
       </div>

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/message-user.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/message-user.tsx
@@ -37,6 +37,10 @@ import type { AttachmentType } from './rich-text/attachments';
 import type { MentionContext } from './rich-text/mentions';
 import type { FileMentionItem } from './rich-text/mentions/types';
 import type { AttachmentMetadata } from '@shared/karton-contracts/ui/agent/metadata';
+import {
+  CHAT_EDIT_USER_MESSAGE_REQUESTED_EVENT,
+  type ChatEditUserMessageRequestedEvent,
+} from '../_lib/chat-edit-user-message-event';
 import { useOpenAgent } from '@ui/hooks/use-open-chat';
 import type { Content } from '@tiptap/core';
 import { IconMagicWandSparkle } from 'nucleo-micro-bold';
@@ -440,6 +444,14 @@ export const MessageUser = memo(
       },
     );
 
+    useEventListener(
+      CHAT_EDIT_USER_MESSAGE_REQUESTED_EVENT,
+      (e: ChatEditUserMessageRequestedEvent) => {
+        if (isEditing && e.detail.messageId === editMessageId) return;
+        if (e.detail.messageId === editMessageId) handleStartEditing();
+      },
+    );
+
     // Handle textclip-expand during edit mode: replace the attachment node
     // with inline text and remove the file attachment from local state.
     // The blob file is intentionally NOT deleted — the user may cancel the edit.
@@ -626,6 +638,9 @@ export const MessageUser = memo(
                     canEdit &&
                     'group/chat-message-user cursor-pointer hover:bg-hover-derived active:bg-active-derived',
                 )}
+                data-editable-user-message-id={
+                  !isEditing && canEdit ? msg.id : undefined
+                }
                 onClick={!isEditing && canEdit ? handleStartEditing : undefined}
                 role={!isEditing && canEdit ? 'button' : undefined}
                 tabIndex={!isEditing && canEdit ? 0 : undefined}

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/model-select.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/model-select.tsx
@@ -13,10 +13,16 @@ import {
   ComboboxItemIndicator,
   ComboboxList,
 } from '@stagewise/stage-ui/components/combobox';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@stagewise/stage-ui/components/tooltip';
 import type { ModelId } from '@shared/available-models';
 import { IconBrainOutline18 } from 'nucleo-ui-outline-18';
 import { IconChevronDownFill18 } from 'nucleo-ui-fill-18';
 import { availableModels } from '@shared/available-models';
+import { HotkeyActions } from '@shared/hotkeys';
 import { useKartonProcedure, useKartonState } from '@ui/hooks/use-karton';
 import { useOpenAgent } from '@ui/hooks/use-open-chat';
 import {
@@ -30,6 +36,8 @@ import {
 } from 'react';
 import { cn } from '@ui/utils';
 import { useScrollFadeMask } from '@ui/hooks/use-scroll-fade-mask';
+import { useHotKeyListener } from '@ui/hooks/use-hotkey-listener';
+import { HotkeyCombo } from '@ui/components/hotkey-combo';
 
 interface ModelOption {
   modelId: string;
@@ -151,6 +159,8 @@ export const ModelSelect = memo(function ModelSelect({
     return groups;
   }, [modelOptions]);
 
+  const [open, setOpen] = useState(false);
+
   // Search / filter state
   const [query, setQuery] = useState('');
 
@@ -179,6 +189,8 @@ export const ModelSelect = memo(function ModelSelect({
     if (!selectedModel) return 'Select model';
     return modelMap.get(selectedModel)?.displayName ?? selectedModel;
   }, [modelMap, selectedModel]);
+
+  const inputRef = useRef<HTMLInputElement>(null);
 
   // Side-panel hover state
   const containerRef = useRef<HTMLDivElement>(null);
@@ -240,34 +252,58 @@ export const ModelSelect = memo(function ModelSelect({
     [openAgent, setSelectedModel, onModelChange],
   );
 
-  const handleOpenChange = useCallback((open: boolean) => {
-    if (!open) {
+  const handleOpenChange = useCallback((nextOpen: boolean) => {
+    setOpen(nextOpen);
+    if (!nextOpen) {
       setHoveredModel(null);
       setQuery('');
     }
   }, []);
 
+  useHotKeyListener(
+    useCallback(() => {
+      setOpen(true);
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          inputRef.current?.focus();
+        });
+      });
+    }, []),
+    HotkeyActions.OPEN_MODEL_SELECT,
+  );
+
   return (
     <Combobox
       value={selectedModel}
+      open={open}
       onValueChange={handleValueChange}
       onOpenChange={handleOpenChange}
       filter={null}
     >
-      <ComboboxBase.Trigger
-        className={cn(
-          'inline-flex min-w-0 max-w-full cursor-pointer items-center justify-between gap-1 rounded-lg p-0 font-normal text-xs shadow-none transition-colors',
-          'focus-visible:outline-1 focus-visible:outline-muted-foreground/35 focus-visible:-outline-offset-2',
-          'has-disabled:pointer-events-none has-disabled:opacity-50',
-          'bg-transparent text-muted-foreground hover:text-foreground data-popup-open:text-foreground',
-          'h-4 w-auto',
-        )}
-      >
-        <span className="truncate">{selectedDisplayName}</span>
-        <ComboboxBase.Icon className="shrink-0">
-          <IconChevronDownFill18 className="size-3" />
-        </ComboboxBase.Icon>
-      </ComboboxBase.Trigger>
+      <Tooltip>
+        <TooltipTrigger>
+          <ComboboxBase.Trigger
+            className={cn(
+              'inline-flex min-w-0 max-w-full cursor-pointer items-center justify-between gap-1 rounded-lg p-0 font-normal text-xs shadow-none transition-colors',
+              'focus-visible:outline-1 focus-visible:outline-muted-foreground/35 focus-visible:-outline-offset-2',
+              'has-disabled:pointer-events-none has-disabled:opacity-50',
+              'bg-transparent text-muted-foreground hover:text-foreground data-popup-open:text-foreground',
+              'h-4 w-auto',
+            )}
+          >
+            <span className="truncate">{selectedDisplayName}</span>
+            <ComboboxBase.Icon className="shrink-0">
+              <IconChevronDownFill18 className="size-3" />
+            </ComboboxBase.Icon>
+          </ComboboxBase.Trigger>
+        </TooltipTrigger>
+        <TooltipContent side="top">
+          <span className="flex items-center gap-1.5">
+            <span>Switch model</span>
+            <HotkeyCombo action={HotkeyActions.OPEN_MODEL_SELECT} size="xs" />
+          </span>
+        </TooltipContent>
+      </Tooltip>
 
       <ComboboxBase.Portal>
         <ComboboxBase.Backdrop className="fixed inset-0 z-50" />
@@ -293,6 +329,7 @@ export const ModelSelect = memo(function ModelSelect({
             >
               <div className="mb-1 rounded-md">
                 <ComboboxInput
+                  ref={inputRef}
                   size="xs"
                   placeholder="Search…"
                   value={query}

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/panel-footer.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/panel-footer.tsx
@@ -615,7 +615,10 @@ export const ChatPanelFooter = memo(function ChatPanelFooter() {
   }, []);
 
   const abortAgent = useCallback(async () => {
-    if (isEarlyAbortEligible()) {
+    const inputIsEmpty =
+      (chatInputRef.current?.getTextContent()?.trim().length ?? 0) === 0;
+
+    if (inputIsEmpty && isEarlyAbortEligible()) {
       const currentHistory = historyRef.current ?? [];
       for (let i = currentHistory.length - 1; i >= 0; i--) {
         if (currentHistory[i]?.role === 'user') {
@@ -639,16 +642,30 @@ export const ChatPanelFooter = memo(function ChatPanelFooter() {
   abortAgentRef.current = abortAgent;
   const stableAbortAgent = useCallback(() => abortAgentRef.current(), []);
 
+  const shouldPreserveNativeCopy = useCallback((event: KeyboardEvent) => {
+    if (event.key.toLowerCase() !== 'c' || !event.ctrlKey) return false;
+
+    const target = event.target;
+    if (
+      target instanceof HTMLInputElement ||
+      target instanceof HTMLTextAreaElement
+    ) {
+      return target.selectionStart !== target.selectionEnd;
+    }
+
+    if (target instanceof HTMLElement && target.isContentEditable) {
+      const selection = window.getSelection();
+      return !!selection && !selection.isCollapsed;
+    }
+
+    const selection = window.getSelection();
+    return !!selection && !selection.isCollapsed;
+  }, []);
+
   const handleEscape = useCallback(() => {
     if (elementSelectionActive) stopContextSelector();
-    else if (
-      isWorkingRef.current &&
-      isEarlyAbortEligible() &&
-      (chatInputRef.current?.getTextContent()?.trim().length ?? 0) === 0
-    )
-      void abortAgentRef.current();
     else setChatInputActive(false);
-  }, [elementSelectionActive, stopContextSelector, isEarlyAbortEligible]);
+  }, [elementSelectionActive, stopContextSelector]);
 
   const isVerboseMode = useKartonState(
     (s) => s.appInfo.releaseChannel === 'dev',
@@ -1219,6 +1236,18 @@ export const ChatPanelFooter = memo(function ChatPanelFooter() {
       chatInputRef.current?.focus();
     }, [chatInputActive, setChatInputActive, togglePanelKeyboardFocus]),
     HotkeyActions.FOCUS_CHAT_INPUT,
+  );
+
+  useHotKeyListener(
+    useCallback(
+      (event: KeyboardEvent) => {
+        if (shouldPreserveNativeCopy(event)) return false;
+        void abortAgentRef.current();
+      },
+      [shouldPreserveNativeCopy],
+    ),
+    HotkeyActions.STOP_AGENT,
+    isWorking && !hasPendingQuestion,
   );
 
   useEventListener(

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/workspace-select.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/workspace-select.tsx
@@ -50,8 +50,10 @@ import { CheckIcon, XIcon, Loader2Icon } from 'lucide-react';
 import { useKartonProcedure, useKartonState } from '@ui/hooks/use-karton';
 import { useScrollFadeMask } from '@ui/hooks/use-scroll-fade-mask';
 import { useTrack } from '@ui/hooks/use-track';
+import { useHotKeyListener } from '@ui/hooks/use-hotkey-listener';
 import { IdeLogo } from '@ui/components/ide-logo';
 import { getIDEFileUrl, IDE_SELECTION_ITEMS } from '@ui/utils';
+import { HotkeyActions } from '@shared/hotkeys';
 import { getBaseName } from '@shared/path-utils';
 import { FileContextMenu } from '@ui/components/file-context-menu';
 import type { OpenFilesInIde } from '@shared/karton-contracts/ui/shared-types';
@@ -1601,6 +1603,7 @@ const WorkspaceActionSelect = memo(function WorkspaceActionSelect({
   const [worktreesResult, setWorktreesResult] =
     useState<WorkspaceGitWorktreesResult | null>(null);
   const [gitDataLoaded, setGitDataLoaded] = useState(false);
+  const popupRef = useRef<HTMLDivElement>(null);
 
   const sourceBranchItems = useMemo(
     () => getBranchSelectItemsFromGit(branchesResult, gitRef, 'source'),
@@ -1896,6 +1899,53 @@ const WorkspaceActionSelect = memo(function WorkspaceActionSelect({
     [handleActionUpdate],
   );
 
+  const handlePopupKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLDivElement>) => {
+      const isNextKey =
+        event.key === 'ArrowDown' ||
+        (event.ctrlKey &&
+          !event.metaKey &&
+          !event.altKey &&
+          !event.shiftKey &&
+          event.key.toLowerCase() === 'n');
+      const isPreviousKey =
+        event.key === 'ArrowUp' ||
+        (event.ctrlKey &&
+          !event.metaKey &&
+          !event.altKey &&
+          !event.shiftKey &&
+          event.key.toLowerCase() === 'p');
+
+      if (!isNextKey && !isPreviousKey) return;
+
+      const popup = popupRef.current;
+      if (!popup) return;
+
+      const items = Array.from(
+        popup.querySelectorAll<HTMLElement>('[role="radio"]'),
+      ).filter(
+        (item) =>
+          !(item instanceof HTMLButtonElement && item.disabled) &&
+          item.getAttribute('aria-disabled') !== 'true',
+      );
+      if (items.length === 0) return;
+
+      const activeElement = document.activeElement;
+      const currentIndex =
+        activeElement instanceof HTMLElement
+          ? items.indexOf(activeElement)
+          : -1;
+      const nextIndex = isNextKey
+        ? (currentIndex + 1) % items.length
+        : (currentIndex <= 0 ? items.length : currentIndex) - 1;
+
+      event.preventDefault();
+      event.stopPropagation();
+      items[nextIndex]?.focus();
+    },
+    [],
+  );
+
   const triggerSummary = useMemo<React.ReactNode>(() => {
     switch (config.selectedAction) {
       case 'create-worktree':
@@ -2012,7 +2062,9 @@ const WorkspaceActionSelect = memo(function WorkspaceActionSelect({
           className="z-50"
         >
           <PopoverBase.Popup
+            ref={popupRef}
             onClick={(e) => e.stopPropagation()}
+            onKeyDown={handlePopupKeyDown}
             className={cn(
               // `group/rows` enables the cross-row "hover steals the
               // foreground color from the active row" behavior on
@@ -2470,6 +2522,7 @@ function ConnectInlineActionSelect({
       <PopoverTrigger>
         <button
           type="button"
+          data-connect-action-trigger=""
           onClick={(e) => e.stopPropagation()}
           onPointerDown={(e) => e.stopPropagation()}
           className={cn(
@@ -2514,15 +2567,17 @@ function ConnectInlineActionSelect({
               'data-ending-style:opacity-0 data-starting-style:opacity-0',
             )}
           >
-            <WorkspaceActionPickerContent
-              config={state}
-              sourceBranchItems={sourceBranchItems}
-              checkoutBranchItems={checkoutBranchItems}
-              worktreeItems={worktreeItems}
-              branchSelectPortalContainer={popupRef}
-              onCommit={handleSelect}
-              onUpdateAction={handleActionUpdate}
-            />
+            <div data-connect-action-popup="">
+              <WorkspaceActionPickerContent
+                config={state}
+                sourceBranchItems={sourceBranchItems}
+                checkoutBranchItems={checkoutBranchItems}
+                worktreeItems={worktreeItems}
+                branchSelectPortalContainer={popupRef}
+                onCommit={handleSelect}
+                onUpdateAction={handleActionUpdate}
+              />
+            </div>
           </PopoverBase.Popup>
         </PopoverBase.Positioner>
       </PopoverBase.Portal>
@@ -2617,6 +2672,8 @@ const ConnectWorkspaceSelect = memo(function ConnectWorkspaceSelectInner({
   >(() => new Map());
   const [connectError, setConnectError] = useState<string | null>(null);
   const [pendingRowKey, setPendingRowKey] = useState<string | null>(null);
+  const [focusedRowKey, setFocusedRowKey] = useState<string | null>(null);
+  const popupRef = useRef<HTMLDivElement>(null);
   const recentListScrollRef = useRef<HTMLDivElement>(null);
   const { maskStyle: recentListMaskStyle } = useScrollFadeMask(
     recentListScrollRef,
@@ -2904,28 +2961,117 @@ const ConnectWorkspaceSelect = memo(function ConnectWorkspaceSelectInner({
     ],
   );
 
+  const getConnectNavigationItems = useCallback(() => {
+    const popup = popupRef.current;
+    if (!popup) return [];
+
+    return Array.from(
+      popup.querySelectorAll<HTMLElement>(
+        '[data-connect-row], [data-connect-new-row]',
+      ),
+    ).filter(
+      (item) =>
+        !(item instanceof HTMLButtonElement && item.disabled) &&
+        item.getAttribute('aria-disabled') !== 'true',
+    );
+  }, []);
+
+  const focusFirstConnectItem = useCallback(() => {
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        getConnectNavigationItems()[0]?.focus();
+      });
+    });
+  }, [getConnectNavigationItems]);
+
+  const openConnectPopover = useCallback(() => {
+    setOpen(true);
+    setConnectError(null);
+    initializePathStates();
+    for (const workspace of recentPaths) {
+      const rowKey = `workspace:${workspace.path}`;
+      void loadGitOptionsForPath(workspace.path, rowKey);
+    }
+    focusFirstConnectItem();
+  }, [
+    focusFirstConnectItem,
+    initializePathStates,
+    loadGitOptionsForPath,
+    recentPaths,
+  ]);
+
   const handleOpenChange = useCallback(
     (next: boolean) => {
-      setOpen(next);
       if (next) {
-        setConnectError(null);
-        initializePathStates();
-        for (const workspace of recentPaths) {
-          const rowKey = `workspace:${workspace.path}`;
-          void loadGitOptionsForPath(workspace.path, rowKey);
-        }
+        openConnectPopover();
         return;
       }
 
+      setOpen(false);
       // Reset transient state on close so each open is a fresh
       // decision.
       setConnectError(null);
       setPendingRowKey(null);
+      setFocusedRowKey(null);
       setPathStates(new Map());
       setPathGitOptions(new Map());
       setPathGitCapability(new Map());
     },
-    [initializePathStates, loadGitOptionsForPath, recentPaths],
+    [openConnectPopover],
+  );
+
+  useHotKeyListener(
+    useCallback(() => {
+      openConnectPopover();
+    }, [openConnectPopover]),
+    HotkeyActions.OPEN_WORKSPACE_SELECT,
+  );
+
+  const handlePopupKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLDivElement>) => {
+      const isNextKey =
+        event.key === 'ArrowDown' ||
+        (event.ctrlKey &&
+          !event.metaKey &&
+          !event.altKey &&
+          !event.shiftKey &&
+          event.key.toLowerCase() === 'n');
+      const isPreviousKey =
+        event.key === 'ArrowUp' ||
+        (event.ctrlKey &&
+          !event.metaKey &&
+          !event.altKey &&
+          !event.shiftKey &&
+          event.key.toLowerCase() === 'p');
+
+      if (!isNextKey && !isPreviousKey) return;
+
+      const target = event.target;
+      if (
+        target instanceof HTMLElement &&
+        target.closest(
+          '[data-connect-action-trigger], [data-connect-action-popup]',
+        )
+      )
+        return;
+
+      const items = getConnectNavigationItems();
+      if (items.length === 0) return;
+
+      const activeElement = document.activeElement;
+      const currentIndex =
+        activeElement instanceof HTMLElement
+          ? items.indexOf(activeElement)
+          : -1;
+      const nextIndex = isNextKey
+        ? (currentIndex + 1) % items.length
+        : (currentIndex <= 0 ? items.length : currentIndex) - 1;
+
+      event.preventDefault();
+      event.stopPropagation();
+      items[nextIndex]?.focus();
+    },
+    [getConnectNavigationItems],
   );
 
   return (
@@ -2975,7 +3121,9 @@ const ConnectWorkspaceSelect = memo(function ConnectWorkspaceSelectInner({
           className="z-50"
         >
           <PopoverBase.Popup
+            ref={popupRef}
             onClick={(e) => e.stopPropagation()}
+            onKeyDown={handlePopupKeyDown}
             className={cn(
               'group/connect-list flex w-80 max-w-[calc(100vw-2rem)] flex-col gap-0 p-1',
               'rounded-lg bg-background ring-1 ring-border-subtle',
@@ -3014,12 +3162,15 @@ const ConnectWorkspaceSelect = memo(function ConnectWorkspaceSelectInner({
                     gitOptions?.checkoutBranchItems ?? fallbackBranchItems;
                   const worktreeItems =
                     gitOptions?.worktreeItems ?? fallbackWorktreeItems;
+                  const showActionByDefault = index === 0 && !focusedRowKey;
+                  const showActionForFocus = focusedRowKey === rowKey;
                   return (
                     <div
                       key={rowKey}
                       role="button"
                       tabIndex={0}
                       data-connect-row=""
+                      onFocus={() => setFocusedRowKey(rowKey)}
                       onClick={(e) => {
                         e.stopPropagation();
                         // Parent-row click commits whichever action is
@@ -3050,9 +3201,12 @@ const ConnectWorkspaceSelect = memo(function ConnectWorkspaceSelectInner({
                             'flex shrink-0 text-subtle-foreground transition-opacity group-hover/connect-row:text-muted-foreground',
                             'group-hover/connect-row:!pointer-events-auto group-hover/connect-row:!opacity-100',
                             'has-[[data-popup-open]]:!pointer-events-auto has-[[data-popup-open]]:!opacity-100',
-                            index === 0
-                              ? 'pointer-events-auto opacity-100 group-has-[[data-connect-row]:hover]/connect-list:pointer-events-none group-has-[[data-connect-row]:hover]/connect-list:opacity-0'
+                            showActionForFocus || showActionByDefault
+                              ? 'pointer-events-auto opacity-100'
                               : 'pointer-events-none opacity-0',
+                            showActionByDefault
+                              ? 'group-has-[[data-connect-row]:hover]/connect-list:pointer-events-none group-has-[[data-connect-row]:hover]/connect-list:opacity-0'
+                              : null,
                           )}
                         >
                           {gitCapability === 'git' && (
@@ -3094,6 +3248,8 @@ const ConnectWorkspaceSelect = memo(function ConnectWorkspaceSelectInner({
 
             <button
               type="button"
+              data-connect-new-row=""
+              onFocus={() => setFocusedRowKey(CONNECT_NEW_KEY)}
               onClick={(e) => {
                 e.stopPropagation();
                 const state = getOrInitState(CONNECT_NEW_KEY);

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_lib/chat-edit-user-message-event.ts
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_lib/chat-edit-user-message-event.ts
@@ -1,0 +1,12 @@
+export const CHAT_EDIT_USER_MESSAGE_REQUESTED_EVENT =
+  'chat-edit-user-message-requested';
+
+export type ChatEditUserMessageRequestedEvent = CustomEvent<{
+  messageId: string;
+}>;
+
+declare global {
+  interface WindowEventMap {
+    [CHAT_EDIT_USER_MESSAGE_REQUESTED_EVENT]: ChatEditUserMessageRequestedEvent;
+  }
+}

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_lib/chat-history-scroll-event.ts
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_lib/chat-history-scroll-event.ts
@@ -1,0 +1,23 @@
+export const CHAT_HISTORY_SCROLL_EVENT = 'chat-history-scroll';
+
+export type ChatHistoryScrollDirection = 'up' | 'down';
+
+export interface ChatHistoryScrollEventDetail {
+  direction: ChatHistoryScrollDirection;
+}
+
+declare global {
+  interface WindowEventMap {
+    [CHAT_HISTORY_SCROLL_EVENT]: CustomEvent<ChatHistoryScrollEventDetail>;
+  }
+}
+
+export function dispatchChatHistoryScroll(
+  direction: ChatHistoryScrollDirection,
+) {
+  window.dispatchEvent(
+    new CustomEvent(CHAT_HISTORY_SCROLL_EVENT, {
+      detail: { direction },
+    }),
+  );
+}

--- a/apps/browser/src/ui/screens/main/content/_components/agent-preview-badge.tsx
+++ b/apps/browser/src/ui/screens/main/content/_components/agent-preview-badge.tsx
@@ -6,7 +6,7 @@ import {
   TooltipContent,
 } from '@stagewise/stage-ui/components/tooltip';
 import { HotkeyActions } from '@shared/hotkeys';
-import { HotkeyComboText } from '@ui/components/hotkey-combo-text';
+import { HotkeyCombo } from '@ui/components/hotkey-combo';
 import { useKartonState } from '@ui/hooks/use-karton';
 import { cn } from '@ui/utils';
 import { useOpenAgent } from '@ui/hooks/use-open-chat';
@@ -40,15 +40,12 @@ export function AgentPreviewBadge({ onClick }: AgentPreviewBadgeProps) {
           </Button>
         </TooltipTrigger>
         <TooltipContent>
-          <div className="flex flex-row items-center gap-1">
+          <div className="flex flex-row items-center gap-1.5">
             <span className="text-xs">Toggle chat panel</span>
-            <div className="pointer-events-none flex shrink-0 flex-row items-center gap-0 opacity-40">
-              <span className="font-mono text-muted-foreground text-xs">
-                <HotkeyComboText
-                  action={HotkeyActions.TOGGLE_CONTEXT_SELECTOR}
-                />
-              </span>
-            </div>
+            <HotkeyCombo
+              action={HotkeyActions.TOGGLE_CONTEXT_SELECTOR}
+              size="xs"
+            />
           </div>
         </TooltipContent>
       </Tooltip>

--- a/apps/browser/src/ui/screens/main/content/_components/control-buttons/chrome-devtools.tsx
+++ b/apps/browser/src/ui/screens/main/content/_components/control-buttons/chrome-devtools.tsx
@@ -1,3 +1,4 @@
+import { HotkeyActions } from '@shared/hotkeys';
 import { useKartonProcedure } from '@ui/hooks/use-karton';
 import { IconSquareCodeOutline18 } from 'nucleo-ui-outline-18';
 import type { TabState } from '@shared/karton-contracts/ui';
@@ -7,6 +8,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from '@stagewise/stage-ui/components/tooltip';
+import { HotkeyCombo } from '@ui/components/hotkey-combo';
 
 export function ChromeDevToolsWidget({ tab }: { tab: TabState }) {
   const toggleChromeDevTools = useKartonProcedure(
@@ -21,8 +23,8 @@ export function ChromeDevToolsWidget({ tab }: { tab: TabState }) {
           size="icon-sm"
           aria-label={
             tab.devTools.chromeOpen
-              ? 'Hide Chrome DevTools'
-              : 'Show Chrome DevTools'
+              ? 'Hide Stagewise DevTools'
+              : 'Show Stagewise DevTools'
           }
           onClick={() => toggleChromeDevTools(tab.id)}
           className={
@@ -33,7 +35,16 @@ export function ChromeDevToolsWidget({ tab }: { tab: TabState }) {
           <IconSquareCodeOutline18 className="size-4" />
         </Button>
       </TooltipTrigger>
-      <TooltipContent>Show Chrome DevTools</TooltipContent>
+      <TooltipContent>
+        <span className="flex items-center gap-1.5">
+          <span>
+            {tab.devTools.chromeOpen
+              ? 'Hide Stagewise DevTools'
+              : 'Show Stagewise DevTools'}
+          </span>
+          <HotkeyCombo action={HotkeyActions.DEV_TOOLS} size="xs" />
+        </span>
+      </TooltipContent>
     </Tooltip>
   );
 }

--- a/apps/browser/src/ui/screens/main/content/_components/control-buttons/downloads.tsx
+++ b/apps/browser/src/ui/screens/main/content/_components/control-buttons/downloads.tsx
@@ -31,6 +31,7 @@ import {
 import { useHotKeyListener } from '@ui/hooks/use-hotkey-listener';
 import { DOWNLOADS_PAGE_URL } from '@shared/internal-urls';
 import { HotkeyActions } from '@shared/hotkeys';
+import { HotkeyCombo } from '@ui/components/hotkey-combo';
 import { AreaChart, Area, ResponsiveContainer, XAxis } from 'recharts';
 
 function getDownloadStateLabel(state: DownloadState): string {
@@ -398,11 +399,16 @@ export function DownloadsControlButton({ isActive }: { isActive: boolean }) {
           </PopoverTrigger>
         </TooltipTrigger>
         <TooltipContent side="bottom">
-          {hasActiveDownloads
-            ? `${activeCount} download${activeCount > 1 ? 's' : ''} in progress`
-            : hasUnseenDownloads
-              ? 'New downloads available'
-              : 'Recent downloads'}
+          <span className="flex items-center gap-1.5">
+            <span>
+              {hasActiveDownloads
+                ? `${activeCount} download${activeCount > 1 ? 's' : ''} in progress`
+                : hasUnseenDownloads
+                  ? 'New downloads available'
+                  : 'Recent downloads'}
+            </span>
+            <HotkeyCombo action={HotkeyActions.DOWNLOADS} size="xs" />
+          </span>
         </TooltipContent>
       </Tooltip>
       <PopoverContent className="w-84 rounded-xl p-3">

--- a/apps/browser/src/ui/screens/main/content/_components/control-buttons/search-bar.tsx
+++ b/apps/browser/src/ui/screens/main/content/_components/control-buttons/search-bar.tsx
@@ -16,6 +16,13 @@ import { Button } from '@stagewise/stage-ui/components/button';
 import { IconSearchContentOutline18 } from 'nucleo-ui-outline-18';
 import { useHotKeyListener } from '@ui/hooks/use-hotkey-listener';
 import { HotkeyActions } from '@shared/hotkeys';
+import { ShortcutCombo } from '@stagewise/stage-ui/components/shortcut-key';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@stagewise/stage-ui/components/tooltip';
+import { HotkeyCombo } from '@ui/components/hotkey-combo';
 
 export interface SearchBarRef {
   focus: () => void;
@@ -105,11 +112,6 @@ export function SearchBar({ tabId, ref }: SearchBarProps) {
       setPendingKeyboardFocus(false);
     }
   }, [pendingKeyboardFocus, shouldShow]);
-
-  const _handleMouseEnter = useCallback(() => {
-    // Mouse interaction should always use transitions
-    setIsKeyboardInteraction(false);
-  }, []);
 
   // Sync shouldShow with isSearchBarActive from backend
   useEffect(() => {
@@ -216,37 +218,70 @@ export function SearchBar({ tabId, ref }: SearchBarProps) {
       />
       {searchString.length > 0 && (
         <div className="flex flex-row items-center gap-0.5">
-          <Button
-            variant="ghost"
-            size="icon-xs"
-            disabled={!tabSearch || tabSearch.resultsCount === 0}
-            onClick={() => previousSearchResult(tabId)}
-          >
-            <IconChevronLeft className="size-3" />
-          </Button>
+          <Tooltip>
+            <TooltipTrigger>
+              <Button
+                variant="ghost"
+                size="icon-xs"
+                aria-label="Previous search result"
+                disabled={!tabSearch || tabSearch.resultsCount === 0}
+                onClick={() => previousSearchResult(tabId)}
+              >
+                <IconChevronLeft className="size-3" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>
+              <span className="flex items-center gap-1.5">
+                <span>Previous match</span>
+                <HotkeyCombo action={HotkeyActions.FIND_PREV} size="xs" />
+              </span>
+            </TooltipContent>
+          </Tooltip>
           <span className="text-muted-foreground text-xs">
             {tabSearch?.activeMatchIndex ?? 0} / {tabSearch?.resultsCount ?? 0}
           </span>
+          <Tooltip>
+            <TooltipTrigger>
+              <Button
+                variant="ghost"
+                size="icon-xs"
+                aria-label="Next search result"
+                disabled={!tabSearch || tabSearch.resultsCount === 0}
+                onClick={() => nextSearchResult(tabId)}
+              >
+                <IconChevronRight className="size-3" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>
+              <span className="flex items-center gap-1.5">
+                <span>Next match</span>
+                <HotkeyCombo action={HotkeyActions.FIND_NEXT} size="xs" />
+              </span>
+            </TooltipContent>
+          </Tooltip>
+        </div>
+      )}
+      <Tooltip>
+        <TooltipTrigger>
           <Button
             variant="ghost"
             size="icon-xs"
-            disabled={!tabSearch || tabSearch.resultsCount === 0}
-            onClick={() => nextSearchResult(tabId)}
+            aria-label="Close search"
+            onClick={() => {
+              setShouldShow(false);
+              deactivateSearchBar();
+            }}
           >
-            <IconChevronRight className="size-3" />
+            <IconXmark className="size-3" />
           </Button>
-        </div>
-      )}
-      <Button
-        variant="ghost"
-        size="icon-xs"
-        onClick={() => {
-          setShouldShow(false);
-          deactivateSearchBar();
-        }}
-      >
-        <IconXmark className="size-3" />
-      </Button>
+        </TooltipTrigger>
+        <TooltipContent>
+          <span className="flex items-center gap-1.5">
+            <span>Close search</span>
+            <ShortcutCombo value="Esc" size="xs" />
+          </span>
+        </TooltipContent>
+      </Tooltip>
     </div>
   );
 }

--- a/apps/browser/src/ui/screens/main/content/_components/control-buttons/zoom-bar.tsx
+++ b/apps/browser/src/ui/screens/main/content/_components/control-buttons/zoom-bar.tsx
@@ -4,7 +4,7 @@ import {
   IconMagnifierMinusOutline18,
   IconMagnifierPlusOutline18,
 } from 'nucleo-ui-outline-18';
-import { HotkeyComboText } from '@ui/components/hotkey-combo-text';
+import { HotkeyCombo } from '@ui/components/hotkey-combo';
 import {
   Tooltip,
   TooltipContent,
@@ -116,9 +116,24 @@ export function ZoomBar({ tabId }: ZoomBarProps) {
       onMouseLeave={handleMouseLeave}
     >
       <div className="flex flex-row items-center gap-0">
-        <Button variant="ghost" size="icon-xs" onClick={zoomOut}>
-          <IconMagnifierMinusOutline18 className="size-4" />
-        </Button>
+        <Tooltip>
+          <TooltipTrigger>
+            <Button
+              variant="ghost"
+              size="icon-xs"
+              aria-label="Zoom out"
+              onClick={zoomOut}
+            >
+              <IconMagnifierMinusOutline18 className="size-4" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>
+            <span className="flex items-center gap-1.5">
+              <span>Zoom out</span>
+              <HotkeyCombo action={HotkeyActions.ZOOM_OUT} size="xs" />
+            </span>
+          </TooltipContent>
+        </Tooltip>
         <Tooltip>
           <TooltipTrigger>
             <Button variant="ghost" size="xs" onClick={resetZoom}>
@@ -126,12 +141,30 @@ export function ZoomBar({ tabId }: ZoomBarProps) {
             </Button>
           </TooltipTrigger>
           <TooltipContent>
-            Reset zoom <HotkeyComboText action={HotkeyActions.ZOOM_RESET} />
+            <span className="flex items-center gap-1.5">
+              <span>Reset zoom</span>
+              <HotkeyCombo action={HotkeyActions.ZOOM_RESET} size="xs" />
+            </span>
           </TooltipContent>
         </Tooltip>
-        <Button variant="ghost" size="icon-xs" onClick={zoomIn}>
-          <IconMagnifierPlusOutline18 className="size-4" />
-        </Button>
+        <Tooltip>
+          <TooltipTrigger>
+            <Button
+              variant="ghost"
+              size="icon-xs"
+              aria-label="Zoom in"
+              onClick={zoomIn}
+            >
+              <IconMagnifierPlusOutline18 className="size-4" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>
+            <span className="flex items-center gap-1.5">
+              <span>Zoom in</span>
+              <HotkeyCombo action={HotkeyActions.ZOOM_IN} size="xs" />
+            </span>
+          </TooltipContent>
+        </Tooltip>
       </div>
     </div>
   );

--- a/apps/browser/src/ui/screens/main/content/_components/nav-buttons.tsx
+++ b/apps/browser/src/ui/screens/main/content/_components/nav-buttons.tsx
@@ -1,5 +1,11 @@
+import { HotkeyActions } from '@shared/hotkeys';
 import { useKartonProcedure } from '@ui/hooks/use-karton';
 import { Button } from '@stagewise/stage-ui/components/button';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@stagewise/stage-ui/components/tooltip';
 import {
   IconArrowLeft,
   IconArrowRight,
@@ -7,6 +13,7 @@ import {
 } from 'nucleo-micro-bold';
 import { IconMediaStopFill18 } from 'nucleo-ui-fill-18';
 import type { TabState } from '@shared/karton-contracts/ui';
+import { HotkeyCombo } from '@ui/components/hotkey-combo';
 
 interface NavButtonsProps {
   tabId: string;
@@ -25,30 +32,67 @@ export function NavButtons({ tabId, tab }: NavButtonsProps) {
 
   return (
     <div className="flex flex-row items-center gap-0.5">
-      <Button
-        variant="ghost"
-        size="icon-sm"
-        disabled={!canGoBack}
-        onClick={() => {
-          goBack(tabId);
-        }}
-      >
-        <IconArrowLeft className={`size-4 ${!canGoBack && 'opacity-50'}`} />
-      </Button>
-      <Button
-        variant="ghost"
-        size="icon-sm"
-        disabled={!canGoForward}
-        onClick={() => {
-          goForward(tabId);
-        }}
-      >
-        <IconArrowRight className={`size-4 ${!canGoForward && 'opacity-50'}`} />
-      </Button>
+      <Tooltip>
+        <TooltipTrigger
+          render={
+            <span className="inline-flex">
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                aria-label="Back"
+                disabled={!canGoBack}
+                className={!canGoBack ? 'pointer-events-none' : undefined}
+                onClick={() => {
+                  goBack(tabId);
+                }}
+              >
+                <IconArrowLeft
+                  className={canGoBack ? 'size-4' : 'size-4 opacity-50'}
+                />
+              </Button>
+            </span>
+          }
+        />
+        <TooltipContent>
+          <span className="flex items-center gap-1.5">
+            <span>Back</span>
+            <HotkeyCombo action={HotkeyActions.HISTORY_BACK} size="xs" />
+          </span>
+        </TooltipContent>
+      </Tooltip>
+      <Tooltip>
+        <TooltipTrigger
+          render={
+            <span className="inline-flex">
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                aria-label="Forward"
+                disabled={!canGoForward}
+                className={!canGoForward ? 'pointer-events-none' : undefined}
+                onClick={() => {
+                  goForward(tabId);
+                }}
+              >
+                <IconArrowRight
+                  className={canGoForward ? 'size-4' : 'size-4 opacity-50'}
+                />
+              </Button>
+            </span>
+          }
+        />
+        <TooltipContent>
+          <span className="flex items-center gap-1.5">
+            <span>Forward</span>
+            <HotkeyCombo action={HotkeyActions.HISTORY_FORWARD} size="xs" />
+          </span>
+        </TooltipContent>
+      </Tooltip>
       {isLoading ? (
         <Button
           variant="ghost"
           size="icon-sm"
+          aria-label="Stop loading"
           onClick={() => {
             stop(tabId);
           }}
@@ -56,15 +100,26 @@ export function NavButtons({ tabId, tab }: NavButtonsProps) {
           <IconMediaStopFill18 className="size-3.5" />
         </Button>
       ) : (
-        <Button
-          variant="ghost"
-          size="icon-sm"
-          onClick={() => {
-            reload(tabId);
-          }}
-        >
-          <IconArrowRotateAnticlockwise className="size-4" />
-        </Button>
+        <Tooltip>
+          <TooltipTrigger>
+            <Button
+              variant="ghost"
+              size="icon-sm"
+              aria-label="Reload"
+              onClick={() => {
+                reload(tabId);
+              }}
+            >
+              <IconArrowRotateAnticlockwise className="size-4" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>
+            <span className="flex items-center gap-1.5">
+              <span>Reload</span>
+              <HotkeyCombo action={HotkeyActions.RELOAD} size="xs" />
+            </span>
+          </TooltipContent>
+        </Tooltip>
       )}
     </div>
   );

--- a/apps/browser/src/ui/screens/main/content/index.tsx
+++ b/apps/browser/src/ui/screens/main/content/index.tsx
@@ -34,6 +34,7 @@ import {
   type SortableTabItem,
 } from '@stagewise/stage-ui/components/sortable-tabs';
 import { Button } from '@stagewise/stage-ui/components/button';
+import { HotkeyCombo } from '@ui/components/hotkey-combo';
 import {
   Tooltip,
   TooltipContent,
@@ -46,6 +47,7 @@ import {
 } from 'nucleo-ui-outline-18';
 import { GlobePlusIcon } from '../_components/globe-plus-icon';
 import type { KartonContract, TabState } from '@shared/karton-contracts/ui';
+import { HotkeyActions } from '@shared/hotkeys';
 
 // ---------------------------------------------------------------------------
 // Local sub-component: audio mute toggle shown as an `actions` slot on tabs
@@ -426,6 +428,9 @@ export function MainSection({
             void closeTab(id);
             removeTabUiState(id);
           },
+          closeShortcut: (
+            <HotkeyCombo action={HotkeyActions.CLOSE_TAB} size="xs" />
+          ),
           onAuxClick: (e: React.MouseEvent) => {
             if (e.button !== 1) return;
             e.preventDefault();
@@ -647,7 +652,12 @@ export function MainSection({
                 <GlobePlusIcon className="size-4" />
               </Button>
             </TooltipTrigger>
-            <TooltipContent>Open browsing tab</TooltipContent>
+            <TooltipContent>
+              <span className="flex items-center gap-1.5">
+                <span>Open browsing tab</span>
+                <HotkeyCombo action={HotkeyActions.NEW_TAB} size="xs" />
+              </span>
+            </TooltipContent>
           </Tooltip>
         </div>
         {/* Content area with per-tab UI */}

--- a/apps/browser/src/ui/screens/main/index.tsx
+++ b/apps/browser/src/ui/screens/main/index.tsx
@@ -12,6 +12,7 @@ import { Sidebar } from './sidebar';
 import { useKartonState, useKartonProcedure } from '@ui/hooks/use-karton';
 import { OpenAgentProvider, useOpenAgent } from '@ui/hooks/use-open-chat';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { HotkeyActions } from '@shared/hotkeys';
 import { Button } from '@stagewise/stage-ui/components/button';
 import {
   Tooltip,
@@ -19,6 +20,7 @@ import {
   TooltipContent,
 } from '@stagewise/stage-ui/components/tooltip';
 import { GlobePlusIcon } from './_components/globe-plus-icon';
+import { HotkeyCombo } from '@ui/components/hotkey-combo';
 import { ChatDraftProvider } from '@ui/hooks/use-chat-draft';
 import { PendingRemovalsProvider } from '@ui/hooks/use-pending-agent-removals';
 import { useAutoSelectFirstAgent } from '@ui/hooks/use-auto-select-agent';
@@ -207,7 +209,12 @@ function DefaultLayoutInner({ show }: { show: boolean }) {
                       <GlobePlusIcon className="size-4" />
                     </Button>
                   </TooltipTrigger>
-                  <TooltipContent>Open browsing tab</TooltipContent>
+                  <TooltipContent>
+                    <span className="flex items-center gap-1.5">
+                      <span>Open browsing tab</span>
+                      <HotkeyCombo action={HotkeyActions.NEW_TAB} size="xs" />
+                    </span>
+                  </TooltipContent>
                 </Tooltip>
               )}
             </div>

--- a/apps/browser/src/ui/screens/main/sidebar/index.tsx
+++ b/apps/browser/src/ui/screens/main/sidebar/index.tsx
@@ -15,6 +15,7 @@ import {
   TooltipContent,
 } from '@stagewise/stage-ui/components/tooltip';
 import { SETTINGS_PAGE_URL, ACCOUNT_PAGE_URL } from '@shared/internal-urls';
+import { HotkeyActions } from '@shared/hotkeys';
 import { useTrack } from '@ui/hooks/use-track';
 import { useKartonProcedure, useKartonState } from '@ui/hooks/use-karton';
 import { useUiZoomCounterScale } from '@ui/hooks/use-ui-zoom-counter-scale';
@@ -27,6 +28,7 @@ import {
 import { NotificationBanners } from '../agent-chat/chat/_components/notification-banners';
 import { UsageWarningBadge } from '../agent-chat/chat/_components/usage-warning-badge';
 import { WorktreeCleanupBadge } from './worktree-cleanup-badge';
+import { HotkeyCombo } from '@ui/components/hotkey-combo';
 
 // Read the persisted collapsed state *once* at module eval so we can seed
 // `defaultSize` on first render. Without this the panel mounts expanded
@@ -170,7 +172,15 @@ export function Sidebar() {
                     <IconGear2Outline18 className="size-4" />
                   </Button>
                 </TooltipTrigger>
-                <TooltipContent side="top">Settings</TooltipContent>
+                <TooltipContent side="top">
+                  <span className="flex items-center gap-1.5">
+                    <span>Settings</span>
+                    <HotkeyCombo
+                      action={HotkeyActions.OPEN_SETTINGS}
+                      size="xs"
+                    />
+                  </span>
+                </TooltipContent>
               </Tooltip>
             </div>
           </div>

--- a/packages/stage-ui/src/components/button.tsx
+++ b/packages/stage-ui/src/components/button.tsx
@@ -2,7 +2,7 @@ import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '../lib/utils';
 
 export const buttonVariants = cva(
-  'app-no-drag relative box-border block flex not-disabled:cursor-pointer flex-row items-center justify-center disabled:opacity-50',
+  'app-no-drag group/button relative box-border block flex not-disabled:cursor-pointer flex-row items-center justify-center disabled:opacity-50',
   {
     variants: {
       variant: {

--- a/packages/stage-ui/src/components/select.tsx
+++ b/packages/stage-ui/src/components/select.tsx
@@ -248,6 +248,12 @@ export interface SelectProps<
    * @default true
    */
   showItemIndicator?: boolean;
+
+  /**
+   * Whether to move keyboard highlight to the first item when the popup opens.
+   * @default false
+   */
+  highlightFirstItemOnOpen?: boolean;
 }
 
 // ============================================================================
@@ -320,9 +326,58 @@ function SelectInner<Value = string | null, Multiple extends boolean = false>(
     onOpenChange,
     modal,
     showItemIndicator = true,
+    highlightFirstItemOnOpen = false,
   }: SelectProps<Value, Multiple>,
   ref: React.ForwardedRef<HTMLButtonElement>,
 ) {
+  const popupRef = React.useRef<HTMLDivElement>(null);
+  const wasOpenRef = React.useRef(open ?? defaultOpen ?? false);
+
+  const highlightFirstItem = React.useCallback(() => {
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        popupRef.current?.dispatchEvent(
+          new KeyboardEvent('keydown', {
+            key: 'ArrowDown',
+            code: 'ArrowDown',
+            bubbles: true,
+            cancelable: true,
+          }),
+        );
+      });
+    });
+  }, []);
+
+  const handleOpenChange = React.useCallback(
+    (
+      nextOpen: boolean,
+      event: {
+        event: Event | React.SyntheticEvent | undefined;
+        reason: string;
+      },
+    ) => {
+      const wasOpen = wasOpenRef.current;
+      wasOpenRef.current = nextOpen;
+      onOpenChange?.(nextOpen, event);
+
+      if (highlightFirstItemOnOpen && nextOpen && !wasOpen) {
+        highlightFirstItem();
+      }
+    },
+    [highlightFirstItem, highlightFirstItemOnOpen, onOpenChange],
+  );
+
+  React.useEffect(() => {
+    if (open === undefined) return;
+
+    const wasOpen = wasOpenRef.current;
+    wasOpenRef.current = open;
+
+    if (highlightFirstItemOnOpen && open && !wasOpen) {
+      highlightFirstItem();
+    }
+  }, [highlightFirstItem, highlightFirstItemOnOpen, open]);
+
   // Filter out separators to get actual items
   const actualItems = React.useMemo(
     () => items.filter((item): item is SelectItem<Value> => !isSeparator(item)),
@@ -456,7 +511,7 @@ function SelectInner<Value = string | null, Multiple extends boolean = false>(
       name={name}
       open={open}
       defaultOpen={defaultOpen}
-      onOpenChange={onOpenChange as any}
+      onOpenChange={handleOpenChange as any}
       modal={modal}
       items={convertedItems as any}
     >
@@ -521,6 +576,7 @@ function SelectInner<Value = string | null, Multiple extends boolean = false>(
           className="z-50"
         >
           <SelectBase.Popup
+            ref={popupRef}
             className={cn(
               'flex origin-(--transform-origin) flex-col items-stretch gap-0.5',
               'rounded-lg border border-derived bg-background p-1 shadow-lg',

--- a/packages/stage-ui/src/components/shortcut-key.tsx
+++ b/packages/stage-ui/src/components/shortcut-key.tsx
@@ -17,19 +17,21 @@ const KEY_LABELS: Record<string, string> = {
   escape: 'Esc',
   return: '↵',
   shift: '⇧',
+  slash: '/',
   tab: '⇥',
 };
 
 const shortcutKeyVariants = cva(
-  'inline-flex items-center justify-center rounded border font-medium font-mono leading-none',
+  'inline-flex items-center justify-center rounded border font-medium font-mono text-current leading-none',
   {
     variants: {
       variant: {
-        chrome: 'border-foreground/10 bg-foreground/5 text-muted-foreground',
-        default: 'border-border-subtle bg-surface-2 text-muted-foreground',
-        subtle:
-          'border-border-subtle/70 bg-background/70 text-subtle-foreground',
-        surface: 'border-border-subtle bg-surface-1 text-muted-foreground',
+        chrome: 'border-transparent bg-foreground/5 text-muted-foreground',
+        default: 'border-derived bg-active-derived',
+        subtle: 'border-derived bg-active-derived opacity-80',
+        surface: 'border-derived-strong bg-active-derived',
+        solid:
+          'border-transparent bg-shortcut-solid-derived group-hover/button:bg-shortcut-solid-hover-derived group-focus-visible/button:bg-shortcut-solid-hover-derived group-active/button:bg-shortcut-solid-active-derived',
       },
       size: {
         xs: 'h-4 min-w-4 px-1 text-[10px]',

--- a/packages/stage-ui/src/components/sortable-tabs.tsx
+++ b/packages/stage-ui/src/components/sortable-tabs.tsx
@@ -75,6 +75,7 @@ import {
 } from 'react';
 import { XIcon } from 'lucide-react';
 import { cn } from '../lib/utils';
+import { Tooltip, TooltipContent, TooltipTrigger } from './tooltip';
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -103,6 +104,11 @@ export interface SortableTabItem {
    * Only rendered in the `"bar"` variant when provided.
    */
   onClose?: () => void;
+  /**
+   * Optional shortcut hint rendered in the close button tooltip.
+   * Bar variant only.
+   */
+  closeShortcut?: ReactNode;
   /**
    * Middle-click (auxclick) handler on the outer tab wrapper.
    * Bar variant only. Safe to combine with dnd-kit — the PointerSensor
@@ -184,6 +190,20 @@ function BarTriggerContent({
   isActive?: boolean;
 }) {
   const showClose = item.closeable !== false && !!item.onClose;
+  const closeButton = item.onClose ? (
+    <button
+      type="button"
+      aria-label="Close tab"
+      // Prevent dnd-kit's PointerSensor from activating on the close btn
+      onPointerDown={(e) => e.stopPropagation()}
+      onClick={item.onClose}
+      className={cn(
+        'absolute top-1/2 right-0.5 flex shrink-0 -translate-y-1/2 items-center justify-center p-1 text-muted-foreground opacity-0 transition-colors hover:text-foreground focus-visible:opacity-100 group-focus-within:opacity-100 group-hover:opacity-100',
+      )}
+    >
+      <XIcon className="size-3" />
+    </button>
+  ) : null;
 
   const el = (
     <div
@@ -219,19 +239,16 @@ function BarTriggerContent({
       {item.actions}
 
       {/* Close button — absolute overlay on the right, fades in on hover/active */}
-      {showClose && (
-        <button
-          type="button"
-          aria-label="Close tab"
-          // Prevent dnd-kit's PointerSensor from activating on the close btn
-          onPointerDown={(e) => e.stopPropagation()}
-          onClick={item.onClose}
-          className={cn(
-            'absolute top-1/2 right-0.5 flex shrink-0 -translate-y-1/2 items-center justify-center p-1 text-muted-foreground opacity-0 transition-colors hover:text-foreground group-hover:opacity-100',
-          )}
-        >
-          <XIcon className="size-3" />
-        </button>
+      {showClose && closeButton && (
+        <Tooltip>
+          <TooltipTrigger>{closeButton}</TooltipTrigger>
+          <TooltipContent>
+            <span className="flex items-center gap-1.5">
+              <span>Close tab</span>
+              {item.closeShortcut}
+            </span>
+          </TooltipContent>
+        </Tooltip>
       )}
     </div>
   );

--- a/packages/stage-ui/src/styles/derived-utilities.css
+++ b/packages/stage-ui/src/styles/derived-utilities.css
@@ -32,6 +32,13 @@
   --active-derived-l: -0.05;
   --active-derived-c: -0.005;
 
+  --shortcut-solid-derived-l: 0.06;
+  --shortcut-solid-derived-c: 0.011;
+  --shortcut-solid-hover-derived-l: 0.03;
+  --shortcut-solid-hover-derived-c: 0.008;
+  --shortcut-solid-active-derived-l: 0.01;
+  --shortcut-solid-active-derived-c: 0.006;
+
   --border-derived-subtle-l: -0.020;
   --border-derived-subtle-c: -0.003;
 
@@ -55,6 +62,13 @@
 
     --active-derived-l: 0.07;
     --active-derived-c: 0.001;
+
+    --shortcut-solid-derived-l: -0.06;
+    --shortcut-solid-derived-c: -0.011;
+    --shortcut-solid-hover-derived-l: -0.03;
+    --shortcut-solid-hover-derived-c: -0.008;
+    --shortcut-solid-active-derived-l: 0.01;
+    --shortcut-solid-active-derived-c: -0.006;
 
     --border-derived-subtle-l: 0.07;
     --border-derived-subtle-c: 0.012;
@@ -151,3 +165,17 @@
 @utility bg-derived-darker {
   background-color: oklch(from var(--cm-bg-color, var(--color-border-subtle)) calc(l - 0.09) calc(c - 0.014) h);
 }
+
+/* stylelint-disable scss/at-rule-no-unknown -- Tailwind CSS v4 @utility directives. */
+@utility bg-shortcut-solid-derived {
+  background-color: oklch(from var(--cm-bg-color, var(--color-border-subtle)) calc(l + var(--shortcut-solid-derived-l)) calc(c + var(--shortcut-solid-derived-c)) h);
+}
+
+@utility bg-shortcut-solid-hover-derived {
+  background-color: oklch(from var(--cm-bg-color, var(--color-border-subtle)) calc(l + var(--shortcut-solid-hover-derived-l)) calc(c + var(--shortcut-solid-hover-derived-c)) h);
+}
+
+@utility bg-shortcut-solid-active-derived {
+  background-color: oklch(from var(--cm-bg-color, var(--color-border-subtle)) calc(l + var(--shortcut-solid-active-derived-l)) calc(c + var(--shortcut-solid-active-derived-c)) h);
+}
+/* stylelint-enable scss/at-rule-no-unknown */


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds more global hotkeys and consistent shortcut hints across the app, plus smarter chat paging and editing. Aligns shortcut chip styling in `@stagewise/stage-ui`.

- **New Features**
  - Global hotkeys: Settings (Mod+,), Model select (Mod+/), Workspace select (Mod+O), Implement plan (Mod+Enter), Stop agent (Ctrl+C), Edit nearest user message (Ctrl+Shift+E / Cmd+Shift+I), DevTools (F12).
  - Chat navigation: PageUp/PageDown or Ctrl+U/Ctrl+D page-scrolls chat; in the input it scrolls the input if possible, else the chat.
  - Slash commands: Shift+Tab cycles the leading slash between Plan, Preview, Debug, Learn.
  - Pickers: Model/Workspace open via hotkeys and auto-focus search; workspace list supports Arrow keys or Ctrl+N/Ctrl+P; `Select` adds `highlightFirstItemOnOpen`.
  - Shortcut hints: Chips added across UI (sidebar/content toggles, Settings, nav back/forward/reload, zoom, search prev/next/close, downloads, DevTools, new tab, close tab, model/workspace selects, Implement plan, Stop agent); new “solid” shortcut style in `@stagewise/stage-ui`.
  - Safer Stop + shell stdin chips: Ctrl+C respects native copy when text is selected and only early-aborts when input is empty; Execute Shell Command shows control sequences as shortcut chips.

<sup>Written for commit 42ef40bebc8f9f198641b9b5277474be80b1b566. Summary will update on new commits. <a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1169?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Global and component hotkeys for settings, workspace/model switching, edit-nearest-message, implement/stop agent, tab controls, and close-tab hint.
  * Chat-history page-wise scrolling and keyboard-driven “edit nearest message”.
  * Shift+Tab cycling for slash commands.

* **Improvements**
  * Keyboard shortcut hints rendered consistently inline in tooltips and controls.
  * Tokenized stdin rendering with shortcut visuals.
  * Optional select behavior to highlight first item on open.
  * Escape/stop behavior refined to preserve native copy and abort logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stagewise-io/stagewise/pull/1169?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->