### PR TITLE
fix(stagewise): handle createAgent rejection and add min-w-0 for titl…

### DIFF
--- a/apps/browser/src/ui/screens/main/_components/sidebar-titlebar-row.tsx
+++ b/apps/browser/src/ui/screens/main/_components/sidebar-titlebar-row.tsx
@@ -95,7 +95,7 @@ export function SidebarTitlebarRow({
       )}
       {sidebarCollapsed && agentTitle && (
         <span
-          className="app-no-drag ml-2 select-none truncate font-medium text-foreground text-sm"
+          className="app-no-drag ml-2 min-w-0 select-none truncate font-medium text-foreground text-sm"
           style={
             isMacOs ? { marginTop: TITLEBAR_ICON_OPTICAL_OFFSET } : undefined
           }

--- a/apps/browser/src/ui/screens/main/agent-chat/index.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/index.tsx
@@ -85,11 +85,16 @@ export function AgentChat() {
       currentModelId,
       currentToolApprovalMode,
       paths.length > 0 ? paths : undefined,
-    ).then((id) => {
-      setOpenAgent(id);
-      setPendingCreate(false);
-      void setLastOpenAgentId(id);
-    });
+    )
+      .then((id) => {
+        setOpenAgent(id);
+        setPendingCreate(false);
+        void setLastOpenAgentId(id);
+      })
+      .catch((err) => {
+        console.error('Failed to create agent:', err);
+        setPendingCreate(false);
+      });
   }, [pendingCreate, createAgent, emptyAgentIdRef, setOpenAgent, track]);
 
   return (


### PR DESCRIPTION
…e truncation

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents the UI from getting stuck on agent creation failures and fixes sidebar title truncation when collapsed. Supports Linear 1135 by making agent creation robust and improving sidebar text handling.

- **Bug Fixes**
  - Catch `createAgent` rejections, clear the pending state, and log the error.
  - Add `min-w-0` to the sidebar title span so `truncate` works and long titles don't overflow.

<sup>Written for commit c6178dfe677f6a8640e3bc637ed796db54b1e64f. Summary will update on new commits. <a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1175?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved collapsed sidebar title display with better text truncation and proper layout alignment within its container
  * Added error handling to agent creation that logs failures and automatically resets the operation state, allowing users to retry after encountering errors

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stagewise-io/stagewise/pull/1175?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->