### PR TITLE
feat(stagewise): prepare nightly release infrastructure

### DIFF
--- a/.github/workflows/_release-browser.yml
+++ b/.github/workflows/_release-browser.yml
@@ -14,7 +14,12 @@ on:
       channel:
         required: true
         type: string
-        description: "Release channel (alpha, beta, release)"
+        description: "Release channel (alpha, beta, nightly, release)"
+      ref:
+        required: false
+        type: string
+        default: main
+        description: "Git ref to tag and release"
     secrets:
       NUCLEO_LICENSE_KEY:
         required: false
@@ -67,6 +72,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          ref: ${{ inputs.ref }}
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -242,7 +248,8 @@ jobs:
           AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
           AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
           # Release channel
-          RELEASE_CHANNEL: ${{ inputs.channel == 'release' && 'release' || 'prerelease' }}
+          RELEASE_CHANNEL: ${{ inputs.channel == 'release' && 'release' || inputs.channel == 'nightly' && 'nightly' || 'prerelease' }}
+          APP_VERSION_OVERRIDE: ${{ inputs.version }}
 
       - name: List build output
         working-directory: apps/browser

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -1,0 +1,85 @@
+name: "Nightly Release"
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Git ref to build"
+        required: false
+        type: string
+        default: main
+      date:
+        description: "Nightly date override (YYYYMMDD)"
+        required: false
+        type: string
+      counter:
+        description: "Nightly counter override (1-999)"
+        required: false
+        type: string
+
+run-name: "Nightly Release: ${{ inputs.ref || 'main' }}"
+
+permissions:
+  contents: read
+
+jobs:
+  version:
+    name: Compute nightly version
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      tag: ${{ steps.version.outputs.tag }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          ref: ${{ inputs.ref || 'main' }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa
+        with:
+          version: 10.30.3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version: 22
+          cache: 'pnpm'
+
+      - name: Install Dependencies
+        run: pnpm install --frozen-lockfile
+        env:
+          NUCLEO_LICENSE_KEY: ${{ secrets.NUCLEO_LICENSE_KEY }}
+
+      - name: Compute version
+        id: version
+        env:
+          NIGHTLY_DATE: ${{ inputs.date }}
+          NIGHTLY_COUNTER: ${{ inputs.counter }}
+        run: |
+          ARGS=(--github-output)
+          if [ -n "$NIGHTLY_DATE" ]; then
+            ARGS+=(--date "$NIGHTLY_DATE")
+          fi
+          if [ -n "$NIGHTLY_COUNTER" ]; then
+            ARGS+=(--counter "$NIGHTLY_COUNTER")
+          fi
+          pnpm tsx scripts/release/nightly-version.ts "${ARGS[@]}" >> "$GITHUB_OUTPUT"
+
+  release-nightly:
+    name: Release nightly
+    needs: version
+    permissions:
+      contents: write
+    uses: ./.github/workflows/_release-browser.yml
+    with:
+      version: ${{ needs.version.outputs.version }}
+      tag: ${{ needs.version.outputs.tag }}
+      channel: nightly
+      ref: ${{ inputs.ref || 'main' }}
+    secrets: inherit

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -75,11 +75,20 @@ The channel name and counter are intentionally concatenated (no dot separator) s
 
 The counter is **capped at `999`**. Going beyond would break lexical ordering — for example `alpha1000` sorts lower than `alpha999` because SemVer 2.0 compares non-purely-numeric prerelease identifiers as ASCII strings. The bump script hard-fails if the limit is reached. If you're about to hit it, promote to the next channel (`alpha` → `beta` → `release`) or bump the base version so the counter resets.
 
+### Nightly Versions
+
+Nightly versions are generated dynamically by CI and are **not committed** to `apps/browser/package.json`.
+
+Format: `MAJOR.MINOR.PATCH-nightlyYYYYMMDDNNN` (e.g. `1.0.1-nightly20260525001`). The base version is the next patch after the current stable package version. For example, if `apps/browser/package.json` is `1.0.0`, the nightly base is `1.0.1`.
+
+The nightly suffix is a single SemVer prerelease identifier so the version remains compatible with Squirrel.Windows. `YYYYMMDD` is the UTC date and `NNN` is a 3-digit per-day counter.
+
 Examples:
 
 - `1.0.1-alpha001` - First alpha for upcoming 1.0.1
 - `1.0.1-alpha002` - Second alpha
 - `1.0.1-beta001` - First beta (after alpha phase)
+- `1.0.1-nightly20260525001` - Nightly build for the 1.0.1 release line
 - `1.0.1` - Final release
 
 ### Version Transitions
@@ -97,7 +106,8 @@ Examples:
 | Channel | npm Tag | Purpose |
 |---------|---------|---------|
 | alpha | `alpha` | Early testing, unstable |
-| beta | `beta` | Feature complete, testing |
+| beta | `beta` | Legacy prerelease testing during transition |
+| nightly | n/a | Scheduled/manual nightly builds from main |
 | release | `latest` | Production ready |
 
 ## Versioning Commands
@@ -137,6 +147,8 @@ Releases are driven by a two-step workflow:
    This opens a release PR that bumps the version and updates the changelog.
 
 2. **Auto Release** (automatic, `.github/workflows/auto-release.yml`) — fires when the release PR merges to `main`. It detects which packages need a release (based on tag absence), then invokes the reusable `_Release Browser` or `_Release Karton` workflow to build artifacts and publish.
+
+Nightly releases are separate from the release PR flow. `.github/workflows/nightly-release.yml` can be triggered manually and computes a dynamic nightly version without modifying package.json. Alpha and beta are legacy prerelease channels and should no longer be used for new releases; use the nightly workflow for nightly builds instead of creating new alpha/beta releases.
 
 **Prerequisites for release:**
 

--- a/apps/browser/build-constants.ts
+++ b/apps/browser/build-constants.ts
@@ -1,13 +1,16 @@
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { readFileSync } from 'node:fs';
+import semver from 'semver';
 
-// Release channel: 'dev' | 'prerelease' | 'release'
-type ReleaseChannel = 'dev' | 'prerelease' | 'release';
+// Release channel: 'dev' | 'prerelease' | 'nightly' | 'release'
+type ReleaseChannel = 'dev' | 'prerelease' | 'nightly' | 'release';
 export const __APP_RELEASE_CHANNEL__: ReleaseChannel = (() => {
   switch (process.env.RELEASE_CHANNEL) {
     case 'release':
       return 'release';
+    case 'nightly':
+      return 'nightly';
     case 'prerelease':
       return 'prerelease';
     case 'dev':
@@ -27,6 +30,8 @@ export const __APP_BASE_NAME__ = (() => {
   switch (__APP_RELEASE_CHANNEL__) {
     case 'release':
       return 'stagewise';
+    case 'nightly':
+      return 'stagewise-nightly';
     case 'prerelease':
       return 'stagewise-prerelease';
     case 'dev':
@@ -40,6 +45,8 @@ export const __APP_NAME__ = (() => {
   switch (__APP_RELEASE_CHANNEL__) {
     case 'release':
       return 'stagewise';
+    case 'nightly':
+      return 'stagewise Nightly';
     case 'prerelease':
       return 'stagewise (Pre-Release)';
     case 'dev':
@@ -52,6 +59,8 @@ export const __APP_BUNDLE_ID__ = (() => {
   switch (__APP_RELEASE_CHANNEL__) {
     case 'release':
       return 'io.stagewise.app';
+    case 'nightly':
+      return 'io.stagewise.nightly';
     case 'prerelease':
       return 'io.stagewise.prerelease';
     case 'dev':
@@ -61,9 +70,15 @@ export const __APP_BUNDLE_ID__ = (() => {
 })();
 
 export const __APP_VERSION__ = (() => {
-  const version = packageJson.version;
+  const override = process.env.APP_VERSION_OVERRIDE;
+  const version = override || packageJson.version;
   if (typeof version !== 'string') {
     throw new Error('Version not found in package.json');
+  }
+  if (!semver.valid(version)) {
+    throw new Error(
+      `Invalid app version${override ? ' override' : ''}: ${version}`,
+    );
   }
   return version;
 })();

--- a/apps/browser/forge.config.mts
+++ b/apps/browser/forge.config.mts
@@ -31,6 +31,11 @@ const windowsSignConfig = getWindowsSignConfig();
 console.log(
   `[forge.config] Release channel: ${buildConstants.__APP_RELEASE_CHANNEL__}`,
 );
+const visualAssetChannel =
+  buildConstants.__APP_RELEASE_CHANNEL__ === 'nightly'
+    ? 'prerelease'
+    : buildConstants.__APP_RELEASE_CHANNEL__;
+
 // DMG volume name (shown when mounted)
 const dmgVolumeName = 'Install stagewise';
 
@@ -300,7 +305,7 @@ const config: ForgeConfig = {
     extraResource: [
       './bundled',
       './assets/sounds',
-      `./assets/icons/${buildConstants.__APP_RELEASE_CHANNEL__}/icon.png`,
+      `./assets/icons/${visualAssetChannel}/icon.png`,
     ],
     prune: true,
     afterCopy: [
@@ -309,7 +314,7 @@ const config: ForgeConfig = {
       uploadSourceMapsAndCleanup,
     ],
     afterComplete: [copyVcRedist], // sources DLLs directly from VS install on the runner
-    icon: `./assets/icons/${buildConstants.__APP_RELEASE_CHANNEL__}/icon`,
+    icon: `./assets/icons/${visualAssetChannel}/icon`,
     appCopyright: `Copyright © ${new Date().getFullYear()} stagewise Inc.`,
     win32metadata: {
       CompanyName: 'stagewise Inc.',
@@ -359,8 +364,8 @@ const config: ForgeConfig = {
       version: buildConstants.__APP_VERSION__,
       setupExe: `${buildConstants.__APP_BASE_NAME__}-${buildConstants.__APP_VERSION__}-${arch}-setup.exe`,
       copyright: `Copyright © ${new Date().getFullYear()} stagewise Inc.`,
-      setupIcon: `./assets/icons/${buildConstants.__APP_RELEASE_CHANNEL__}/icon.ico`,
-      loadingGif: `./assets/install/${buildConstants.__APP_RELEASE_CHANNEL__}/windows-install-image.gif`,
+      setupIcon: `./assets/icons/${visualAssetChannel}/icon.ico`,
+      loadingGif: `./assets/install/${visualAssetChannel}/windows-install-image.gif`,
       title: `Installing ${buildConstants.__APP_NAME__}...`,
       // Windows code signing for the installer (uses same config as packager)
       ...(windowsSignConfig ? { windowsSign: windowsSignConfig } : {}),
@@ -371,7 +376,7 @@ const config: ForgeConfig = {
         bin: buildConstants.__APP_BASE_NAME__,
         productName: buildConstants.__APP_NAME__,
         genericName: 'Web Browser',
-        icon: `./assets/icons/${buildConstants.__APP_RELEASE_CHANNEL__}/icon.png`,
+        icon: `./assets/icons/${visualAssetChannel}/icon.png`,
         homepage: 'https://stagewise.io',
         categories: ['Development', 'Network', 'Utility'],
       },
@@ -382,7 +387,7 @@ const config: ForgeConfig = {
         bin: buildConstants.__APP_BASE_NAME__,
         productName: buildConstants.__APP_NAME__,
         genericName: 'Web Browser',
-        icon: `./assets/icons/${buildConstants.__APP_RELEASE_CHANNEL__}/icon.png`,
+        icon: `./assets/icons/${visualAssetChannel}/icon.png`,
         homepage: 'https://stagewise.io',
         categories: ['Development', 'Network', 'Utility'],
         section: 'devel',
@@ -392,7 +397,7 @@ const config: ForgeConfig = {
     new MakerDMG({
       format: 'UDZO',
       title: dmgVolumeName,
-      icon: `./assets/icons/${buildConstants.__APP_RELEASE_CHANNEL__}/icon.icns`,
+      icon: `./assets/icons/${visualAssetChannel}/icon.icns`,
       additionalDMGOptions: {},
       background: './assets/install/macos-dmg-background.png',
       contents: [

--- a/apps/browser/src/backend/index.ts
+++ b/apps/browser/src/backend/index.ts
@@ -25,6 +25,8 @@ const appBaseName = (() => {
   switch (__APP_RELEASE_CHANNEL__) {
     case 'release':
       return 'stagewise';
+    case 'nightly':
+      return 'stagewise-nightly';
     case 'prerelease':
       return 'stagewise-prerelease';
     case 'dev':
@@ -37,6 +39,8 @@ const appName = (() => {
   switch (__APP_RELEASE_CHANNEL__) {
     case 'release':
       return 'stagewise';
+    case 'nightly':
+      return 'stagewise Nightly';
     case 'prerelease':
       return 'stagewise (Pre-Release)';
     case 'dev':

--- a/apps/browser/src/backend/main.ts
+++ b/apps/browser/src/backend/main.ts
@@ -47,6 +47,7 @@ import {
   getRipgrepBasePath,
 } from './utils/paths';
 import { migrateLegacyPaths } from './utils/migrate-legacy-paths';
+import { importLegacyPrereleaseData } from './utils/import-legacy-prerelease-data';
 import { discoverPlugins } from './utils/discover-plugins';
 import { discoverSkills } from './agents/shared/prompts/utils/get-skills';
 import type { SkillDefinition } from '@shared/skills';
@@ -66,6 +67,8 @@ export async function main({ launchOptions: { verbose } }: MainParameters) {
   // In this file you can include the rest of your app's specific main process
   // code. You can also put them in separate files and import them here.
   const logger = new Logger(verbose ?? false);
+
+  await importLegacyPrereleaseData(logger);
 
   migrateLegacyPaths(logger);
 

--- a/apps/browser/src/backend/services/auth/callback-scheme.ts
+++ b/apps/browser/src/backend/services/auth/callback-scheme.ts
@@ -1,6 +1,7 @@
 type AuthCallbackScheme =
   | 'stagewise'
   | 'stagewise-prerelease'
+  | 'stagewise-nightly'
   | 'stagewise-dev';
 
 function getDefaultAuthCallbackScheme(): AuthCallbackScheme {
@@ -9,6 +10,8 @@ function getDefaultAuthCallbackScheme(): AuthCallbackScheme {
       return 'stagewise';
     case 'prerelease':
       return 'stagewise-prerelease';
+    case 'nightly':
+      return 'stagewise-nightly';
     case 'dev':
       return 'stagewise-dev';
     default:

--- a/apps/browser/src/backend/services/auto-update.ts
+++ b/apps/browser/src/backend/services/auto-update.ts
@@ -19,7 +19,11 @@ import type { PreferencesService } from './preferences';
 import type { KartonService } from './karton';
 import type { UpdateChannel } from '@shared/karton-contracts/ui/shared-types';
 
-declare const __APP_RELEASE_CHANNEL__: 'dev' | 'prerelease' | 'release';
+declare const __APP_RELEASE_CHANNEL__:
+  | 'dev'
+  | 'prerelease'
+  | 'nightly'
+  | 'release';
 declare const __APP_VERSION__: string;
 declare const __APP_PLATFORM__: string;
 declare const __APP_ARCH__: string;
@@ -251,6 +255,8 @@ export class AutoUpdateService extends DisposableService {
     switch (__APP_RELEASE_CHANNEL__) {
       case 'release':
         return 'release';
+      case 'nightly':
+        return 'nightly';
       case 'prerelease': {
         const prefs = this.preferencesService.get();
         return prefs.updateChannel ?? this.inferChannelFromVersion();

--- a/apps/browser/src/backend/utils/import-legacy-prerelease-data.ts
+++ b/apps/browser/src/backend/utils/import-legacy-prerelease-data.ts
@@ -1,0 +1,134 @@
+import { app } from 'electron';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import type { Logger } from '../services/logger';
+import { getDataRoot } from './paths';
+
+declare const __APP_RELEASE_CHANNEL__:
+  | 'dev'
+  | 'prerelease'
+  | 'nightly'
+  | 'release';
+
+const LEGACY_PRERELEASE_BASE_NAME = 'stagewise-prerelease';
+const DATA_ROOT_DIR_NAME = 'stagewise';
+const MIGRATION_MARKER_RELATIVE_PATH = path.join(
+  '.migrations',
+  'prerelease-import.json',
+);
+
+async function pathExists(filePath: string): Promise<boolean> {
+  try {
+    await fs.access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function isDirectoryEmpty(dirPath: string): Promise<boolean> {
+  try {
+    const entries = await fs.readdir(dirPath);
+    return entries.length === 0;
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === 'ENOENT') return true;
+    return false;
+  }
+}
+
+async function writeMigrationMarker(
+  targetDataRoot: string,
+  sourceDataRoot: string,
+): Promise<void> {
+  const markerPath = path.join(targetDataRoot, MIGRATION_MARKER_RELATIVE_PATH);
+  await fs.mkdir(path.dirname(markerPath), { recursive: true });
+  await fs.writeFile(
+    markerPath,
+    `${JSON.stringify(
+      {
+        sourceDataRoot,
+        targetDataRoot,
+        importedAt: new Date().toISOString(),
+        releaseChannel: __APP_RELEASE_CHANNEL__,
+      },
+      null,
+      2,
+    )}\n`,
+    'utf-8',
+  );
+}
+
+export async function importLegacyPrereleaseData(
+  logger: Logger,
+): Promise<void> {
+  if (
+    __APP_RELEASE_CHANNEL__ !== 'release' &&
+    __APP_RELEASE_CHANNEL__ !== 'nightly'
+  ) {
+    logger.debug(
+      `[LegacyPrereleaseImport] Skipping for ${__APP_RELEASE_CHANNEL__} build`,
+    );
+    return;
+  }
+
+  const sourceDataRoot = path.join(
+    app.getPath('appData'),
+    LEGACY_PRERELEASE_BASE_NAME,
+    DATA_ROOT_DIR_NAME,
+  );
+  const targetDataRoot = getDataRoot();
+
+  if (sourceDataRoot === targetDataRoot) {
+    logger.debug(
+      '[LegacyPrereleaseImport] Source and target data roots are identical, skipping',
+    );
+    return;
+  }
+
+  if (!(await pathExists(sourceDataRoot))) {
+    logger.debug(
+      `[LegacyPrereleaseImport] No legacy prerelease data found at ${sourceDataRoot}`,
+    );
+    return;
+  }
+
+  const targetExists = await pathExists(targetDataRoot);
+  if (targetExists && !(await isDirectoryEmpty(targetDataRoot))) {
+    logger.debug(
+      `[LegacyPrereleaseImport] Target data root already exists and is non-empty at ${targetDataRoot}, skipping`,
+    );
+    return;
+  }
+
+  const targetParent = path.dirname(targetDataRoot);
+  const tempTarget = path.join(
+    targetParent,
+    `${path.basename(targetDataRoot)}.importing-${process.pid}-${Date.now()}`,
+  );
+
+  try {
+    await fs.mkdir(targetParent, { recursive: true });
+    await fs.rm(tempTarget, { recursive: true, force: true });
+    await fs.cp(sourceDataRoot, tempTarget, {
+      recursive: true,
+      errorOnExist: false,
+      force: false,
+    });
+    await writeMigrationMarker(tempTarget, sourceDataRoot);
+
+    if (targetExists) {
+      await fs.rmdir(targetDataRoot);
+    }
+    await fs.rename(tempTarget, targetDataRoot);
+
+    logger.info(
+      `[LegacyPrereleaseImport] Imported legacy prerelease data from ${sourceDataRoot} to ${targetDataRoot}`,
+    );
+  } catch (error) {
+    await fs.rm(tempTarget, { recursive: true, force: true }).catch(() => {});
+    logger.warn(
+      `[LegacyPrereleaseImport] Failed to import legacy prerelease data: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}

--- a/apps/browser/src/shared/constants.d.ts
+++ b/apps/browser/src/shared/constants.d.ts
@@ -1,4 +1,8 @@
-declare const __APP_RELEASE_CHANNEL__: 'dev' | 'prerelease' | 'release';
+declare const __APP_RELEASE_CHANNEL__:
+  | 'dev'
+  | 'prerelease'
+  | 'nightly'
+  | 'release';
 declare const __APP_BASE_NAME__: string;
 declare const __APP_NAME__: string;
 declare const __APP_BUNDLE_ID__: string;

--- a/apps/browser/src/shared/internal-urls.ts
+++ b/apps/browser/src/shared/internal-urls.ts
@@ -4,8 +4,9 @@
  *
  * The `stagewise://internal` origin is intentionally stable across release
  * channels. Do not couple it to OAuth callback schemes such as
- * `stagewise-dev://` or `stagewise-prerelease://`; those are OS-level deep
- * links, while this origin is the app's privileged in-browser page host.
+ * `stagewise-dev://`, `stagewise-prerelease://`, or
+ * `stagewise-nightly://`; those are OS-level deep links, while this origin is
+ * the app's privileged in-browser page host.
  */
 
 /** The home page URL - displayed when opening a new tab or on startup */

--- a/apps/browser/src/shared/karton-contracts/pages-api/index.ts
+++ b/apps/browser/src/shared/karton-contracts/pages-api/index.ts
@@ -84,7 +84,7 @@ export type PagesApiState = {
     version: string; // The version of the app.
     platform: 'darwin' | 'linux' | 'win32'; // The platform on which the app is running.
     // Build-time constants
-    releaseChannel: 'dev' | 'prerelease' | 'release'; // The release channel of the app.
+    releaseChannel: 'dev' | 'prerelease' | 'nightly' | 'release'; // The release channel of the app.
     author: string; // Author name.
     copyright: string; // Copyright string.
     homepage: string; // Homepage URL.

--- a/apps/browser/src/shared/karton-contracts/ui/index.ts
+++ b/apps/browser/src/shared/karton-contracts/ui/index.ts
@@ -673,7 +673,7 @@ export type AppState = {
     platform: 'darwin' | 'linux' | 'win32'; // The platform on which the app is running.
     isFullScreen: boolean; // Whether the app window is in fullscreen mode.
     // Build-time constants
-    releaseChannel: 'dev' | 'prerelease' | 'release'; // The release channel of the app.
+    releaseChannel: 'dev' | 'prerelease' | 'nightly' | 'release'; // The release channel of the app.
     author: string; // Author name.
     copyright: string; // Copyright string.
     homepage: string; // Homepage URL.

--- a/apps/update-server/spec.md
+++ b/apps/update-server/spec.md
@@ -12,11 +12,12 @@ Build a auto-update / download server that responds to certain request paths wit
   - The app name should be configurable with an env var (`APP_NAME`).
   - The app is released and files are hosted in a github repo. Make this configurable as well (`APP_GITHUB_ORG` and `APP_GITHUB_REPO`)
 - The server offers multiple update channels:
-  - Release updates (returns only stable versions) under channel `release`
-  - Pre-Release updates (returns newest versions, including pre-release)
-    - Alpha channel (returns the latest pre-release, including pre-releases with alpha and beta version suffix) under channel `alpha`
-    - Beta channel (returns the latest pre-release, including pre-releases with beta version suffix, but no alpha versions) under channel `beta`.
-  - The channel param in URLs can be `release`, `beta` or `alpha`.
+  - Release updates (returns only stable versions) under channel `release`.
+  - Nightly updates (returns only nightly versions such as `1.0.1-nightly20260525001`) under channel `nightly`.
+  - Legacy pre-release updates are kept during the migration window:
+    - Alpha channel (returns the latest legacy pre-release, including pre-releases with alpha and beta version suffix) under channel `alpha`.
+    - Beta channel (returns the latest legacy pre-release with beta version suffix, but no alpha versions) under channel `beta`.
+  - The channel param in URLs can be `release`, `nightly`, `beta` or `alpha`.
 - The releases that are available should be fetched from github releases of the repository. Always fetch all releases (including pre-releases) that begin with the configured app name (like `${APP_NAME}@1.0.0-beta.1`) and ignore other releases.
   - The release assets include all the files that are needed in order to generate all responses.
   - The list of releases should be fetched once on start and then every 15 minutes again. Cache the fetched list until a refresh from github releases happens.
@@ -35,11 +36,11 @@ Build a auto-update / download server that responds to certain request paths wit
 
 ## App release format
 
-The versioning of the app is in semver with optional suffixes for pre-release versions. Examples: `1.2.3`, `1.1.0-alpha.2`, `2.2.0-beta.5`.
+The versioning of the app is in semver with optional suffixes for pre-release versions. Examples: `1.2.3`, `1.1.0-alpha001`, `2.2.0-beta005`, `1.0.1-nightly20260525001`.
 
-Release versions don't have suffixes, pre-releases always have a suffix with either "alpha" or "beta".
+Release versions don't have suffixes. Legacy pre-releases use a suffix with either "alpha" or "beta". Nightly versions use a suffix in the form `nightlyYYYYMMDDNNN`, where `NNN` is a three-digit per-day counter.
 
-Beta versions are newer than Alpha versions if the semver version is equal.
+The suffix name and counter are intentionally concatenated without dot separators so Squirrel.Windows' NuGet parser can read versions from update package filenames.
 
 ## GitHub releases file format
 
@@ -59,8 +60,9 @@ Note that release files may either start with `${APP_NAME}` or `${APP_NAME}-prer
 
 The update endpoint for macOS should offer the latest update for the given arch, channel and version. If there is no release at all available for the given arch, respond with HTTP code 204 (No content).
 
-- If the channel is alpha, offer the latest beta or alpha pre-release. Don't offer production releases for this channel.
-- If the channel is beta, only offer the latest beta pre-release.
+- If the channel is alpha, offer the latest beta or alpha legacy pre-release. Don't offer release or nightly releases for this channel.
+- If the channel is beta, only offer the latest beta legacy pre-release.
+- If the channel is nightly, only offer the latest nightly release.
 - If the channel is release, only offer the latest release.
 - The request will most likely include the request header set to type `application/json`. Always set the response header to `application/json` unless nothing is available (then it's plaintext).
 - If the latest release is equal to or lower than the user-given version, the server should also respond with 204 (No content). Make sure that versions are properly compared, including the beta and alpha release.
@@ -85,8 +87,9 @@ The update response should look like this:
 
 The update endpoint for Windows should offer the latest update for the given arch, channel and version. If there is no release at all available for the given arch, respond with an rempty response.
 
-- If the channel is alpha, offer the latest beta or alpha pre-release. Don't offer production releases for this channel.
-- If the channel is beta, only offer the latest beta pre-release.
+- If the channel is alpha, offer the latest beta or alpha legacy pre-release. Don't offer release or nightly releases for this channel.
+- If the channel is beta, only offer the latest beta legacy pre-release.
+- If the channel is nightly, only offer the latest nightly release.
 - If the channel is release, only offer the latest release.
 - Always set the response header datatype to plaintext.
 - If the latest release is equal to or lower than the user-given version, the server should also respond with an empty response. Make sure that versions are properly compared, including the beta and alpha release.

--- a/apps/update-server/src/config.ts
+++ b/apps/update-server/src/config.ts
@@ -28,6 +28,6 @@ export function validateConfig(): void {
   }
 }
 
-export type Channel = 'release' | 'beta' | 'alpha';
+export type Channel = 'release' | 'nightly' | 'beta' | 'alpha';
 export type Platform = 'macos' | 'win' | 'linux';
 export type LinuxFormat = 'deb' | 'rpm';

--- a/apps/update-server/src/routes.ts
+++ b/apps/update-server/src/routes.ts
@@ -51,7 +51,12 @@ function resolveBaseUrl(req: Request): string {
 const router = Router();
 
 function isValidChannel(channel: string): channel is Channel {
-  return channel === 'release' || channel === 'beta' || channel === 'alpha';
+  return (
+    channel === 'release' ||
+    channel === 'nightly' ||
+    channel === 'beta' ||
+    channel === 'alpha'
+  );
 }
 
 function isValidLinuxFormat(format: string): format is LinuxFormat {

--- a/apps/update-server/src/version.ts
+++ b/apps/update-server/src/version.ts
@@ -8,8 +8,22 @@ export interface ParsedVersion {
   minor: number;
   patch: number;
   prerelease: string | null;
-  prereleaseType: 'alpha' | 'beta' | null;
+  prereleaseType: 'alpha' | 'beta' | 'nightly' | null;
   prereleaseNum: number | null;
+  nightlyDate: string | null;
+}
+
+function isValidNightlyDate(value: string): boolean {
+  const year = Number.parseInt(value.slice(0, 4), 10);
+  const month = Number.parseInt(value.slice(4, 6), 10);
+  const day = Number.parseInt(value.slice(6, 8), 10);
+  const date = new Date(Date.UTC(year, month - 1, day));
+
+  return (
+    date.getUTCFullYear() === year &&
+    date.getUTCMonth() === month - 1 &&
+    date.getUTCDate() === day
+  );
 }
 
 export function parseVersion(version: string): ParsedVersion | null {
@@ -19,8 +33,9 @@ export function parseVersion(version: string): ParsedVersion | null {
   const parsed = semver.parse(clean);
   if (!parsed) return null;
 
-  let prereleaseType: 'alpha' | 'beta' | null = null;
+  let prereleaseType: 'alpha' | 'beta' | 'nightly' | null = null;
   let prereleaseNum: number | null = null;
+  let nightlyDate: string | null = null;
   let prereleaseStr: string | null = null;
 
   if (parsed.prerelease.length > 0) {
@@ -31,9 +46,14 @@ export function parseVersion(version: string): ParsedVersion | null {
     // This is SemVer 1.0-compatible so Squirrel.Windows' embedded NuGet parser
     // (used client-side on Windows) can handle the filename-derived version.
     const concatenatedMatch = first.match(/^(alpha|beta)(\d+)$/);
+    const nightlyMatch = first.match(/^nightly(\d{8})(\d{3})$/);
     if (concatenatedMatch) {
       prereleaseType = concatenatedMatch[1] as 'alpha' | 'beta';
       prereleaseNum = Number.parseInt(concatenatedMatch[2], 10);
+    } else if (nightlyMatch && isValidNightlyDate(nightlyMatch[1])) {
+      prereleaseType = 'nightly';
+      nightlyDate = nightlyMatch[1];
+      prereleaseNum = Number.parseInt(nightlyMatch[2] ?? '0', 10);
     } else if (first === 'alpha' || first === 'beta') {
       // Legacy format: two identifiers like ["alpha", 63].
       // Kept so the server can still reason about historical releases
@@ -57,6 +77,7 @@ export function parseVersion(version: string): ParsedVersion | null {
     prerelease: prereleaseStr,
     prereleaseType,
     prereleaseNum,
+    nightlyDate,
   };
 }
 
@@ -75,6 +96,8 @@ export function matchesChannel(
   switch (channel) {
     case 'release':
       return version.prereleaseType === null;
+    case 'nightly':
+      return version.prereleaseType === 'nightly';
     case 'beta':
       return version.prereleaseType === 'beta';
     case 'alpha':

--- a/scripts/release/nightly-version.ts
+++ b/scripts/release/nightly-version.ts
@@ -1,0 +1,133 @@
+#!/usr/bin/env tsx
+
+import { readFile } from 'node:fs/promises';
+import { exec as execCallback } from 'node:child_process';
+import { promisify } from 'node:util';
+import path from 'node:path';
+import { parseArgs } from 'node:util';
+import semver from 'semver';
+import { getRepoRoot } from './git-utils.js';
+
+const exec = promisify(execCallback);
+const NIGHTLY_COUNTER_PADDING = 3;
+const NIGHTLY_COUNTER_MAX = 10 ** NIGHTLY_COUNTER_PADDING - 1;
+
+function formatDate(date: Date): string {
+  const year = date.getUTCFullYear();
+  const month = String(date.getUTCMonth() + 1).padStart(2, '0');
+  const day = String(date.getUTCDate()).padStart(2, '0');
+  return `${year}${month}${day}`;
+}
+
+function isValidNightlyDate(value: string): boolean {
+  const year = Number.parseInt(value.slice(0, 4), 10);
+  const month = Number.parseInt(value.slice(4, 6), 10);
+  const day = Number.parseInt(value.slice(6, 8), 10);
+  const date = new Date(Date.UTC(year, month - 1, day));
+
+  return (
+    date.getUTCFullYear() === year &&
+    date.getUTCMonth() === month - 1 &&
+    date.getUTCDate() === day
+  );
+}
+
+function formatCounter(counter: number): string {
+  if (
+    !Number.isInteger(counter) ||
+    counter < 1 ||
+    counter > NIGHTLY_COUNTER_MAX
+  ) {
+    throw new Error(
+      `Nightly counter must be an integer between 1 and ${NIGHTLY_COUNTER_MAX}`,
+    );
+  }
+  return String(counter).padStart(NIGHTLY_COUNTER_PADDING, '0');
+}
+
+async function getStablePackageVersion(): Promise<string> {
+  const repoRoot = await getRepoRoot();
+  const packageJsonPath = path.join(repoRoot, 'apps/browser/package.json');
+  const packageJson = JSON.parse(await readFile(packageJsonPath, 'utf-8'));
+  const version = packageJson.version;
+  if (typeof version !== 'string' || !semver.valid(version)) {
+    throw new Error(`Invalid stagewise package version: ${String(version)}`);
+  }
+  return version;
+}
+
+async function getNextCounter(
+  baseVersion: string,
+  date: string,
+): Promise<number> {
+  const tagPrefix = `stagewise@${baseVersion}-nightly${date}`;
+  const { stdout } = await exec(
+    `git tag --list "${tagPrefix}*" --sort=-version:refname`,
+  );
+  const counters = stdout
+    .split('\n')
+    .map((tag) => tag.trim())
+    .filter(Boolean)
+    .map((tag) => tag.match(/nightly\d{8}(\d{3})$/)?.[1])
+    .filter((counter): counter is string => Boolean(counter))
+    .map((counter) => Number.parseInt(counter, 10))
+    .filter((counter) => Number.isInteger(counter));
+
+  const maxCounter = counters.length > 0 ? Math.max(...counters) : 0;
+  return maxCounter + 1;
+}
+
+async function main(): Promise<void> {
+  const { values } = parseArgs({
+    options: {
+      date: { type: 'string' },
+      counter: { type: 'string' },
+      'github-output': { type: 'boolean', default: false },
+    },
+  });
+
+  const stableVersion = await getStablePackageVersion();
+  const stableCore = semver.coerce(stableVersion);
+  if (!stableCore) {
+    throw new Error(`Invalid stable version: ${stableVersion}`);
+  }
+
+  const baseVersion = semver.inc(stableCore, 'patch');
+  if (!baseVersion) {
+    throw new Error(
+      `Failed to compute next patch version from ${stableVersion}`,
+    );
+  }
+
+  const date = values.date ?? formatDate(new Date());
+  if (!/^\d{8}$/.test(date) || !isValidNightlyDate(date)) {
+    throw new Error(`Invalid nightly date: ${date}. Expected YYYYMMDD.`);
+  }
+
+  if (values.counter && !/^\d+$/.test(values.counter)) {
+    throw new Error(`Invalid nightly counter: ${values.counter}`);
+  }
+
+  const counter = values.counter
+    ? Number.parseInt(values.counter, 10)
+    : await getNextCounter(baseVersion, date);
+  const version = `${baseVersion}-nightly${date}${formatCounter(counter)}`;
+  const tag = `stagewise@${version}`;
+
+  if (!semver.valid(version)) {
+    throw new Error(`Generated invalid nightly version: ${version}`);
+  }
+
+  if (values['github-output']) {
+    console.log(`version=${version}`);
+    console.log(`tag=${tag}`);
+    return;
+  }
+
+  console.log(JSON.stringify({ version, tag }, null, 2));
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+});


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduce a full nightly release channel with CI versioning, app/build support, update-server handling, and first-run data import from legacy prerelease installs. Nightlies default to `main`, support ref/date/counter overrides, auto-update correctly, and use distinct identity and tags.

- **New Features**
  - CI: Added `Nightly Release` workflow to compute `MAJOR.MINOR.PATCH-nightlyYYYYMMDDNNN` from the next patch (script `scripts/release/nightly-version.ts`), with date/counter overrides; outputs `version`/`tag`, reuses `_release-browser.yml` with `channel: nightly`, accepts `ref`, and passes `APP_VERSION_OVERRIDE`.
  - App/build: Introduced `nightly` channel with name `stagewise Nightly`, base `stagewise-nightly`, bundle ID `io.stagewise.nightly`; visuals reuse prerelease assets; `APP_VERSION_OVERRIDE` validated via `semver`.
  - Auto-update and contracts: Added `nightly` to shared types; `AutoUpdateService` maps build channel to `nightly`.
  - Update server: Added `nightly` channel; parses `nightlyYYYYMMDDNNN`; filters by `release | nightly | beta | alpha`; spec updated.
  - Migration: On first run of `release` or `nightly`, import data from legacy `stagewise-prerelease` into the new data root and write a migration marker.
  - Docs: `VERSIONING.md` documents nightly format, next-patch base, CI-only nightly flow, and marks alpha/beta as legacy prerelease channels.

<sup>Written for commit 13825a3531bcbe662326e57ced0803b782a20bb7. Summary will update on new commits. <a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1179?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an explicit nightly release channel, a manual nightly release workflow, and an automated nightly-version generator.

* **Improvements**
  * App branding, packaging, update feeds, auth callback behavior, and startup migration now honor nightly channel semantics.
  * Version parsing/validation and release-channel mappings expanded to support nightly; release workflow inputs refined for selected refs.

* **Documentation**
  * VERSIONING and update-server docs updated to describe nightly formats and channel behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stagewise-io/stagewise/pull/1179?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->