### PR TITLE
fix(browser): resume last agent after recovery

### DIFF
--- a/apps/browser/src/ui/screens/main/_components/global-hotkey-bindings.tsx
+++ b/apps/browser/src/ui/screens/main/_components/global-hotkey-bindings.tsx
@@ -6,8 +6,8 @@ import {
 } from '@shared/hotkeys';
 import { SETTINGS_PAGE_URL } from '@shared/internal-urls';
 import { useHotKeyListener } from '@ui/hooks/use-hotkey-listener';
-import { useKartonProcedure } from '@ui/hooks/use-karton';
-import { useAgentSwitcher } from '@ui/hooks/use-open-chat';
+import { useKartonProcedure, useKartonState } from '@ui/hooks/use-karton';
+import { useAgentSwitcher, useOpenAgent } from '@ui/hooks/use-open-chat';
 import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { useSidebarCollapsed } from './sidebar-collapsed-context';
 import { useCommandCenter } from '../command-center';
@@ -34,6 +34,10 @@ function getVisibleAgentIds() {
 export function GlobalHotkeyBindings() {
   const { isOpen: isCommandCenterOpen } = useCommandCenter();
   const globalHotkeysEnabled = !isCommandCenterOpen;
+  const lastOpenAgentId = useKartonState(
+    (state) => state.browser.lastOpenAgentId,
+  );
+  const [, setOpenAgent] = useOpenAgent();
 
   // -- Agent switching --------------------------------------------------
   const resumeAgent = useKartonProcedure((p) => p.agents.resume);
@@ -55,6 +59,7 @@ export function GlobalHotkeyBindings() {
   const isCyclingAgentsRef = useRef(isCyclingAgents);
   isCyclingAgentsRef.current = isCyclingAgents;
   const hasActiveCycleRef = useRef(false);
+  const lastRecoveryResumeAtRef = useRef(0);
 
   const openAgentInBackend = useCallback((id: string) => {
     void setLastOpenAgentIdRef
@@ -63,6 +68,45 @@ export function GlobalHotkeyBindings() {
       .then(() => resumeAgentRef.current(id))
       .catch(() => undefined);
   }, []);
+
+  const resumeLastOpenAgentAfterRecovery = useCallback(() => {
+    if (!lastOpenAgentId) return;
+
+    const now = Date.now();
+    if (now - lastRecoveryResumeAtRef.current < 1000) return;
+    lastRecoveryResumeAtRef.current = now;
+
+    setOpenAgent(lastOpenAgentId);
+    void setLastOpenAgentIdRef
+      .current(lastOpenAgentId)
+      .catch(() => undefined)
+      .then(() => resumeAgentRef.current(lastOpenAgentId))
+      .catch(() => undefined);
+  }, [lastOpenAgentId, setOpenAgent]);
+
+  useEffect(() => {
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'visible') {
+        resumeLastOpenAgentAfterRecovery();
+      }
+    };
+    const handleKartonReconnect = (event: Event) => {
+      const customEvent = event as CustomEvent<{ type?: string }>;
+      if (customEvent.detail?.type === 'reconnected') {
+        resumeLastOpenAgentAfterRecovery();
+      }
+    };
+
+    window.addEventListener('online', resumeLastOpenAgentAfterRecovery);
+    window.addEventListener('karton-reconnect', handleKartonReconnect);
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+
+    return () => {
+      window.removeEventListener('online', resumeLastOpenAgentAfterRecovery);
+      window.removeEventListener('karton-reconnect', handleKartonReconnect);
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+    };
+  }, [resumeLastOpenAgentAfterRecovery]);
 
   const handleAgentCycle = useCallback(
     (direction: 'next' | 'previous') => {


### PR DESCRIPTION
## Summary
- resumes the last-open agent when the browser comes back online
- resumes on Karton reconnect events after backend transport recovery
- resumes when the app becomes visible again after sleep/backgrounding
- throttles recovery-triggered resumes to avoid duplicate calls from clustered events

Fixes #1168.

## Verification
- git diff --check
- attempted pnpm check on global-hotkey-bindings.tsx, but this checkout has no node_modules installed, so biome was unavailable

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically resumes the last open agent after network or app recovery so users return to where they left off. Handles online, visibility, and backend reconnect events with throttling to prevent duplicate resumes.

- **Bug Fixes**
  - Resume last open agent when the browser goes online, on `karton-reconnect`, or when the app becomes visible.
  - Throttle recovery-triggered resumes to once per second.
  - Open the agent in the UI before calling backend resume to keep state in sync.
  - Fixes #1168.

<sup>Written for commit 44ad2b517c814f5ae5b4562c256761f1e2b41f86. Summary will update on new commits. <a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1186?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery of the last active agent following network reconnection or browser visibility changes. The app now automatically resumes your previous agent when connectivity is restored or you return to the browser window.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stagewise-io/stagewise/pull/1186?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->