### PR TITLE
feat(browser): keep app awake during active agents

### DIFF
--- a/apps/browser/src/backend/main.ts
+++ b/apps/browser/src/backend/main.ts
@@ -62,12 +62,15 @@ import { readPersistedDataSync } from './utils/persisted-data';
 import { z } from 'zod';
 import { discoverPlugins } from './utils/discover-plugins';
 import { discoverSkills } from './agents/shared/prompts/utils/get-skills';
-import type { SkillDefinition } from '@shared/skills';
+import type { Skill } from './agents/shared/prompts/utils/get-skills';
+import type { SkillDefinition, SkillDefinitionUI } from '@shared/skills';
 import { AssetCacheService } from './services/asset-cache';
 import { detectShell, resolveShellEnv } from './utils/shell-env';
 import path from 'node:path';
 import { registerStartupUrlHandler } from './startup-url-events';
 import { AgentPowerSaveBlockerService } from './services/agent-power-save-blocker';
+import { AgentRuntimeRecoveryService } from './services/agent-runtime-recovery';
+import { MacOSClosedLidSleepService } from './services/macos-closed-lid-sleep';
 import type {
   HistoryFilter,
   HistoryResult,
@@ -499,7 +502,7 @@ export async function main({ launchOptions: { verbose } }: MainParameters) {
     learn: 3,
   };
 
-  discoverSkills(getBuiltinSkillsPath()).then((skills) => {
+  discoverSkills(getBuiltinSkillsPath()).then((skills: Skill[]) => {
     const builtins: SkillDefinition[] = skills
       .map((s) => ({
         id: `command:${s.name.toLowerCase()}`,
@@ -672,8 +675,9 @@ export async function main({ launchOptions: { verbose } }: MainParameters) {
   agentManagerService.registerEnvAdapter(
     createEnabledSkillsDomainAdapter({
       host: agentCoreHost,
-      getSkillDetails: async (agentInstanceId) => {
-        const skills = await toolboxService.getSkillsList(agentInstanceId);
+      getSkillDetails: async (agentInstanceId: string) => {
+        const skills: SkillDefinitionUI[] =
+          await toolboxService.getSkillsList(agentInstanceId);
         return new Map(
           skills
             .filter((s) => s.agentInvocable !== false && s.skillPath)
@@ -723,6 +727,14 @@ export async function main({ launchOptions: { verbose } }: MainParameters) {
   const agentPowerSaveBlockerService = AgentPowerSaveBlockerService.create(
     logger,
     uiKarton,
+  );
+  const macOSClosedLidSleepService = MacOSClosedLidSleepService.create(
+    logger,
+    uiKarton,
+  );
+  const agentRuntimeRecoveryService = AgentRuntimeRecoveryService.create(
+    logger,
+    agentManagerService,
   );
 
   // Wire all uiKarton-to-pages state syncs (pending edits, mounts,
@@ -797,6 +809,16 @@ export async function main({ launchOptions: { verbose } }: MainParameters) {
       }
 
       return imported;
+    },
+  );
+
+  uiKarton.registerServerProcedureHandler('closedLidSleep.toggle', async () => {
+    return macOSClosedLidSleepService.toggle();
+  });
+  uiKarton.registerServerProcedureHandler(
+    'closedLidSleep.refresh',
+    async () => {
+      return macOSClosedLidSleepService.refresh();
     },
   );
 
@@ -972,6 +994,12 @@ export async function main({ launchOptions: { verbose } }: MainParameters) {
       runTeardown('autoUpdateService', () => autoUpdateService.teardown());
       runTeardown('agentPowerSaveBlockerService', () =>
         agentPowerSaveBlockerService.teardown(),
+      );
+      runTeardown('macOSClosedLidSleepService', () =>
+        macOSClosedLidSleepService.teardown(),
+      );
+      runTeardown('agentRuntimeRecoveryService', () =>
+        agentRuntimeRecoveryService.teardown(),
       );
 
       // Shared budget for async teardowns. Toolbox teardown kills live

--- a/apps/browser/src/backend/main.ts
+++ b/apps/browser/src/backend/main.ts
@@ -67,6 +67,7 @@ import { AssetCacheService } from './services/asset-cache';
 import { detectShell, resolveShellEnv } from './utils/shell-env';
 import path from 'node:path';
 import { registerStartupUrlHandler } from './startup-url-events';
+import { AgentPowerSaveBlockerService } from './services/agent-power-save-blocker';
 import type {
   HistoryFilter,
   HistoryResult,
@@ -719,6 +720,11 @@ export async function main({ launchOptions: { verbose } }: MainParameters) {
     getLogIngestSnapshot: () => toolboxService.getLogIngestSnapshot(),
   });
 
+  const agentPowerSaveBlockerService = AgentPowerSaveBlockerService.create(
+    logger,
+    uiKarton,
+  );
+
   // Wire all uiKarton-to-pages state syncs (pending edits, mounts,
   // workspace-md generating, search engines, global config, auth)
   await wirePagesStateSync({
@@ -964,6 +970,9 @@ export async function main({ launchOptions: { verbose } }: MainParameters) {
       runTeardown('agentCorePersistence', () => persistence.teardown());
       runTeardown('assetCacheService', () => assetCacheService.teardown());
       runTeardown('autoUpdateService', () => autoUpdateService.teardown());
+      runTeardown('agentPowerSaveBlockerService', () =>
+        agentPowerSaveBlockerService.teardown(),
+      );
 
       // Shared budget for async teardowns. Toolbox teardown kills live
       // PTY sessions before Node env teardown begins — this is what

--- a/apps/browser/src/backend/services/agent-manager/agent-manager.ts
+++ b/apps/browser/src/backend/services/agent-manager/agent-manager.ts
@@ -19,6 +19,7 @@ import type { AttachmentsService } from '@stagewise/agent-core/attachments';
 import type { AgentPersistenceDB } from '@stagewise/agent-core/agent-persistence';
 import type { DomainAdapter, DomainId } from '@stagewise/agent-core/env';
 import type { AgentHistoryEntry } from '@stagewise/agent-core/types/agent';
+import { net } from 'electron';
 import { DisposableService } from '../disposable';
 import type { KartonService } from '../karton';
 import type { SkillDefinitionUI } from '@shared/skills';
@@ -106,6 +107,7 @@ export class AgentManagerService extends DisposableService {
         renderHostMention: renderBrowserExtraMention,
         skillsForSlashRedaction: getSkillsForSlashRedaction,
         enrichHistoryEntries,
+        isNetworkOnline: () => net.isOnline(),
       },
     });
     this.registerKartonForwarders();
@@ -134,6 +136,17 @@ export class AgentManagerService extends DisposableService {
     workspacePath: string,
   ): Promise<void> {
     await this.manager.generateWorkspaceMdForPath(workspacePath);
+  }
+
+  public async recoverInterruptedActiveAgents(
+    reason: 'system-resumed' | 'event-loop-stalled',
+    details?: { stalledForMs?: number },
+  ): Promise<void> {
+    await this.manager.recoverInterruptedActiveAgents(reason, details);
+  }
+
+  public async retryNetworkFailedAgentsNow(reason: string): Promise<void> {
+    await this.manager.retryNetworkFailedAgentsNow(reason);
   }
 
   private registerKartonForwarders(): void {

--- a/apps/browser/src/backend/services/agent-power-save-blocker.ts
+++ b/apps/browser/src/backend/services/agent-power-save-blocker.ts
@@ -16,7 +16,7 @@ type PowerSaveState = {
 function messageHasPendingApproval(message: AgentMessage): boolean {
   if (message.role !== 'assistant') return false;
 
-  return message.parts.some((part) => {
+  return message.parts.some((part: AgentMessage['parts'][number]) => {
     if (!(part.type === 'dynamic-tool' || part.type.startsWith('tool-'))) {
       return false;
     }

--- a/apps/browser/src/backend/services/agent-power-save-blocker.ts
+++ b/apps/browser/src/backend/services/agent-power-save-blocker.ts
@@ -1,0 +1,134 @@
+import { powerSaveBlocker } from 'electron';
+import type { AppState } from '@shared/karton-contracts/ui';
+import type { AgentMessage } from '@shared/karton-contracts/ui/agent';
+import type { GlobalConfig } from '@shared/karton-contracts/ui/shared-types';
+import { syncDerivedState } from '../utils/sync-derived-state';
+import { DisposableService } from './disposable';
+import type { KartonService } from './karton';
+import type { Logger } from './logger';
+
+type PowerSaveState = {
+  enabled: boolean;
+  hasActiveAgent: boolean;
+};
+
+function messageHasPendingApproval(message: AgentMessage): boolean {
+  if (message.role !== 'assistant') return false;
+
+  return message.parts.some((part) => {
+    if (!(part.type === 'dynamic-tool' || part.type.startsWith('tool-'))) {
+      return false;
+    }
+
+    return (part as { state?: string }).state === 'approval-requested';
+  });
+}
+
+function hasPendingToolApproval(history: AgentMessage[]): boolean {
+  for (let i = history.length - 1; i >= 0; i--) {
+    const message = history[i];
+    if (message?.role === 'assistant') {
+      return messageHasPendingApproval(message);
+    }
+  }
+
+  return false;
+}
+
+function agentIsActiveForPowerSave(
+  state: AppState,
+  agentInstanceId: string,
+): boolean {
+  const agent = state.agents.instances[agentInstanceId];
+  if (!agent?.state.isWorking) return false;
+
+  if (state.toolbox[agentInstanceId]?.pendingUserQuestion) return false;
+
+  return !hasPendingToolApproval(agent.state.history);
+}
+
+function derivePowerSaveState(state: AppState): PowerSaveState {
+  const config: GlobalConfig = state.globalConfig;
+  const enabled = config.blockAppSuspensionWhenAgentsActive ?? true;
+
+  if (!enabled) return { enabled, hasActiveAgent: false };
+
+  return {
+    enabled,
+    hasActiveAgent: Object.keys(state.agents.instances).some((agentId) =>
+      agentIsActiveForPowerSave(state, agentId),
+    ),
+  };
+}
+
+export class AgentPowerSaveBlockerService extends DisposableService {
+  private blockerId: number | null = null;
+  private unsubscribe: (() => void) | null = null;
+
+  private constructor(
+    private readonly logger: Logger,
+    private readonly uiKarton: KartonService,
+  ) {
+    super();
+  }
+
+  public static create(
+    logger: Logger,
+    uiKarton: KartonService,
+  ): AgentPowerSaveBlockerService {
+    const instance = new AgentPowerSaveBlockerService(logger, uiKarton);
+    instance.initialize();
+    return instance;
+  }
+
+  private initialize(): void {
+    this.unsubscribe = syncDerivedState(
+      this.uiKarton,
+      derivePowerSaveState,
+      ({ enabled, hasActiveAgent }) => {
+        this.setBlocked(enabled && hasActiveAgent);
+      },
+      {
+        fireImmediately: true,
+      },
+    );
+  }
+
+  private setBlocked(shouldBlock: boolean): void {
+    if (shouldBlock) {
+      if (
+        this.blockerId !== null &&
+        powerSaveBlocker.isStarted(this.blockerId)
+      ) {
+        return;
+      }
+
+      this.blockerId = powerSaveBlocker.start('prevent-app-suspension');
+      this.logger.debug(
+        `[AgentPowerSaveBlockerService] Started power save blocker: ${this.blockerId}`,
+      );
+      return;
+    }
+
+    this.releaseBlocker();
+  }
+
+  private releaseBlocker(): void {
+    if (this.blockerId === null) return;
+
+    if (powerSaveBlocker.isStarted(this.blockerId)) {
+      powerSaveBlocker.stop(this.blockerId);
+      this.logger.debug(
+        `[AgentPowerSaveBlockerService] Stopped power save blocker: ${this.blockerId}`,
+      );
+    }
+
+    this.blockerId = null;
+  }
+
+  protected onTeardown(): void {
+    this.unsubscribe?.();
+    this.unsubscribe = null;
+    this.releaseBlocker();
+  }
+}

--- a/apps/browser/src/backend/services/agent-power-save-blocker.ts
+++ b/apps/browser/src/backend/services/agent-power-save-blocker.ts
@@ -10,6 +10,7 @@ import type { Logger } from './logger';
 type PowerSaveState = {
   enabled: boolean;
   hasActiveAgent: boolean;
+  activeAgentCount: number;
 };
 
 function messageHasPendingApproval(message: AgentMessage): boolean {
@@ -51,19 +52,23 @@ function derivePowerSaveState(state: AppState): PowerSaveState {
   const config: GlobalConfig = state.globalConfig;
   const enabled = config.blockAppSuspensionWhenAgentsActive ?? true;
 
-  if (!enabled) return { enabled, hasActiveAgent: false };
+  if (!enabled) return { enabled, hasActiveAgent: false, activeAgentCount: 0 };
+
+  const activeAgentCount = Object.keys(state.agents.instances).filter(
+    (agentId) => agentIsActiveForPowerSave(state, agentId),
+  ).length;
 
   return {
     enabled,
-    hasActiveAgent: Object.keys(state.agents.instances).some((agentId) =>
-      agentIsActiveForPowerSave(state, agentId),
-    ),
+    hasActiveAgent: activeAgentCount > 0,
+    activeAgentCount,
   };
 }
 
 export class AgentPowerSaveBlockerService extends DisposableService {
   private blockerId: number | null = null;
   private unsubscribe: (() => void) | null = null;
+  private lastState: PowerSaveState | null = null;
 
   private constructor(
     private readonly logger: Logger,
@@ -85,8 +90,9 @@ export class AgentPowerSaveBlockerService extends DisposableService {
     this.unsubscribe = syncDerivedState(
       this.uiKarton,
       derivePowerSaveState,
-      ({ enabled, hasActiveAgent }) => {
-        this.setBlocked(enabled && hasActiveAgent);
+      (state) => {
+        this.logStateTransition(state);
+        this.setBlocked(state.enabled && state.hasActiveAgent, state);
       },
       {
         fireImmediately: true,
@@ -94,7 +100,23 @@ export class AgentPowerSaveBlockerService extends DisposableService {
     );
   }
 
-  private setBlocked(shouldBlock: boolean): void {
+  private logStateTransition(state: PowerSaveState): void {
+    const previous = this.lastState;
+    this.lastState = state;
+
+    if (
+      previous?.enabled === state.enabled &&
+      previous?.activeAgentCount === state.activeAgentCount
+    ) {
+      return;
+    }
+
+    this.logger.debug(
+      `[AgentPowerSaveBlockerService] State changed: enabled=${state.enabled}, activeAgentCount=${state.activeAgentCount}`,
+    );
+  }
+
+  private setBlocked(shouldBlock: boolean, state: PowerSaveState): void {
     if (shouldBlock) {
       if (
         this.blockerId !== null &&
@@ -104,22 +126,24 @@ export class AgentPowerSaveBlockerService extends DisposableService {
       }
 
       this.blockerId = powerSaveBlocker.start('prevent-app-suspension');
-      this.logger.debug(
-        `[AgentPowerSaveBlockerService] Started power save blocker: ${this.blockerId}`,
+      this.logger.info(
+        `[AgentPowerSaveBlockerService] Started power save blocker: ${this.blockerId}. activeAgentCount=${state.activeAgentCount}`,
       );
       return;
     }
 
-    this.releaseBlocker();
+    this.releaseBlocker(state);
   }
 
-  private releaseBlocker(): void {
+  private releaseBlocker(state?: PowerSaveState): void {
     if (this.blockerId === null) return;
 
     if (powerSaveBlocker.isStarted(this.blockerId)) {
       powerSaveBlocker.stop(this.blockerId);
-      this.logger.debug(
-        `[AgentPowerSaveBlockerService] Stopped power save blocker: ${this.blockerId}`,
+      this.logger.info(
+        `[AgentPowerSaveBlockerService] Stopped power save blocker: ${this.blockerId}. enabled=${
+          state?.enabled ?? 'unknown'
+        }, activeAgentCount=${state?.activeAgentCount ?? 'unknown'}`,
       );
     }
 

--- a/apps/browser/src/backend/services/agent-runtime-recovery.ts
+++ b/apps/browser/src/backend/services/agent-runtime-recovery.ts
@@ -28,6 +28,31 @@ export class AgentRuntimeRecoveryService extends DisposableService {
     return instance;
   }
 
+  private recoverInterruptedActiveAgents(
+    reason: 'system-resumed' | 'event-loop-stalled',
+    details?: { stalledForMs?: number },
+  ): void {
+    void this.agentManager
+      .recoverInterruptedActiveAgents(reason, details)
+      .catch((error) => {
+        this.logger.warn(
+          `[AgentRuntimeRecoveryService] Failed to recover interrupted agents. reason=${reason}`,
+          error,
+        );
+      });
+  }
+
+  private retryNetworkFailedAgents(reason: string): void {
+    void this.agentManager
+      .retryNetworkFailedAgentsNow(reason)
+      .catch((error) => {
+        this.logger.warn(
+          `[AgentRuntimeRecoveryService] Failed to retry network-failed agents. reason=${reason}`,
+          error,
+        );
+      });
+  }
+
   private initialize(): void {
     const handleSuspend = () => {
       this.suspendedAt = Date.now();
@@ -49,10 +74,10 @@ export class AgentRuntimeRecoveryService extends DisposableService {
         }`,
       );
 
-      void this.agentManager.recoverInterruptedActiveAgents('system-resumed', {
+      this.recoverInterruptedActiveAgents('system-resumed', {
         stalledForMs: suspendedForMs,
       });
-      void this.agentManager.retryNetworkFailedAgentsNow('system-resumed');
+      this.retryNetworkFailedAgents('system-resumed');
     };
 
     powerMonitor.on('suspend', handleSuspend);
@@ -73,11 +98,10 @@ export class AgentRuntimeRecoveryService extends DisposableService {
         `[AgentRuntimeRecoveryService] Event loop stall detected. elapsedMs=${elapsedMs}`,
       );
 
-      void this.agentManager.recoverInterruptedActiveAgents(
-        'event-loop-stalled',
-        { stalledForMs: elapsedMs },
-      );
-      void this.agentManager.retryNetworkFailedAgentsNow('event-loop-stalled');
+      this.recoverInterruptedActiveAgents('event-loop-stalled', {
+        stalledForMs: elapsedMs,
+      });
+      this.retryNetworkFailedAgents('event-loop-stalled');
     }, EVENT_LOOP_CHECK_INTERVAL_MS);
     this.eventLoopCheckInterval.unref?.();
   }

--- a/apps/browser/src/backend/services/agent-runtime-recovery.ts
+++ b/apps/browser/src/backend/services/agent-runtime-recovery.ts
@@ -1,0 +1,95 @@
+import { powerMonitor } from 'electron';
+import { DisposableService } from './disposable';
+import type { AgentManagerService } from './agent-manager';
+import type { Logger } from './logger';
+
+const EVENT_LOOP_CHECK_INTERVAL_MS = 10_000;
+const EVENT_LOOP_STALL_THRESHOLD_MS = 45_000;
+
+export class AgentRuntimeRecoveryService extends DisposableService {
+  private eventLoopCheckInterval: ReturnType<typeof setInterval> | null = null;
+  private lastEventLoopCheckAt = Date.now();
+  private suspendedAt: number | null = null;
+  private readonly removeListeners: Array<() => void> = [];
+
+  private constructor(
+    private readonly logger: Logger,
+    private readonly agentManager: AgentManagerService,
+  ) {
+    super();
+  }
+
+  public static create(
+    logger: Logger,
+    agentManager: AgentManagerService,
+  ): AgentRuntimeRecoveryService {
+    const instance = new AgentRuntimeRecoveryService(logger, agentManager);
+    instance.initialize();
+    return instance;
+  }
+
+  private initialize(): void {
+    const handleSuspend = () => {
+      this.suspendedAt = Date.now();
+      this.logger.info('[AgentRuntimeRecoveryService] System suspend detected');
+    };
+
+    const handleResume = () => {
+      const now = Date.now();
+      const suspendedForMs =
+        this.suspendedAt === null ? undefined : now - this.suspendedAt;
+      this.suspendedAt = null;
+      this.lastEventLoopCheckAt = now;
+
+      this.logger.info(
+        `[AgentRuntimeRecoveryService] System resume detected${
+          suspendedForMs === undefined
+            ? ''
+            : ` after ${Math.round(suspendedForMs / 1000)}s`
+        }`,
+      );
+
+      void this.agentManager.recoverInterruptedActiveAgents('system-resumed', {
+        stalledForMs: suspendedForMs,
+      });
+      void this.agentManager.retryNetworkFailedAgentsNow('system-resumed');
+    };
+
+    powerMonitor.on('suspend', handleSuspend);
+    powerMonitor.on('resume', handleResume);
+    this.removeListeners.push(() => {
+      powerMonitor.off('suspend', handleSuspend);
+      powerMonitor.off('resume', handleResume);
+    });
+
+    this.eventLoopCheckInterval = setInterval(() => {
+      const now = Date.now();
+      const elapsedMs = now - this.lastEventLoopCheckAt;
+      this.lastEventLoopCheckAt = now;
+
+      if (elapsedMs < EVENT_LOOP_STALL_THRESHOLD_MS) return;
+
+      this.logger.info(
+        `[AgentRuntimeRecoveryService] Event loop stall detected. elapsedMs=${elapsedMs}`,
+      );
+
+      void this.agentManager.recoverInterruptedActiveAgents(
+        'event-loop-stalled',
+        { stalledForMs: elapsedMs },
+      );
+      void this.agentManager.retryNetworkFailedAgentsNow('event-loop-stalled');
+    }, EVENT_LOOP_CHECK_INTERVAL_MS);
+    this.eventLoopCheckInterval.unref?.();
+  }
+
+  protected onTeardown(): void {
+    for (const removeListener of this.removeListeners.splice(0)) {
+      removeListener();
+    }
+
+    if (this.eventLoopCheckInterval) {
+      clearInterval(this.eventLoopCheckInterval);
+      this.eventLoopCheckInterval = null;
+    }
+  }
+}

--- a/apps/browser/src/backend/services/global-config.ts
+++ b/apps/browser/src/backend/services/global-config.ts
@@ -42,8 +42,11 @@ export class GlobalConfigService extends DisposableService {
     });
     this.uiKarton.registerServerProcedureHandler(
       'config.set',
-      async (_callingClientId: string, config: GlobalConfig) =>
-        this.set(config),
+      async (_callingClientId: string, configPatch: Partial<GlobalConfig>) =>
+        this.set({
+          ...this.get(),
+          ...configPatch,
+        }),
     );
 
     this.logger.debug(

--- a/apps/browser/src/backend/services/macos-closed-lid-sleep.ts
+++ b/apps/browser/src/backend/services/macos-closed-lid-sleep.ts
@@ -20,7 +20,11 @@ type ClosedLidSleepState = {
   ownedByStagewise: boolean;
   isChanging: boolean;
   error: string | null;
+  persistenceWarning: string | null;
 };
+
+const CLOSED_LID_SLEEP_PERSISTENCE_WARNING =
+  'This setting changes a persistent macOS power setting. If stagewise quits unexpectedly, closed-lid sleep may remain disabled until you turn it off again.';
 
 function parseDisableSleepState(output: string): boolean | null {
   const match = output.match(
@@ -41,11 +45,11 @@ async function readDisableSleepState(): Promise<boolean> {
 }
 
 function shellQuote(value: string): string {
-  return `'${value.replaceAll("'", `'\\''`)}'`;
+  return `'${value.split("'").join(`'\\''`)}`;
 }
 
 function escapeSudoersUser(value: string): string {
-  return value.replaceAll(/([\\,:=\s])/g, '\\$1');
+  return value.replace(/([\\,:=\s])/g, '\\$1');
 }
 
 function getSudoersRule(): string {
@@ -90,6 +94,20 @@ async function setDisableSleepState(disabled: boolean): Promise<void> {
     await installPasswordlessPmsetRule();
     await runPasswordlessPmset(disabled);
   }
+}
+
+async function removePasswordlessPmsetRule(): Promise<void> {
+  const command = [
+    `/bin/rm -f ${shellQuote(SUDOERS_RULE_PATH)}`,
+    `/usr/sbin/visudo -cf /etc/sudoers`,
+  ].join(' && ');
+
+  await execFileAsync(OSASCRIPT_PATH, [
+    '-e',
+    `do shell script ${JSON.stringify(command)} with prompt ${JSON.stringify(
+      'stagewise wants to remove its restricted closed-lid sleep sudoers rule.',
+    )} with administrator privileges`,
+  ]);
 }
 
 export class MacOSClosedLidSleepService extends DisposableService {
@@ -208,6 +226,13 @@ export class MacOSClosedLidSleepService extends DisposableService {
       this.ownedByStagewise = false;
       this.previousDisabledState = null;
       await this.syncState();
+      await removePasswordlessPmsetRule().catch((error) => {
+        this.logger.warn(
+          '[MacOSClosedLidSleepService] Failed to remove closed-lid sleep sudoers rule',
+          error,
+        );
+      });
+
       this.logger.info(
         '[MacOSClosedLidSleepService] Closed-lid sleep re-enabled',
       );
@@ -262,6 +287,9 @@ export class MacOSClosedLidSleepService extends DisposableService {
       ownedByStagewise: this.ownedByStagewise,
       isChanging: this.isChanging,
       error: this.error,
+      persistenceWarning: isSleepDisabled
+        ? CLOSED_LID_SLEEP_PERSISTENCE_WARNING
+        : null,
     };
 
     this.uiKarton.setState((draft) => {
@@ -280,6 +308,7 @@ export class MacOSClosedLidSleepService extends DisposableService {
       ownedByStagewise: false,
       isChanging: false,
       error: null,
+      persistenceWarning: null,
     };
   }
 

--- a/apps/browser/src/backend/services/macos-closed-lid-sleep.ts
+++ b/apps/browser/src/backend/services/macos-closed-lid-sleep.ts
@@ -45,7 +45,7 @@ async function readDisableSleepState(): Promise<boolean> {
 }
 
 function shellQuote(value: string): string {
-  return `'${value.split("'").join(`'\\''`)}`;
+  return `'${value.split("'").join(`'\\''`)}'`;
 }
 
 function escapeSudoersUser(value: string): string {
@@ -94,20 +94,6 @@ async function setDisableSleepState(disabled: boolean): Promise<void> {
     await installPasswordlessPmsetRule();
     await runPasswordlessPmset(disabled);
   }
-}
-
-async function removePasswordlessPmsetRule(): Promise<void> {
-  const command = [
-    `/bin/rm -f ${shellQuote(SUDOERS_RULE_PATH)}`,
-    `/usr/sbin/visudo -cf /etc/sudoers`,
-  ].join(' && ');
-
-  await execFileAsync(OSASCRIPT_PATH, [
-    '-e',
-    `do shell script ${JSON.stringify(command)} with prompt ${JSON.stringify(
-      'stagewise wants to remove its restricted closed-lid sleep sudoers rule.',
-    )} with administrator privileges`,
-  ]);
 }
 
 export class MacOSClosedLidSleepService extends DisposableService {
@@ -226,12 +212,6 @@ export class MacOSClosedLidSleepService extends DisposableService {
       this.ownedByStagewise = false;
       this.previousDisabledState = null;
       await this.syncState();
-      await removePasswordlessPmsetRule().catch((error) => {
-        this.logger.warn(
-          '[MacOSClosedLidSleepService] Failed to remove closed-lid sleep sudoers rule',
-          error,
-        );
-      });
 
       this.logger.info(
         '[MacOSClosedLidSleepService] Closed-lid sleep re-enabled',

--- a/apps/browser/src/backend/services/macos-closed-lid-sleep.ts
+++ b/apps/browser/src/backend/services/macos-closed-lid-sleep.ts
@@ -1,0 +1,307 @@
+import { execFile } from 'node:child_process';
+import { userInfo } from 'node:os';
+import { promisify } from 'node:util';
+import { DisposableService } from './disposable';
+import type { KartonService } from './karton';
+import type { Logger } from './logger';
+
+const execFileAsync = promisify(execFile);
+
+const PMSET_PATH = '/usr/bin/pmset';
+const OSASCRIPT_PATH = '/usr/bin/osascript';
+const SUDO_PATH = '/usr/bin/sudo';
+const SUDOERS_RULE_PATH = '/etc/sudoers.d/stagewise-closed-lid-sleep';
+const SUDOERS_TEMP_RULE_PATH = '/tmp/stagewise-closed-lid-sleep-sudoers';
+const STATUS_REFRESH_INTERVAL_MS = 5_000;
+
+type ClosedLidSleepState = {
+  isSupported: boolean;
+  isSleepDisabled: boolean;
+  ownedByStagewise: boolean;
+  isChanging: boolean;
+  error: string | null;
+};
+
+function parseDisableSleepState(output: string): boolean | null {
+  const match = output.match(
+    /^\s*(?:disablesleep|SleepDisabled)\s+(\d+)\s*$/im,
+  );
+  if (!match) return null;
+  return match[1] === '1';
+}
+
+async function readDisableSleepState(): Promise<boolean> {
+  const currentResult = await execFileAsync(PMSET_PATH, ['-g']);
+  const currentState = parseDisableSleepState(currentResult.stdout);
+  if (currentState !== null) return currentState;
+
+  const customResult = await execFileAsync(PMSET_PATH, ['-g', 'custom']);
+  const customState = parseDisableSleepState(customResult.stdout);
+  return customState ?? false;
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", `'\\''`)}'`;
+}
+
+function escapeSudoersUser(value: string): string {
+  return value.replaceAll(/([\\,:=\s])/g, '\\$1');
+}
+
+function getSudoersRule(): string {
+  const user = escapeSudoersUser(userInfo().username);
+  return `${user} ALL=(root) NOPASSWD: ${PMSET_PATH} -a disablesleep 1, ${PMSET_PATH} -a disablesleep 0\n`;
+}
+
+async function runPasswordlessPmset(disabled: boolean): Promise<void> {
+  await execFileAsync(SUDO_PATH, [
+    '-n',
+    PMSET_PATH,
+    '-a',
+    'disablesleep',
+    disabled ? '1' : '0',
+  ]);
+}
+
+async function installPasswordlessPmsetRule(): Promise<void> {
+  const rule = getSudoersRule();
+  const command = [
+    '/bin/mkdir -p /etc/sudoers.d',
+    `/usr/bin/printf %s ${shellQuote(rule)} > ${shellQuote(SUDOERS_TEMP_RULE_PATH)}`,
+    `/usr/sbin/chown root:wheel ${shellQuote(SUDOERS_TEMP_RULE_PATH)}`,
+    `/bin/chmod 0440 ${shellQuote(SUDOERS_TEMP_RULE_PATH)}`,
+    `/usr/sbin/visudo -cf ${shellQuote(SUDOERS_TEMP_RULE_PATH)}`,
+    `/bin/mv ${shellQuote(SUDOERS_TEMP_RULE_PATH)} ${shellQuote(SUDOERS_RULE_PATH)}`,
+    `/usr/sbin/visudo -cf /etc/sudoers`,
+  ].join(' && ');
+
+  await execFileAsync(OSASCRIPT_PATH, [
+    '-e',
+    `do shell script ${JSON.stringify(command)} with prompt ${JSON.stringify(
+      'stagewise wants to install a restricted sudoers rule so it can toggle closed-lid sleep without asking every time.',
+    )} with administrator privileges`,
+  ]);
+}
+
+async function setDisableSleepState(disabled: boolean): Promise<void> {
+  try {
+    await runPasswordlessPmset(disabled);
+  } catch {
+    await installPasswordlessPmsetRule();
+    await runPasswordlessPmset(disabled);
+  }
+}
+
+export class MacOSClosedLidSleepService extends DisposableService {
+  private ownedByStagewise = false;
+  private previousDisabledState: boolean | null = null;
+  private isChanging = false;
+  private error: string | null = null;
+  private statusInterval: ReturnType<typeof setInterval> | null = null;
+  private isSyncingState = false;
+  private shouldSyncAgain = false;
+
+  private constructor(
+    private readonly logger: Logger,
+    private readonly uiKarton: KartonService,
+  ) {
+    super();
+  }
+
+  public static create(
+    logger: Logger,
+    uiKarton: KartonService,
+  ): MacOSClosedLidSleepService {
+    const instance = new MacOSClosedLidSleepService(logger, uiKarton);
+    instance.initialize();
+    return instance;
+  }
+
+  private initialize(): void {
+    this.syncState().catch((error) => {
+      this.logger.warn(
+        '[MacOSClosedLidSleepService] Failed to read initial state',
+        error,
+      );
+    });
+
+    this.statusInterval = setInterval(() => {
+      this.syncState().catch((error) => {
+        this.logger.debug(
+          '[MacOSClosedLidSleepService] Failed to refresh state',
+          error,
+        );
+      });
+    }, STATUS_REFRESH_INTERVAL_MS);
+    this.statusInterval.unref?.();
+
+    process.once('exit', () => {
+      // Best effort only. Async work cannot run during `exit`, but keep this as
+      // a final synchronous intent marker for future hardening.
+      if (this.ownedByStagewise) {
+        this.logger.warn(
+          '[MacOSClosedLidSleepService] Process exiting while closed-lid sleep prevention is still active',
+        );
+      }
+    });
+  }
+
+  public async toggle(): Promise<ClosedLidSleepState> {
+    this.assertNotDisposed();
+    if (process.platform !== 'darwin') return this.getUnsupportedState();
+    if (this.isChanging) return this.getCurrentStateSnapshot();
+
+    const isCurrentlyDisabled = await readDisableSleepState();
+    return isCurrentlyDisabled ? this.enableSleep() : this.preventSleep();
+  }
+
+  public async refresh(): Promise<ClosedLidSleepState> {
+    this.assertNotDisposed();
+    await this.syncState();
+    return this.getCurrentStateSnapshot();
+  }
+
+  private async preventSleep(): Promise<ClosedLidSleepState> {
+    this.isChanging = true;
+    this.error = null;
+    this.publishState(false);
+
+    try {
+      const wasDisabled = await readDisableSleepState();
+      this.previousDisabledState = wasDisabled;
+
+      if (!wasDisabled) {
+        await setDisableSleepState(true);
+      }
+
+      this.ownedByStagewise = !wasDisabled;
+      await this.syncState();
+      this.logger.info(
+        `[MacOSClosedLidSleepService] Closed-lid sleep prevention enabled. ownedByStagewise=${this.ownedByStagewise}`,
+      );
+    } catch (error) {
+      this.error = error instanceof Error ? error.message : String(error);
+      this.logger.warn(
+        '[MacOSClosedLidSleepService] Failed to enable closed-lid sleep prevention',
+        error,
+      );
+      this.publishState(false);
+    } finally {
+      this.isChanging = false;
+      await this.syncState().catch(() => this.publishState(false));
+    }
+
+    return this.getCurrentStateSnapshot();
+  }
+
+  private async enableSleep(): Promise<ClosedLidSleepState> {
+    this.isChanging = true;
+    this.error = null;
+    this.publishState(true);
+
+    try {
+      const isSleepDisabled = await readDisableSleepState();
+      if (isSleepDisabled) {
+        await setDisableSleepState(false);
+      }
+
+      this.ownedByStagewise = false;
+      this.previousDisabledState = null;
+      await this.syncState();
+      this.logger.info(
+        '[MacOSClosedLidSleepService] Closed-lid sleep re-enabled',
+      );
+    } catch (error) {
+      this.error = error instanceof Error ? error.message : String(error);
+      this.logger.warn(
+        '[MacOSClosedLidSleepService] Failed to re-enable closed-lid sleep',
+        error,
+      );
+      this.publishState(true);
+    } finally {
+      this.isChanging = false;
+      await this.syncState().catch(() => this.publishState(true));
+    }
+
+    return this.getCurrentStateSnapshot();
+  }
+
+  private async syncState(): Promise<void> {
+    if (this.isSyncingState) {
+      this.shouldSyncAgain = true;
+      return;
+    }
+
+    this.isSyncingState = true;
+
+    try {
+      do {
+        this.shouldSyncAgain = false;
+
+        if (process.platform !== 'darwin') {
+          this.publishState(false);
+          continue;
+        }
+
+        const isSleepDisabled = await readDisableSleepState();
+        if (!isSleepDisabled) {
+          this.ownedByStagewise = false;
+          this.previousDisabledState = null;
+        }
+        this.publishState(isSleepDisabled);
+      } while (this.shouldSyncAgain);
+    } finally {
+      this.isSyncingState = false;
+    }
+  }
+
+  private publishState(isSleepDisabled: boolean): void {
+    const state: ClosedLidSleepState = {
+      isSupported: process.platform === 'darwin',
+      isSleepDisabled,
+      ownedByStagewise: this.ownedByStagewise,
+      isChanging: this.isChanging,
+      error: this.error,
+    };
+
+    this.uiKarton.setState((draft) => {
+      draft.closedLidSleep = state;
+    });
+  }
+
+  private getCurrentStateSnapshot(): ClosedLidSleepState {
+    return this.uiKarton.state.closedLidSleep;
+  }
+
+  private getUnsupportedState(): ClosedLidSleepState {
+    return {
+      isSupported: false,
+      isSleepDisabled: false,
+      ownedByStagewise: false,
+      isChanging: false,
+      error: null,
+    };
+  }
+
+  protected async onTeardown(): Promise<void> {
+    if (this.statusInterval) {
+      clearInterval(this.statusInterval);
+      this.statusInterval = null;
+    }
+
+    if (
+      process.platform === 'darwin' &&
+      this.ownedByStagewise &&
+      this.previousDisabledState === false
+    ) {
+      try {
+        await setDisableSleepState(false);
+      } catch (error) {
+        this.logger.warn(
+          '[MacOSClosedLidSleepService] Failed to re-enable closed-lid sleep during teardown',
+          error,
+        );
+      }
+    }
+  }
+}

--- a/apps/browser/src/backend/services/telemetry.test.ts
+++ b/apps/browser/src/backend/services/telemetry.test.ts
@@ -30,6 +30,21 @@ const METHOD_FAILURE_EVENTS = [
   'chat-auth-method-failed',
 ] as const;
 
+describe('main UI telemetry schemas', () => {
+  it('registers and validates closed-lid sleep toggle events', () => {
+    expect(isUIEventName('closed-lid-sleep-toggled')).toBe(true);
+    expect(
+      parseUIEventProperties('closed-lid-sleep-toggled', { enabled: true }),
+    ).toEqual({ enabled: true });
+    expect(
+      parseUIEventProperties('closed-lid-sleep-toggled', { enabled: false }),
+    ).toEqual({ enabled: false });
+    expect(
+      parseUIEventProperties('closed-lid-sleep-toggled', { enabled: 'true' }),
+    ).toBeNull();
+  });
+});
+
 describe('auth UI telemetry schemas', () => {
   it('registers all social auth UI event names', () => {
     for (const eventName of SOCIAL_AUTH_EVENTS) {

--- a/apps/browser/src/backend/services/telemetry.ts
+++ b/apps/browser/src/backend/services/telemetry.ts
@@ -378,6 +378,7 @@ export type EventProperties = {
   'settings-opened': undefined;
   'account-page-viewed': undefined;
   'chat-sidebar-toggled': { new_value: 'open' | 'closed' };
+  'closed-lid-sleep-toggled': { enabled: boolean };
   'chat-new-agent-clicked': {
     source: 'sidebar-top' | 'sidebar-active-agents' | 'hotkey';
   };
@@ -452,6 +453,7 @@ export const UI_TELEMETRY_EVENT_NAMES = [
   'account-page-viewed',
   'chat-new-agent-clicked',
   'chat-sidebar-toggled',
+  'closed-lid-sleep-toggled',
   'custom-model-add-aborted',
   'custom-model-add-finished',
   'custom-model-add-started',
@@ -505,6 +507,9 @@ const UI_TELEMETRY_EVENT_SCHEMAS = {
   }),
   'chat-sidebar-toggled': z.object({
     new_value: z.enum(['open', 'closed']),
+  }),
+  'closed-lid-sleep-toggled': z.object({
+    enabled: z.boolean(),
   }),
   'custom-model-add-aborted': z.object({
     had_validation_errors: z.boolean(),

--- a/apps/browser/src/backend/services/window-layout/protocol-utils.ts
+++ b/apps/browser/src/backend/services/window-layout/protocol-utils.ts
@@ -7,10 +7,21 @@ import type { OpenFilesInIde } from '@shared/karton-contracts/ui/shared-types';
 import { getIDEFileUrl } from '@shared/ide-url';
 
 /**
- * Protocols that the browser can natively handle and should open in a tab.
+ * Protocols that browsing tabs can natively handle.
  * Other protocols (mailto:, tel:, vscode:, etc.) will be opened externally.
  */
-const BROWSER_HANDLED_PROTOCOLS = new Set(['http:', 'https:', 'stagewise:']);
+const BROWSER_HANDLED_PROTOCOLS = new Set([
+  'http:',
+  'https:',
+  'stagewise:',
+  'app:',
+]);
+
+/**
+ * Protocols that app UI links may open in internal browsing tabs.
+ * External web links from the UI should use the user's default browser.
+ */
+const UI_INTERNAL_TAB_PROTOCOLS = new Set(['stagewise:', 'app:']);
 
 /**
  * Check if the browser can handle the given URL's protocol.
@@ -19,6 +30,7 @@ const BROWSER_HANDLED_PROTOCOLS = new Set(['http:', 'https:', 'stagewise:']);
  * Supported protocols:
  * - http: and https: (standard web protocols)
  * - stagewise: (internal app protocol)
+ * - app: (agent/plugin mini-app protocol)
  * - Any custom protocol registered on the browser-content session
  *
  * @param url The URL to check
@@ -40,6 +52,14 @@ export function canBrowserHandleUrl(url: string): boolean {
     return false;
   } catch {
     // Invalid URL - can't be handled
+    return false;
+  }
+}
+
+export function shouldOpenUiUrlInInternalTab(url: string): boolean {
+  try {
+    return UI_INTERNAL_TAB_PROTOCOLS.has(new URL(url).protocol);
+  } catch {
     return false;
   }
 }

--- a/apps/browser/src/backend/services/window-layout/ui-controller.ts
+++ b/apps/browser/src/backend/services/window-layout/ui-controller.ts
@@ -14,9 +14,9 @@ import type { SelectedElement } from '@shared/selected-elements';
 import type { SettingsRoute } from '@shared/settings-route';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import {
-  canBrowserHandleUrl,
   openFolderFirstFileInIde,
   revealPathInFileManager,
+  shouldOpenUiUrlInInternalTab,
 } from './protocol-utils';
 import {
   default as installExtension,
@@ -304,6 +304,7 @@ export class UIController extends EventEmitter<UIControllerEventMap> {
     this.registerAttachmentProtocol();
     this.registerWorkspaceFileProtocol();
     this.registerAppProtocol();
+    this.registerAppProtocol('persist:browser-content');
     this.view = this.createView();
     this.loadApp();
     this.registerKartonProcedures();
@@ -403,10 +404,10 @@ export class UIController extends EventEmitter<UIControllerEventMap> {
    *   app://agents/{agentId}/{appId}/{relativePath}
    *   app://plugins/{pluginId}/{appId}/{relativePath}
    */
-  private registerAppProtocol(): void {
-    const uiSession = session.fromPartition(UI_SESSION_PARTITION);
+  private registerAppProtocol(partition = UI_SESSION_PARTITION): void {
+    const targetSession = session.fromPartition(partition);
 
-    uiSession.protocol.handle('app', async (request) => {
+    targetSession.protocol.handle('app', async (request) => {
       try {
         const url = new URL(request.url);
         const namespace = url.hostname;
@@ -540,24 +541,24 @@ export class UIController extends EventEmitter<UIControllerEventMap> {
         return { action: 'deny' };
       }
 
-      // Check if the browser can handle this URL's protocol
-      if (!canBrowserHandleUrl(details.url)) {
-        // Open in external application (mailto:, tel:, vscode:, etc.)
-        this.logger.debug(
-          `[UIController] Opening URL with external handler: ${details.url}`,
-        );
-        if (details.url.startsWith('file://')) {
-          const filePath = fileURLToPath(details.url).replace(/:\d+$/, '');
-          revealPathInFileManager(filePath);
-        } else shell.openExternal(details.url);
-
+      if (shouldOpenUiUrlInInternalTab(details.url)) {
+        // Check disposition to determine if tab should be opened in background
+        // disposition can be: 'default', 'foreground-tab', 'background-tab', 'new-window', etc.
+        const setActive = details.disposition !== 'background-tab';
+        this.emit('createTab', details.url, setActive);
         return { action: 'deny' };
       }
 
-      // Check disposition to determine if tab should be opened in background
-      // disposition can be: 'default', 'foreground-tab', 'background-tab', 'new-window', etc.
-      const setActive = details.disposition !== 'background-tab';
-      this.emit('createTab', details.url, setActive);
+      // UI links should not create internal browsing tabs by default.
+      // External web links and custom external protocols go to the OS handler.
+      this.logger.debug(
+        `[UIController] Opening URL with external handler: ${details.url}`,
+      );
+      if (details.url.startsWith('file://')) {
+        const filePath = fileURLToPath(details.url).replace(/:\d+$/, '');
+        revealPathInFileManager(filePath);
+      } else shell.openExternal(details.url);
+
       return { action: 'deny' };
     });
 

--- a/apps/browser/src/shared/hooks/use-file-ide-href.ts
+++ b/apps/browser/src/shared/hooks/use-file-ide-href.ts
@@ -5,10 +5,12 @@ import type {
   GlobalConfig,
 } from '@shared/karton-contracts/ui/shared-types';
 
+type IdeConfigPatch = Pick<GlobalConfig, 'openFilesInIde' | 'hasSetIde'>;
+
 export type UseFileIDEHrefOptions = {
   resolvePath: (relativePath: string) => string | null;
   globalConfig: GlobalConfig;
-  setGlobalConfig: (config: GlobalConfig) => Promise<void>;
+  setGlobalConfig: (config: IdeConfigPatch) => Promise<void>;
 };
 
 export function useFileIDEHref({
@@ -34,7 +36,6 @@ export function useFileIDEHref({
   const pickIdeAndOpen = useCallback(
     async (ide: OpenFilesInIde, relativePath: string, lineNumber?: number) => {
       await setGlobalConfig({
-        ...globalConfig,
         openFilesInIde: ide,
         hasSetIde: true,
       });
@@ -44,7 +45,7 @@ export function useFileIDEHref({
       const url = getIDEFileUrl(absolutePath, ide, lineNumber);
       window.open(url, '_blank');
     },
-    [globalConfig, setGlobalConfig, resolvePath],
+    [setGlobalConfig, resolvePath],
   );
 
   return {

--- a/apps/browser/src/shared/hotkeys.ts
+++ b/apps/browser/src/shared/hotkeys.ts
@@ -111,6 +111,9 @@ export enum HotkeyActions {
   // Dev tools
   DEV_TOOLS = 'dev_tools',
 
+  // Color scheme
+  CYCLE_COLOR_SCHEME = 'cycle_color_scheme',
+
   // Zoom
   ZOOM_IN = 'zoom_in',
   ZOOM_OUT = 'zoom_out',
@@ -326,8 +329,8 @@ export const hotkeyDefinitions: Record<HotkeyActions, HotkeyDefinition> = {
 
   // URL bar
   [HotkeyActions.FOCUS_URL_BAR]: {
-    accelerator: 'Mod+Alt+L',
-    aliases: ['Alt+D', 'F6'],
+    accelerator: 'Alt+D',
+    aliases: ['F6'],
     captureDominantly: true,
   },
 
@@ -359,10 +362,17 @@ export const hotkeyDefinitions: Record<HotkeyActions, HotkeyDefinition> = {
 
   // Dev tools
   [HotkeyActions.DEV_TOOLS]: {
-    accelerator: 'Ctrl+Shift+I',
-    aliases: ['F12', 'Ctrl+Shift+J'],
+    accelerator: 'Ctrl+Alt+I',
+    aliases: ['F12', 'Ctrl+Shift+I', 'Ctrl+Shift+J'],
     mac: 'Mod+Alt+I',
     macAliases: ['F12'],
+    captureDominantly: true,
+  },
+
+  // Color scheme
+  [HotkeyActions.CYCLE_COLOR_SCHEME]: {
+    accelerator: 'Ctrl+Alt+L',
+    mac: 'Mod+Alt+L',
     captureDominantly: true,
   },
 

--- a/apps/browser/src/shared/karton-contracts/pages-api/index.ts
+++ b/apps/browser/src/shared/karton-contracts/pages-api/index.ts
@@ -96,6 +96,7 @@ export const defaultState: PagesApiState = {
     availableSoundPacks: ['bubble-pops'],
     packDisplayNames: {},
     dockBounceEnabled: true,
+    blockAppSuspensionWhenAgentsActive: true,
   },
   workspaceMounts: [],
   plans: [],

--- a/apps/browser/src/shared/karton-contracts/ui/index.ts
+++ b/apps/browser/src/shared/karton-contracts/ui/index.ts
@@ -793,6 +793,7 @@ export type AppState = {
     ownedByStagewise: boolean;
     isChanging: boolean;
     error: string | null;
+    persistenceWarning: string | null;
   };
   /** Auto-update status synced from the backend AutoUpdateService */
   autoUpdate: {
@@ -1237,6 +1238,7 @@ export type KartonContract = {
         ownedByStagewise: boolean;
         isChanging: boolean;
         error: string | null;
+        persistenceWarning: string | null;
       }>;
       refresh: () => Promise<{
         isSupported: boolean;
@@ -1244,6 +1246,7 @@ export type KartonContract = {
         ownedByStagewise: boolean;
         isChanging: boolean;
         error: string | null;
+        persistenceWarning: string | null;
       }>;
     };
     autoUpdate: {
@@ -1673,6 +1676,7 @@ export const defaultState: KartonContract['state'] = {
     ownedByStagewise: false,
     isChanging: false,
     error: null,
+    persistenceWarning: null,
   },
   autoUpdate: {
     status: 'idle',

--- a/apps/browser/src/shared/karton-contracts/ui/index.ts
+++ b/apps/browser/src/shared/karton-contracts/ui/index.ts
@@ -787,6 +787,13 @@ export type AppState = {
     arch: string; // Architecture (e.g., 'x64', 'arm64').
     otherVersions: Record<string, string | undefined>; // Other versions of the app.
   };
+  closedLidSleep: {
+    isSupported: boolean;
+    isSleepDisabled: boolean;
+    ownedByStagewise: boolean;
+    isChanging: boolean;
+    error: string | null;
+  };
   /** Auto-update status synced from the backend AutoUpdateService */
   autoUpdate: {
     status:
@@ -1223,6 +1230,22 @@ export type KartonContract = {
       triggerAction: (id: string, actionIndex: number) => Promise<void>;
       dismiss: (id: string) => Promise<void>;
     };
+    closedLidSleep: {
+      toggle: () => Promise<{
+        isSupported: boolean;
+        isSleepDisabled: boolean;
+        ownedByStagewise: boolean;
+        isChanging: boolean;
+        error: string | null;
+      }>;
+      refresh: () => Promise<{
+        isSupported: boolean;
+        isSleepDisabled: boolean;
+        ownedByStagewise: boolean;
+        isChanging: boolean;
+        error: string | null;
+      }>;
+    };
     autoUpdate: {
       /** Manually trigger an update check */
       checkForUpdates: () => Promise<void>;
@@ -1643,6 +1666,13 @@ export const defaultState: KartonContract['state'] = {
     homepage: __APP_HOMEPAGE__,
     arch: __APP_ARCH__,
     otherVersions: {},
+  },
+  closedLidSleep: {
+    isSupported: __APP_PLATFORM__ === 'darwin',
+    isSleepDisabled: false,
+    ownedByStagewise: false,
+    isChanging: false,
+    error: null,
   },
   autoUpdate: {
     status: 'idle',

--- a/apps/browser/src/shared/karton-contracts/ui/index.ts
+++ b/apps/browser/src/shared/karton-contracts/ui/index.ts
@@ -1230,7 +1230,7 @@ export type KartonContract = {
       quitAndInstall: () => Promise<void>;
     };
     config: {
-      set: (config: GlobalConfig) => Promise<void>;
+      set: (config: Partial<GlobalConfig>) => Promise<void>;
       previewSoundPack: (
         packId: string,
         loudness: 'off' | 'subtle' | 'default',
@@ -1659,6 +1659,7 @@ export const defaultState: KartonContract['state'] = {
     availableSoundPacks: ['bubble-pops'],
     packDisplayNames: {},
     dockBounceEnabled: true,
+    blockAppSuspensionWhenAgentsActive: true,
   },
   userExperience: {
     storedExperienceData: {

--- a/apps/browser/src/shared/karton-contracts/ui/shared-types.ts
+++ b/apps/browser/src/shared/karton-contracts/ui/shared-types.ts
@@ -245,6 +245,7 @@ export const globalConfigSchema = z
     availableSoundPacks: z.array(z.string()).default(['bubble-pops']),
     packDisplayNames: z.record(z.string(), z.string()).default({}),
     dockBounceEnabled: z.boolean().default(true),
+    blockAppSuspensionWhenAgentsActive: z.boolean().default(true),
   })
   .loose();
 

--- a/apps/browser/src/ui/components/streamdown/index.tsx
+++ b/apps/browser/src/ui/components/streamdown/index.tsx
@@ -21,6 +21,7 @@ import {
   createContext,
   useRef,
   useCallback,
+  useEffect,
   type AnchorHTMLAttributes,
   type InputHTMLAttributes,
   useMemo,
@@ -54,13 +55,10 @@ import {
 import { resolveLinkAlias } from './link-aliases';
 import { useKartonProcedure } from '@ui/hooks/use-karton';
 
-function isInternalTabUrl(url: string): boolean {
-  try {
-    const protocol = new URL(url).protocol;
-    return protocol === 'stagewise:' || protocol === 'app:';
-  } catch {
-    return false;
-  }
+const ChatLinkModifierContext = createContext(false);
+
+function getChatLinkTooltipText(isAltPressed: boolean): string {
+  return isAltPressed ? 'Open in content tab' : 'Open in browser';
 }
 
 type AttachmentData =
@@ -427,6 +425,7 @@ const AnchorComponent = ({
 > &
   ExtraProps) => {
   const [openAgent] = useOpenAgent();
+  const isAltPressed = useContext(ChatLinkModifierContext);
 
   // Parse href for attachment links (path:, color:, tab:)
   const attachmentLink = useMemo(() => parseAttachmentLink(href), [href]);
@@ -451,21 +450,6 @@ const AnchorComponent = ({
     );
   }, [openAgent, href]);
 
-  const openExternalUrl = useKartonProcedure((p) => p.openExternalUrl);
-  const createTab = useKartonProcedure((p) => p.browser.createTab);
-
-  const handleLinkClick = useCallback(
-    (url: string) => (event: MouseEvent<HTMLAnchorElement>) => {
-      event.preventDefault();
-      if (isInternalTabUrl(url)) {
-        void createTab(url, true);
-      } else {
-        void openExternalUrl(url);
-      }
-    },
-    [createTab, openExternalUrl],
-  );
-
   // If it's an attachment link, render the appropriate component
   if (attachmentLink) return <AttachmentLinkRouter linkData={attachmentLink} />;
 
@@ -477,8 +461,9 @@ const AnchorComponent = ({
           <a
             {...props}
             href={resolvedAlias}
+            target="_blank"
             rel="noopener noreferrer"
-            onClick={handleLinkClick(resolvedAlias)}
+            data-chat-link="true"
             className={cn(
               'inline-flex items-baseline justify-start gap-0.5 break-all font-medium text-primary-foreground hover:text-hover-derived',
               className,
@@ -487,7 +472,7 @@ const AnchorComponent = ({
             {children}
           </a>
         </TooltipTrigger>
-        <TooltipContent>{decodeURI(resolvedAlias)}</TooltipContent>
+        <TooltipContent>{getChatLinkTooltipText(isAltPressed)}</TooltipContent>
       </Tooltip>
     );
   }
@@ -499,8 +484,9 @@ const AnchorComponent = ({
         <a
           {...props}
           href={processedHref}
+          target="_blank"
           rel="noopener noreferrer"
-          onClick={handleLinkClick(processedHref)}
+          data-chat-link="true"
           className={cn(
             'inline-flex items-baseline justify-start gap-0.5 break-all font-medium text-primary-foreground hover:text-hover-derived',
             className,
@@ -509,7 +495,7 @@ const AnchorComponent = ({
           {children}
         </a>
       </TooltipTrigger>
-      <TooltipContent>{decodeURI(processedHref)}</TooltipContent>
+      <TooltipContent>{getChatLinkTooltipText(isAltPressed)}</TooltipContent>
     </Tooltip>
   );
 };
@@ -1000,21 +986,74 @@ const STREAMDOWN_REHYPE_PLUGINS = [defaultRehypePlugins.raw!];
 export const Streamdown = memo(
   ({ isAnimating, children }: { isAnimating: boolean; children: string }) => {
     const processed = useMemo(() => preprocessMarkdown(children), [children]);
+    const createTab = useKartonProcedure((p) => p.browser.createTab);
+    const [isAltPressed, setIsAltPressed] = useState(false);
+
+    useEffect(() => {
+      const handleKeyChange = (event: KeyboardEvent) => {
+        setIsAltPressed(event.altKey);
+      };
+      const handleBlur = () => {
+        setIsAltPressed(false);
+      };
+
+      window.addEventListener('keydown', handleKeyChange);
+      window.addEventListener('keyup', handleKeyChange);
+      window.addEventListener('blur', handleBlur);
+
+      return () => {
+        window.removeEventListener('keydown', handleKeyChange);
+        window.removeEventListener('keyup', handleKeyChange);
+        window.removeEventListener('blur', handleBlur);
+      };
+    }, []);
+
+    const handleMouseMoveCapture = useCallback(
+      (event: MouseEvent<HTMLDivElement>) => {
+        setIsAltPressed(event.altKey);
+      },
+      [],
+    );
+
+    const handleClickCapture = useCallback(
+      (event: MouseEvent<HTMLDivElement>) => {
+        if (!event.altKey || event.button !== 0) return;
+
+        const target = event.target;
+        if (!(target instanceof Element)) return;
+
+        const link = target.closest<HTMLAnchorElement>('a[data-chat-link]');
+        const href = link?.getAttribute('href');
+        if (!href) return;
+
+        event.preventDefault();
+        event.stopPropagation();
+        void createTab(href, true);
+      },
+      [createTab],
+    );
 
     return (
       <StreamdownProvider isStreaming={isAnimating}>
-        <StreamdownBase
-          animated={STREAMDOWN_ANIMATED}
-          isAnimating={isAnimating}
-          mode={isAnimating ? 'streaming' : 'static'}
-          shikiTheme={STREAMDOWN_SHIKI_THEME}
-          controls={STREAMDOWN_CONTROLS}
-          plugins={STREAMDOWN_PLUGINS}
-          components={STREAMDOWN_COMPONENTS}
-          rehypePlugins={STREAMDOWN_REHYPE_PLUGINS}
-        >
-          {processed}
-        </StreamdownBase>
+        <ChatLinkModifierContext.Provider value={isAltPressed}>
+          <div
+            onClickCapture={handleClickCapture}
+            onMouseMoveCapture={handleMouseMoveCapture}
+          >
+            <StreamdownBase
+              animated={STREAMDOWN_ANIMATED}
+              isAnimating={isAnimating}
+              mode={isAnimating ? 'streaming' : 'static'}
+              shikiTheme={STREAMDOWN_SHIKI_THEME}
+              controls={STREAMDOWN_CONTROLS}
+              plugins={STREAMDOWN_PLUGINS}
+              components={STREAMDOWN_COMPONENTS}
+              rehypePlugins={STREAMDOWN_REHYPE_PLUGINS}
+            >
+              {processed}
+            </StreamdownBase>
+          </div>
+        </ChatLinkModifierContext.Provider>
       </StreamdownProvider>
     );
   },

--- a/apps/browser/src/ui/components/streamdown/index.tsx
+++ b/apps/browser/src/ui/components/streamdown/index.tsx
@@ -21,7 +21,7 @@ import {
   createContext,
   useRef,
   useCallback,
-  useEffect,
+  useSyncExternalStore,
   type AnchorHTMLAttributes,
   type InputHTMLAttributes,
   useMemo,
@@ -56,6 +56,68 @@ import { resolveLinkAlias } from './link-aliases';
 import { useKartonProcedure } from '@ui/hooks/use-karton';
 
 const ChatLinkModifierContext = createContext(false);
+
+const chatLinkModifierListeners = new Set<() => void>();
+let isChatLinkAltPressed = false;
+let cleanupChatLinkModifierWindowListeners: (() => void) | null = null;
+
+function setChatLinkAltPressed(nextValue: boolean): void {
+  if (isChatLinkAltPressed === nextValue) return;
+
+  isChatLinkAltPressed = nextValue;
+  chatLinkModifierListeners.forEach((listener) => {
+    listener();
+  });
+}
+
+function getChatLinkAltPressedSnapshot(): boolean {
+  return isChatLinkAltPressed;
+}
+
+function subscribeToChatLinkAltPressed(listener: () => void): () => void {
+  chatLinkModifierListeners.add(listener);
+
+  if (
+    chatLinkModifierListeners.size === 1 &&
+    cleanupChatLinkModifierWindowListeners === null &&
+    typeof window !== 'undefined'
+  ) {
+    const handleKeyChange = (event: KeyboardEvent) => {
+      setChatLinkAltPressed(event.altKey);
+    };
+    const handleBlur = () => {
+      setChatLinkAltPressed(false);
+    };
+
+    window.addEventListener('keydown', handleKeyChange);
+    window.addEventListener('keyup', handleKeyChange);
+    window.addEventListener('blur', handleBlur);
+
+    cleanupChatLinkModifierWindowListeners = () => {
+      window.removeEventListener('keydown', handleKeyChange);
+      window.removeEventListener('keyup', handleKeyChange);
+      window.removeEventListener('blur', handleBlur);
+    };
+  }
+
+  return () => {
+    chatLinkModifierListeners.delete(listener);
+
+    if (chatLinkModifierListeners.size === 0) {
+      cleanupChatLinkModifierWindowListeners?.();
+      cleanupChatLinkModifierWindowListeners = null;
+      setChatLinkAltPressed(false);
+    }
+  };
+}
+
+function useChatLinkAltPressed(): boolean {
+  return useSyncExternalStore(
+    subscribeToChatLinkAltPressed,
+    getChatLinkAltPressedSnapshot,
+    () => false,
+  );
+}
 
 function getChatLinkTooltipText(isAltPressed: boolean): string {
   return isAltPressed ? 'Open in content tab' : 'Open in browser';
@@ -987,30 +1049,11 @@ export const Streamdown = memo(
   ({ isAnimating, children }: { isAnimating: boolean; children: string }) => {
     const processed = useMemo(() => preprocessMarkdown(children), [children]);
     const createTab = useKartonProcedure((p) => p.browser.createTab);
-    const [isAltPressed, setIsAltPressed] = useState(false);
-
-    useEffect(() => {
-      const handleKeyChange = (event: KeyboardEvent) => {
-        setIsAltPressed(event.altKey);
-      };
-      const handleBlur = () => {
-        setIsAltPressed(false);
-      };
-
-      window.addEventListener('keydown', handleKeyChange);
-      window.addEventListener('keyup', handleKeyChange);
-      window.addEventListener('blur', handleBlur);
-
-      return () => {
-        window.removeEventListener('keydown', handleKeyChange);
-        window.removeEventListener('keyup', handleKeyChange);
-        window.removeEventListener('blur', handleBlur);
-      };
-    }, []);
+    const isAltPressed = useChatLinkAltPressed();
 
     const handleMouseMoveCapture = useCallback(
       (event: MouseEvent<HTMLDivElement>) => {
-        setIsAltPressed(event.altKey);
+        setChatLinkAltPressed(event.altKey);
       },
       [],
     );

--- a/apps/browser/src/ui/components/streamdown/index.tsx
+++ b/apps/browser/src/ui/components/streamdown/index.tsx
@@ -24,6 +24,7 @@ import {
   type AnchorHTMLAttributes,
   type InputHTMLAttributes,
   useMemo,
+  type MouseEvent,
 } from 'react';
 import { cn } from '@ui/utils';
 import { Button } from '@stagewise/stage-ui/components/button';
@@ -51,6 +52,16 @@ import {
   ColorBadge,
 } from './attachment-links';
 import { resolveLinkAlias } from './link-aliases';
+import { useKartonProcedure } from '@ui/hooks/use-karton';
+
+function isInternalTabUrl(url: string): boolean {
+  try {
+    const protocol = new URL(url).protocol;
+    return protocol === 'stagewise:' || protocol === 'app:';
+  } catch {
+    return false;
+  }
+}
 
 type AttachmentData =
   | {
@@ -440,6 +451,21 @@ const AnchorComponent = ({
     );
   }, [openAgent, href]);
 
+  const openExternalUrl = useKartonProcedure((p) => p.openExternalUrl);
+  const createTab = useKartonProcedure((p) => p.browser.createTab);
+
+  const handleLinkClick = useCallback(
+    (url: string) => (event: MouseEvent<HTMLAnchorElement>) => {
+      event.preventDefault();
+      if (isInternalTabUrl(url)) {
+        void createTab(url, true);
+      } else {
+        void openExternalUrl(url);
+      }
+    },
+    [createTab, openExternalUrl],
+  );
+
   // If it's an attachment link, render the appropriate component
   if (attachmentLink) return <AttachmentLinkRouter linkData={attachmentLink} />;
 
@@ -449,14 +475,14 @@ const AnchorComponent = ({
       <Tooltip>
         <TooltipTrigger>
           <a
+            {...props}
             href={resolvedAlias}
-            target="_blank"
             rel="noopener noreferrer"
+            onClick={handleLinkClick(resolvedAlias)}
             className={cn(
               'inline-flex items-baseline justify-start gap-0.5 break-all font-medium text-primary-foreground hover:text-hover-derived',
               className,
             )}
-            {...props}
           >
             {children}
           </a>
@@ -471,14 +497,14 @@ const AnchorComponent = ({
     <Tooltip>
       <TooltipTrigger>
         <a
+          {...props}
           href={processedHref}
-          target="_blank"
           rel="noopener noreferrer"
+          onClick={handleLinkClick(processedHref)}
           className={cn(
             'inline-flex items-baseline justify-start gap-0.5 break-all font-medium text-primary-foreground hover:text-hover-derived',
             className,
           )}
-          {...props}
         >
           {children}
         </a>

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/message-runtime-error.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/message-runtime-error.tsx
@@ -74,6 +74,8 @@ export function MessageRuntimeError({
    *  that bypass the `canRetry` last-message gate (e.g. upstream-overload). */
   isWorking?: boolean;
 }) {
+  const canShowRetry = canRetry || !isWorking;
+
   if (error.kind === 'upstream-overload') {
     return (
       <UpstreamOverloadError
@@ -88,21 +90,27 @@ export function MessageRuntimeError({
     return (
       <PlanLimitExceededError
         error={error}
-        canRetry={canRetry}
+        canRetry={canShowRetry}
         onRetry={onRetry}
       />
     );
   }
 
   if (error.kind === 'waiting-for-connection') {
-    return <WaitingForConnectionError error={error} />;
+    return (
+      <WaitingForConnectionError
+        error={error}
+        canRetry={canShowRetry}
+        onRetry={onRetry}
+      />
+    );
   }
 
   return (
     <GenericError
       agentInstanceId={agentInstanceId}
       error={error}
-      canRetry={canRetry}
+      canRetry={canShowRetry}
       onRetry={onRetry}
     />
   );
@@ -110,6 +118,8 @@ export function MessageRuntimeError({
 
 function PlanLimitExceededError({
   error,
+  canRetry,
+  onRetry,
 }: {
   error: Extract<AgentRuntimeError, { kind: 'plan-limit-exceeded' }>;
   canRetry: boolean;
@@ -165,8 +175,15 @@ function PlanLimitExceededError({
           Configure API keys
         </button>
 
+        {canRetry && (
+          <Button variant="primary" size="xs" onClick={onRetry}>
+            <RefreshCcwIcon className="size-3" />
+            Retry
+          </Button>
+        )}
+
         <Button
-          variant="primary"
+          variant={canRetry ? 'secondary' : 'primary'}
           size="xs"
           onClick={() => window.open(ctaHref, '_blank', 'noopener,noreferrer')}
         >
@@ -232,8 +249,12 @@ function UpstreamOverloadError({
 
 function WaitingForConnectionError({
   error,
+  canRetry,
+  onRetry,
 }: {
   error: Extract<AgentRuntimeError, { kind: 'waiting-for-connection' }>;
+  canRetry: boolean;
+  onRetry: () => void;
 }) {
   return (
     <div className="mt-6 flex w-full flex-col gap-1.5 rounded-lg border border-warning-solid/30 bg-warning-background p-2 text-sm">
@@ -252,6 +273,15 @@ function WaitingForConnectionError({
       <div className="text-muted-foreground text-xs">
         Last network error: {error.originalMessage}
       </div>
+
+      {canRetry && (
+        <div className="flex flex-row justify-end pt-1">
+          <Button variant="primary" size="xs" onClick={onRetry}>
+            <RefreshCcwIcon className="size-3" />
+            Retry
+          </Button>
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/message-runtime-error.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/message-runtime-error.tsx
@@ -94,6 +94,10 @@ export function MessageRuntimeError({
     );
   }
 
+  if (error.kind === 'waiting-for-connection') {
+    return <WaitingForConnectionError error={error} />;
+  }
+
   return (
     <GenericError
       agentInstanceId={agentInstanceId}
@@ -226,6 +230,32 @@ function UpstreamOverloadError({
   );
 }
 
+function WaitingForConnectionError({
+  error,
+}: {
+  error: Extract<AgentRuntimeError, { kind: 'waiting-for-connection' }>;
+}) {
+  return (
+    <div className="mt-6 flex w-full flex-col gap-1.5 rounded-lg border border-warning-solid/30 bg-warning-background p-2 text-sm">
+      <div className="flex flex-row items-center gap-1.5">
+        <IconTriangleWarning className="size-3.5 shrink-0 text-warning-foreground" />
+        <span className="font-medium text-warning-foreground">
+          Waiting for connection...
+        </span>
+      </div>
+
+      <div className="text-foreground">
+        Your device appears to be offline. The agent will retry automatically
+        once internet access is available again.
+      </div>
+
+      <div className="text-muted-foreground text-xs">
+        Last network error: {error.originalMessage}
+      </div>
+    </div>
+  );
+}
+
 function GenericError({
   agentInstanceId,
   error,
@@ -342,8 +372,8 @@ function GenericError({
       </Collapsible>
 
       {canRetry && (
-        <div className="-mt-1 flex flex-row justify-end">
-          <Button variant="ghost" size="xs" onClick={onRetry}>
+        <div className="flex flex-row justify-end pt-1">
+          <Button variant="primary" size="xs" onClick={onRetry}>
             <RefreshCcwIcon className="size-3" />
             Retry
           </Button>

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/message-runtime-error.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/message-runtime-error.tsx
@@ -127,6 +127,7 @@ function PlanLimitExceededError({
 }) {
   const subscription = useKartonState((s) => s.userAccount.subscription);
   const openSettings = useKartonProcedure((p) => p.appScreen.openSettings);
+  const openExternalUrl = useKartonProcedure((p) => p.openExternalUrl);
   const plan = subscription?.plan;
 
   const resetsAt = error.exceededWindows[0]?.resetsAt;
@@ -185,7 +186,7 @@ function PlanLimitExceededError({
         <Button
           variant={canRetry ? 'secondary' : 'primary'}
           size="xs"
-          onClick={() => window.open(ctaHref, '_blank', 'noopener,noreferrer')}
+          onClick={() => void openExternalUrl(ctaHref)}
         >
           {ctaLabel}
           <ArrowUpRightIcon className="size-3" />
@@ -298,6 +299,7 @@ function GenericError({
   onRetry: () => void;
 }) {
   const [helpExpanded, setHelpExpanded] = useState(false);
+  const openExternalUrl = useKartonProcedure((p) => p.openExternalUrl);
   const [hasCopied, setHasCopied] = useState(false);
   const [openAgent] = useOpenAgent();
   const openSettings = useKartonProcedure((p) => p.appScreen.openSettings);
@@ -328,6 +330,8 @@ function GenericError({
     setHasCopied(true);
     setTimeout(() => setHasCopied(false), 2000);
   };
+
+  const reportIssueUrl = `https://github.com/stagewise-io/stagewise/issues/new?template=5.agent_issue.yml&conversation-id=${agentInstanceId}&error-data=${encodeURIComponent(JSON.stringify(error))}`;
 
   return (
     <div className="mt-6 flex w-full flex-col gap-1.5 rounded-lg border border-derived-strong p-2 text-sm">
@@ -388,9 +392,12 @@ function GenericError({
           <div className="mt-0.5 text-muted-foreground text-xs">
             If this error continues to occur, you can{' '}
             <a
-              href={`https://github.com/stagewise-io/stagewise/issues/new?template=5.agent_issue.yml&conversation-id=${agentInstanceId}&error-data=${encodeURIComponent(JSON.stringify(error))}`}
-              target="_blank"
+              href={reportIssueUrl}
               rel="noopener noreferrer"
+              onClick={(event) => {
+                event.preventDefault();
+                void openExternalUrl(reportIssueUrl);
+              }}
               className="text-primary-foreground underline hover:text-primary-foreground/80"
             >
               report it on GitHub

--- a/apps/browser/src/ui/screens/main/content/_components/browser-tab-hotkeys.tsx
+++ b/apps/browser/src/ui/screens/main/content/_components/browser-tab-hotkeys.tsx
@@ -7,7 +7,7 @@ import { useEffect, useRef } from 'react';
 /**
  * Browser-tab–scoped hotkeys — mounted per content panel. Handles
  * per-tab web actions: history navigation, page reload, find, dev tools,
- * tab-content zoom, and URL bar focus.
+ * color scheme, tab-content zoom, and URL bar focus.
  */
 export function BrowserTabHotkeys({
   onFocusUrlBar,
@@ -29,7 +29,12 @@ export function BrowserTabHotkeys({
   const goBack = useKartonProcedure((p) => p.browser.goBack);
   const goForward = useKartonProcedure((p) => p.browser.goForward);
   const reload = useKartonProcedure((p) => p.browser.reload);
-  const toggleDevTools = useKartonProcedure((p) => p.browser.devTools.toggle);
+  const toggleChromeDevTools = useKartonProcedure(
+    (p) => p.browser.devTools.chrome.toggle,
+  );
+  const cycleColorScheme = useKartonProcedure(
+    (p) => p.browser.cycleColorScheme,
+  );
   const setZoomPercentage = useKartonProcedure(
     (p) => p.browser.setZoomPercentage,
   );
@@ -72,7 +77,7 @@ export function BrowserTabHotkeys({
     setZoomPercentage(100, activeTabId);
   }, HotkeyActions.ZOOM_RESET);
 
-  // URL bar (Mod+Alt+L): always focus the omnibox.
+  // URL bar: always focus the omnibox.
   useHotKeyListener(async () => {
     if (isTerminalTab) return;
     const targetTabId = activeTabId;
@@ -114,11 +119,17 @@ export function BrowserTabHotkeys({
     reload(activeTabId);
   }, HotkeyActions.HARD_RELOAD);
 
-  // Dev tools
+  // Chrome DevTools
   useHotKeyListener(() => {
     if (!activeTabId || isTerminalTab) return;
-    toggleDevTools(activeTabId);
+    toggleChromeDevTools(activeTabId);
   }, HotkeyActions.DEV_TOOLS);
+
+  // Color scheme
+  useHotKeyListener(() => {
+    if (!activeTabId || isTerminalTab) return;
+    cycleColorScheme(activeTabId);
+  }, HotkeyActions.CYCLE_COLOR_SCHEME);
 
   return null;
 }

--- a/apps/browser/src/ui/screens/main/content/_components/control-buttons/chrome-devtools.tsx
+++ b/apps/browser/src/ui/screens/main/content/_components/control-buttons/chrome-devtools.tsx
@@ -22,9 +22,7 @@ export function ChromeDevToolsWidget({ tab }: { tab: TabState }) {
           variant="ghost"
           size="icon-sm"
           aria-label={
-            tab.devTools.chromeOpen
-              ? 'Hide Stagewise DevTools'
-              : 'Show Stagewise DevTools'
+            tab.devTools.chromeOpen ? 'Hide DevTools' : 'Show DevTools'
           }
           onClick={() => toggleChromeDevTools(tab.id)}
           className={
@@ -38,9 +36,7 @@ export function ChromeDevToolsWidget({ tab }: { tab: TabState }) {
       <TooltipContent>
         <span className="flex items-center gap-1.5">
           <span>
-            {tab.devTools.chromeOpen
-              ? 'Hide Stagewise DevTools'
-              : 'Show Stagewise DevTools'}
+            {tab.devTools.chromeOpen ? 'Hide DevTools' : 'Show DevTools'}
           </span>
           <HotkeyCombo action={HotkeyActions.DEV_TOOLS} size="xs" />
         </span>

--- a/apps/browser/src/ui/screens/main/content/_components/control-buttons/color-scheme.tsx
+++ b/apps/browser/src/ui/screens/main/content/_components/control-buttons/color-scheme.tsx
@@ -1,3 +1,4 @@
+import { HotkeyActions } from '@shared/hotkeys';
 import { useKartonProcedure, useKartonState } from '@ui/hooks/use-karton';
 import { IconSunOutline18, IconMoonOutline18 } from 'nucleo-ui-outline-18';
 import { cn } from '@stagewise/stage-ui/lib/utils';
@@ -9,6 +10,7 @@ import {
   TooltipTrigger,
   TooltipContent,
 } from '@stagewise/stage-ui/components/tooltip';
+import { HotkeyCombo } from '@ui/components/hotkey-combo';
 
 export function ColorSchemeWidget({ tab }: { tab: TabState }) {
   const cycleColorScheme = useKartonProcedure(
@@ -57,9 +59,11 @@ export function ColorSchemeWidget({ tab }: { tab: TabState }) {
         </Button>
       </TooltipTrigger>
       <TooltipContent>
-        Toggle color scheme
-        <br />
-        <span className="text-muted-foreground text-xs">
+        <span className="flex items-center gap-1.5">
+          <span>Toggle color scheme</span>
+          <HotkeyCombo action={HotkeyActions.CYCLE_COLOR_SCHEME} size="xs" />
+        </span>
+        <span className="mt-0.5 block text-muted-foreground text-xs">
           Current:{' '}
           {tab.colorScheme === 'light'
             ? 'Light'

--- a/apps/browser/src/ui/screens/main/sidebar/index.tsx
+++ b/apps/browser/src/ui/screens/main/sidebar/index.tsx
@@ -76,11 +76,18 @@ export function Sidebar() {
   }, [openSettings, track]);
 
   const handleToggleClosedLidSleep = useCallback(() => {
+    if (closedLidSleep.isChanging) return;
+
     track('closed-lid-sleep-toggled', {
       enabled: !closedLidSleep.isSleepDisabled,
     });
     void toggleClosedLidSleep();
-  }, [closedLidSleep.isSleepDisabled, toggleClosedLidSleep, track]);
+  }, [
+    closedLidSleep.isChanging,
+    closedLidSleep.isSleepDisabled,
+    toggleClosedLidSleep,
+    track,
+  ]);
 
   // Sync context-driven collapse state to the imperative panel handle.
   // Guards prevent infinite loops with onCollapse/onExpand callbacks.
@@ -184,15 +191,15 @@ export function Sidebar() {
                             : 'Prevent sleep on closed lid'
                         }
                         className="app-no-drag shrink-0"
-                        disabled={closedLidSleep.isChanging}
+                        aria-disabled={closedLidSleep.isChanging}
                         onClick={handleToggleClosedLidSleep}
                       >
                         <IconHotDrinkOutline18
                           className={cn(
-                            'size-4',
+                            'size-4 transition-[color,filter] duration-150 ease-out',
                             closedLidSleep.isSleepDisabled
                               ? 'text-[oklch(0.66_0.169_var(--H-yellow))] drop-shadow-[0_0_1.5px_oklch(from_var(--color-warning-solid)_l_c_h_/_0.5)] dark:text-[oklch(0.78_0.112_var(--H-yellow))]'
-                              : 'text-muted-foreground',
+                              : 'text-muted-foreground drop-shadow-[0_0_1.5px_oklch(from_var(--color-warning-solid)_l_c_h_/_0)]',
                           )}
                         />
                       </Button>

--- a/apps/browser/src/ui/screens/main/sidebar/index.tsx
+++ b/apps/browser/src/ui/screens/main/sidebar/index.tsx
@@ -198,9 +198,18 @@ export function Sidebar() {
                       </Button>
                     </TooltipTrigger>
                     <TooltipContent side="top">
-                      {closedLidSleep.isSleepDisabled
-                        ? 'Re-enable sleep on closed lid'
-                        : 'Prevent sleep on closed lid'}
+                      <div className="flex max-w-64 flex-col gap-1">
+                        <span>
+                          {closedLidSleep.isSleepDisabled
+                            ? 'Re-enable sleep on closed lid'
+                            : 'Prevent sleep on closed lid'}
+                        </span>
+                        {closedLidSleep.persistenceWarning && (
+                          <span className="text-muted-foreground text-xs">
+                            {closedLidSleep.persistenceWarning}
+                          </span>
+                        )}
+                      </div>
                     </TooltipContent>
                   </Tooltip>
                 )}

--- a/apps/browser/src/ui/screens/main/sidebar/index.tsx
+++ b/apps/browser/src/ui/screens/main/sidebar/index.tsx
@@ -5,7 +5,8 @@ import {
 import { useRef, useCallback, useEffect } from 'react';
 import { Button } from '@stagewise/stage-ui/components/button';
 import {
-  IconGear2Outline18,
+  IconGear3Outline18,
+  IconHotDrinkOutline18,
   IconOpenRectArrowInOutline18,
 } from 'nucleo-ui-outline-18';
 import { AgentsList } from './agents-list';
@@ -15,6 +16,7 @@ import {
   TooltipContent,
 } from '@stagewise/stage-ui/components/tooltip';
 import { useTrack } from '@ui/hooks/use-track';
+import { cn } from '@stagewise/stage-ui/lib/utils';
 import { useKartonProcedure, useKartonState } from '@ui/hooks/use-karton';
 import { useUiZoomCounterScale } from '@ui/hooks/use-ui-zoom-counter-scale';
 import { TITLEBAR_HEIGHT } from '@shared/titlebar';
@@ -45,11 +47,16 @@ export function Sidebar() {
 
   const track = useTrack();
   const openSettings = useKartonProcedure((p) => p.appScreen.openSettings);
+  const toggleClosedLidSleep = useKartonProcedure(
+    (p) => p.closedLidSleep.toggle,
+  );
   const counterScale = useUiZoomCounterScale();
 
   const { collapsed, setCollapsed } = useSidebarCollapsed();
 
   const userAccount = useKartonState((s) => s.userAccount);
+  const isMacOs = useKartonState((s) => s.appInfo.platform === 'darwin');
+  const closedLidSleep = useKartonState((s) => s.closedLidSleep);
 
   const isAuthenticated =
     userAccount.status === 'authenticated' ||
@@ -67,6 +74,13 @@ export function Sidebar() {
     track('account-opened');
     void openSettings({ section: 'account' });
   }, [openSettings, track]);
+
+  const handleToggleClosedLidSleep = useCallback(() => {
+    track('closed-lid-sleep-toggled', {
+      enabled: !closedLidSleep.isSleepDisabled,
+    });
+    void toggleClosedLidSleep();
+  }, [closedLidSleep.isSleepDisabled, toggleClosedLidSleep, track]);
 
   // Sync context-driven collapse state to the imperative panel handle.
   // Guards prevent infinite loops with onCollapse/onExpand callbacks.
@@ -157,20 +171,55 @@ export function Sidebar() {
                 </button>
               )}
 
-              <Tooltip>
-                <TooltipTrigger>
-                  <Button
-                    variant="ghost"
-                    size="icon-sm"
-                    aria-label="Settings"
-                    className="app-no-drag shrink-0"
-                    onClick={handleOpenSettings}
-                  >
-                    <IconGear2Outline18 className="size-4" />
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent side="top">Settings</TooltipContent>
-              </Tooltip>
+              <div className="flex shrink-0 flex-row items-center gap-1">
+                {isMacOs && (
+                  <Tooltip>
+                    <TooltipTrigger>
+                      <Button
+                        variant="ghost"
+                        size="icon-sm"
+                        aria-label={
+                          closedLidSleep.isSleepDisabled
+                            ? 'Re-enable sleep on closed lid'
+                            : 'Prevent sleep on closed lid'
+                        }
+                        className="app-no-drag shrink-0"
+                        disabled={closedLidSleep.isChanging}
+                        onClick={handleToggleClosedLidSleep}
+                      >
+                        <IconHotDrinkOutline18
+                          className={cn(
+                            'size-4',
+                            closedLidSleep.isSleepDisabled
+                              ? 'text-[oklch(0.66_0.169_var(--H-yellow))] drop-shadow-[0_0_1.5px_oklch(from_var(--color-warning-solid)_l_c_h_/_0.5)] dark:text-[oklch(0.78_0.112_var(--H-yellow))]'
+                              : 'text-muted-foreground',
+                          )}
+                        />
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent side="top">
+                      {closedLidSleep.isSleepDisabled
+                        ? 'Re-enable sleep on closed lid'
+                        : 'Prevent sleep on closed lid'}
+                    </TooltipContent>
+                  </Tooltip>
+                )}
+
+                <Tooltip>
+                  <TooltipTrigger>
+                    <Button
+                      variant="ghost"
+                      size="icon-sm"
+                      aria-label="Settings"
+                      className="app-no-drag shrink-0"
+                      onClick={handleOpenSettings}
+                    >
+                      <IconGear3Outline18 className="size-4" />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent side="top">Settings</TooltipContent>
+                </Tooltip>
+              </div>
             </div>
           </div>
         </div>

--- a/apps/browser/src/ui/screens/settings/sections/account-section.tsx
+++ b/apps/browser/src/ui/screens/settings/sections/account-section.tsx
@@ -76,7 +76,7 @@ function AuthenticatedView({
   machineId?: string;
   onLogout: () => void;
 }) {
-  const openTab = useKartonProcedure((p) => p.browser.createTab);
+  const openExternalUrl = useKartonProcedure((p) => p.openExternalUrl);
 
   return (
     <>
@@ -162,7 +162,7 @@ function AuthenticatedView({
         <Button
           variant="primary"
           size="sm"
-          onClick={() => void openTab(CONSOLE_URL, true)}
+          onClick={() => void openExternalUrl(CONSOLE_URL)}
         >
           Open Console
         </Button>

--- a/apps/browser/src/ui/screens/settings/sections/general-settings-section.tsx
+++ b/apps/browser/src/ui/screens/settings/sections/general-settings-section.tsx
@@ -9,7 +9,7 @@ import { useKartonState, useKartonProcedure } from '@ui/hooks/use-karton';
 import { IdeLogo } from '@ui/components/ide-logo';
 import type { OpenFilesInIde } from '@shared/karton-contracts/ui/shared-types';
 import { IDE_SELECTION_ITEMS } from '@ui/utils';
-import { PlayIcon, UploadIcon } from 'lucide-react';
+import { PlayIcon, TriangleAlertIcon, UploadIcon } from 'lucide-react';
 
 // =============================================================================
 // IDE Selection Setting Component
@@ -79,6 +79,7 @@ function IdeSelectionSetting() {
 
 function PowerSaveBlockerSetting() {
   const globalConfig = useKartonState((s) => s.globalConfig);
+  const isMacOs = useKartonState((s) => s.appInfo.platform === 'darwin');
   const setGlobalConfig = useKartonProcedure((p) => p.config.set);
 
   const isEnabled = globalConfig.blockAppSuspensionWhenAgentsActive ?? true;
@@ -90,23 +91,36 @@ function PowerSaveBlockerSetting() {
   };
 
   return (
-    <div className="flex items-center justify-between gap-4">
-      <label htmlFor="agent-power-save-blocker" className="min-w-0 flex-1">
-        <h3 className="font-medium text-base text-foreground">
-          Keep app awake while agents work
-        </h3>
-        <p className="text-muted-foreground text-sm">
-          Prevent app suspension while agents run tool loops or other active
-          work. Waiting for questions or tool approval still counts as idle.
-        </p>
-      </label>
+    <div className="flex items-start justify-between gap-4">
+      <div className="min-w-0 flex-1">
+        <label htmlFor="agent-power-save-blocker">
+          <h3 className="font-medium text-base text-foreground">
+            Keep app awake while agents work
+          </h3>
+          <p className="text-muted-foreground text-sm">
+            Prevent app suspension while agents run tool loops or other active
+            work. Waiting for questions or tool approval still counts as idle.
+          </p>
+        </label>
+
+        {isMacOs && (
+          <div className="mt-2 flex items-start gap-1.5 rounded-md bg-warning-background/45 p-2 text-warning-foreground text-xs leading-snug ring-1 ring-warning-solid/20">
+            <TriangleAlertIcon className="mt-0.5 size-3.5 shrink-0 text-warning-foreground" />
+            <p>
+              To prevent sleep in battery mode on macOS devices, including when
+              the lid is closed, you must enable “Keep awake” mode in the
+              bottom-right corner of the sidebar.
+            </p>
+          </div>
+        )}
+      </div>
 
       <Switch
         id="agent-power-save-blocker"
         checked={isEnabled}
         onCheckedChange={handleChange}
-        size="sm"
-        className="shrink-0"
+        size="xs"
+        className="mt-1 shrink-0"
       />
     </div>
   );

--- a/apps/browser/src/ui/screens/settings/sections/general-settings-section.tsx
+++ b/apps/browser/src/ui/screens/settings/sections/general-settings-section.tsx
@@ -33,7 +33,6 @@ function IdeSelectionSetting() {
 
   const handleIdeChange = async (value: string) => {
     await setGlobalConfig({
-      ...globalConfig,
       openFilesInIde: value as OpenFilesInIde,
       hasSetIde: true,
     });
@@ -69,6 +68,45 @@ function IdeSelectionSetting() {
         size="xs"
         triggerClassName="w-auto min-w-0 px-2 py-3"
         side="bottom"
+      />
+    </div>
+  );
+}
+
+// =============================================================================
+// Power Save Blocker Setting Component
+// =============================================================================
+
+function PowerSaveBlockerSetting() {
+  const globalConfig = useKartonState((s) => s.globalConfig);
+  const setGlobalConfig = useKartonProcedure((p) => p.config.set);
+
+  const isEnabled = globalConfig.blockAppSuspensionWhenAgentsActive ?? true;
+
+  const handleChange = async (checked: boolean) => {
+    await setGlobalConfig({
+      blockAppSuspensionWhenAgentsActive: checked,
+    });
+  };
+
+  return (
+    <div className="flex items-center justify-between gap-4">
+      <label htmlFor="agent-power-save-blocker" className="min-w-0 flex-1">
+        <h3 className="font-medium text-base text-foreground">
+          Keep app awake while agents work
+        </h3>
+        <p className="text-muted-foreground text-sm">
+          Prevent app suspension while agents run tool loops or other active
+          work. Waiting for questions or tool approval still counts as idle.
+        </p>
+      </label>
+
+      <Switch
+        id="agent-power-save-blocker"
+        checked={isEnabled}
+        onCheckedChange={handleChange}
+        size="sm"
+        className="shrink-0"
       />
     </div>
   );
@@ -139,7 +177,6 @@ function NotificationsSetting() {
     previewSound(currentPack, notificationSoundLoudness);
 
     await setGlobalConfig({
-      ...globalConfig,
       notificationSoundsEnabled: notificationSoundLoudness !== 'off',
       notificationSoundLoudness,
     });
@@ -149,7 +186,6 @@ function NotificationsSetting() {
     if (typeof value !== 'string' || !packOptions.includes(value)) return;
     previewSound(value, soundLoudness);
     await setGlobalConfig({
-      ...globalConfig,
       notificationSoundPack: value,
     });
   };
@@ -192,7 +228,6 @@ function NotificationsSetting() {
 
   const handleDockBounceChange = async (checked: boolean) => {
     await setGlobalConfig({
-      ...globalConfig,
       dockBounceEnabled: checked,
     });
   };
@@ -319,6 +354,7 @@ export function GeneralSettingsSection() {
           </div>
           <section className="space-y-6">
             <IdeSelectionSetting />
+            <PowerSaveBlockerSetting />
           </section>
 
           <hr className="border-derived-subtle border-t" />

--- a/apps/browser/src/ui/screens/settings/sections/history-section.tsx
+++ b/apps/browser/src/ui/screens/settings/sections/history-section.tsx
@@ -370,7 +370,7 @@ export function HistorySection() {
   const getFaviconBitmaps = useKartonProcedure(
     (p) => p.browser.getFaviconBitmaps,
   );
-  const createTab = useKartonProcedure((p) => p.browser.createTab);
+  const openExternalUrl = useKartonProcedure((p) => p.openExternalUrl);
   const getHistoryRef = useRef(getHistory);
   const getFaviconBitmapsRef = useRef(getFaviconBitmaps);
   const listRef = useRef<{
@@ -569,12 +569,12 @@ export function HistorySection() {
     [hasMore, isLoadingMore, isLoading, rows.length, loadMoreHistory],
   );
 
-  // Handle opening URL in new tab
+  // Handle opening URL in the user's default browser.
   const handleOpenUrl = useCallback(
     (url: string) => {
-      void createTab(url, true);
+      void openExternalUrl(url);
     },
-    [createTab],
+    [openExternalUrl],
   );
 
   // Row props

--- a/packages/agent-core/src/agents/base-agent.ts
+++ b/packages/agent-core/src/agents/base-agent.ts
@@ -904,14 +904,12 @@ export abstract class BaseAgent<
   ): Promise<void> {
     const historyLengthBefore = this.state.get().history.length;
 
-    this.logger.info(
+    this.host.logger.info(
       `[BaseAgent:${this.instanceId}] Recovering interrupted run with synthetic continuation. reason=${reason}, historyLength=${historyLengthBefore}`,
     );
 
     await this.internalStop('system-interrupted');
-    this.state.set((draft) => {
-      draft.isWorking = false;
-    });
+    this.state.commands.setIsWorkingFalse();
 
     this._pendingSyntheticContinuation = { reason };
     void this.runStep();
@@ -1536,7 +1534,7 @@ export abstract class BaseAgent<
     // Check canRunStep BEFORE setting isWorking to avoid deadlock
     if (!this.canRunStep()) {
       if (this._pendingSyntheticContinuation) {
-        this.logger.warn(
+        this.host.logger.warn(
           `[BaseAgent:${this.instanceId}] Dropping synthetic continuation because the agent cannot run a new step. reason=${this._pendingSyntheticContinuation.reason}`,
         );
         this._pendingSyntheticContinuation = null;
@@ -2438,13 +2436,13 @@ export abstract class BaseAgent<
 
     const lastMessage = modelMessages.at(-1);
     if (lastMessage?.role === 'user' || lastMessage?.role === 'tool') {
-      this.logger.info(
+      this.host.logger.info(
         `[BaseAgent:${this.instanceId}] Synthetic continuation not appended because model context already ends with ${lastMessage.role}. reason=${continuation.reason}`,
       );
       return modelMessages;
     }
 
-    this.logger.info(
+    this.host.logger.info(
       `[BaseAgent:${this.instanceId}] Appending synthetic model-only continuation. reason=${continuation.reason}, previousLastRole=${lastMessage?.role ?? 'none'}`,
     );
 

--- a/packages/agent-core/src/agents/base-agent.ts
+++ b/packages/agent-core/src/agents/base-agent.ts
@@ -584,6 +584,15 @@ export abstract class BaseAgent<
   private _pendingContinue: boolean | null = null;
 
   /**
+   * Set only for runtime recovery after a suspend/resume or event-loop stall.
+   * It appends a transient model-only `continue` user message for the next
+   * step without writing anything to visible/persisted chat history.
+   */
+  private _pendingSyntheticContinuation: {
+    reason: 'system-resumed' | 'event-loop-stalled';
+  } | null = null;
+
+  /**
    * Tracks approval IDs for which we have already emitted a
    * `tool-approval-requested` telemetry event. The stream merge loop runs
    * per chunk, so the same `approval-requested` state is observed many
@@ -881,6 +890,31 @@ export abstract class BaseAgent<
   public async stop(): Promise<void> {
     await this.internalStop('user-stopped');
     this.state.commands.setIsWorkingFalse();
+  }
+
+  /**
+   * Stops a potentially stale in-flight step and asks the model to continue.
+   * Used after system suspend/resume or event-loop stalls where sockets and
+   * provider streams may have been torn down without a clean SDK error.
+   *
+   * @note DO NOT OVERRIDE
+   */
+  public async recoverInterruptedRun(
+    reason: 'system-resumed' | 'event-loop-stalled',
+  ): Promise<void> {
+    const historyLengthBefore = this.state.get().history.length;
+
+    this.logger.info(
+      `[BaseAgent:${this.instanceId}] Recovering interrupted run with synthetic continuation. reason=${reason}, historyLength=${historyLengthBefore}`,
+    );
+
+    await this.internalStop('system-interrupted');
+    this.state.set((draft) => {
+      draft.isWorking = false;
+    });
+
+    this._pendingSyntheticContinuation = { reason };
+    void this.runStep();
   }
 
   /**
@@ -1500,7 +1534,15 @@ export abstract class BaseAgent<
    */
   private async runStep(isApprovalContinuation = false): Promise<void> {
     // Check canRunStep BEFORE setting isWorking to avoid deadlock
-    if (!this.canRunStep()) return;
+    if (!this.canRunStep()) {
+      if (this._pendingSyntheticContinuation) {
+        this.logger.warn(
+          `[BaseAgent:${this.instanceId}] Dropping synthetic continuation because the agent cannot run a new step. reason=${this._pendingSyntheticContinuation.reason}`,
+        );
+        this._pendingSyntheticContinuation = null;
+      }
+      return;
+    }
 
     // Increment step generation so stale callbacks from previous steps are
     // ignored. Capture it in a local const for the closures below.
@@ -1553,6 +1595,7 @@ export abstract class BaseAgent<
       this.host.logger.error(
         `[BaseAgent:${this.instanceId}] Failed to resolve model "${stepModelId}": ${err.message}`,
       );
+      this._pendingSyntheticContinuation = null;
       this.report(err, 'resolveModel');
       this.state.commands.recordStepError({
         error: {
@@ -1591,6 +1634,7 @@ export abstract class BaseAgent<
       this.host.logger.error(
         `[BaseAgent:${this.instanceId}] Failed to prepare step context: ${this.formatError(error)}`,
       );
+      this._pendingSyntheticContinuation = null;
       this.report(error, 'prepareStepContext');
       this.state.commands.recordStepError({
         error: {
@@ -1922,6 +1966,7 @@ export abstract class BaseAgent<
       // Drop any deferred continuation decision — we must not schedule
       // the next step or fire onIdle after an error here.
       this._pendingContinue = null;
+      this._pendingSyntheticContinuation = null;
       try {
         this.stepAbortController?.abort();
       } catch {}
@@ -2373,10 +2418,37 @@ export abstract class BaseAgent<
     );
 
     // Then, we allow another step to modify the final model messages
-    const finalModelMessages =
+    const transformedModelMessages =
       await this.transformModelMessagesBeforeStep(modelMessages);
 
+    const finalModelMessages = this.appendSyntheticContinuationIfNeeded(
+      transformedModelMessages,
+    );
+
     return finalModelMessages;
+  }
+
+  private appendSyntheticContinuationIfNeeded(
+    modelMessages: ModelMessage[],
+  ): ModelMessage[] {
+    const continuation = this._pendingSyntheticContinuation;
+    if (!continuation) return modelMessages;
+
+    this._pendingSyntheticContinuation = null;
+
+    const lastMessage = modelMessages.at(-1);
+    if (lastMessage?.role === 'user' || lastMessage?.role === 'tool') {
+      this.logger.info(
+        `[BaseAgent:${this.instanceId}] Synthetic continuation not appended because model context already ends with ${lastMessage.role}. reason=${continuation.reason}`,
+      );
+      return modelMessages;
+    }
+
+    this.logger.info(
+      `[BaseAgent:${this.instanceId}] Appending synthetic model-only continuation. reason=${continuation.reason}, previousLastRole=${lastMessage?.role ?? 'none'}`,
+    );
+
+    return [...modelMessages, { role: 'user', content: 'continue' }];
   }
 
   /**
@@ -2688,15 +2760,20 @@ export abstract class BaseAgent<
   }
 
   private async internalStop(
-    stopReason: 'user-stopped' | 'user-flushed-queue' = 'user-stopped',
+    stopReason:
+      | 'user-stopped'
+      | 'user-flushed-queue'
+      | 'system-interrupted' = 'user-stopped',
   ): Promise<void> {
     // Invalidate pending callbacks BEFORE firing abort — onAbort fires
     // synchronously and must see the new generation to be ignored.
     this._stepGeneration++;
     // Discard any deferred continuation so runStep's tail cannot
     // schedule another step or flip to idle after we've already
-    // intervened.
+    // intervened. Also discard synthetic recovery continuations; the
+    // recovery path sets a fresh one after calling internalStop().
     this._pendingContinue = null;
+    this._pendingSyntheticContinuation = null;
     try {
       this.stepAbortController?.abort();
     } catch {}
@@ -2707,18 +2784,22 @@ export abstract class BaseAgent<
     this.toolbox.cancelPendingAgentDialogs(this.instanceId);
 
     const toolCallAbortReason =
-      stopReason === 'user-stopped'
-        ? (this.config.stopToolCallAbortReason ??
-          'User stopped agent before tool call finished.')
-        : (this.config.flushQueueToolCallAbortReason ??
-          'User sent new message before tool call finished.');
+      stopReason === 'system-interrupted'
+        ? 'System was suspended or stalled before tool call finished.'
+        : stopReason === 'user-stopped'
+          ? (this.config.stopToolCallAbortReason ??
+            'User stopped agent before tool call finished.')
+          : (this.config.flushQueueToolCallAbortReason ??
+            'User sent new message before tool call finished.');
 
     const toolCallRequestApprovalAbortReason =
-      stopReason === 'user-stopped'
-        ? (this.config.stopToolCallRequestApprovalReason ??
-          'User stopped agent before tool call approval was granted.')
-        : (this.config.flushQueueToolCallRequestApprovalReason ??
-          'User sent new message before tool call approval was granted.');
+      stopReason === 'system-interrupted'
+        ? 'System was suspended or stalled before tool call approval was granted.'
+        : stopReason === 'user-stopped'
+          ? (this.config.stopToolCallRequestApprovalReason ??
+            'User stopped agent before tool call approval was granted.')
+          : (this.config.flushQueueToolCallRequestApprovalReason ??
+            'User sent new message before tool call approval was granted.');
 
     this.state.commands.terminateNonTerminalToolPartsInLastAssistant({
       approvalDenyReason: toolCallRequestApprovalAbortReason,

--- a/packages/agent-core/src/services/agent-manager/agent-manager.ts
+++ b/packages/agent-core/src/services/agent-manager/agent-manager.ts
@@ -69,6 +69,62 @@ function toFiniteTimestamp(value: unknown): number | undefined {
   return undefined;
 }
 
+const NETWORK_RETRYABLE_ERROR_PATTERNS = [
+  'network',
+  'fetch failed',
+  'failed to fetch',
+  'socket',
+  'connection',
+  'timeout',
+  'timed out',
+  'econnreset',
+  'etimedout',
+  'enotfound',
+  'eai_again',
+  'econnrefused',
+  'und_err',
+  'terminated',
+];
+
+function getNetworkRetryableErrorMessage(
+  error: AgentState['error'],
+): string | null {
+  if (!error) return null;
+  if (error.kind === 'plan-limit-exceeded') return null;
+  if (error.kind === 'upstream-overload') return null;
+  if (error.kind === 'waiting-for-connection') return error.originalMessage;
+
+  const message = error.message.toLowerCase();
+  return NETWORK_RETRYABLE_ERROR_PATTERNS.some((pattern) =>
+    message.includes(pattern),
+  )
+    ? error.message
+    : null;
+}
+
+function messageHasPendingApproval(message: AgentMessage): boolean {
+  if (message.role !== 'assistant') return false;
+
+  return message.parts.some((part) => {
+    if (!(part.type === 'dynamic-tool' || part.type.startsWith('tool-'))) {
+      return false;
+    }
+
+    return (part as { state?: string }).state === 'approval-requested';
+  });
+}
+
+function hasPendingToolApproval(history: AgentMessage[]): boolean {
+  for (let i = history.length - 1; i >= 0; i--) {
+    const message = history[i];
+    if (message?.role === 'assistant') {
+      return messageHasPendingApproval(message);
+    }
+  }
+
+  return false;
+}
+
 /**
  * @note Due to the complex type inference for all this stuff, we sometimes explicitly define types here to avoid errors.
  *       This is a bit of a hack, but it's the best we can do for now.
@@ -81,10 +137,21 @@ export class AgentManager extends DisposableService {
   private static readonly TITLE_MIN_LENGTH = 1;
   private static readonly TITLE_MAX_LENGTH = 200;
 
+  private static readonly NETWORK_RETRY_SCAN_INTERVAL_MS = 5_000;
+  private static readonly NETWORK_RETRY_BACKOFF_MS: [number, ...number[]] = [
+    5_000, 15_000, 30_000, 60_000, 120_000,
+  ];
+
   private activeAgents = new Map<
     string,
     BaseAgent<any, any> | BaseAgent<never, any>
   >();
+
+  private readonly pendingNetworkRetries = new Map<
+    string,
+    { retryCount: number; nextRetryAt: number; lastErrorMessage: string }
+  >();
+  private readonly networkRetryInterval: ReturnType<typeof setInterval>;
 
   private readonly commandRegistry: CommandRegistry;
   private readonly managerToolbox: AgentManagerToolboxPort;
@@ -124,6 +191,7 @@ export class AgentManager extends DisposableService {
   private readonly enrichHistoryEntries?: (
     entries: AgentHistoryEntry[],
   ) => Promise<AgentHistoryEntry[]>;
+  private readonly isNetworkOnline?: () => boolean;
   private readonly imageCache?: ProcessedImageCacheService;
   /**
    * App-wide `FileReadCacheService` shared across all agent instances.
@@ -202,12 +270,18 @@ export class AgentManager extends DisposableService {
     this.renderHostMention = hooks?.renderHostMention;
     this.onAgentEvent = hooks?.onAgentEvent;
     this.enrichHistoryEntries = hooks?.enrichHistoryEntries;
+    this.isNetworkOnline = hooks?.isNetworkOnline;
     this.getSkillsForSlashRedaction =
       hooks?.skillsForSlashRedaction ?? (() => []);
 
     this.domainAdapterRegistry = new DomainAdapterRegistry(host.logger);
 
     this.unregisterCommands = this.registerCommandHandlers();
+
+    this.networkRetryInterval = setInterval(() => {
+      void this.processNetworkRetries();
+    }, AgentManager.NETWORK_RETRY_SCAN_INTERVAL_MS);
+    this.networkRetryInterval.unref?.();
 
     // The persistence DB is owned by `AgentCorePersistence` and is
     // fully migrated by the time the host hands it to us, so the
@@ -702,11 +776,176 @@ export class AgentManager extends DisposableService {
   }
 
   protected async onTeardown(): Promise<void> {
+    clearInterval(this.networkRetryInterval);
+    this.pendingNetworkRetries.clear();
     this.unregisterCommands();
     for (const agent of this.activeAgents.values()) {
       await agent.onTeardown();
     }
     this.activeAgents.clear();
+  }
+
+  private getNetworkRetryBackoffMs(retryCount: number): number {
+    return (
+      AgentManager.NETWORK_RETRY_BACKOFF_MS[
+        Math.min(retryCount, AgentManager.NETWORK_RETRY_BACKOFF_MS.length - 1)
+      ] ?? AgentManager.NETWORK_RETRY_BACKOFF_MS[0]
+    );
+  }
+
+  public async retryNetworkFailedAgentsNow(reason: string): Promise<void> {
+    this.logger.info(
+      `[AgentManager] Triggering immediate network retry scan. reason=${reason}`,
+    );
+    await this.processNetworkRetries(true);
+  }
+
+  private async processNetworkRetries(force = false): Promise<void> {
+    if (!this.isNetworkOnline) return;
+
+    const now = Date.now();
+
+    for (const [agentInstanceId, agent] of this.activeAgents.entries()) {
+      const agentState =
+        this.agentStore.get().agents.instances[agentInstanceId]?.state;
+      if (!agentState) {
+        this.pendingNetworkRetries.delete(agentInstanceId);
+        continue;
+      }
+
+      if (agentState.isWorking) continue;
+
+      const errorMessage = getNetworkRetryableErrorMessage(agentState.error);
+      if (!errorMessage) {
+        if (this.pendingNetworkRetries.delete(agentInstanceId)) {
+          this.logger.info(
+            `[AgentManager] Cleared network retry tracking for agent ${agentInstanceId}`,
+          );
+        }
+        continue;
+      }
+
+      const isOnline = this.isNetworkOnline();
+      let pending = this.pendingNetworkRetries.get(agentInstanceId);
+      if (!pending) {
+        if (isOnline) {
+          this.logger.debug(
+            `[AgentManager] Not auto-retrying agent ${agentInstanceId}; retryable-looking error occurred while internet access is available: ${errorMessage}`,
+          );
+          continue;
+        }
+
+        pending = {
+          retryCount: 0,
+          nextRetryAt: now,
+          lastErrorMessage: errorMessage,
+        };
+        this.pendingNetworkRetries.set(agentInstanceId, pending);
+        this.setWaitingForConnectionError(agentInstanceId, errorMessage);
+        this.logger.info(
+          `[AgentManager] Registered offline agent ${agentInstanceId} for automatic retry when internet access returns: ${errorMessage}`,
+        );
+      } else if (pending.lastErrorMessage !== errorMessage) {
+        pending.lastErrorMessage = errorMessage;
+        pending.nextRetryAt = now;
+      }
+
+      if (!isOnline) {
+        pending.nextRetryAt = now;
+        this.setWaitingForConnectionError(agentInstanceId, errorMessage);
+        continue;
+      }
+
+      if (!force && now < pending.nextRetryAt) continue;
+
+      const attempt = pending.retryCount + 1;
+      pending.retryCount = attempt;
+      pending.nextRetryAt = now + this.getNetworkRetryBackoffMs(attempt);
+
+      this.logger.info(
+        `[AgentManager] Internet access restored; retrying offline-failed agent ${agentInstanceId}. attempt=${attempt}`,
+      );
+
+      try {
+        await agent.retryLastUserMessage();
+      } catch (error) {
+        this.logger.warn(
+          `[AgentManager] Failed to retry network-failed agent ${agentInstanceId}`,
+          { error },
+        );
+      }
+    }
+  }
+
+  private setWaitingForConnectionError(
+    agentInstanceId: string,
+    originalMessage: string,
+  ): void {
+    const currentError =
+      this.agentStore.get().agents.instances[agentInstanceId]?.state.error;
+    if (currentError?.kind === 'waiting-for-connection') return;
+
+    this.agentStore.update((draft) => {
+      const state = draft.agents.instances[agentInstanceId]?.state;
+      if (!state || state.isWorking) return;
+
+      const existingError = state.error;
+      state.error = {
+        kind: 'waiting-for-connection',
+        message: 'Waiting for internet connection...',
+        originalMessage,
+        code: existingError?.kind ? undefined : existingError?.code,
+        stack: existingError?.kind ? undefined : existingError?.stack,
+      };
+    });
+  }
+
+  private isRecoverableInterruptedAgent(agentInstanceId: string): boolean {
+    const state = this.agentStore.get();
+    const instance = state.agents.instances[agentInstanceId];
+    if (!instance?.state.isWorking) return false;
+
+    if (state.toolbox[agentInstanceId]?.pendingUserQuestion) {
+      return false;
+    }
+
+    return !hasPendingToolApproval(instance.state.history);
+  }
+
+  public async recoverInterruptedActiveAgents(
+    reason: 'system-resumed' | 'event-loop-stalled',
+    details?: { stalledForMs?: number },
+  ): Promise<void> {
+    const recoverableAgentIds = [...this.activeAgents.keys()].filter((id) =>
+      this.isRecoverableInterruptedAgent(id),
+    );
+
+    if (recoverableAgentIds.length === 0) {
+      this.logger.debug(
+        `[AgentManager] No active agents needed recovery after ${reason}`,
+      );
+      return;
+    }
+
+    this.logger.info(
+      `[AgentManager] Recovering ${recoverableAgentIds.length} interrupted active agent(s). reason=${reason}${
+        details?.stalledForMs ? `, stalledForMs=${details.stalledForMs}` : ''
+      }`,
+    );
+
+    for (const agentInstanceId of recoverableAgentIds) {
+      const agent = this.activeAgents.get(agentInstanceId);
+      if (!agent) continue;
+
+      try {
+        await agent.recoverInterruptedRun(reason);
+      } catch (error) {
+        this.logger.warn(
+          `[AgentManager] Failed to recover interrupted agent ${agentInstanceId}`,
+          { error },
+        );
+      }
+    }
   }
 
   /**

--- a/packages/agent-core/src/services/agent-manager/options.ts
+++ b/packages/agent-core/src/services/agent-manager/options.ts
@@ -104,6 +104,13 @@ export interface AgentManagerHooksOptions {
   enrichHistoryEntries?: (
     entries: AgentHistoryEntry[],
   ) => Promise<AgentHistoryEntry[]>;
+  /**
+   * Optional host-provided network reachability check. When present,
+   * network-looking agent errors are auto-retried only after this returns
+   * `false` at least once, preventing provider-side failures from entering
+   * an offline retry loop.
+   */
+  isNetworkOnline?: () => boolean;
 }
 
 /**

--- a/packages/agent-core/src/types/agent.ts
+++ b/packages/agent-core/src/types/agent.ts
@@ -38,6 +38,13 @@ export type AgentRuntimeError =
       providerName?: string;
       statusCode?: number;
       modelId?: string;
+    }
+  | {
+      kind: 'waiting-for-connection';
+      message: string;
+      originalMessage: string;
+      code?: number;
+      stack?: string;
     };
 
 /**


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps the app awake while agents work, adds auto‑recovery after sleep/stalls and offline retries for long tasks, improves link handling so external URLs open in the default browser, and adds/refines shortcuts. Includes a macOS closed‑lid sleep toggle in the sidebar to keep work going on laptops.

- **New Features**
  - Power save blocker: uses `electron.powerSaveBlocker` only while agents are truly active (not waiting for questions or tool approvals); toggle in Settings; driven by `globalConfig.blockAppSuspensionWhenAgentsActive` (default: `true`).
  - Runtime recovery: after system resume or event‑loop stalls, agents auto‑continue with a synthetic “continue”; network‑looking failures show “Waiting for connection…” and auto‑retry with backoff once `electron.net.isOnline()` is true, plus a Retry button in chat.
  - macOS: closed‑lid sleep toggle in the sidebar with live state sync and a persistence warning; installs a minimal sudoers rule to run `pmset` without repeated prompts, tracks ownership and restores on teardown; adds `closedLidSleep.toggle/refresh` and telemetry event `closed-lid-sleep-toggled`.
  - Browser shortcuts: DevTools hotkey is now Ctrl+Alt+I (Mac: Mod+Alt+I), URL bar focus is Alt+D (F6 alias), and a new “cycle color scheme” hotkey Ctrl+Alt+L (Mac: Mod+Alt+L).

- **Bug Fixes**
  - Config updates accept partial patches on the backend; UI sends only changed fields (IDE picker, notification sounds, dock bounce).
  - Link handling: UI opens external web URLs in the default browser; only `stagewise:` and `app:` links open in internal tabs. Chat links open externally by default, with Alt‑click to open in a content tab; settings/history links use `openExternalUrl`. Registered the `app:` protocol for both UI and persisted browser sessions. Fixed duplicate chat‑link listeners in streaming messages.

<sup>Written for commit 8cab1c5e0d0818f770e00ecd1ea9e9c1de6240dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1192?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Keep app awake while agents work" toggle in General Settings (default: enabled).

* **Behavior**
  * When enabled, the app prevents system suspension while agents are actively working and releases the blocker when they stop.
  * Settings now update as patches (only changed fields are sent) and take effect immediately and persist.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stagewise-io/stagewise/pull/1192?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->