### PR TITLE
feat(stagewise): add social-signins to login options

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,12 @@ POSTHOG_CLI_HOST=https://eu.posthog.com
 # ===============================
 API_URL=https://api.stagewise.io
 
+# OAuth callback scheme for the Electron auth handoff is derived from RELEASE_CHANNEL:
+# - release: stagewise://
+# - prerelease: stagewise-prerelease://
+# - dev: stagewise-dev://
+# Google/GitHub OAuth callbacks still point to the API auth callback URLs.
+
 # Link to the standard stagewise LLM proxy service
 LLM_PROXY_URL=https://api.stagewise.io/v1/ai
 

--- a/apps/browser/src/backend/index.ts
+++ b/apps/browser/src/backend/index.ts
@@ -4,6 +4,7 @@ unhandled();
 import { app, protocol } from 'electron';
 import started from 'electron-squirrel-startup';
 import path from 'node:path';
+import { installStartupOpenUrlListener } from './startup-url-events';
 
 // CRITICAL: `main` is imported dynamically (below in the 'ready' handler)
 // instead of statically. On Windows machines without the VC++ redistributable
@@ -50,6 +51,7 @@ if (process.platform === 'win32') {
   app.setAppUserModelId(`com.squirrel.${appBaseName}.${appBaseName}`);
 }
 app.applicationMenu = null;
+installStartupOpenUrlListener();
 
 // Set the right path structure for the app
 // We keep userData where it is, but we will put session data into a sub-folder called "session"

--- a/apps/browser/src/backend/main.ts
+++ b/apps/browser/src/backend/main.ts
@@ -53,6 +53,8 @@ import type { SkillDefinition } from '@shared/skills';
 import { AssetCacheService } from './services/asset-cache';
 import { ProcessedImageCacheService } from './services/processed-image-cache';
 import { detectShell, resolveShellEnv } from './utils/shell-env';
+import { AUTH_CALLBACK_PROTOCOL } from './services/auth/callback-scheme';
+import { registerStartupUrlHandler } from './startup-url-events';
 
 export type MainParameters = {
   launchOptions: {
@@ -161,7 +163,7 @@ export async function main({ launchOptions: { verbose } }: MainParameters) {
   preferencesService.connectKarton(uiKarton, pagesService);
 
   // Create OmniboxSuggestionsService for omnibox autocomplete
-  const _omniboxSuggestionsService = await OmniboxSuggestionsService.create(
+  await OmniboxSuggestionsService.create(
     logger,
     uiKarton,
     historyService,
@@ -171,7 +173,10 @@ export async function main({ launchOptions: { verbose } }: MainParameters) {
   );
 
   // Set up URL handlers
-  setupUrlHandlers(windowLayoutService, logger);
+  const registerAuthCallbackHandler = setupUrlHandlers(
+    windowLayoutService,
+    logger,
+  );
 
   const notificationService = await NotificationService.create(
     logger,
@@ -349,11 +354,7 @@ export async function main({ launchOptions: { verbose } }: MainParameters) {
   const filePickerService = await FilePickerService.create(logger, uiKarton);
 
   // DevToolAPIService handles devtools-related functionality and state
-  const _devToolAPIService = await DevToolAPIService.create(
-    logger,
-    uiKarton,
-    windowLayoutService,
-  );
+  await DevToolAPIService.create(logger, uiKarton, windowLayoutService);
 
   // URIHandlerService registers the app as the default protocol client for stagewise://
   // URL handling is done in main.ts via setupUrlHandlers() and handleCommandLineUrls()
@@ -365,6 +366,7 @@ export async function main({ launchOptions: { verbose } }: MainParameters) {
     notificationService,
     logger,
   );
+  registerAuthCallbackHandler((url) => authService.handleAuthCallbackUrl(url));
 
   const credentialsService = await CredentialsService.create(logger);
 
@@ -452,11 +454,7 @@ export async function main({ launchOptions: { verbose } }: MainParameters) {
       );
   });
 
-  const _appMenuService = new AppMenuService(
-    logger,
-    authService,
-    windowLayoutService,
-  );
+  new AppMenuService(logger, authService, windowLayoutService);
 
   const modelProviderService = new ModelProviderService(
     telemetryService,
@@ -557,7 +555,9 @@ export async function main({ launchOptions: { verbose } }: MainParameters) {
   logger.debug('[Main] Startup complete');
 
   // Handle command line arguments for URLs on initial startup
-  handleCommandLineUrls(process.argv, windowLayoutService, logger);
+  handleCommandLineUrls(process.argv, windowLayoutService, logger, (url) =>
+    authService.handleAuthCallbackUrl(url),
+  );
 
   // Set up graceful shutdown to clean up database connections
   let isShuttingDown = false;
@@ -643,16 +643,28 @@ export async function main({ launchOptions: { verbose } }: MainParameters) {
 }
 
 /**
+ * Checks if a URL points at a stable internal app page.
+ */
+function isInternalAppUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === 'stagewise:' && parsed.host === 'internal';
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Checks if a string is a valid URL that the browser can open
  */
 function isOpenableUrl(url: string): boolean {
   try {
     const parsed = new URL(url);
-    return (
-      parsed.protocol === 'http:' ||
-      parsed.protocol === 'https:' ||
-      parsed.protocol === 'stagewise:'
-    );
+    if (isInternalAppUrl(url)) return true;
+    if (parsed.protocol === AUTH_CALLBACK_PROTOCOL) {
+      return isAuthCallbackUrl(url);
+    }
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:';
   } catch {
     return false;
   }
@@ -678,12 +690,79 @@ function extractUrlsFromArgs(argv: string[]): string[] {
 /**
  * Opens a URL in a new browser tab (handles both http/https and stagewise:// URLs)
  */
+function isAuthCallbackUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol !== AUTH_CALLBACK_PROTOCOL) return false;
+    const fragmentParams = new URLSearchParams(parsed.hash.slice(1));
+    return (
+      parsed.host === 'auth' ||
+      parsed.pathname.includes('auth') ||
+      parsed.searchParams.has('code') ||
+      parsed.searchParams.has('token') ||
+      parsed.searchParams.has('error') ||
+      fragmentParams.has('code') ||
+      fragmentParams.has('token') ||
+      fragmentParams.has('error')
+    );
+  } catch {
+    return false;
+  }
+}
+
+type AuthCallbackHandler = (url: string) => boolean | Promise<boolean>;
+const MAX_QUEUED_AUTH_CALLBACK_URLS = 5;
+
+function describeIncomingUrl(url: string): string {
+  try {
+    const parsed = new URL(url);
+    if (isAuthCallbackUrl(url)) return 'auth callback';
+    return `${parsed.protocol}//${parsed.host || '(no-host)'}`;
+  } catch {
+    return 'unparseable URL';
+  }
+}
+
+function handleAuthCallbackUrl(
+  url: string,
+  logger: Logger,
+  authCallbackHandler: AuthCallbackHandler,
+): void {
+  void Promise.resolve(authCallbackHandler(url)).catch((error) => {
+    logger.error(`[Main] Auth callback handling failed: ${String(error)}`);
+  });
+}
+
 function openIncomingUrl(
   url: string,
   windowLayoutService: WindowLayoutService,
   logger: Logger,
+  authCallbackHandler: AuthCallbackHandler | null,
+  queueAuthCallbackUrl?: (url: string) => void,
 ): void {
-  logger.debug(`[Main] Opening incoming URL: ${url}`);
+  if (isAuthCallbackUrl(url)) {
+    logger.debug('[Main] Received auth callback URL');
+    if (authCallbackHandler) {
+      handleAuthCallbackUrl(url, logger, authCallbackHandler);
+    } else {
+      queueAuthCallbackUrl?.(url);
+    }
+    return;
+  }
+  try {
+    if (
+      new URL(url).protocol === AUTH_CALLBACK_PROTOCOL &&
+      !isInternalAppUrl(url)
+    ) {
+      logger.warn(
+        `[Main] Ignoring malformed auth callback URL: ${describeIncomingUrl(url)}`,
+      );
+      return;
+    }
+  } catch {
+    return;
+  }
+  logger.debug(`[Main] Opening incoming URL: ${describeIncomingUrl(url)}`);
   void windowLayoutService.openUrlInNewTab(url);
 }
 
@@ -693,25 +772,55 @@ function openIncomingUrl(
 function setupUrlHandlers(
   windowLayoutService: WindowLayoutService,
   logger: Logger,
-): void {
-  // Handle 'open-url' event (macOS) - for both http/https and stagewise:// URLs
-  app.on('open-url', (ev: Electron.Event, url: string) => {
-    ev.preventDefault();
-    logger.debug(`[Main] open-url event received: ${url}`);
+): (handler: AuthCallbackHandler) => void {
+  let authCallbackHandler: AuthCallbackHandler | null = null;
+  const pendingAuthCallbackUrls: string[] = [];
+  const queueAuthCallbackUrl = (url: string) => {
+    if (pendingAuthCallbackUrls.length >= MAX_QUEUED_AUTH_CALLBACK_URLS) {
+      pendingAuthCallbackUrls.shift();
+    }
+    pendingAuthCallbackUrls.push(url);
+    logger.debug('[Main] Queued auth callback URL until handler is ready');
+  };
+
+  registerStartupUrlHandler((url) => {
+    logger.debug(`[Main] open-url event received: ${describeIncomingUrl(url)}`);
     if (isOpenableUrl(url)) {
-      openIncomingUrl(url, windowLayoutService, logger);
+      openIncomingUrl(
+        url,
+        windowLayoutService,
+        logger,
+        authCallbackHandler,
+        queueAuthCallbackUrl,
+      );
     }
   });
 
   // Handle 'second-instance' event (when app is already running)
   // This fires when user opens another URL while the app is running
   app.on('second-instance', (_ev: Electron.Event, argv: string[]) => {
-    logger.debug(`[Main] second-instance event received with argv: ${argv}`);
+    logger.debug(
+      `[Main] second-instance event received with ${argv.length} arguments`,
+    );
     const urls = extractUrlsFromArgs(argv);
     for (const url of urls) {
-      openIncomingUrl(url, windowLayoutService, logger);
+      openIncomingUrl(
+        url,
+        windowLayoutService,
+        logger,
+        authCallbackHandler,
+        queueAuthCallbackUrl,
+      );
     }
   });
+
+  return (handler: AuthCallbackHandler) => {
+    authCallbackHandler = handler;
+    const urls = pendingAuthCallbackUrls.splice(0);
+    for (const url of urls) {
+      handleAuthCallbackUrl(url, logger, handler);
+    }
+  };
 }
 
 /**
@@ -721,17 +830,29 @@ function handleCommandLineUrls(
   argv: string[],
   windowLayoutService: WindowLayoutService,
   logger: Logger,
+  authCallbackHandler: AuthCallbackHandler | null,
 ): void {
-  // Skip the first two args (node executable and script path)
-  const urls = extractUrlsFromArgs(argv.slice(2));
+  // Packaged protocol launches may pass the callback as the second argument
+  // without a script path. Scan all args and let URL filtering ignore argv[0]
+  // and non-URL flags.
+  const urls = extractUrlsFromArgs(argv);
   if (urls.length > 0) {
-    logger.debug(`[Main] Found URLs in command line arguments: ${urls}`);
+    logger.debug(
+      `[Main] Found ${urls.length} URLs in command line arguments: ${urls
+        .map(describeIncomingUrl)
+        .join(', ')}`,
+    );
     // Open the first URL immediately, others will be queued
-    openIncomingUrl(urls[0], windowLayoutService, logger);
+    openIncomingUrl(urls[0], windowLayoutService, logger, authCallbackHandler);
     // Open remaining URLs after a short delay to ensure the first one is processed
     for (let i = 1; i < urls.length; i++) {
       setTimeout(() => {
-        openIncomingUrl(urls[i], windowLayoutService, logger);
+        openIncomingUrl(
+          urls[i],
+          windowLayoutService,
+          logger,
+          authCallbackHandler,
+        );
       }, i * 100);
     }
   }

--- a/apps/browser/src/backend/services/asset-cache/index.ts
+++ b/apps/browser/src/backend/services/asset-cache/index.ts
@@ -13,7 +13,7 @@ import { DisposableService } from '../disposable';
 import type { Logger } from '../logger';
 
 const API_URL =
-  (process.env.API_URL as string | undefined) ?? 'https://v1.api.stagewise.io';
+  (process.env.API_URL as string | undefined) ?? 'https://api.stagewise.io';
 
 /**
  * Allowed MIME types for upload — mirrors the server-side ALLOWED_MEDIA_TYPES
@@ -135,9 +135,6 @@ export class AssetCacheService extends DisposableService {
 
     const buffer = await fs.readFile(filePath);
     const hash = createHash('sha256').update(buffer).digest('hex');
-    this.logger.warn(
-      `[AssetCacheService] resolve() — file: ${filePath}, mediaType: ${mediaType}, hash: ${hash.slice(0, 12)}…`,
-    );
 
     // Check cache — require at least EXPIRY_SAFETY_MARGIN_S seconds left.
     const minExpiresAt = Math.floor(Date.now() / 1000) + EXPIRY_SAFETY_MARGIN_S;
@@ -146,36 +143,33 @@ export class AssetCacheService extends DisposableService {
       .from(assetCache)
       .where(eq(assetCache.fileHash, hash))
       .get();
-    this.logger.warn(
-      `[AssetCacheService] Cache lookup — found: ${!!cached}, expiresAt: ${cached?.expiresAt ?? 'n/a'}, minExpiresAt: ${minExpiresAt}`,
-    );
 
     // Fire-and-forget background sweep (throttled to once per minute).
     this.sweepExpired();
 
     if (cached && cached.expiresAt > minExpiresAt) {
-      this.logger.warn(
-        `[AssetCacheService] Cache hit → returning url: ${cached.readUrl.slice(0, 80)}…`,
-      );
+      this.logger.debug('[AssetCacheService] Cache hit');
       return { type: 'url', url: cached.readUrl };
     }
 
     // No valid cache entry — attempt upload.
     const token = this.getAccessToken();
     if (!token) {
-      this.logger.warn('[AssetCacheService] No access token — buffer fallback');
+      this.logger.debug(
+        '[AssetCacheService] No access token — buffer fallback',
+      );
       return { type: 'buffer', buffer };
     }
 
     if (!ALLOWED_MEDIA_TYPES.has(mediaType)) {
-      this.logger.warn(
+      this.logger.debug(
         `[AssetCacheService] Unsupported mediaType: ${mediaType} — buffer fallback`,
       );
       return { type: 'buffer', buffer };
     }
 
-    this.logger.warn(
-      `[AssetCacheService] Uploading ${filename} (${mediaType}, ${buffer.length} bytes)…`,
+    this.logger.debug(
+      `[AssetCacheService] Uploading attachment (${mediaType}, ${buffer.length} bytes)…`,
     );
 
     try {
@@ -190,12 +184,8 @@ export class AssetCacheService extends DisposableService {
         >[0]['mediaType'],
         contentLength: buffer.length,
       });
-      this.logger.warn(
-        `[AssetCacheService] Upload API response — error: ${JSON.stringify(error)}, uploadUrl: ${data?.uploadUrl?.slice(0, 80) ?? 'n/a'}`,
-      );
-
       if (error || !data) {
-        this.logger.warn(
+        this.logger.debug(
           `[AssetCacheService] Upload API failed — buffer fallback`,
         );
         return { type: 'buffer', buffer };
@@ -217,9 +207,6 @@ export class AssetCacheService extends DisposableService {
       ) as ArrayBuffer;
       formData.append('file', new Blob([arrayBuffer], { type: mediaType }));
 
-      this.logger.warn(
-        `[AssetCacheService] S3 POST → ${data.uploadUrl.slice(0, 80)}… fields: ${Object.keys(data.uploadFields).join(', ')}`,
-      );
       const postResponse = await fetch(data.uploadUrl, {
         method: 'POST',
         body: formData,
@@ -227,24 +214,19 @@ export class AssetCacheService extends DisposableService {
       const postBody = !postResponse.ok
         ? await postResponse.text().catch(() => '(unreadable)')
         : null;
-      this.logger.warn(
-        `[AssetCacheService] S3 POST response: ${postResponse.status} ${postResponse.statusText}${postBody ? ` — ${postBody.slice(0, 300)}` : ''}`,
-      );
+      if (!postResponse.ok) {
+        this.logger.debug(
+          `[AssetCacheService] S3 POST failed with ${postResponse.status} ${postResponse.statusText}${postBody ? ` (body length: ${postBody.length})` : ''}`,
+        );
+      }
 
       if (!postResponse.ok) {
-        this.logger.warn(
-          '[AssetCacheService] S3 POST failed — buffer fallback',
-        );
         return { type: 'buffer', buffer };
       }
 
       // Fixed 22-hour TTL — the read URL is valid for 24 hours on the server,
       // so this gives a comfortable 2-hour safety buffer.
       const expiresAt = Math.floor(Date.now() / 1000) + 22 * 60 * 60;
-      this.logger.warn(
-        `[AssetCacheService] S3 upload OK — readUrl: ${data.readUrl.slice(0, 80)}… expiresAt: ${expiresAt}`,
-      );
-
       // UPSERT in case the same hash was uploaded concurrently.
       await this.db
         .insert(assetCache)
@@ -254,10 +236,10 @@ export class AssetCacheService extends DisposableService {
           set: { readUrl: data.readUrl, expiresAt },
         });
 
-      this.logger.warn('[AssetCacheService] Cache written — returning url');
+      this.logger.debug('[AssetCacheService] Cache written — returning url');
       return { type: 'url', url: data.readUrl };
     } catch (err) {
-      this.logger.warn(
+      this.logger.debug(
         `[AssetCacheService] Upload pipeline threw — buffer fallback`,
         err,
       );

--- a/apps/browser/src/backend/services/auth/callback-scheme.ts
+++ b/apps/browser/src/backend/services/auth/callback-scheme.ts
@@ -1,0 +1,23 @@
+type AuthCallbackScheme =
+  | 'stagewise'
+  | 'stagewise-prerelease'
+  | 'stagewise-dev';
+
+function getDefaultAuthCallbackScheme(): AuthCallbackScheme {
+  switch (__APP_RELEASE_CHANNEL__) {
+    case 'release':
+      return 'stagewise';
+    case 'prerelease':
+      return 'stagewise-prerelease';
+    case 'dev':
+      return 'stagewise-dev';
+    default:
+      throw new Error(
+        `Unexpected app release channel for auth callback scheme: ${String(__APP_RELEASE_CHANNEL__)}`,
+      );
+  }
+}
+
+export const AUTH_CALLBACK_SCHEME = getDefaultAuthCallbackScheme();
+
+export const AUTH_CALLBACK_PROTOCOL = `${AUTH_CALLBACK_SCHEME}:`;

--- a/apps/browser/src/backend/services/auth/dev-loopback-auth.ts
+++ b/apps/browser/src/backend/services/auth/dev-loopback-auth.ts
@@ -1,0 +1,198 @@
+import { createServer, type IncomingMessage, type Server } from 'node:http';
+import { randomBytes } from 'node:crypto';
+import { app } from 'electron';
+import { AUTH_CALLBACK_SCHEME } from './callback-scheme';
+
+const LOOPBACK_HOST = '127.0.0.1';
+const CALLBACK_PATH = '/auth/callback';
+const SERVER_TIMEOUT_MS = 5 * 60 * 1000;
+const MAX_POST_BODY_BYTES = 4096;
+
+function createLoopbackState(): string {
+  return randomBytes(16).toString('base64url');
+}
+
+export type DevLoopbackAuthServer = {
+  callbackUrl: string;
+  dispose: () => Promise<void>;
+};
+
+function closeServer(server: Server): Promise<void> {
+  return new Promise((resolve) => {
+    server.close(() => resolve());
+  });
+}
+
+function readRequestBody(req: IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let body = '';
+    req.setEncoding('utf8');
+    req.on('data', (chunk: string) => {
+      body += chunk;
+      if (body.length > MAX_POST_BODY_BYTES) {
+        reject(new Error('Request body too large'));
+        req.destroy();
+      }
+    });
+    req.on('end', () => resolve(body));
+    req.on('error', reject);
+  });
+}
+
+// OAuth handoff tokens use URL fragments so they are not exposed in ordinary
+// query-string logs. Fragments are browser-only and never reach the loopback
+// HTTP server, so this page reads the fragment client-side and POSTs it back.
+function fragmentRelayPage(): string {
+  return `<!doctype html>
+<html>
+  <head><meta charset="utf-8"><title>Completing authentication</title></head>
+  <body>
+    <p>Completing authentication…</p>
+    <script>
+      (async () => {
+        try {
+          const params = new URLSearchParams(window.location.hash.slice(1));
+          const response = await fetch('/auth/callback', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              state: new URLSearchParams(window.location.search).get('state'),
+              token: params.get('token'),
+              error: params.get('error_description') || params.get('error'),
+            }),
+          });
+          if (!response.ok) {
+            const text = await response.text();
+            document.body.textContent = text
+              ? 'Failed to complete authentication: ' + response.status + ' ' + text
+              : 'Failed to complete authentication: HTTP ' + response.status;
+            return;
+          }
+          document.body.textContent = 'Authentication complete. You can close this window.';
+          window.close();
+        } catch {
+          document.body.textContent = 'Failed to contact the local authentication server.';
+        }
+      })();
+    </script>
+  </body>
+</html>`;
+}
+
+export async function createDevLoopbackAuthServer(
+  onCallback: (url: string) => Promise<boolean>,
+): Promise<DevLoopbackAuthServer | null> {
+  if (app.isPackaged) return null;
+
+  const loopbackState = createLoopbackState();
+  let timeout: NodeJS.Timeout | null = null;
+  let disposed = false;
+
+  const server = createServer((req, res) => {
+    const requestUrl = new URL(req.url ?? '/', `http://${LOOPBACK_HOST}`);
+
+    if (requestUrl.pathname !== CALLBACK_PATH) {
+      res.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' });
+      res.end('Not found');
+      return;
+    }
+
+    void (async () => {
+      if (req.method !== 'POST') {
+        if (requestUrl.searchParams.get('state') !== loopbackState) {
+          res.writeHead(400, { 'Content-Type': 'text/plain; charset=utf-8' });
+          res.end('Invalid authentication callback.');
+          return;
+        }
+        res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+        res.end(fragmentRelayPage());
+        return;
+      }
+
+      let body: unknown;
+      try {
+        body = JSON.parse(await readRequestBody(req));
+      } catch {
+        res.writeHead(400, { 'Content-Type': 'text/plain; charset=utf-8' });
+        res.end('Invalid authentication callback.');
+        return;
+      }
+
+      const payload = body as {
+        state?: unknown;
+        token?: unknown;
+        error?: unknown;
+      };
+      if (payload.state !== loopbackState) {
+        res.writeHead(400, { 'Content-Type': 'text/plain; charset=utf-8' });
+        res.end('Invalid authentication callback.');
+        return;
+      }
+
+      const token = typeof payload.token === 'string' ? payload.token : null;
+      const error = typeof payload.error === 'string' ? payload.error : null;
+      if (!token && !error) {
+        res.writeHead(400, { 'Content-Type': 'text/plain; charset=utf-8' });
+        res.end('Invalid authentication callback.');
+        return;
+      }
+
+      const callbackUrl = new URL(`${AUTH_CALLBACK_SCHEME}://auth/callback`);
+      if (token) {
+        callbackUrl.hash = `token=${encodeURIComponent(token)}`;
+      } else if (error) {
+        callbackUrl.searchParams.set('error', error);
+      }
+
+      const handled = await onCallback(callbackUrl.toString());
+
+      res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+      res.end(`<!doctype html>
+<html>
+  <head><meta charset="utf-8"><title>Authentication complete</title></head>
+  <body>
+    <p>${handled ? 'Authentication complete. You can close this window.' : 'Authentication callback was not handled.'}</p>
+    ${handled ? '<script>window.close();</script>' : ''}
+  </body>
+</html>`);
+
+      await dispose();
+    })().catch(() => {
+      res.writeHead(500, { 'Content-Type': 'text/plain; charset=utf-8' });
+      res.end('Failed to complete authentication.');
+    });
+  });
+
+  const dispose = async () => {
+    if (disposed) return;
+    disposed = true;
+    if (timeout) {
+      clearTimeout(timeout);
+      timeout = null;
+    }
+    await closeServer(server);
+  };
+
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, LOOPBACK_HOST, () => {
+      server.off('error', reject);
+      resolve();
+    });
+  });
+
+  timeout = setTimeout(() => {
+    void dispose();
+  }, SERVER_TIMEOUT_MS);
+
+  const address = server.address();
+  if (!address || typeof address === 'string') {
+    await dispose();
+    return null;
+  }
+
+  return {
+    callbackUrl: `http://${LOOPBACK_HOST}:${address.port}${CALLBACK_PATH}?state=${loopbackState}`,
+    dispose,
+  };
+}

--- a/apps/browser/src/backend/services/auth/index.ts
+++ b/apps/browser/src/backend/services/auth/index.ts
@@ -8,8 +8,15 @@ import type { Logger } from '../logger';
 import {
   AuthServerInterop,
   createBetterAuthClient,
+  openSocialAuthInSystemBrowser,
   type BetterAuthClient,
 } from './server-interop';
+import type { SocialAuthProvider } from '@shared/karton-contracts/ui/shared-types';
+import { AUTH_CALLBACK_PROTOCOL } from './callback-scheme';
+import {
+  createDevLoopbackAuthServer,
+  type DevLoopbackAuthServer,
+} from './dev-loopback-auth';
 import type { NotificationService } from '../notification';
 import type { IdentifierService } from '../identifier';
 import { DisposableService } from '../disposable';
@@ -56,6 +63,11 @@ export class AuthService extends DisposableService {
 
   private _refreshInterval: NodeJS.Timeout | null = null;
   private authChangeCallbacks: ((newAuthState: AuthState) => void)[] = [];
+  private pendingSocialAuth: {
+    resolve: (result: { error?: string }) => void;
+    timeout: NodeJS.Timeout;
+  } | null = null;
+  private activeLoopbackAuthServer: DevLoopbackAuthServer | null = null;
 
   private constructor(
     identifierService: IdentifierService,
@@ -142,6 +154,13 @@ export class AuthService extends DisposableService {
     );
 
     this.uiKarton.registerServerProcedureHandler(
+      'userAccount.signInSocial',
+      async (_callingClientId: string, provider: SocialAuthProvider) => {
+        return this.signInSocial(provider);
+      },
+    );
+
+    this.uiKarton.registerServerProcedureHandler(
       'userAccount.logout',
       async (_callingClientId: string) => {
         await this.logout();
@@ -180,13 +199,24 @@ export class AuthService extends DisposableService {
     return authService;
   }
 
-  protected onTeardown(): void {
+  protected async onTeardown(): Promise<void> {
     if (this._refreshInterval) {
       clearInterval(this._refreshInterval);
+      this._refreshInterval = null;
     }
+
+    if (this.pendingSocialAuth) {
+      clearTimeout(this.pendingSocialAuth.timeout);
+      const { resolve } = this.pendingSocialAuth;
+      this.pendingSocialAuth = null;
+      resolve({ error: 'Social sign-in was cancelled.' });
+    }
+
+    await this.disposeActiveLoopbackAuthServer();
 
     this.uiKarton.removeServerProcedureHandler('userAccount.sendOtp');
     this.uiKarton.removeServerProcedureHandler('userAccount.verifyOtp');
+    this.uiKarton.removeServerProcedureHandler('userAccount.signInSocial');
     this.uiKarton.removeServerProcedureHandler('userAccount.logout');
     this.uiKarton.removeServerProcedureHandler('userAccount.refreshStatus');
     this.uiKarton.removeServerProcedureHandler('userAccount.validateApiKeys');
@@ -274,6 +304,199 @@ export class AuthService extends DisposableService {
     } catch (err) {
       this.logger.error(`[AuthService] Unexpected error verifying OTP: ${err}`);
       return { error: 'An unexpected error occurred.' };
+    }
+  }
+
+  private completePendingSocialAuth(result: { error?: string }): void {
+    if (!this.pendingSocialAuth) return;
+    clearTimeout(this.pendingSocialAuth.timeout);
+    const { resolve } = this.pendingSocialAuth;
+    this.pendingSocialAuth = null;
+    void this.disposeActiveLoopbackAuthServer();
+    resolve(result);
+  }
+
+  private async disposeActiveLoopbackAuthServer(): Promise<void> {
+    const server = this.activeLoopbackAuthServer;
+    if (!server) return;
+    this.activeLoopbackAuthServer = null;
+    await server.dispose();
+  }
+
+  public async handleAuthCallbackUrl(url: string): Promise<boolean> {
+    let parsed: URL;
+    try {
+      parsed = new URL(url);
+    } catch {
+      return false;
+    }
+
+    let activeLoopbackCallback: URL | null = null;
+    if (this.activeLoopbackAuthServer) {
+      try {
+        activeLoopbackCallback = new URL(
+          this.activeLoopbackAuthServer.callbackUrl,
+        );
+      } catch {
+        activeLoopbackCallback = null;
+      }
+    }
+    const isLoopbackCallback =
+      !!activeLoopbackCallback &&
+      parsed.protocol === activeLoopbackCallback.protocol &&
+      parsed.host === activeLoopbackCallback.host &&
+      parsed.pathname === activeLoopbackCallback.pathname;
+
+    if (parsed.protocol !== AUTH_CALLBACK_PROTOCOL && !isLoopbackCallback) {
+      return false;
+    }
+
+    const callbackPath = parsed.hostname
+      ? `/${parsed.hostname}${parsed.pathname}`
+      : parsed.pathname;
+    const isAuthCallback =
+      callbackPath === '/auth/callback' ||
+      callbackPath.includes('/auth') ||
+      parsed.searchParams.has('error') ||
+      parsed.hash.startsWith('#token=');
+
+    if (!isAuthCallback) return false;
+    if (!this.pendingSocialAuth) return false;
+    const currentPending = this.pendingSocialAuth;
+
+    const fragmentParams = new URLSearchParams(parsed.hash.slice(1));
+    const callbackError =
+      parsed.searchParams.get('error_description') ??
+      parsed.searchParams.get('error') ??
+      fragmentParams.get('error_description') ??
+      fragmentParams.get('error');
+
+    if (callbackError) {
+      this.logger.error(
+        `[AuthService] Social sign-in failed: ${callbackError}`,
+      );
+      this.completePendingSocialAuth({ error: callbackError });
+      return true;
+    }
+
+    const token =
+      fragmentParams.get('token') ?? parsed.searchParams.get('token');
+
+    if (!token) {
+      const message = 'Social sign-in callback did not include a token.';
+      this.logger.error(`[AuthService] ${message}`);
+      this.completePendingSocialAuth({ error: message });
+      return true;
+    }
+
+    try {
+      const { data, error } = await this.authClient.authenticate({ token });
+      if (this.pendingSocialAuth !== currentPending) {
+        this.logger.debug(
+          '[AuthService] Ignoring stale social sign-in callback after authentication',
+        );
+        return true;
+      }
+      if (error || !data?.token) {
+        const message = error?.message ?? 'Social sign-in failed.';
+        this.logger.error(`[AuthService] Social sign-in failed: ${message}`);
+        if (this.pendingSocialAuth !== currentPending) {
+          this.logger.debug(
+            '[AuthService] Ignoring stale social sign-in failure after authentication',
+          );
+          return true;
+        }
+        this.completePendingSocialAuth({ error: message });
+        return true;
+      }
+
+      this.persistCredentials({
+        token: data.token,
+        user: {
+          id: data.user.id,
+          email: data.user.email ?? undefined,
+          name: data.user.name ?? undefined,
+        },
+      });
+
+      this.updateAuthState((draft) => {
+        draft.userAccount = {
+          ...draft.userAccount,
+          status: 'authenticated',
+          machineId: this.identifierService.getMachineId(),
+          user: { id: data.user.id, email: data.user.email ?? '' },
+        };
+      });
+
+      this.logger.debug('[AuthService] Completed social sign-in callback');
+      this.completePendingSocialAuth({});
+      void this.refreshSession().catch((refreshError) => {
+        this.logger.warn(
+          `[AuthService] Session refresh after social sign-in failed: ${refreshError}`,
+        );
+      });
+      return true;
+    } catch (err) {
+      this.logger.error(
+        `[AuthService] Unexpected error handling auth callback: ${err}`,
+      );
+      if (this.pendingSocialAuth !== currentPending) {
+        this.logger.debug(
+          '[AuthService] Ignoring stale social sign-in error after callback failure',
+        );
+        return true;
+      }
+      this.completePendingSocialAuth({
+        error: 'Failed to complete social sign-in.',
+      });
+      return true;
+    }
+  }
+
+  public async signInSocial(
+    provider: SocialAuthProvider,
+  ): Promise<{ error?: string }> {
+    if (this.pendingSocialAuth) {
+      return { error: 'A social sign-in flow is already in progress.' };
+    }
+
+    const completion = new Promise<{ error?: string }>((resolve) => {
+      const timeout = setTimeout(
+        () => {
+          this.pendingSocialAuth = null;
+          void this.disposeActiveLoopbackAuthServer();
+          resolve({ error: 'Social sign-in timed out.' });
+        },
+        5 * 60 * 1000,
+      );
+
+      this.pendingSocialAuth = { resolve, timeout };
+    });
+
+    try {
+      this.logger.debug(`[AuthService] Starting social sign-in: ${provider}`);
+      this.activeLoopbackAuthServer = await createDevLoopbackAuthServer(
+        (callbackUrl) => this.handleAuthCallbackUrl(callbackUrl),
+      );
+      await openSocialAuthInSystemBrowser(
+        provider,
+        this.activeLoopbackAuthServer
+          ? {
+              kind: 'loopback',
+              callbackUrl: this.activeLoopbackAuthServer.callbackUrl,
+            }
+          : undefined,
+      );
+      return await completion;
+    } catch (err) {
+      await this.disposeActiveLoopbackAuthServer();
+      this.logger.error(
+        `[AuthService] Unexpected error during social sign-in: ${err}`,
+      );
+      this.completePendingSocialAuth({
+        error: 'Failed to complete social sign-in.',
+      });
+      return await completion;
     }
   }
 

--- a/apps/browser/src/backend/services/auth/server-interop.ts
+++ b/apps/browser/src/backend/services/auth/server-interop.ts
@@ -1,22 +1,92 @@
 import { createApiClient } from '@stagewise/api-client';
+import { createHash, randomBytes } from 'node:crypto';
+import { shell } from 'electron';
 import { createAuthClient } from 'better-auth/client';
 import { emailOTPClient } from 'better-auth/client/plugins';
+import { electronClient } from '@better-auth/electron/client';
 import type { Logger } from '../logger';
+import { AUTH_CALLBACK_SCHEME } from './callback-scheme';
 import type {
   CurrentUsageResponse,
   UsageHistoryResponse,
 } from '@shared/karton-contracts/pages-api/types';
+import type { SocialAuthProvider } from '@shared/karton-contracts/ui/shared-types';
 
-export const API_URL = process.env.API_URL || 'https://v1.api.stagewise.io';
-const AUTH_URL = process.env.AUTH_URL || API_URL;
+export const API_URL = process.env.API_URL || 'https://api.stagewise.io';
+const ELECTRON_CLIENT_ID = 'electron';
+// @better-auth/electron stores Electron OAuth PKCE code verifiers in this
+// process-global map keyed by OAuth state. Our API-hosted handoff constructs
+// the same PKCE request manually, so it must seed the official store before
+// calling `authClient.authenticate({ token })`.
+const ELECTRON_AUTH_STORE = Symbol.for('better-auth:electron');
 
 type BetterAuthClientOptions = {
-  plugins: [ReturnType<typeof emailOTPClient>];
+  plugins: [
+    ReturnType<typeof emailOTPClient>,
+    ReturnType<typeof electronClient>,
+  ];
 };
 
 export type BetterAuthClient = ReturnType<
   typeof createAuthClient<BetterAuthClientOptions>
 >;
+
+export type SocialAuthRedirectTarget =
+  | { kind: 'custom-scheme'; scheme: string }
+  | { kind: 'loopback'; callbackUrl: string };
+
+function getElectronAuthStore(): Map<string, string> {
+  const globalStore = globalThis as Record<
+    symbol,
+    Map<string, string> | undefined
+  >;
+  let store = globalStore[ELECTRON_AUTH_STORE];
+  if (!store) {
+    store = new Map<string, string>();
+    globalStore[ELECTRON_AUTH_STORE] = store;
+  }
+  return store;
+}
+
+function createBase64UrlRandomString(byteLength: number): string {
+  return randomBytes(byteLength).toString('base64url');
+}
+
+export async function openSocialAuthInSystemBrowser(
+  provider: SocialAuthProvider,
+  redirectTarget: SocialAuthRedirectTarget = {
+    kind: 'custom-scheme',
+    scheme: AUTH_CALLBACK_SCHEME,
+  },
+): Promise<void> {
+  const state = createBase64UrlRandomString(16);
+  const codeVerifier = createBase64UrlRandomString(32);
+  const codeChallenge = createHash('sha256')
+    .update(codeVerifier)
+    .digest('base64url');
+
+  const authStore = getElectronAuthStore();
+  authStore.set(state, codeVerifier);
+
+  const url = new URL(`${API_URL}/v1/auth/electron/start`);
+  url.searchParams.set('provider', provider);
+  url.searchParams.set('client_id', ELECTRON_CLIENT_ID);
+  url.searchParams.set('code_challenge', codeChallenge);
+  url.searchParams.set('code_challenge_method', 'S256');
+  url.searchParams.set('state', state);
+  if (redirectTarget.kind === 'loopback') {
+    url.searchParams.set('callback_url', redirectTarget.callbackUrl);
+  } else {
+    url.searchParams.set('callback_scheme', redirectTarget.scheme);
+  }
+
+  try {
+    await shell.openExternal(url.toString(), { activate: true });
+  } catch (error) {
+    authStore.delete(state);
+    throw error;
+  }
+}
 
 /**
  * Creates a better-auth client for the Electron main process.
@@ -34,10 +104,9 @@ export function createBetterAuthClient(
   onTokenReceived: (token: string) => void,
 ): BetterAuthClient {
   return createAuthClient({
-    baseURL: AUTH_URL,
+    baseURL: API_URL,
     basePath: '/v1/auth',
     disableDefaultFetchPlugins: true,
-    plugins: [emailOTPClient()],
     fetchOptions: {
       auth: {
         type: 'Bearer',
@@ -50,6 +119,24 @@ export function createBetterAuthClient(
         }
       },
     },
+    plugins: [
+      emailOTPClient(),
+      electronClient({
+        protocol: {
+          scheme: AUTH_CALLBACK_SCHEME,
+        },
+        signInURL: `${API_URL}/v1/auth/electron/start`,
+        // Session persistence is handled by AuthService's encrypted
+        // `auth-session` store. The Electron plugin still requires a storage
+        // adapter for cookie/cache helpers, but this client uses bearer tokens
+        // and the API handoff, so those plugin-backed values are intentionally
+        // not persisted here.
+        storage: {
+          getItem: () => null,
+          setItem: () => {},
+        },
+      }),
+    ],
   });
 }
 

--- a/apps/browser/src/backend/services/pages.ts
+++ b/apps/browser/src/backend/services/pages.ts
@@ -23,6 +23,7 @@ import type {
   Patch,
   GlobalConfig,
   ModelProvider,
+  SocialAuthProvider,
 } from '@shared/karton-contracts/ui/shared-types';
 import { validateApiKeys } from '../utils/validate-api-keys';
 import { listAwsProfiles } from '../utils/aws-profiles';
@@ -99,6 +100,9 @@ export class PagesService extends DisposableService {
   private verifyOtpHandler?: (
     email: string,
     code: string,
+  ) => Promise<{ error?: string }>;
+  private signInSocialHandler?: (
+    provider: SocialAuthProvider,
   ) => Promise<{ error?: string }>;
   private logoutHandler?: () => Promise<void>;
   // Home page service dependencies
@@ -1193,6 +1197,16 @@ export class PagesService extends DisposableService {
     );
 
     this.kartonServer.registerServerProcedureHandler(
+      'signInSocial',
+      async (_callingClientId: string, provider: SocialAuthProvider) => {
+        if (!this.signInSocialHandler) {
+          return { error: 'Auth service not available' };
+        }
+        return this.signInSocialHandler(provider);
+      },
+    );
+
+    this.kartonServer.registerServerProcedureHandler(
       'logout',
       async (_callingClientId: string) => {
         if (!this.logoutHandler) {
@@ -1302,10 +1316,12 @@ export class PagesService extends DisposableService {
       turnstileToken: string,
     ) => Promise<{ error?: string }>;
     verifyOtp: (email: string, code: string) => Promise<{ error?: string }>;
+    signInSocial: (provider: SocialAuthProvider) => Promise<{ error?: string }>;
     logout: () => Promise<void>;
   }): void {
     this.sendOtpHandler = handlers.sendOtp;
     this.verifyOtpHandler = handlers.verifyOtp;
+    this.signInSocialHandler = handlers.signInSocial;
     this.logoutHandler = handlers.logout;
   }
 
@@ -1590,6 +1606,7 @@ export class PagesService extends DisposableService {
     this.kartonServer.removeServerProcedureHandler('disconnectProvider');
     this.kartonServer.removeServerProcedureHandler('sendOtp');
     this.kartonServer.removeServerProcedureHandler('verifyOtp');
+    this.kartonServer.removeServerProcedureHandler('signInSocial');
     this.kartonServer.removeServerProcedureHandler('logout');
 
     this.kartonServer.removeServerProcedureHandler('getUsageCurrent');
@@ -1628,6 +1645,7 @@ export class PagesService extends DisposableService {
     this.getUsageHistoryHandler = undefined;
     this.sendOtpHandler = undefined;
     this.verifyOtpHandler = undefined;
+    this.signInSocialHandler = undefined;
     this.logoutHandler = undefined;
 
     await this.transport.close();

--- a/apps/browser/src/backend/services/telemetry.test.ts
+++ b/apps/browser/src/backend/services/telemetry.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it } from 'vitest';
+import { isUIEventName, parseUIEventProperties } from './telemetry';
+
+const SOCIAL_AUTH_EVENTS = [
+  'onboarding-auth-social-requested',
+  'onboarding-auth-social-verified',
+  'account-auth-social-requested',
+  'account-auth-social-verified',
+  'chat-auth-social-requested',
+  'chat-auth-social-verified',
+] as const;
+
+const OTP_AUTH_EVENTS = [
+  'onboarding-auth-otp-requested',
+  'onboarding-auth-otp-verified',
+  'account-auth-otp-requested',
+  'account-auth-otp-verified',
+  'chat-auth-otp-requested',
+  'chat-auth-otp-verified',
+] as const;
+
+const OTP_FAILURE_EVENTS = [
+  'onboarding-auth-otp-failed',
+  'account-auth-otp-failed',
+  'chat-auth-otp-failed',
+] as const;
+
+const METHOD_FAILURE_EVENTS = [
+  'account-auth-method-failed',
+  'chat-auth-method-failed',
+] as const;
+
+describe('auth UI telemetry schemas', () => {
+  it('registers all social auth UI event names', () => {
+    for (const eventName of SOCIAL_AUTH_EVENTS) {
+      expect(isUIEventName(eventName)).toBe(true);
+    }
+  });
+
+  it('accepts Google and GitHub as social providers', () => {
+    for (const eventName of SOCIAL_AUTH_EVENTS) {
+      expect(parseUIEventProperties(eventName, { provider: 'google' })).toEqual(
+        {
+          provider: 'google',
+        },
+      );
+      expect(parseUIEventProperties(eventName, { provider: 'github' })).toEqual(
+        {
+          provider: 'github',
+        },
+      );
+    }
+  });
+
+  it('rejects non-social providers for social auth events', () => {
+    for (const eventName of SOCIAL_AUTH_EVENTS) {
+      expect(
+        parseUIEventProperties(eventName, { provider: 'openai' }),
+      ).toBeNull();
+      expect(parseUIEventProperties(eventName, {})).toBeNull();
+    }
+  });
+
+  it('accepts OTP requested and verified events without properties', () => {
+    for (const eventName of OTP_AUTH_EVENTS) {
+      expect(parseUIEventProperties(eventName, undefined)).toBeUndefined();
+    }
+  });
+
+  it('rejects unexpected properties for OTP requested and verified events', () => {
+    for (const eventName of OTP_AUTH_EVENTS) {
+      expect(
+        parseUIEventProperties(eventName, { provider: 'google' }),
+      ).toBeNull();
+    }
+  });
+
+  it('validates OTP failure kinds', () => {
+    for (const eventName of OTP_FAILURE_EVENTS) {
+      expect(
+        parseUIEventProperties(eventName, { error_kind: 'backend-error' }),
+      ).toEqual({ error_kind: 'backend-error' });
+      expect(
+        parseUIEventProperties(eventName, {
+          error_kind: 'turnstile-not-ready',
+        }),
+      ).toEqual({ error_kind: 'turnstile-not-ready' });
+      expect(
+        parseUIEventProperties(eventName, { error_kind: 'validation-error' }),
+      ).toBeNull();
+    }
+  });
+
+  it('validates account and chat auth method failure metadata', () => {
+    for (const eventName of METHOD_FAILURE_EVENTS) {
+      expect(
+        parseUIEventProperties(eventName, {
+          auth_method: 'stagewise',
+          provider: 'google',
+          error_kind: 'network-error',
+        }),
+      ).toEqual({
+        auth_method: 'stagewise',
+        provider: 'google',
+        error_kind: 'network-error',
+      });
+      expect(
+        parseUIEventProperties(eventName, {
+          auth_method: 'stagewise',
+          error_kind: 'validation-error',
+        }),
+      ).toEqual({
+        auth_method: 'stagewise',
+        error_kind: 'validation-error',
+      });
+      expect(
+        parseUIEventProperties(eventName, {
+          auth_method: 'api-keys',
+          provider: 'google',
+          error_kind: 'network-error',
+        }),
+      ).toBeNull();
+      expect(
+        parseUIEventProperties(eventName, {
+          auth_method: 'stagewise',
+          provider: 'anthropic',
+          error_kind: 'network-error',
+        }),
+      ).toBeNull();
+    }
+  });
+
+  it('accepts model and social providers for onboarding method failures', () => {
+    expect(
+      parseUIEventProperties('onboarding-auth-method-failed', {
+        auth_method: 'api-keys',
+        provider: 'openai',
+        error_kind: 'backend-error',
+      }),
+    ).toEqual({
+      auth_method: 'api-keys',
+      provider: 'openai',
+      error_kind: 'backend-error',
+    });
+    expect(
+      parseUIEventProperties('onboarding-auth-method-failed', {
+        auth_method: 'stagewise',
+        provider: 'github',
+        error_kind: 'backend-error',
+      }),
+    ).toEqual({
+      auth_method: 'stagewise',
+      provider: 'github',
+      error_kind: 'backend-error',
+    });
+    expect(
+      parseUIEventProperties('onboarding-auth-method-failed', {
+        auth_method: 'stagewise',
+        provider: 'not-a-provider',
+        error_kind: 'backend-error',
+      }),
+    ).toBeNull();
+  });
+});

--- a/apps/browser/src/backend/services/telemetry.ts
+++ b/apps/browser/src/backend/services/telemetry.ts
@@ -6,7 +6,9 @@ import type { IdentifierService } from './identifier';
 import type { PreferencesService } from './preferences';
 import {
   modelProviderSchema,
+  socialAuthProviderSchema,
   type ModelProvider,
+  type SocialAuthProvider,
   type TelemetryLevel,
   type ToolApprovalMode,
 } from '@shared/karton-contracts/ui/shared-types';
@@ -19,6 +21,7 @@ type OnboardingAuthMethod = 'stagewise' | 'api-keys' | 'coding-plan';
 type OnboardingAuthCompletionMethod = OnboardingAuthMethod | 'unknown';
 type OnboardingAuthFailureKind =
   | 'validation-error'
+  | 'backend-error'
   | 'network-error'
   | 'unknown-error';
 type OnboardingOtpFailureKind =
@@ -39,6 +42,7 @@ const codingPlanIdSchema = z.enum([
 ]);
 const onboardingAuthFailureKindSchema = z.enum([
   'validation-error',
+  'backend-error',
   'network-error',
   'unknown-error',
 ]);
@@ -84,6 +88,8 @@ export type EventProperties = {
     plan_id: CodingPlanId;
     provider: ModelProvider;
   };
+  'onboarding-auth-social-requested': { provider: SocialAuthProvider };
+  'onboarding-auth-social-verified': { provider: SocialAuthProvider };
   'onboarding-auth-otp-requested': undefined;
   'onboarding-auth-otp-verified': undefined;
   'onboarding-auth-otp-failed': {
@@ -96,7 +102,7 @@ export type EventProperties = {
   };
   'onboarding-auth-method-failed': {
     auth_method: OnboardingAuthMethod;
-    provider?: ModelProvider;
+    provider?: ModelProvider | SocialAuthProvider;
     plan_id?: CodingPlanId;
     error_kind: OnboardingAuthFailureKind;
   };
@@ -104,6 +110,30 @@ export type EventProperties = {
     auth_method: 'api-keys' | 'coding-plan';
     provider: ModelProvider;
     plan_id?: CodingPlanId;
+  };
+  'account-auth-social-requested': { provider: SocialAuthProvider };
+  'account-auth-social-verified': { provider: SocialAuthProvider };
+  'account-auth-otp-requested': undefined;
+  'account-auth-otp-verified': undefined;
+  'account-auth-otp-failed': {
+    error_kind: OnboardingOtpFailureKind;
+  };
+  'account-auth-method-failed': {
+    auth_method: 'stagewise';
+    provider?: SocialAuthProvider;
+    error_kind: OnboardingAuthFailureKind;
+  };
+  'chat-auth-social-requested': { provider: SocialAuthProvider };
+  'chat-auth-social-verified': { provider: SocialAuthProvider };
+  'chat-auth-otp-requested': undefined;
+  'chat-auth-otp-verified': undefined;
+  'chat-auth-otp-failed': {
+    error_kind: OnboardingOtpFailureKind;
+  };
+  'chat-auth-method-failed': {
+    auth_method: 'stagewise';
+    provider?: SocialAuthProvider;
+    error_kind: OnboardingAuthFailureKind;
   };
 
   // Workspace
@@ -435,11 +465,25 @@ export const UI_TELEMETRY_EVENT_NAMES = [
   'onboarding-auth-method-completed',
   'onboarding-auth-method-failed',
   'onboarding-auth-mode-switched',
+  'onboarding-auth-social-requested',
+  'onboarding-auth-social-verified',
   'onboarding-auth-otp-failed',
   'onboarding-auth-otp-requested',
   'onboarding-auth-otp-verified',
   'onboarding-auth-provider-disconnected',
   'onboarding-auth-providers-expanded',
+  'account-auth-method-failed',
+  'account-auth-otp-failed',
+  'account-auth-otp-requested',
+  'account-auth-otp-verified',
+  'account-auth-social-requested',
+  'account-auth-social-verified',
+  'chat-auth-method-failed',
+  'chat-auth-otp-failed',
+  'chat-auth-otp-requested',
+  'chat-auth-otp-verified',
+  'chat-auth-social-requested',
+  'chat-auth-social-verified',
   'onboarding-demo-slide-clicked',
   'settings-opened',
   'suggestion-clicked',
@@ -505,13 +549,21 @@ const UI_TELEMETRY_EVENT_SCHEMAS = {
   }),
   'onboarding-auth-method-failed': z.object({
     auth_method: onboardingAuthMethodSchema,
-    provider: modelProviderSchema.optional(),
+    provider: z
+      .union([modelProviderSchema, socialAuthProviderSchema])
+      .optional(),
     plan_id: codingPlanIdSchema.optional(),
     error_kind: onboardingAuthFailureKindSchema,
   }),
   'onboarding-auth-mode-switched': z.object({
     from: onboardingAuthMethodSchema,
     to: onboardingAuthMethodSchema,
+  }),
+  'onboarding-auth-social-requested': z.object({
+    provider: socialAuthProviderSchema,
+  }),
+  'onboarding-auth-social-verified': z.object({
+    provider: socialAuthProviderSchema,
   }),
   'onboarding-auth-otp-failed': z.object({
     error_kind: onboardingOtpFailureKindSchema,
@@ -525,6 +577,38 @@ const UI_TELEMETRY_EVENT_SCHEMAS = {
   }),
   'onboarding-auth-providers-expanded': z.object({
     expanded: z.boolean(),
+  }),
+  'account-auth-social-requested': z.object({
+    provider: socialAuthProviderSchema,
+  }),
+  'account-auth-social-verified': z.object({
+    provider: socialAuthProviderSchema,
+  }),
+  'account-auth-otp-failed': z.object({
+    error_kind: onboardingOtpFailureKindSchema,
+  }),
+  'account-auth-otp-requested': z.undefined().optional(),
+  'account-auth-otp-verified': z.undefined().optional(),
+  'account-auth-method-failed': z.object({
+    auth_method: z.literal('stagewise'),
+    provider: socialAuthProviderSchema.optional(),
+    error_kind: onboardingAuthFailureKindSchema,
+  }),
+  'chat-auth-social-requested': z.object({
+    provider: socialAuthProviderSchema,
+  }),
+  'chat-auth-social-verified': z.object({
+    provider: socialAuthProviderSchema,
+  }),
+  'chat-auth-otp-failed': z.object({
+    error_kind: onboardingOtpFailureKindSchema,
+  }),
+  'chat-auth-otp-requested': z.undefined().optional(),
+  'chat-auth-otp-verified': z.undefined().optional(),
+  'chat-auth-method-failed': z.object({
+    auth_method: z.literal('stagewise'),
+    provider: socialAuthProviderSchema.optional(),
+    error_kind: onboardingAuthFailureKindSchema,
   }),
   'onboarding-demo-slide-clicked': z.object({
     slide_name: z.string(),

--- a/apps/browser/src/backend/services/uri-handler.ts
+++ b/apps/browser/src/backend/services/uri-handler.ts
@@ -2,10 +2,13 @@ import { app } from 'electron';
 import type { Logger } from './logger';
 import path from 'node:path';
 import { DisposableService } from './disposable';
+import { AUTH_CALLBACK_SCHEME } from './auth/callback-scheme';
+
+const STABLE_APP_SCHEME = 'stagewise';
 
 /**
- * Service responsible for registering the app as the default protocol client for stagewise:// URLs.
- * This enables the OS to route stagewise:// URLs to this app.
+ * Service responsible for registering the app as the default protocol client for auth callback URLs.
+ * This enables the OS to route configured callback scheme URLs to this app.
  *
  * Note: URL handling is done in main.ts via setupUrlHandlers() and handleCommandLineUrls().
  * This service only sets up the protocol registration.
@@ -26,22 +29,53 @@ export class URIHandlerService extends DisposableService {
   }
 
   private async initialize(): Promise<void> {
-    // Register as default protocol client for stagewise:// URLs
-    app.setAsDefaultProtocolClient('stagewise');
+    const schemes = Array.from(
+      new Set([STABLE_APP_SCHEME, AUTH_CALLBACK_SCHEME]),
+    );
 
-    // In development mode, we need to pass the script path for the protocol to work
-    if (process.defaultApp) {
-      if (process.argv.length >= 2) {
-        app.setAsDefaultProtocolClient('stagewise', process.execPath, [
-          path.resolve(process.argv[1]),
-        ]);
+    for (const scheme of schemes) {
+      const registered = app.setAsDefaultProtocolClient(scheme);
+      if (!registered) {
+        this.logger.error(
+          `[URIHandlerService] Failed to register protocol client for ${scheme} (defaultApp: ${process.defaultApp ? 'yes' : 'no'})`,
+        );
       }
     }
 
-    this.logger.debug('[URIHandlerService] Set as default protocol client');
-    this.logger.debug(
-      `[URIHandlerService] Is default protocol client: ${app.isDefaultProtocolClient('stagewise') ? 'yes' : 'no'}`,
+    // In development mode, we need to pass the script path for the protocol to work.
+    if (process.defaultApp && process.argv.length >= 2) {
+      const scriptPath = path.resolve(process.argv[1]);
+      for (const scheme of schemes) {
+        const registered = app.setAsDefaultProtocolClient(
+          scheme,
+          process.execPath,
+          [scriptPath],
+        );
+        if (!registered) {
+          this.logger.error(
+            `[URIHandlerService] Failed to register development protocol client for ${scheme} (defaultApp: ${process.defaultApp ? 'yes' : 'no'}, execPath: ${process.execPath}, scriptPath: ${scriptPath})`,
+          );
+        }
+      }
+    }
+
+    const unconfirmedSchemes = schemes.filter(
+      (scheme) => !app.isDefaultProtocolClient(scheme),
     );
+    if (unconfirmedSchemes.length === 0) {
+      this.logger.debug(
+        `[URIHandlerService] Set as default protocol client for ${schemes.join(', ')}`,
+      );
+    } else {
+      this.logger.warn(
+        `[URIHandlerService] Protocol client registration not confirmed for ${unconfirmedSchemes.join(', ')} after attempting ${schemes.join(', ')}`,
+      );
+    }
+    for (const scheme of schemes) {
+      this.logger.debug(
+        `[URIHandlerService] Is default protocol client for ${scheme}: ${app.isDefaultProtocolClient(scheme) ? 'yes' : 'no'}`,
+      );
+    }
   }
 
   protected onTeardown(): void {

--- a/apps/browser/src/backend/startup-url-events.ts
+++ b/apps/browser/src/backend/startup-url-events.ts
@@ -1,0 +1,55 @@
+import { app } from 'electron';
+
+const MAX_QUEUED_STARTUP_URLS = 10;
+
+type StartupUrlHandler = (url: string) => void;
+
+let installed = false;
+let runtimeHandler: StartupUrlHandler | null = null;
+const pendingUrls: string[] = [];
+
+function invokeHandler(handler: StartupUrlHandler, url: string): void {
+  try {
+    handler(url);
+  } catch {
+    // A bad URL handler must not prevent later startup URLs from draining.
+  }
+}
+
+function handleOrQueueUrl(url: string): void {
+  if (runtimeHandler) {
+    invokeHandler(runtimeHandler, url);
+    return;
+  }
+
+  if (pendingUrls.length >= MAX_QUEUED_STARTUP_URLS) {
+    pendingUrls.shift();
+  }
+  pendingUrls.push(url);
+}
+
+export function installStartupOpenUrlListener(): void {
+  if (installed) return;
+  installed = true;
+
+  app.on('open-url', (event, url) => {
+    event.preventDefault();
+    handleOrQueueUrl(url);
+  });
+}
+
+export function registerStartupUrlHandler(
+  handler: StartupUrlHandler,
+): () => void {
+  runtimeHandler = handler;
+  const urls = pendingUrls.splice(0);
+  for (const url of urls) {
+    invokeHandler(handler, url);
+  }
+
+  return () => {
+    if (runtimeHandler === handler) {
+      runtimeHandler = null;
+    }
+  };
+}

--- a/apps/browser/src/backend/wiring/pages-handler-wiring.ts
+++ b/apps/browser/src/backend/wiring/pages-handler-wiring.ts
@@ -71,6 +71,7 @@ export function wirePagesHandlers(deps: {
     sendOtp: (email, turnstileToken) =>
       authService.sendOtp(email, turnstileToken),
     verifyOtp: (email, code) => authService.verifyOtp(email, code),
+    signInSocial: (provider) => authService.signInSocial(provider),
     logout: () => authService.logout(),
   });
 

--- a/apps/browser/src/pages/routes/_internal-app/account.tsx
+++ b/apps/browser/src/pages/routes/_internal-app/account.tsx
@@ -1,15 +1,14 @@
-import { createFileRoute } from '@tanstack/react-router';
+import { createFileRoute, useNavigate } from '@tanstack/react-router';
 import { Button } from '@stagewise/stage-ui/components/button';
 import { Checkbox } from '@stagewise/stage-ui/components/checkbox';
-import { Input } from '@stagewise/stage-ui/components/input';
-import { InputOtp } from '@stagewise/stage-ui/components/input-otp';
 import { useKartonState, useKartonProcedure } from '@pages/hooks/use-karton';
 import { useTrack } from '@pages/hooks/use-track';
-import { useState, useCallback, useRef, useEffect } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import { OverlayScrollbar } from '@stagewise/stage-ui/components/overlay-scrollbar';
 import { cn } from '@pages/utils';
 import { produceWithPatches } from 'immer';
 import type { TelemetryLevel } from '@shared/karton-contracts/ui/shared-types';
+import { SignInOptionsPanel } from '@ui/components/auth/sign-in-options-panel';
 import type { CurrentUsageResponse } from '@shared/karton-contracts/pages-api/types';
 
 const CONSOLE_URL =
@@ -26,12 +25,11 @@ export const Route = createFileRoute('/_internal-app/account')({
   }),
 });
 
-type AuthPhase = 'form-input' | 'waiting-for-otp';
-
 function Page() {
   const userAccount = useKartonState((s) => s.userAccount);
   const sendOtp = useKartonProcedure((p) => p.sendOtp);
   const verifyOtp = useKartonProcedure((p) => p.verifyOtp);
+  const signInSocial = useKartonProcedure((p) => p.signInSocial);
   const logout = useKartonProcedure((p) => p.logout);
   // `useTrack` swallows RPC errors so a failed telemetry capture (e.g.
   // backend karton server unavailable) cannot crash the page.
@@ -50,14 +48,14 @@ function Page() {
   return (
     <div className="flex h-full w-full flex-col">
       {/* Header */}
-      <div className="flex flex-col items-center border-border-subtle border-b px-6 py-4">
+      <div className="flex flex-col items-center border-border-subtle border-b px-6 py-6">
         <div className="w-full max-w-3xl">
           <h1 className="font-semibold text-foreground text-xl">Account</h1>
         </div>
       </div>
 
       {/* Content */}
-      <OverlayScrollbar className="flex-1" contentClassName="px-6 pt-6 pb-24">
+      <OverlayScrollbar className="flex-1" contentClassName="px-6 pt-12 pb-24">
         <div className="mx-auto flex w-full max-w-3xl shrink-0 flex-col gap-8">
           {userAccount?.status === 'authenticated' ||
           userAccount?.status === 'server_unreachable' ? (
@@ -68,7 +66,11 @@ function Page() {
               onLogout={() => void logout()}
             />
           ) : (
-            <LoginView sendOtp={sendOtp} verifyOtp={verifyOtp} />
+            <LoginView
+              sendOtp={(email, token) => sendOtp(email, token ?? '')}
+              verifyOtp={verifyOtp}
+              signInSocial={signInSocial}
+            />
           )}
         </div>
       </OverlayScrollbar>
@@ -366,141 +368,37 @@ function TelemetrySetting() {
 function LoginView({
   sendOtp,
   verifyOtp,
+  signInSocial,
 }: {
-  sendOtp: (email: string) => Promise<{ error?: string }>;
+  sendOtp: (email: string, token?: string) => Promise<{ error?: string }>;
   verifyOtp: (email: string, code: string) => Promise<{ error?: string }>;
+  signInSocial: (provider: 'google' | 'github') => Promise<{ error?: string }>;
 }) {
-  const [phase, setPhase] = useState<AuthPhase>('form-input');
-  const [email, setEmail] = useState('');
-  const [code, setCode] = useState('');
-  const [error, setError] = useState<string | null>(null);
-  const [loading, setLoading] = useState(false);
-  const emailRef = useRef<HTMLInputElement>(null);
-  const otpRef = useRef<HTMLInputElement>(null);
-
-  useEffect(() => {
-    if (phase === 'form-input') emailRef.current?.focus();
-  }, [phase]);
-
-  useEffect(() => {
-    if (phase === 'waiting-for-otp') otpRef.current?.focus();
-  }, [phase]);
-
-  const handleSendOtp = useCallback(async () => {
-    if (!email.trim()) return;
-    setError(null);
-    setLoading(true);
-    try {
-      const result = await sendOtp(email.trim());
-      if (result?.error) setError(result.error);
-      else setPhase('waiting-for-otp');
-    } catch {
-      setError('Failed to send verification code.');
-    } finally {
-      setLoading(false);
-    }
-  }, [email, sendOtp]);
-
-  const handleVerifyOtp = useCallback(async () => {
-    if (!code.trim()) return;
-    setError(null);
-    setLoading(true);
-    try {
-      const result = await verifyOtp(email.trim(), code.trim());
-      if (result?.error) setError(result.error);
-      // On success, the auth state change callback will update userAccount
-      // and the parent component will switch to AuthenticatedView
-    } catch {
-      setError('Failed to verify code.');
-    } finally {
-      setLoading(false);
-    }
-  }, [email, code, verifyOtp]);
+  const navigate = useNavigate();
+  const track = useTrack();
 
   return (
-    <>
-      <div className="flex flex-col gap-2">
-        <h2 className="font-medium text-foreground text-lg">Authenticate</h2>
-        {phase === 'form-input' && (
-          <p className="text-muted-foreground text-sm">
-            Get access to the latest models with stagewise.
-          </p>
-        )}
-        {phase === 'waiting-for-otp' && (
-          <p className="text-muted-foreground text-sm">
-            We sent a code to{' '}
-            <span className="font-medium text-foreground">{email}</span>.
-          </p>
-        )}
-      </div>
-
-      <hr className="border-border-subtle" />
-
-      {phase === 'form-input' && (
-        <div className="flex max-w-sm flex-col gap-4">
-          <div className="flex gap-2">
-            <Input
-              ref={emailRef}
-              placeholder="you@example.com"
-              size="sm"
-              type="email"
-              value={email}
-              onValueChange={(v) => setEmail(v)}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter') void handleSendOtp();
-              }}
-              disabled={loading}
-            />
-            <Button
-              variant="primary"
-              size="sm"
-              className="shrink-0"
-              onClick={() => void handleSendOtp()}
-              disabled={loading || !email.trim()}
-            >
-              Sign in
-            </Button>
-          </div>
-        </div>
-      )}
-
-      {phase === 'waiting-for-otp' && (
-        <div className="flex flex-col items-start gap-4">
-          <div className="flex items-center gap-2">
-            <InputOtp
-              ref={otpRef}
-              length={6}
-              size="sm"
-              value={code}
-              onChange={(val) => setCode(val)}
-              onComplete={() => void handleVerifyOtp()}
-              disabled={loading}
-            />
-            <Button
-              variant="primary"
-              size="sm"
-              className="shrink-0"
-              onClick={() => void handleVerifyOtp()}
-              disabled={loading || code.length < 6}
-            >
-              {loading ? 'Verifying...' : 'Verify'}
-            </Button>
-          </div>
-          <Button
-            variant="ghost"
-            size="xs"
-            onClick={() => {
-              setPhase('form-input');
-              setCode('');
-              setError(null);
-            }}
-          >
-            Use a different email
-          </Button>
-        </div>
-      )}
-
-      {error && <p className="text-error-foreground text-sm">{error}</p>}
-    </>
+    <SignInOptionsPanel
+      title="Authenticate"
+      description="Get access to the latest models with stagewise."
+      variant="centered"
+      sendOtp={sendOtp}
+      verifyOtp={verifyOtp}
+      signInSocial={signInSocial}
+      trackingPrefix="account-auth"
+      track={track}
+      onUseApiKeys={() =>
+        navigate({
+          to: '/agent-settings/models-providers',
+          hash: 'api-keys',
+        })
+      }
+      onUseSubscription={() =>
+        navigate({
+          to: '/agent-settings/models-providers',
+          hash: 'coding-plans',
+        })
+      }
+    />
   );
 }

--- a/apps/browser/src/pages/routes/_internal-app/agent-settings.models-providers.tsx
+++ b/apps/browser/src/pages/routes/_internal-app/agent-settings.models-providers.tsx
@@ -12,11 +12,11 @@ import type {
   CustomModel,
   ModelCapabilities,
   ModelProvider,
-  ProviderEndpointMode,
 } from '@shared/karton-contracts/ui/shared-types';
 import {
   PROVIDER_DISPLAY_INFO,
   PROVIDER_OFFICIAL_URLS,
+  providerEndpointModeSchema,
 } from '@shared/karton-contracts/ui/shared-types';
 import { availableModels } from '@shared/available-models';
 import { CODING_PLANS, type CodingPlan } from '@shared/coding-plans';
@@ -118,9 +118,13 @@ function ProviderConfigCard({ provider }: { provider: ModelProvider }) {
   }, [validated]);
 
   const handleModeChange = useCallback(
-    async (newMode: string) => {
+    async (newMode: unknown) => {
+      const parsedMode = providerEndpointModeSchema.safeParse(newMode);
+      if (!parsedMode.success) return;
+
       const [, patches] = produceWithPatches(preferences, (draft) => {
-        draft.providerConfigs[provider].mode = newMode as ProviderEndpointMode;
+        draft.providerConfigs[provider] ??= { mode: 'stagewise' };
+        draft.providerConfigs[provider].mode = parsedMode.data;
       });
       await updatePreferences(patches);
     },
@@ -1267,6 +1271,23 @@ function CustomModelsSection() {
 
 function Page() {
   const navigate = useNavigate();
+  useEffect(() => {
+    const scrollToHash = () => {
+      const targetId = window.location.hash.slice(1);
+      if (!targetId) return;
+
+      requestAnimationFrame(() => {
+        document.getElementById(targetId)?.scrollIntoView({
+          block: 'start',
+          behavior: 'smooth',
+        });
+      });
+    };
+
+    scrollToHash();
+    window.addEventListener('hashchange', scrollToHash);
+    return () => window.removeEventListener('hashchange', scrollToHash);
+  }, []);
 
   return (
     <div className="flex h-full w-full flex-col">
@@ -1283,7 +1304,7 @@ function Page() {
       <OverlayScrollbar className="flex-1" contentClassName="px-6 pt-6 pb-24">
         <div className="mx-auto max-w-3xl space-y-8">
           {/* Coding Plans Section */}
-          <section className="space-y-6">
+          <section id="coding-plans" className="scroll-mt-6 space-y-6">
             <div>
               <h2 className="font-medium text-foreground text-lg">
                 Coding Plans
@@ -1300,7 +1321,7 @@ function Page() {
           <hr className="border-derived-subtle border-t" />
 
           {/* API Keys Section */}
-          <section className="space-y-6">
+          <section id="api-keys" className="scroll-mt-6 space-y-6">
             <div>
               <h2 className="font-medium text-foreground text-lg">API Keys</h2>
               <p className="text-muted-foreground text-sm">

--- a/apps/browser/src/shared/internal-urls.ts
+++ b/apps/browser/src/shared/internal-urls.ts
@@ -1,6 +1,11 @@
 /**
  * Internal URLs used by the browser.
  * These URLs are handled specially by the browser and don't navigate to external sites.
+ *
+ * The `stagewise://internal` origin is intentionally stable across release
+ * channels. Do not couple it to OAuth callback schemes such as
+ * `stagewise-dev://` or `stagewise-prerelease://`; those are OS-level deep
+ * links, while this origin is the app's privileged in-browser page host.
  */
 
 /** The home page URL - displayed when opening a new tab or on startup */
@@ -12,6 +17,8 @@ export const ABOUT_PAGE_URL = 'stagewise://internal/about';
 /** The settings page URL */
 export const SETTINGS_PAGE_URL =
   'stagewise://internal/agent-settings/models-providers';
+export const SETTINGS_API_KEYS_PAGE_URL = `${SETTINGS_PAGE_URL}#api-keys`;
+export const SETTINGS_CODING_PLANS_PAGE_URL = `${SETTINGS_PAGE_URL}#coding-plans`;
 
 /** The history page URL */
 export const HISTORY_PAGE_URL = 'stagewise://internal/history';

--- a/apps/browser/src/shared/karton-contracts/pages-api/index.ts
+++ b/apps/browser/src/shared/karton-contracts/pages-api/index.ts
@@ -19,6 +19,7 @@ import type {
   Patch,
   GlobalConfig,
   ModelProvider,
+  SocialAuthProvider,
 } from '../ui/shared-types';
 import type { CodingPlanId } from '../../coding-plans';
 import type {
@@ -265,6 +266,8 @@ export type PagesApiContract = {
     ) => Promise<{ error?: string }>;
     /** Verify an OTP code for the given email */
     verifyOtp: (email: string, code: string) => Promise<{ error?: string }>;
+    /** Start social sign-in in the system browser */
+    signInSocial: (provider: SocialAuthProvider) => Promise<{ error?: string }>;
     /** Log the current user out */
     logout: () => Promise<void>;
     /** Get current usage stats (window percentages + prepaid balance) */

--- a/apps/browser/src/shared/karton-contracts/ui/index.ts
+++ b/apps/browser/src/shared/karton-contracts/ui/index.ts
@@ -29,6 +29,7 @@ import type {
   WidgetId,
   DevToolbarOriginSettings,
   ToolApprovalMode,
+  SocialAuthProvider,
 } from './shared-types';
 import {
   defaultUserPreferences,
@@ -1013,6 +1014,9 @@ export type KartonContract = {
         turnstileToken: string,
       ) => Promise<{ error?: string }>;
       verifyOtp: (email: string, code: string) => Promise<{ error?: string }>;
+      signInSocial: (
+        provider: SocialAuthProvider,
+      ) => Promise<{ error?: string }>;
       refreshStatus: () => Promise<void>;
       logout: () => Promise<void>;
       validateApiKeys: (keys: {

--- a/apps/browser/src/shared/karton-contracts/ui/shared-types.ts
+++ b/apps/browser/src/shared/karton-contracts/ui/shared-types.ts
@@ -21,6 +21,9 @@ export const modelProviderSchema = z.enum([
 ]);
 export type ModelProvider = z.infer<typeof modelProviderSchema>;
 
+export const socialAuthProviderSchema = z.enum(['google', 'github']);
+export type SocialAuthProvider = z.infer<typeof socialAuthProviderSchema>;
+
 /** Endpoint mode for a provider */
 export const providerEndpointModeSchema = z.enum([
   'stagewise',
@@ -790,7 +793,7 @@ export type ConfigurablePermissionType =
  */
 export const hostPermissionExceptionSchema = z.object({
   /** The permission setting for this origin */
-  setting: z.nativeEnum(PermissionSetting),
+  setting: z.enum(PermissionSetting),
   /** Unix timestamp when this exception was last modified */
   lastModified: z.number().optional(),
 });
@@ -804,30 +807,20 @@ export type HostPermissionException = z.infer<
  * These are used when no host-specific exception exists.
  */
 export const defaultPermissionSettingsSchema = z.object({
-  media: z.nativeEnum(PermissionSetting).default(PermissionSetting.Ask),
-  geolocation: z.nativeEnum(PermissionSetting).default(PermissionSetting.Ask),
-  notifications: z.nativeEnum(PermissionSetting).default(PermissionSetting.Ask),
-  fullscreen: z.nativeEnum(PermissionSetting).default(PermissionSetting.Allow),
-  bluetooth: z.nativeEnum(PermissionSetting).default(PermissionSetting.Ask),
-  hid: z.nativeEnum(PermissionSetting).default(PermissionSetting.Ask),
-  serial: z.nativeEnum(PermissionSetting).default(PermissionSetting.Ask),
-  usb: z.nativeEnum(PermissionSetting).default(PermissionSetting.Ask),
-  'clipboard-read': z
-    .nativeEnum(PermissionSetting)
-    .default(PermissionSetting.Ask),
-  'display-capture': z
-    .nativeEnum(PermissionSetting)
-    .default(PermissionSetting.Ask),
-  midi: z.nativeEnum(PermissionSetting).default(PermissionSetting.Allow),
-  'idle-detection': z
-    .nativeEnum(PermissionSetting)
-    .default(PermissionSetting.Ask),
-  'speaker-selection': z
-    .nativeEnum(PermissionSetting)
-    .default(PermissionSetting.Ask),
-  'storage-access': z
-    .nativeEnum(PermissionSetting)
-    .default(PermissionSetting.Ask),
+  media: z.enum(PermissionSetting).default(PermissionSetting.Ask),
+  geolocation: z.enum(PermissionSetting).default(PermissionSetting.Ask),
+  notifications: z.enum(PermissionSetting).default(PermissionSetting.Ask),
+  fullscreen: z.enum(PermissionSetting).default(PermissionSetting.Allow),
+  bluetooth: z.enum(PermissionSetting).default(PermissionSetting.Ask),
+  hid: z.enum(PermissionSetting).default(PermissionSetting.Ask),
+  serial: z.enum(PermissionSetting).default(PermissionSetting.Ask),
+  usb: z.enum(PermissionSetting).default(PermissionSetting.Ask),
+  'clipboard-read': z.enum(PermissionSetting).default(PermissionSetting.Ask),
+  'display-capture': z.enum(PermissionSetting).default(PermissionSetting.Ask),
+  midi: z.enum(PermissionSetting).default(PermissionSetting.Allow),
+  'idle-detection': z.enum(PermissionSetting).default(PermissionSetting.Ask),
+  'speaker-selection': z.enum(PermissionSetting).default(PermissionSetting.Ask),
+  'storage-access': z.enum(PermissionSetting).default(PermissionSetting.Ask),
 });
 
 export type DefaultPermissionSettings = z.infer<

--- a/apps/browser/src/ui/components/auth/sign-in-options-panel.tsx
+++ b/apps/browser/src/ui/components/auth/sign-in-options-panel.tsx
@@ -1,0 +1,526 @@
+import { Button } from '@stagewise/stage-ui/components/button';
+import { Input } from '@stagewise/stage-ui/components/input';
+import { InputOtp } from '@stagewise/stage-ui/components/input-otp';
+import { useTurnstile } from '@ui/hooks/use-turnstile';
+import { GithubMark } from '@ui/components/icons/github-mark';
+import { GoogleLogo } from '@ui/components/provider-logos/google';
+import { ProviderLogo } from '@ui/components/provider-logos';
+import { IconEnvelopeOutline18, IconKey2Outline18 } from 'nucleo-ui-outline-18';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { cn } from '@stagewise/stage-ui/lib/utils';
+import type { SocialAuthProvider } from '@shared/karton-contracts/ui/shared-types';
+export type SignInMethod = SocialAuthProvider | 'email';
+
+type AuthPhase = 'options' | 'email' | 'otp';
+type TrackingPrefix = 'onboarding-auth' | 'account-auth' | 'chat-auth';
+type TrackEvent = (
+  eventName: string,
+  properties?: Record<string, unknown>,
+) => void | Promise<void>;
+
+// This component is shared by both Electron renderer hosts: the main UI
+// preload exposes `window.electron`, while internal pages expose
+// `window.stagewisePagesApi`. Keep host-bound services injected through props
+// and avoid importing Karton/telemetry hooks here.
+export type SignInOptionsPanelProps = {
+  title?: string;
+  description?: string;
+  variant?: 'centered' | 'section';
+  sendOtp: (
+    email: string,
+    turnstileToken?: string,
+  ) => Promise<{ error?: string }>;
+  verifyOtp: (email: string, code: string) => Promise<{ error?: string }>;
+  signInSocial: (provider: SocialAuthProvider) => Promise<{ error?: string }>;
+  onUseApiKeys: () => void;
+  onUseSubscription: () => void;
+  trackingPrefix: TrackingPrefix;
+  track: TrackEvent;
+  onAuthenticated?: (method: SignInMethod) => void;
+  className?: string;
+};
+
+const LAST_USED_SIGN_IN_METHOD_KEY = 'stagewise:last-used-sign-in-method';
+
+function LastUsedBadge() {
+  return (
+    <span className="absolute -top-2 right-2 rounded-full border border-derived-lighter-subtle bg-primary-solid px-2 py-0.5 font-medium text-[10px] text-solid-foreground leading-none shadow-elevation-1">
+      Last used
+    </span>
+  );
+}
+
+const CODING_PLAN_LOGO_PROVIDERS = [
+  'z-ai',
+  'moonshotai',
+  'alibaba',
+  'minimax',
+] as const;
+
+function CodingPlanLogoStack() {
+  const providers = CODING_PLAN_LOGO_PROVIDERS;
+  const [providerIndex, setProviderIndex] = useState(0);
+  const provider = providers[providerIndex] ?? providers[0];
+
+  useEffect(() => {
+    const interval = window.setInterval(() => {
+      setProviderIndex((index) => (index + 1) % providers.length);
+    }, 1800);
+
+    return () => window.clearInterval(interval);
+  }, []);
+
+  return (
+    <span
+      key={provider}
+      className="relative flex size-5 items-center justify-center rounded-full text-foreground"
+      aria-hidden
+    >
+      <span className="absolute size-4 animate-[coding-plan-ink-pulse_350ms_cubic-bezier(0.16,1,0.3,1)] rounded-full bg-foreground/10 opacity-0" />
+      <ProviderLogo
+        provider={provider}
+        className="relative size-4 animate-[coding-plan-logo-swap_350ms_cubic-bezier(0.16,1,0.3,1)]"
+      />
+      <style>{`
+        @keyframes coding-plan-logo-swap {
+          0% { opacity: 0; filter: blur(4px); transform: scale(0.88) translateY(2px); }
+          100% { opacity: 1; filter: blur(0); transform: scale(1) translateY(0); }
+        }
+
+        @keyframes coding-plan-ink-pulse {
+          0% { opacity: 0.18; transform: scale(0.45); }
+          45% { opacity: 0.28; transform: scale(1); }
+          100% { opacity: 0; transform: scale(1.55); }
+        }
+      `}</style>
+    </span>
+  );
+}
+
+export function SignInOptionsPanel({
+  title = 'Authenticate',
+  description = 'Choose a sign-in method to continue.',
+  variant = 'centered',
+  sendOtp,
+  verifyOtp,
+  signInSocial,
+  onUseApiKeys,
+  onUseSubscription,
+  trackingPrefix,
+  track,
+  onAuthenticated,
+  className,
+}: SignInOptionsPanelProps) {
+  const [phase, setPhase] = useState<AuthPhase>('options');
+  const [email, setEmail] = useState('');
+  const [code, setCode] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [socialLoading, setSocialLoading] = useState<SocialAuthProvider | null>(
+    null,
+  );
+  const [lastUsedMethod, setLastUsedMethod] = useState<SignInMethod | null>(
+    null,
+  );
+  const pendingSocialAuth = !!socialLoading;
+  const emailRef = useRef<HTMLInputElement>(null);
+  const otpRef = useRef<HTMLInputElement>(null);
+  const {
+    containerRef: turnstileRef,
+    token: turnstileToken,
+    ready: turnstileReady,
+    error: turnstileError,
+    enabled: turnstileEnabled,
+    reset: resetTurnstile,
+  } = useTurnstile();
+
+  useEffect(() => {
+    let storedMethod: string | null = null;
+    try {
+      storedMethod = window.localStorage.getItem(LAST_USED_SIGN_IN_METHOD_KEY);
+    } catch {}
+    if (
+      storedMethod === 'google' ||
+      storedMethod === 'github' ||
+      storedMethod === 'email'
+    ) {
+      setLastUsedMethod(storedMethod);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (phase === 'email') emailRef.current?.focus();
+  }, [phase]);
+
+  useEffect(() => {
+    if (phase === 'otp') otpRef.current?.focus();
+  }, [phase]);
+
+  const rememberSignInMethod = useCallback((method: SignInMethod) => {
+    setLastUsedMethod(method);
+    try {
+      window.localStorage.setItem(LAST_USED_SIGN_IN_METHOD_KEY, method);
+    } catch {}
+  }, []);
+
+  const clearRememberedSignInMethod = useCallback(() => {
+    setLastUsedMethod(null);
+    try {
+      window.localStorage.removeItem(LAST_USED_SIGN_IN_METHOD_KEY);
+    } catch {}
+  }, []);
+
+  const handleSocialSignIn = useCallback(
+    async (provider: SocialAuthProvider) => {
+      if (loading || socialLoading) return;
+      setError(null);
+      setSocialLoading(provider);
+      rememberSignInMethod(provider);
+      void track(`${trackingPrefix}-social-requested`, { provider });
+      try {
+        const result = await signInSocial(provider);
+        if (result?.error) {
+          void track(`${trackingPrefix}-method-failed`, {
+            auth_method: 'stagewise',
+            provider,
+            error_kind: 'backend-error',
+          });
+          clearRememberedSignInMethod();
+          setError(result.error);
+          return;
+        }
+        void track(`${trackingPrefix}-social-verified`, { provider });
+        onAuthenticated?.(provider);
+      } catch {
+        void track(`${trackingPrefix}-method-failed`, {
+          auth_method: 'stagewise',
+          provider,
+          error_kind: 'network-error',
+        });
+        clearRememberedSignInMethod();
+        setError('Failed to complete social sign-in.');
+      } finally {
+        setSocialLoading(null);
+      }
+    },
+    [
+      clearRememberedSignInMethod,
+      loading,
+      onAuthenticated,
+      rememberSignInMethod,
+      signInSocial,
+      socialLoading,
+      track,
+      trackingPrefix,
+    ],
+  );
+
+  const handleSendOtp = useCallback(async () => {
+    if (!email.trim()) return;
+    if (turnstileEnabled && !turnstileToken && !turnstileError) {
+      void track(`${trackingPrefix}-otp-failed`, {
+        error_kind: 'turnstile-not-ready',
+      });
+      setError('Security verification not ready. Please wait a moment.');
+      return;
+    }
+    void track(`${trackingPrefix}-otp-requested`);
+    setError(null);
+    setLoading(true);
+    try {
+      const result = await sendOtp(email.trim(), turnstileToken ?? '');
+      if (result?.error) {
+        void track(`${trackingPrefix}-otp-failed`, {
+          error_kind: 'backend-error',
+        });
+        setError(result.error);
+        resetTurnstile();
+      } else {
+        setPhase('otp');
+      }
+    } catch {
+      void track(`${trackingPrefix}-otp-failed`, {
+        error_kind: 'network-error',
+      });
+      setError('Failed to send verification code.');
+      resetTurnstile();
+    } finally {
+      setLoading(false);
+    }
+  }, [
+    email,
+    resetTurnstile,
+    sendOtp,
+    track,
+    trackingPrefix,
+    turnstileEnabled,
+    turnstileError,
+    turnstileToken,
+  ]);
+
+  const handleVerifyOtp = useCallback(async () => {
+    if (!code.trim()) return;
+    setError(null);
+    setLoading(true);
+    try {
+      const result = await verifyOtp(email.trim(), code.trim());
+      if (result?.error) {
+        void track(`${trackingPrefix}-otp-failed`, {
+          error_kind: 'backend-error',
+        });
+        void track(`${trackingPrefix}-method-failed`, {
+          auth_method: 'stagewise',
+          error_kind: 'validation-error',
+        });
+        setError(result.error);
+      } else {
+        void track(`${trackingPrefix}-otp-verified`);
+        rememberSignInMethod('email');
+        onAuthenticated?.('email');
+      }
+    } catch {
+      void track(`${trackingPrefix}-otp-failed`, {
+        error_kind: 'network-error',
+      });
+      void track(`${trackingPrefix}-method-failed`, {
+        auth_method: 'stagewise',
+        error_kind: 'network-error',
+      });
+      setError('Failed to verify code.');
+    } finally {
+      setLoading(false);
+    }
+  }, [
+    code,
+    email,
+    onAuthenticated,
+    rememberSignInMethod,
+    track,
+    trackingPrefix,
+    verifyOtp,
+  ]);
+
+  const headerDescription =
+    phase === 'email'
+      ? 'Enter your email to receive a verification code.'
+      : phase === 'otp'
+        ? `We sent a code to ${email}. Enter it below.`
+        : description;
+
+  return (
+    <div
+      className={cn(
+        'flex w-full flex-col gap-4',
+        variant === 'centered' && 'items-center text-center',
+        className,
+      )}
+    >
+      {(title || headerDescription) && (
+        <div
+          className={cn(
+            'flex flex-col gap-2',
+            variant === 'centered' && 'items-center',
+          )}
+        >
+          {title && (
+            <h2 className="font-medium text-foreground text-xl">{title}</h2>
+          )}
+          {headerDescription && (
+            <p className="text-muted-foreground text-sm">
+              {phase === 'otp' ? (
+                <>
+                  We sent a code to{' '}
+                  <span className="font-semibold text-muted-foreground">
+                    {email}
+                  </span>
+                  . Enter it below.
+                </>
+              ) : (
+                headerDescription
+              )}
+            </p>
+          )}
+        </div>
+      )}
+
+      <div ref={turnstileRef} className="empty:hidden" />
+
+      {phase === 'options' && (
+        <div className="app-no-drag flex w-full max-w-sm flex-col gap-4">
+          <div className="grid gap-2">
+            <Button
+              variant="secondary"
+              size="sm"
+              className="relative w-full overflow-visible"
+              onClick={() => void handleSocialSignIn('google')}
+              disabled={loading || !!socialLoading}
+            >
+              {lastUsedMethod === 'google' && <LastUsedBadge />}
+              <GoogleLogo className="size-4" aria-hidden />
+              {socialLoading === 'google'
+                ? 'Opening Google…'
+                : 'Continue with Google'}
+            </Button>
+            <Button
+              variant="secondary"
+              size="sm"
+              className="relative w-full overflow-visible"
+              onClick={() => void handleSocialSignIn('github')}
+              disabled={loading || !!socialLoading}
+            >
+              {lastUsedMethod === 'github' && <LastUsedBadge />}
+              <GithubMark className="size-4" aria-hidden="true" />
+              {socialLoading === 'github'
+                ? 'Opening GitHub…'
+                : 'Continue with GitHub'}
+            </Button>
+            <Button
+              variant="secondary"
+              size="sm"
+              className="relative w-full overflow-visible"
+              onClick={() => {
+                if (pendingSocialAuth) return;
+                setPhase('email');
+                setError(null);
+              }}
+              disabled={pendingSocialAuth}
+            >
+              {lastUsedMethod === 'email' && <LastUsedBadge />}
+              <IconEnvelopeOutline18 className="size-4" />
+              Continue with Email
+            </Button>
+          </div>
+          <div className="relative text-center text-subtle-foreground text-xs after:absolute after:inset-x-0 after:top-1/2 after:border-border-subtle after:border-t">
+            <span className="relative z-10 bg-background px-2">or</span>
+          </div>
+          <div className="grid gap-2">
+            <Button
+              variant="secondary"
+              size="sm"
+              className="w-full"
+              onClick={() => {
+                if (pendingSocialAuth) return;
+                setError(null);
+                onUseApiKeys();
+              }}
+              disabled={pendingSocialAuth}
+            >
+              <IconKey2Outline18 className="size-4" />
+              Use your own API keys
+            </Button>
+            <Button
+              variant="secondary"
+              size="sm"
+              className="w-full"
+              onClick={() => {
+                if (pendingSocialAuth) return;
+                setError(null);
+                onUseSubscription();
+              }}
+              disabled={pendingSocialAuth}
+            >
+              <CodingPlanLogoStack />
+              Use existing subscription
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {phase === 'email' && (
+        <div className="app-no-drag grid w-full max-w-sm gap-3">
+          <Input
+            ref={emailRef}
+            placeholder="you@example.com"
+            size="sm"
+            className="w-full"
+            type="email"
+            value={email}
+            onValueChange={(v) => setEmail(v)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') void handleSendOtp();
+            }}
+            disabled={loading || !!socialLoading}
+          />
+          <Button
+            variant="primary"
+            className="relative w-full overflow-visible"
+            size="sm"
+            onClick={() => void handleSendOtp()}
+            disabled={
+              loading ||
+              !!socialLoading ||
+              !email.trim() ||
+              (turnstileEnabled && !turnstileError && !turnstileToken)
+            }
+          >
+            {lastUsedMethod === 'email' && <LastUsedBadge />}
+            {turnstileEnabled && !turnstileReady && !turnstileError
+              ? 'Loading...'
+              : 'Send code'}
+          </Button>
+          <Button
+            variant="ghost"
+            size="xs"
+            onClick={() => {
+              if (loading) return;
+              setPhase('options');
+              setError(null);
+              resetTurnstile();
+            }}
+            disabled={loading}
+          >
+            Back to sign-in options
+          </Button>
+        </div>
+      )}
+
+      {phase === 'otp' && (
+        <div className="flex flex-col items-center gap-4">
+          <InputOtp
+            ref={otpRef}
+            length={6}
+            size={variant === 'centered' ? 'md' : 'sm'}
+            value={code}
+            onChange={(val) => setCode(val)}
+            onComplete={() => void handleVerifyOtp()}
+            disabled={loading}
+            className="app-no-drag"
+          />
+          <Button
+            variant="primary"
+            size="sm"
+            onClick={() => void handleVerifyOtp()}
+            disabled={loading || code.length < 6}
+          >
+            {loading ? 'Verifying...' : 'Verify'}
+          </Button>
+          <Button
+            variant="ghost"
+            size="xs"
+            onClick={() => {
+              if (loading) return;
+              setPhase('email');
+              setCode('');
+              setError(null);
+              resetTurnstile();
+            }}
+            disabled={loading}
+          >
+            Use a different email
+          </Button>
+        </div>
+      )}
+
+      {error && (
+        <p
+          role="alert"
+          aria-live="assertive"
+          aria-atomic="true"
+          className="text-error-foreground text-sm"
+        >
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/browser/src/ui/components/provider-logos/google.tsx
+++ b/apps/browser/src/ui/components/provider-logos/google.tsx
@@ -1,26 +1,48 @@
-import type { SVGProps } from 'react';
+import { useId, type SVGProps } from 'react';
 
 /**
  * Google brand mark.
  *
- * Sourced from @lobehub/icons-static-svg (MIT). Uses `currentColor` so it
- * inherits the nearest `color` / `text-*` class.
+ * Uses the same four-color mark as the console login screen.
  */
 export function GoogleLogo(props: SVGProps<SVGSVGElement>) {
+  const id = useId();
+  const pathId = `${id}-google-g`;
+  const clipId = `${id}-google-g-clip`;
+
   return (
     <svg
-      fill="currentColor"
-      fillRule="evenodd"
-      viewBox="0 0 24 24"
+      viewBox="0 0 48 48"
       xmlns="http://www.w3.org/2000/svg"
       role="img"
       aria-label="Google"
       {...props}
     >
-      <path d="M23 12.245c0-.905-.075-1.565-.236-2.25h-10.54v4.083h6.186c-.124 1.014-.797 2.542-2.294 3.569l-.021.136 3.332 2.53.23.022C21.779 18.417 23 15.593 23 12.245z" />
-      <path d="M12.225 23c3.03 0 5.574-.978 7.433-2.665l-3.542-2.688c-.948.648-2.22 1.1-3.891 1.1a6.745 6.745 0 01-6.386-4.572l-.132.011-3.465 2.628-.045.124C4.043 20.531 7.835 23 12.225 23z" />
-      <path d="M5.84 14.175A6.65 6.65 0 015.463 12c0-.758.138-1.491.361-2.175l-.006-.147-3.508-2.67-.115.054A10.831 10.831 0 001 12c0 1.772.436 3.447 1.197 4.938l3.642-2.763z" />
-      <path d="M12.225 5.253c2.108 0 3.529.892 4.34 1.638l3.167-3.031C17.787 2.088 15.255 1 12.225 1 7.834 1 4.043 3.469 2.197 7.062l3.63 2.763a6.77 6.77 0 016.398-4.572z" />
+      <defs>
+        <path
+          id={pathId}
+          d="M44.5 20H24v8.5h11.8C34.7 33.9 30.1 37 24 37c-7.2 0-13-5.8-13-13s5.8-13 13-13c3.1 0 5.9 1.1 8.1 2.9l6.4-6.4C34.6 4.1 29.6 2 24 2 11.8 2 2 11.8 2 24s9.8 22 22 22c11 0 21-8 21-22 0-1.3-.2-2.7-.5-4z"
+        />
+      </defs>
+      <clipPath id={clipId}>
+        <use href={`#${pathId}`} overflow="visible" />
+      </clipPath>
+      <path clipPath={`url(#${clipId})`} fill="#FBBC05" d="M0 37V11l17 13z" />
+      <path
+        clipPath={`url(#${clipId})`}
+        fill="#EA4335"
+        d="M0 11l17 13 7-6.1L48 14V0H0z"
+      />
+      <path
+        clipPath={`url(#${clipId})`}
+        fill="#34A853"
+        d="M0 37l30-23 7.9 1L48 0v48H0z"
+      />
+      <path
+        clipPath={`url(#${clipId})`}
+        fill="#4285F4"
+        d="M48 48L17 24l-4-3 35-10z"
+      />
     </svg>
   );
 }

--- a/apps/browser/src/ui/components/ui/logo.tsx
+++ b/apps/browser/src/ui/components/ui/logo.tsx
@@ -23,7 +23,8 @@ export const Logo: FC<LogoProps> = ({
   ...props
 }) => {
   const colorStyle: Record<LogoColor, string> = {
-    default: 'fill-current text-primary-solid stroke-none',
+    default:
+      'fill-current text-primary-solid dark:text-primary-400 stroke-none',
     black: 'fill-current text-foreground stroke-none',
     white: 'fill-white stroke-none',
     zinc: 'fill-current text-muted-foreground stroke-none',

--- a/apps/browser/src/ui/hooks/use-turnstile.ts
+++ b/apps/browser/src/ui/hooks/use-turnstile.ts
@@ -31,6 +31,11 @@ const TURNSTILE_SITE_KEY = import.meta.env.VITE_TURNSTILE_SITE_KEY ?? '';
  *
  * When `VITE_TURNSTILE_SITE_KEY` is not set, the hook is inert —
  * `enabled` is false and `token` stays null.
+ *
+ * Internal app pages run on the custom `stagewise://` scheme. Turnstile is
+ * intentionally disabled there because custom-scheme origins are not reliable
+ * challenge targets; OTP still goes through the backend auth flow without a
+ * captcha token and surfaces any server-side rejection normally.
  */
 export function useTurnstile() {
   const [token, setToken] = useState<string | null>(null);
@@ -39,7 +44,8 @@ export function useTurnstile() {
   const widgetIdRef = useRef<string | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
 
-  const enabled = !!TURNSTILE_SITE_KEY;
+  const isUnsupportedOrigin = window.location.protocol === 'stagewise:';
+  const enabled = !!TURNSTILE_SITE_KEY && !isUnsupportedOrigin;
 
   const initWidget = useCallback(() => {
     if (!window.turnstile || !containerRef.current) return;

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/not-signed-in.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/not-signed-in.tsx
@@ -1,163 +1,36 @@
-import { Button, buttonVariants } from '@stagewise/stage-ui/components/button';
-import { Input } from '@stagewise/stage-ui/components/input';
-import { InputOtp } from '@stagewise/stage-ui/components/input-otp';
 import { useKartonProcedure } from '@ui/hooks/use-karton';
 import { Logo } from '@ui/components/ui/logo';
-import { useState, useCallback } from 'react';
-import { cn } from '@ui/utils';
-import { useTurnstile } from '@ui/hooks/use-turnstile';
-
-type OtpPhase = 'email' | 'code';
+import { SignInOptionsPanel } from '@ui/components/auth/sign-in-options-panel';
+import { useTrack } from '@ui/hooks/use-track';
+import {
+  SETTINGS_API_KEYS_PAGE_URL,
+  SETTINGS_CODING_PLANS_PAGE_URL,
+} from '@shared/internal-urls';
+import type { SocialAuthProvider } from '@shared/karton-contracts/ui/shared-types';
 
 export function NotSignedIn() {
   const sendOtp = useKartonProcedure((p) => p.userAccount.sendOtp);
   const verifyOtp = useKartonProcedure((p) => p.userAccount.verifyOtp);
-
-  const [phase, setPhase] = useState<OtpPhase>('email');
-  const [email, setEmail] = useState('');
-  const [code, setCode] = useState('');
-  const [error, setError] = useState<string | null>(null);
-  const [loading, setLoading] = useState(false);
-
-  const {
-    containerRef,
-    token,
-    ready,
-    error: turnstileError,
-    enabled,
-    reset,
-  } = useTurnstile();
-
-  const handleSendOtp = useCallback(async () => {
-    if (!email.trim()) return;
-    if (enabled && !token && !turnstileError) {
-      setError('Security verification not ready. Please wait a moment.');
-      return;
-    }
-    setError(null);
-    setLoading(true);
-    try {
-      const result = await sendOtp(email.trim(), token ?? '');
-      if (result?.error) {
-        setError(result.error);
-        reset();
-      } else {
-        setPhase('code');
-      }
-    } catch {
-      setError('Failed to send verification code.');
-      reset();
-    } finally {
-      setLoading(false);
-    }
-  }, [email, sendOtp, token, enabled, reset, turnstileError]);
-
-  const handleVerifyOtp = useCallback(async () => {
-    if (!code.trim()) return;
-    setError(null);
-    setLoading(true);
-    try {
-      const result = await verifyOtp(email.trim(), code.trim());
-      if (result?.error) setError(result.error);
-    } catch {
-      setError('Failed to verify code.');
-    } finally {
-      setLoading(false);
-    }
-  }, [email, code, verifyOtp]);
-
-  const canSend = enabled
-    ? (!!token || turnstileError) && !!email.trim()
-    : !!email.trim();
+  const signInSocial = useKartonProcedure((p) => p.userAccount.signInSocial);
+  const createTab = useKartonProcedure((p) => p.browser.createTab);
+  const track = useTrack();
 
   return (
     <div className="flex size-full flex-col items-center justify-center gap-4 p-6 text-center">
-      <div className="flex flex-col items-center justify-center gap-2">
-        <Logo className="mb-2 size-12" />
-        <span className="font-medium text-foreground text-xl">
-          Authenticate
-        </span>
-        <span className="text-muted-foreground text-sm">
-          Get access to the latest models with stagewise.
-        </span>
-      </div>
-
-      {/* Turnstile container — visible so interactive challenges can render */}
-      <div ref={containerRef} />
-
-      {phase === 'email' && (
-        <div className="flex gap-2">
-          <Input
-            placeholder="you@example.com"
-            size="sm"
-            className="app-no-drag"
-            type="email"
-            value={email}
-            onValueChange={(v) => setEmail(v)}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter') void handleSendOtp();
-            }}
-            disabled={loading}
-          />
-          <Button
-            variant="primary"
-            size="sm"
-            className="shrink-0"
-            onClick={() => void handleSendOtp()}
-            disabled={loading || !canSend}
-          >
-            {enabled && !ready && !turnstileError ? 'Loading...' : 'Sign in'}
-          </Button>
-        </div>
-      )}
-      {phase === 'email' && (
-        <a
-          href="stagewise://internal/agent-settings/models-providers"
-          className={cn(buttonVariants({ variant: 'ghost', size: 'xs' }))}
-        >
-          I want to use my own API keys
-        </a>
-      )}
-
-      {phase === 'code' && (
-        <div className="flex flex-col items-center gap-4">
-          <p className="font-normal text-muted-foreground text-sm">
-            We sent a code to{' '}
-            <span className="font-medium text-muted-foreground">{email}</span>.
-          </p>
-          <InputOtp
-            length={6}
-            size="sm"
-            value={code}
-            onChange={(val) => setCode(val)}
-            onComplete={() => void handleVerifyOtp()}
-            disabled={loading}
-            className="app-no-drag"
-          />
-          <Button
-            variant="primary"
-            size="sm"
-            onClick={() => void handleVerifyOtp()}
-            disabled={loading || code.length < 6}
-          >
-            {loading ? 'Verifying...' : 'Verify'}
-          </Button>
-          <Button
-            variant="ghost"
-            size="xs"
-            onClick={() => {
-              setPhase('email');
-              setCode('');
-              setError(null);
-              reset();
-            }}
-          >
-            Use a different email
-          </Button>
-        </div>
-      )}
-
-      {error && <p className="text-error-foreground text-sm">{error}</p>}
+      <Logo className="mb-2 size-12" />
+      <SignInOptionsPanel
+        title="Authenticate"
+        description="Get access to the latest models with stagewise."
+        sendOtp={(email, token) => sendOtp(email, token ?? '')}
+        verifyOtp={verifyOtp}
+        signInSocial={(provider: SocialAuthProvider) => signInSocial(provider)}
+        trackingPrefix="chat-auth"
+        track={track}
+        onUseApiKeys={() => void createTab(SETTINGS_API_KEYS_PAGE_URL, true)}
+        onUseSubscription={() =>
+          void createTab(SETTINGS_CODING_PLANS_PAGE_URL, true)
+        }
+      />
     </div>
   );
 }

--- a/apps/browser/src/ui/screens/onboarding/steps/02-auth.tsx
+++ b/apps/browser/src/ui/screens/onboarding/steps/02-auth.tsx
@@ -2,13 +2,11 @@ import { Button } from '@stagewise/stage-ui/components/button';
 import { Checkbox } from '@stagewise/stage-ui/components/checkbox';
 import { cn } from '@ui/utils';
 import { Input } from '@stagewise/stage-ui/components/input';
-import { InputOtp } from '@stagewise/stage-ui/components/input-otp';
 import { OverlayScrollbar } from '@stagewise/stage-ui/components/overlay-scrollbar';
 import { useKartonProcedure, useKartonState } from '@ui/hooks/use-karton';
 import { useState, useCallback, useRef, useEffect, useMemo } from 'react';
 import { useScrollFadeMask } from '@ui/hooks/use-scroll-fade-mask';
 import { useTrack } from '@ui/hooks/use-track';
-import { useTurnstile } from '@ui/hooks/use-turnstile';
 import {
   Tooltip,
   TooltipTrigger,
@@ -22,6 +20,10 @@ import {
 } from '@ui/components/coding-plan-card';
 import { ProviderLogo } from '@ui/components/provider-logos';
 import {
+  SignInOptionsPanel,
+  type SignInMethod,
+} from '@ui/components/auth/sign-in-options-panel';
+import {
   IconChevronLeftOutline18,
   IconChevronRightOutline18,
 } from 'nucleo-ui-outline-18';
@@ -32,7 +34,8 @@ import type {
 } from '@shared/karton-contracts/ui/shared-types';
 
 type AuthMode = 'stagewise' | 'api-keys' | 'coding-plan';
-type AuthPhase = 'form-input' | 'waiting-for-otp' | 'authentication-validated';
+type CompletionAuthMode = 'stagewise' | 'api-keys' | 'coding-plan';
+type AuthPhase = 'form-input' | 'authentication-validated';
 type ProviderKey =
   | 'anthropic'
   | 'openai'
@@ -54,8 +57,18 @@ const API_KEY_PROVIDERS: ProviderKey[] = [
 
 type ConnectResult = { success: true } | { success: false; error: string };
 
+const API_KEY_URLS: Record<ProviderKey, string> = {
+  anthropic: 'https://console.anthropic.com/settings/keys',
+  openai: 'https://platform.openai.com/api-keys',
+  google: 'https://aistudio.google.com/app/apikey',
+  moonshotai: 'https://platform.moonshot.ai/console/api-keys',
+  alibaba: 'https://dashscope.console.aliyun.com/apiKey',
+  deepseek: 'https://platform.deepseek.com/api_keys',
+  'z-ai': 'https://z.ai/manage-apikey/apikey-list',
+};
+
 export type OnboardingAuthCompletion = {
-  auth_method: AuthMode;
+  auth_method: CompletionAuthMode;
   provider?: ModelProvider;
   plan_id?: CodingPlanId;
 };
@@ -72,6 +85,7 @@ export function StepAuth({
 }) {
   const sendOtp = useKartonProcedure((p) => p.userAccount.sendOtp);
   const verifyOtp = useKartonProcedure((p) => p.userAccount.verifyOtp);
+  const signInSocial = useKartonProcedure((p) => p.userAccount.signInSocial);
   const disconnectProvider = useKartonProcedure(
     (p) => p.preferences.disconnectProvider,
   );
@@ -99,27 +113,11 @@ export function StepAuth({
       ? 'authentication-validated'
       : 'form-input',
   );
-  const [email, setEmail] = useState('');
-  const [code, setCode] = useState('');
-  const [error, setError] = useState<string | null>(null);
-  const [loading, setLoading] = useState(false);
   // The anonymous telemetry toggle has been removed from onboarding.
   // Basic (anonymous) telemetry is enabled by default and is only opt-out
   // from the settings page. This state only governs the identifiable /
   // "full" telemetry upgrade checkbox shown below.
   const [telemetry, setTelemetry] = useState<TelemetryLevel>('anonymous');
-  const emailRef = useRef<HTMLInputElement>(null);
-  const otpRef = useRef<HTMLInputElement>(null);
-
-  const {
-    containerRef: turnstileRef,
-    token: turnstileToken,
-    ready: turnstileReady,
-    error: turnstileError,
-    enabled: turnstileEnabled,
-    reset: resetTurnstile,
-  } = useTurnstile();
-
   const [showMoreProviders, setShowMoreProviders] = useState(false);
 
   // API-keys list scroll fadeout — mirrors the models-list pattern in
@@ -133,15 +131,6 @@ export function StepAuth({
     axis: 'vertical',
     fadeDistance: 24,
   });
-
-  useEffect(() => {
-    if (isActive && mode === 'stagewise' && phase === 'form-input')
-      requestAnimationFrame(() => emailRef.current?.focus());
-  }, [isActive, mode, phase]);
-
-  useEffect(() => {
-    if (phase === 'waiting-for-otp') otpRef.current?.focus();
-  }, [phase]);
 
   const hasConnectedApiKey = useMemo(() => {
     const cfgs = preferences.providerConfigs ?? {};
@@ -183,8 +172,6 @@ export function StepAuth({
     ) {
       setPhase('form-input');
       switchMode('stagewise');
-      setCode('');
-      setError(null);
       setSelectedCodingPlanId(null);
     }
   }, [authStatus, phase, switchMode]);
@@ -242,48 +229,6 @@ export function StepAuth({
       );
     }
   }, [isActive, isValid, onValidityChange]);
-
-  const handleSendOtp = useCallback(async () => {
-    if (!email.trim()) return;
-    if (turnstileEnabled && !turnstileToken && !turnstileError) {
-      void track('onboarding-auth-otp-failed', {
-        error_kind: 'turnstile-not-ready',
-      });
-      setError('Security verification not ready. Please wait a moment.');
-      return;
-    }
-    void track('onboarding-auth-otp-requested');
-    setError(null);
-    setLoading(true);
-    try {
-      const result = await sendOtp(email.trim(), turnstileToken ?? '');
-      if (result?.error) {
-        void track('onboarding-auth-otp-failed', {
-          error_kind: 'backend-error',
-        });
-        setError(result.error);
-        resetTurnstile();
-      } else {
-        setPhase('waiting-for-otp');
-      }
-    } catch {
-      void track('onboarding-auth-otp-failed', {
-        error_kind: 'network-error',
-      });
-      setError('Failed to send verification code.');
-      resetTurnstile();
-    } finally {
-      setLoading(false);
-    }
-  }, [
-    email,
-    sendOtp,
-    track,
-    turnstileToken,
-    turnstileEnabled,
-    resetTurnstile,
-    turnstileError,
-  ]);
 
   const codingPlans = useMemo(() => Object.values(CODING_PLANS), []);
 
@@ -350,39 +295,13 @@ export function StepAuth({
     [disconnectProvider, track],
   );
 
-  const handleVerifyOtp = useCallback(async () => {
-    if (!code.trim()) return;
-    setError(null);
-    setLoading(true);
-    try {
-      const result = await verifyOtp(email.trim(), code.trim());
-      if (result?.error) {
-        void track('onboarding-auth-otp-failed', {
-          error_kind: 'backend-error',
-        });
-        void track('onboarding-auth-method-failed', {
-          auth_method: 'stagewise',
-          error_kind: 'validation-error',
-        });
-        setError(result.error);
-      } else {
-        void track('onboarding-auth-otp-verified');
-        trackAuthCompleted({ auth_method: 'stagewise' });
-        setPhase('authentication-validated');
-      }
-    } catch {
-      void track('onboarding-auth-otp-failed', {
-        error_kind: 'network-error',
-      });
-      void track('onboarding-auth-method-failed', {
-        auth_method: 'stagewise',
-        error_kind: 'network-error',
-      });
-      setError('Failed to verify code.');
-    } finally {
-      setLoading(false);
-    }
-  }, [email, code, verifyOtp, track, trackAuthCompleted]);
+  const handleStagewiseAuthenticated = useCallback(
+    (_method: SignInMethod) => {
+      trackAuthCompleted({ auth_method: 'stagewise' });
+      setPhase('authentication-validated');
+    },
+    [trackAuthCompleted],
+  );
 
   if (phase === 'authentication-validated' && mode === 'stagewise') {
     return (
@@ -397,8 +316,6 @@ export function StepAuth({
             size="xs"
             onClick={() => {
               setPhase('form-input');
-              setCode('');
-              setError(null);
             }}
           >
             Use a different email
@@ -437,105 +354,37 @@ export function StepAuth({
 
   return (
     <div className="flex flex-1 flex-col items-center justify-center gap-4">
-      {!(mode === 'coding-plan' && selectedCodingPlanId !== null) && (
-        <div className="flex flex-col items-center gap-2 pb-2">
-          <h1 className="font-medium text-foreground text-xl">Authenticate</h1>
-          {mode === 'stagewise' && phase === 'form-input' && (
-            <p className="text-muted-foreground text-sm">
-              Get access to the latest models with stagewise.
-            </p>
-          )}
-          {mode === 'stagewise' && phase === 'waiting-for-otp' && (
-            <p className="text-muted-foreground text-sm">
-              We sent a code to{' '}
-              <span className="font-semibold text-muted-foreground">
-                {email}
-              </span>
-              . Enter it below.
-            </p>
-          )}
-          {mode === 'api-keys' && (
-            <p className="text-muted-foreground text-sm">
-              Enter at least one provider key to authenticate.
-            </p>
-          )}
-          {mode === 'coding-plan' && (
-            <p className="text-muted-foreground text-sm">
-              Connect a GLM, Kimi, Qwen, or MiniMax coding plan to authenticate.
-            </p>
-          )}
-        </div>
-      )}
-
-      {/* Turnstile container — visible so interactive challenges can render */}
-      <div ref={turnstileRef} />
+      {!(mode === 'coding-plan' && selectedCodingPlanId !== null) &&
+        mode !== 'stagewise' && (
+          <div className="flex flex-col items-center gap-2 pb-2">
+            <h1 className="font-medium text-foreground text-xl">
+              Authenticate
+            </h1>
+            {mode === 'api-keys' && (
+              <p className="text-muted-foreground text-sm">
+                Enter at least one provider key to authenticate.
+              </p>
+            )}
+            {mode === 'coding-plan' && (
+              <p className="text-muted-foreground text-sm">
+                Connect a GLM, Kimi, Qwen, or MiniMax coding plan to
+                authenticate.
+              </p>
+            )}
+          </div>
+        )}
 
       {mode === 'stagewise' && phase === 'form-input' && (
-        <div className="flex gap-2">
-          <Input
-            ref={emailRef}
-            placeholder="you@example.com"
-            size="sm"
-            className="app-no-drag w-64"
-            type="email"
-            value={email}
-            onValueChange={(v) => setEmail(v)}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter') void handleSendOtp();
-            }}
-            disabled={loading}
-          />
-          <Button
-            variant="primary"
-            className="shrink-0"
-            size="sm"
-            onClick={() => void handleSendOtp()}
-            disabled={
-              loading ||
-              !email.trim() ||
-              (turnstileEnabled && !turnstileError && !turnstileToken)
-            }
-          >
-            {turnstileEnabled && !turnstileReady && !turnstileError
-              ? 'Loading...'
-              : 'Sign in'}
-          </Button>
-        </div>
-      )}
-
-      {mode === 'stagewise' && phase === 'waiting-for-otp' && (
-        <div className="flex flex-col items-center gap-4">
-          <InputOtp
-            ref={otpRef}
-            length={6}
-            size="md"
-            value={code}
-            onChange={(val) => setCode(val)}
-            onComplete={() => void handleVerifyOtp()}
-            disabled={loading}
-            className="app-no-drag"
-          />
-          <Button
-            variant="primary"
-            size="sm"
-            onClick={() => void handleVerifyOtp()}
-            disabled={loading || code.length < 6}
-          >
-            {loading ? 'Verifying...' : 'Verify'}
-          </Button>
-          <Button
-            variant="ghost"
-            size="xs"
-            onClick={() => {
-              setPhase('form-input');
-              setCode('');
-              setError(null);
-              resetTurnstile();
-            }}
-          >
-            Use a different email
-          </Button>
-        </div>
+        <SignInOptionsPanel
+          sendOtp={(email, token) => sendOtp(email, token ?? '')}
+          verifyOtp={verifyOtp}
+          signInSocial={signInSocial}
+          trackingPrefix="onboarding-auth"
+          track={track}
+          onUseApiKeys={() => switchMode('api-keys')}
+          onUseSubscription={() => switchMode('coding-plan')}
+          onAuthenticated={handleStagewiseAuthenticated}
+        />
       )}
 
       {mode === 'api-keys' && (
@@ -556,6 +405,8 @@ export function StepAuth({
               }
               onConnect={handleConnectSingleKey}
               onDisconnect={handleDisconnectApiKey}
+              apiKeyUrl={API_KEY_URLS.anthropic}
+              onGetApiKey={handleGetApiKey}
               onFocusProvider={(provider) => {
                 void track('onboarding-auth-api-key-input-focused', {
                   provider,
@@ -571,6 +422,8 @@ export function StepAuth({
               }
               onConnect={handleConnectSingleKey}
               onDisconnect={handleDisconnectApiKey}
+              apiKeyUrl={API_KEY_URLS.openai}
+              onGetApiKey={handleGetApiKey}
               onFocusProvider={(provider) => {
                 void track('onboarding-auth-api-key-input-focused', {
                   provider,
@@ -586,6 +439,8 @@ export function StepAuth({
               }
               onConnect={handleConnectSingleKey}
               onDisconnect={handleDisconnectApiKey}
+              apiKeyUrl={API_KEY_URLS.google}
+              onGetApiKey={handleGetApiKey}
               onFocusProvider={(provider) => {
                 void track('onboarding-auth-api-key-input-focused', {
                   provider,
@@ -605,6 +460,8 @@ export function StepAuth({
                   }
                   onConnect={handleConnectSingleKey}
                   onDisconnect={handleDisconnectApiKey}
+                  apiKeyUrl={API_KEY_URLS.moonshotai}
+                  onGetApiKey={handleGetApiKey}
                   onFocusProvider={(provider) => {
                     void track('onboarding-auth-api-key-input-focused', {
                       provider,
@@ -622,6 +479,8 @@ export function StepAuth({
                   }
                   onConnect={handleConnectSingleKey}
                   onDisconnect={handleDisconnectApiKey}
+                  apiKeyUrl={API_KEY_URLS.alibaba}
+                  onGetApiKey={handleGetApiKey}
                   onFocusProvider={(provider) => {
                     void track('onboarding-auth-api-key-input-focused', {
                       provider,
@@ -639,6 +498,8 @@ export function StepAuth({
                   }
                   onConnect={handleConnectSingleKey}
                   onDisconnect={handleDisconnectApiKey}
+                  apiKeyUrl={API_KEY_URLS.deepseek}
+                  onGetApiKey={handleGetApiKey}
                   onFocusProvider={(provider) => {
                     void track('onboarding-auth-api-key-input-focused', {
                       provider,
@@ -656,6 +517,8 @@ export function StepAuth({
                   }
                   onConnect={handleConnectSingleKey}
                   onDisconnect={handleDisconnectApiKey}
+                  apiKeyUrl={API_KEY_URLS['z-ai']}
+                  onGetApiKey={handleGetApiKey}
                   onFocusProvider={(provider) => {
                     void track('onboarding-auth-api-key-input-focused', {
                       provider,
@@ -671,7 +534,6 @@ export function StepAuth({
               size="xs"
               onClick={() => {
                 switchMode('stagewise');
-                setError(null);
                 setSelectedCodingPlanId(null);
               }}
             >
@@ -695,8 +557,6 @@ export function StepAuth({
           </div>
         </div>
       )}
-
-      {error && <p className="text-error-foreground text-sm">{error}</p>}
 
       {mode === 'coding-plan' && selectedCodingPlanId === null && (
         <div className="app-no-drag flex w-full max-w-md flex-col gap-3">
@@ -731,7 +591,6 @@ export function StepAuth({
               size="xs"
               onClick={() => {
                 switchMode('stagewise');
-                setError(null);
                 setSelectedCodingPlanId(null);
               }}
             >
@@ -782,34 +641,6 @@ export function StepAuth({
             </div>
           );
         })()}
-
-      {mode === 'stagewise' && phase === 'form-input' && (
-        <div className="flex flex-col items-center gap-1.5">
-          <Button
-            variant="ghost"
-            size="xs"
-            onClick={() => {
-              switchMode('api-keys');
-              setError(null);
-            }}
-          >
-            Use own API keys
-          </Button>
-          <div className="flex items-center gap-0">
-            <span className="text-subtle-foreground text-xs">or</span>
-            <Button
-              variant="ghost"
-              size="xs"
-              onClick={() => {
-                switchMode('coding-plan');
-                setError(null);
-              }}
-            >
-              Use existing subscription
-            </Button>
-          </div>
-        </div>
-      )}
     </div>
   );
 }
@@ -822,6 +653,8 @@ function ApiKeyRow({
   config,
   onConnect,
   onDisconnect,
+  apiKeyUrl,
+  onGetApiKey,
   onFocusProvider,
 }: {
   provider: ProviderKey;
@@ -834,6 +667,8 @@ function ApiKeyRow({
   };
   onConnect: (provider: ProviderKey, apiKey: string) => Promise<ConnectResult>;
   onDisconnect: (provider: ProviderKey) => Promise<void>;
+  apiKeyUrl: string;
+  onGetApiKey: (url: string) => void;
   onFocusProvider?: (provider: ProviderKey) => void;
 }) {
   const isConnected = !!config.encryptedApiKey && config.mode === 'official';
@@ -841,6 +676,7 @@ function ApiKeyRow({
   const [isConnecting, setIsConnecting] = useState(false);
   const [isDisconnecting, setIsDisconnecting] = useState(false);
   const [localError, setLocalError] = useState<string | null>(null);
+  const [isCreateKeyVisible, setIsCreateKeyVisible] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
   // Synchronous in-flight guards. React state updates are async, so overlapping
   // handlers (blur + click, Enter + click) within the same event cycle would
@@ -906,10 +742,37 @@ function ApiKeyRow({
   }, [onDisconnect, provider]);
 
   return (
-    <div className="flex flex-col gap-1">
-      <label htmlFor={inputId} className="text-muted-foreground text-xs">
-        {label}
-      </label>
+    <div
+      className="flex flex-col gap-1"
+      onMouseEnter={() => setIsCreateKeyVisible(true)}
+      onMouseLeave={() => setIsCreateKeyVisible(false)}
+      onFocus={() => setIsCreateKeyVisible(true)}
+      onBlur={(event) => {
+        if (!event.currentTarget.contains(event.relatedTarget)) {
+          setIsCreateKeyVisible(false);
+        }
+      }}
+    >
+      <div className="flex min-h-4 items-center justify-between gap-2">
+        <label htmlFor={inputId} className="text-muted-foreground text-xs">
+          {label}
+        </label>
+        {!isConnected && isCreateKeyVisible && (
+          <Tooltip>
+            <TooltipTrigger>
+              <button
+                type="button"
+                data-skip-auto-connect="true"
+                className="text-primary-foreground text-xs transition-colors hover:cursor-pointer hover:text-hover-derived"
+                onClick={() => onGetApiKey(apiKeyUrl)}
+              >
+                Create key
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>{apiKeyUrl}</TooltipContent>
+          </Tooltip>
+        )}
+      </div>
       <div className="flex gap-1.5">
         <Input
           ref={inputRef}
@@ -949,8 +812,14 @@ function ApiKeyRow({
               void handleConnect();
             }
           }}
-          onBlur={() => {
+          onBlur={(event) => {
             if (isConnected) return;
+            if (
+              event.relatedTarget instanceof HTMLElement &&
+              event.relatedTarget.closest('[data-skip-auto-connect="true"]')
+            ) {
+              return;
+            }
             if (localInput.trim() && !isConnecting) {
               void handleConnect();
             }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Google and GitHub sign-in via the system browser and unify the sign-in UI across onboarding, account, and chat. Improves callback reliability with per-channel URL schemes, startup open‑url buffering, and a dev loopback server; defaults to the production API and expands auth telemetry.

- **New Features**
  - Social sign-in (`google`, `github`) via a shared `SignInOptionsPanel` used in onboarding, account, and chat.
  - OAuth opens in the system browser; callbacks use `stagewise://`, `stagewise-prerelease://`, or `stagewise-dev://` with a startup listener that buffers and drains `open-url` events.
  - Exposes `signInSocial(provider)` in the pages contract; backend uses `@better-auth/electron` (PKCE) with an optional local loopback HTTP server for dev OAuth testing.

- **Refactors**
  - Default `API_URL` set to `https://api.stagewise.io` (including asset cache).
  - Registers the OS protocol handler for per-channel auth callbacks while keeping `stagewise://internal` stable and decoupled from OAuth schemes.
  - Unifies OTP UI, disables Turnstile on `stagewise://` pages, adds settings hash anchors for API keys and coding plans, and updates the Google brand mark.
  - Expands telemetry for social and OTP auth (adds `backend-error`) with schema tests.

<sup>Written for commit 2de4efd2e0bf7c0dde88d298b63c02ac98ac1589. Summary will update on new commits. <a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1174?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Social sign-in via system browser for Google/GitHub; unified Sign-In panel (social, email OTP, API keys/subscription actions).

* **Improvements**
  * Robust auth callback flow: deferred startup URL buffering/dispatch, per-channel callback schemes, dev loopback for local flows, and protocol registration across release channels.
  * Account/onboarding adopt new sign-in UI; settings pages support hash-linked scrolling.
  * Telemetry expanded for social/auth events; Turnstile disabled on internal pages.
  * Asset/cache HTTP base URL default updated to api.stagewise.io.

* **Documentation**
  * .env.example documents auth callback URL schemes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stagewise-io/stagewise/pull/1174?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->