### PR TITLE
fix(stagewise): harden shell output pattern matching

### DIFF
--- a/apps/browser/src/backend/services/toolbox/services/shell/session-manager.test.ts
+++ b/apps/browser/src/backend/services/toolbox/services/shell/session-manager.test.ts
@@ -558,6 +558,8 @@ describeIfShell('SessionManager (integration)', () => {
       });
 
       expect(r.output).toContain('RECENT_TAIL_MARKER');
+      expect(r.timedOut).toBe(false);
+      expect(r.resolvedBy).toBe('pattern');
       expect(r.recentOutput).toContain('RECENT_TAIL_MARKER');
       expect(r.recentOutput?.length ?? 0).toBeLessThanOrEqual(
         SHELL_RESPONSE_TAIL_MAX_CHARS,
@@ -593,6 +595,7 @@ describeIfShell('SessionManager (integration)', () => {
 
       expect(r.output).toContain('BUFFER_MARKER_123');
       expect(r.timedOut).toBe(false);
+      expect(r.resolvedBy).toBe('pattern');
       expect(elapsed).toBeLessThan(8000);
     } finally {
       sm?.killAll();

--- a/apps/browser/src/backend/services/toolbox/services/shell/session-manager.ts
+++ b/apps/browser/src/backend/services/toolbox/services/shell/session-manager.ts
@@ -250,6 +250,10 @@ interface PendingCommand {
   rawOutputCapped: boolean;
   /** Serialized buffer text captured at the moment of a buffer-based pattern match. */
   bufferSnapshot?: string;
+  /** Sanitized regex match captured from raw output when buffer matching fails. */
+  rawPatternSnapshot?: string;
+  /** Whether the first command-output start marker has already set markLine. */
+  hasCommandStart: boolean;
   /** Idle-detection state (see `DEFAULT_IDLE_MS`). */
   idleTimerHandle: NodeJS.Timeout | null;
   /** Silence threshold in ms (0 disables idle detection for this command). */
@@ -438,9 +442,12 @@ export class SessionManager {
       const cid = this.sessionCommandMap.get(sessionId);
       if (!cid) return;
       const pending = this.pendingCommands.get(cid);
-      if (!pending) return;
+      if (!pending || pending.hasCommandStart) return;
       const newMark = session.logger?.getMarkPosition();
-      if (newMark !== undefined) pending.markLine = newMark;
+      if (newMark !== undefined) {
+        pending.markLine = newMark;
+        pending.hasCommandStart = true;
+      }
     });
 
     parser.on('sentinelDone', (id, exitCode) => {
@@ -549,6 +556,7 @@ export class SessionManager {
         waitUntil: request.waitUntil,
         rawOutput: '',
         rawOutputCapped: false,
+        hasCommandStart: false,
         idleTimerHandle: null,
         idleMs,
       };
@@ -890,16 +898,26 @@ export class SessionManager {
   }
 
   private collectOutput(pending: PendingCommand): string {
+    const rawOutput = stripAnsi(pending.rawOutput).trimEnd();
+
     // If a buffer snapshot was captured at pattern-match time, return it
     // directly. This avoids a second serialization that may produce a
-    // different (possibly empty) range if the cursor moved since the match.
+    // different range if the cursor moved since the match.
     if (pending.bufferSnapshot != null) {
       const snapLines = pending.bufferSnapshot.split('\n');
       return applyHeadTailCap(snapLines).trimEnd();
     }
 
+    // If logger matching failed but sanitized raw command output matched the
+    // requested pattern, return only the matched visible text. Do not fall back
+    // to the full raw stream for logger-backed sessions: it can include text
+    // that the terminal later cleared or redrew away.
+    if (pending.rawPatternSnapshot != null) {
+      return pending.rawPatternSnapshot;
+    }
+
     const session = this.sessions.get(pending.sessionId);
-    if (!session?.logger) return stripAnsi(pending.rawOutput).trimEnd();
+    if (!session?.logger) return rawOutput;
 
     const logger = session.logger;
     const isAlt = logger.isAlternateBufferActive();
@@ -936,18 +954,11 @@ export class SessionManager {
 
     const session = this.sessions.get(sessionId);
 
-    // Gate for the no-logger fallback path only: accumulate raw output
-    // (used by the regex matcher when no xterm is attached) exclusively
-    // while inside real command output. This prevents prompt text and
-    // the echoed command line from polluting `pending.rawOutput` and
-    // triggering spurious matches.
-    //
-    // NOTE: we intentionally do NOT gate the logger-based matcher below.
-    // On CI and minimal shells the parser may stay in `detecting` mode
-    // for the entire command (OSC 133 never arrives), and gating there
-    // would make patterns never resolve. The logger-based matcher scopes
-    // to `pending.markLine` and skips the first serialized line (the
-    // prompt + echoed command) to avoid echo-leak matches.
+    // Accumulate raw output exclusively while inside real command output.
+    // This prevents prompt text and the echoed command line from polluting
+    // `pending.rawOutput` and triggering spurious matches. The raw stream is
+    // used directly when no logger exists and as a fallback when logger-backed
+    // xterm serialization is stale or marked from the wrong row.
     const inUserOutput =
       session?.parser.inCommandOutput ||
       session?.parser.currentMode === 'sentinel';
@@ -998,13 +1009,21 @@ export class SessionManager {
           if (matchText && re.test(matchText)) {
             pending.bufferSnapshot = lines.join('\n');
             this.resolveCommand(pending.commandId, null);
+            return;
           }
-        } else if (inUserOutput && !pending.rawOutputCapped) {
-          // Fallback: no logger — match against raw ANSI stream.
-          // Gated on inUserOutput because `rawOutput` can only grow
-          // there (see above).
-          if (re.test(pending.rawOutput))
+        }
+
+        if (inUserOutput && !pending.rawOutputCapped) {
+          // Fallback: match against sanitized visible command output. Capture
+          // only the matched text so logger-backed results do not expose raw
+          // transient output that the terminal later cleared or redrew away.
+          const rawMatchText = stripAnsi(pending.rawOutput).trimEnd();
+          re.lastIndex = 0;
+          const match = re.exec(rawMatchText);
+          if (match?.[0]) {
+            pending.rawPatternSnapshot = match[0];
             this.resolveCommand(pending.commandId, null);
+          }
         }
       } catch {
         // Invalid regex — ignore


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened shell output pattern matching in `SessionManager` to resolve waits reliably on CI and with xterm loggers. Matching ignores ANSI/control noise, filters sentinel echo, captures only the matched visible text from raw output when the buffer is stale, and avoids cleared-screen artifacts.

- **Bug Fixes**
  - Track first command-start to set `markLine` only once.
  - For `outputPattern`: prefer buffer match; if it fails, match sanitized raw output and snapshot only the matched text; otherwise use serialized buffer.
  - Output collection: return buffer snapshot; else raw-match snapshot; else serialized buffer; without a logger, return sanitized raw output.
  - Tests assert `resolvedBy: 'pattern'` with no timeouts.

<sup>Written for commit 178b8d57570b16e8abb8ec177045be015a14237a. Summary will update on new commits. <a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1188?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable output-pattern matching: prefers logged/serialized buffer matches, falls back to sanitized raw-output capture, avoids prompt/echo contamination, and prevents duplicate command-start tracking.

* **Tests**
  * Extended integration tests to cover logger-backed output and raw-fallback matching; added assertions that pattern resolutions report the resolved-by method and that commands do not time out.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stagewise-io/stagewise/pull/1188?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->