### PR TITLE
feat(stagewise): add migrate-to-stable dialog

### DIFF
--- a/apps/browser/src/backend/services/telemetry.ts
+++ b/apps/browser/src/backend/services/telemetry.ts
@@ -74,6 +74,9 @@ export type EventProperties = {
   'onboarding-demo-slide-clicked': {
     slide_name: string;
   };
+  'legacy-prerelease-bridge-shown': undefined;
+  'legacy-prerelease-bridge-dismissed': undefined;
+  'legacy-prerelease-bridge-download-clicked': undefined;
   'onboarding-auth-mode-switched': {
     from: OnboardingAuthMethod;
     to: OnboardingAuthMethod;
@@ -485,6 +488,9 @@ export const UI_TELEMETRY_EVENT_NAMES = [
   'chat-auth-social-requested',
   'chat-auth-social-verified',
   'onboarding-demo-slide-clicked',
+  'legacy-prerelease-bridge-shown',
+  'legacy-prerelease-bridge-dismissed',
+  'legacy-prerelease-bridge-download-clicked',
   'settings-opened',
   'suggestion-clicked',
   'suggestion-dismissed',
@@ -613,6 +619,9 @@ const UI_TELEMETRY_EVENT_SCHEMAS = {
   'onboarding-demo-slide-clicked': z.object({
     slide_name: z.string(),
   }),
+  'legacy-prerelease-bridge-shown': z.undefined().optional(),
+  'legacy-prerelease-bridge-dismissed': z.undefined().optional(),
+  'legacy-prerelease-bridge-download-clicked': z.undefined().optional(),
   'settings-opened': z.undefined().optional(),
   'suggestion-clicked': z.object({
     suggestion_id: z.string(),

--- a/apps/browser/src/ui/components/context-providers.tsx
+++ b/apps/browser/src/ui/components/context-providers.tsx
@@ -5,6 +5,7 @@ import { TooltipProvider } from '@stagewise/stage-ui/components/tooltip';
 import { PostHogProvider } from '@ui/hooks/use-posthog';
 import { TabStateUIProvider } from '../hooks/use-tab-ui-state';
 import { ErrorBoundary } from './error-boundary';
+import { LegacyPrereleaseBridgeDialog } from './legacy-prerelease-bridge-dialog';
 
 export function ContextProviders({ children }: { children?: ReactNode }) {
   return (
@@ -13,7 +14,10 @@ export function ContextProviders({ children }: { children?: ReactNode }) {
         <PostHogProvider>
           <ErrorBoundary>
             <MessageEditStateProvider>
-              <TabStateUIProvider>{children}</TabStateUIProvider>
+              <TabStateUIProvider>
+                {children}
+                <LegacyPrereleaseBridgeDialog />
+              </TabStateUIProvider>
             </MessageEditStateProvider>
           </ErrorBoundary>
         </PostHogProvider>

--- a/apps/browser/src/ui/components/legacy-prerelease-bridge-dialog.tsx
+++ b/apps/browser/src/ui/components/legacy-prerelease-bridge-dialog.tsx
@@ -1,0 +1,165 @@
+import { useEffect, useRef, useState } from 'react';
+import { Button } from '@stagewise/stage-ui/components/button';
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@stagewise/stage-ui/components/dialog';
+import { BellIcon, GitBranchIcon, TerminalIcon } from 'lucide-react';
+import { WorkspacesDark, WorkspacesLight } from '@ui/assets/feature-images';
+import { useTrack } from '@ui/hooks/use-track';
+import { useKartonProcedure } from '../hooks/use-karton';
+
+const STABLE_DOWNLOAD_URL = 'https://stagewise.io/download';
+const stableFeatures = [
+  {
+    title: 'Worktree support',
+    description: 'Run agents across isolated branches without losing context.',
+    icon: GitBranchIcon,
+  },
+  {
+    title: 'Agent notification sounds',
+    description: 'Know when agents need input or finish long-running work.',
+    icon: BellIcon,
+  },
+  {
+    title: 'Built-in terminals',
+    description:
+      'Keep command output close to the work happening in stagewise.',
+    icon: TerminalIcon,
+  },
+];
+
+export function LegacyPrereleaseBridgeDialog() {
+  const [open, setOpen] = useState(true);
+  const [downloadClicked, setDownloadClicked] = useState(false);
+  const [isOpeningDownload, setIsOpeningDownload] = useState(false);
+  const hasTrackedShown = useRef(false);
+  const openExternalUrl = useKartonProcedure((p) => p.openExternalUrl);
+  const track = useTrack();
+  const shouldShow = __APP_RELEASE_CHANNEL__ === 'prerelease';
+
+  useEffect(() => {
+    if (!shouldShow || hasTrackedShown.current) return;
+
+    hasTrackedShown.current = true;
+    void track('legacy-prerelease-bridge-shown');
+  }, [shouldShow, track]);
+
+  if (!shouldShow) return null;
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (open && !nextOpen) {
+      void track('legacy-prerelease-bridge-dismissed');
+    }
+
+    setOpen(nextOpen);
+  };
+
+  const handleDownloadStable = async () => {
+    if (isOpeningDownload) return;
+
+    setIsOpeningDownload(true);
+    void track('legacy-prerelease-bridge-download-clicked');
+
+    try {
+      await openExternalUrl(STABLE_DOWNLOAD_URL);
+      setDownloadClicked(true);
+    } catch {
+      setDownloadClicked(false);
+    } finally {
+      setIsOpeningDownload(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="max-h-[90vh] max-w-3xl gap-5 overflow-y-auto p-6 shadow-elevation-2">
+        <DialogClose aria-label="Close migration dialog" />
+
+        <DialogHeader className="mb-0 gap-3 pr-8">
+          <div className="flex flex-col gap-2">
+            <DialogTitle className="text-2xl leading-tight">
+              stagewise 1.0.0 is available
+            </DialogTitle>
+            <DialogDescription className="max-w-2xl text-base leading-relaxed">
+              stagewise has graduated from prerelease. Install stagewise 1.0.0
+              to keep receiving updates.
+            </DialogDescription>
+          </div>
+        </DialogHeader>
+
+        <div className="grid gap-5 lg:grid-cols-[1.15fr_0.85fr]">
+          <section className="flex flex-col gap-3 rounded-xl border border-derived-subtle bg-surface-1 p-3">
+            <div className="overflow-hidden rounded-lg border border-border-subtle bg-background">
+              <img
+                src={WorkspacesLight}
+                alt="stagewise workspaces preview"
+                className="block h-auto w-full dark:hidden"
+              />
+              <img
+                src={WorkspacesDark}
+                alt="stagewise workspaces preview"
+                className="hidden h-auto w-full dark:block"
+              />
+            </div>
+            <div className="px-1 pb-1">
+              <h2 className="font-medium text-foreground text-sm">
+                What’s new in stable
+              </h2>
+              <p className="text-muted-foreground text-sm">
+                A faster, more capable stagewise with the features from the
+                prerelease channel — now on the stable update path.
+              </p>
+            </div>
+          </section>
+
+          <section className="flex flex-col gap-4">
+            <div className="flex flex-col gap-4">
+              {stableFeatures.map((feature) => {
+                const Icon = feature.icon;
+                return (
+                  <div key={feature.title} className="flex gap-3">
+                    <Icon className="mt-0.5 size-4 shrink-0 text-foreground" />
+                    <div className="flex min-w-0 flex-col gap-1">
+                      <h3 className="font-medium text-foreground text-sm">
+                        {feature.title}
+                      </h3>
+                      <p className="text-muted-foreground text-xs leading-relaxed">
+                        {feature.description}
+                      </p>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </section>
+        </div>
+
+        <DialogFooter className="mt-0 flex-row items-center justify-between border-border-subtle border-t pt-5">
+          <p className="min-w-0 text-muted-foreground text-xs leading-relaxed">
+            {downloadClicked
+              ? 'Once stagewise 1.0.0 is installed and launches successfully, you can safely remove stagewise (Pre-Release) from your system.'
+              : 'Your data persists. You can delete stagewise (Pre-Release) after stable launches successfully.'}
+          </p>
+          {!downloadClicked && (
+            <Button
+              size="md"
+              onClick={handleDownloadStable}
+              disabled={isOpeningDownload}
+              className="shrink-0 whitespace-nowrap"
+            >
+              {isOpeningDownload
+                ? 'Opening download…'
+                : 'Download stagewise 1.0.0'}
+            </Button>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a migrate-to-stable dialog for prerelease builds that guides users to install stagewise 1.0.0, with a download button and a light/dark features preview. The dialog renders globally, opens https://stagewise.io/download via the app’s external URL handler, and tracks when it’s shown, dismissed, and the download is clicked.

<sup>Written for commit ac6fad89a15b3c7f5d3541e8b4dddcf65135005f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1190?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a prerelease-to-stable bridge dialog displaying new features and improvements available in the stable release with a download link
  * Extended telemetry event tracking to capture user interactions with the bridge dialog (display, dismissal, and download events)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stagewise-io/stagewise/pull/1190?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->