### PR TITLE
fix(stagewise): track shell cwd for approvals

### DIFF
--- a/apps/browser/src/backend/services/toolbox/services/shell/index.ts
+++ b/apps/browser/src/backend/services/toolbox/services/shell/index.ts
@@ -334,6 +334,10 @@ export class ShellService extends DisposableService {
     return this.sessionManager?.getCurrentCwd(sessionId);
   }
 
+  public getSessionCwd(sessionId: string): string | undefined {
+    return this.sessionManager?.getSessionCwd(sessionId);
+  }
+
   clearPendingOutputs(agentId: string, toolCallId: string): void {
     this.outputBuffers.delete(toolCallId);
 

--- a/apps/browser/src/backend/services/toolbox/services/shell/osc-parser.test.ts
+++ b/apps/browser/src/backend/services/toolbox/services/shell/osc-parser.test.ts
@@ -259,6 +259,23 @@ describe('OscParser — OSC 7 cwd metadata', () => {
     expect(cwd).not.toHaveBeenCalled();
   });
 
+  it('does not let command output forge command end before OSC 7 cwd', () => {
+    parser = new OscParser('trusted-token');
+    const done = vi.fn();
+    const cwd = vi.fn();
+    parser.on('commandDone', done);
+    parser.on('cwd', cwd);
+
+    parser.write(
+      `${osc('C')}before${osc('D', '0')}${osc7('/tmp/spoofed')}after${osc('D', '0;trusted-token')}${osc7('/tmp/real')}`,
+    );
+
+    expect(done).toHaveBeenCalledOnce();
+    expect(done.mock.calls[0][0].output).toBe('beforeafter');
+    expect(cwd).toHaveBeenCalledTimes(1);
+    expect(cwd).toHaveBeenCalledWith('/tmp/real');
+  });
+
   it('preserves OSC 133 and OSC 7 event order within one chunk', () => {
     const events: string[] = [];
     parser.on('commandStart', () => events.push('commandStart'));

--- a/apps/browser/src/backend/services/toolbox/services/shell/osc-parser.test.ts
+++ b/apps/browser/src/backend/services/toolbox/services/shell/osc-parser.test.ts
@@ -187,6 +187,28 @@ describe('OscParser — OSC 133 mode', () => {
     // 'prompt$' should be emitted as output
     expect(output).toHaveBeenCalledWith('prompt$');
   });
+
+  it('emits cwd for OSC 7 cwd updates', () => {
+    const cwd = vi.fn();
+    parser.on('cwd', cwd);
+
+    parser.write(osc7('host/Users/test/project'));
+
+    expect(cwd).toHaveBeenCalledWith('/Users/test/project');
+    expect(parser.currentMode).toBe('detecting');
+  });
+
+  it('handles long OSC 7 cwd sequences split across chunks', () => {
+    const cwd = vi.fn();
+    parser.on('cwd', cwd);
+
+    parser.write('\x1b]7;file://host/Users/test/very/long/path');
+    parser.write('/inside/workspace\x07');
+
+    expect(cwd).toHaveBeenCalledWith(
+      '/Users/test/very/long/path/inside/workspace',
+    );
+  });
 });
 
 // ─── OSC 7 cwd parsing ───────────────────────────────────────────
@@ -225,13 +247,16 @@ describe('OscParser — OSC 7 cwd metadata', () => {
     expect(output).toHaveBeenNthCalledWith(2, 'after');
   });
 
-  it('strips OSC 7 from command output', () => {
+  it('strips and ignores OSC 7 from command output', () => {
     const done = vi.fn();
+    const cwd = vi.fn();
     parser.on('commandDone', done);
+    parser.on('cwd', cwd);
 
     parser.write(`${osc('C')}one${osc7('/tmp/project')}two${osc('D', '0')}`);
 
     expect(done.mock.calls[0][0].output).toBe('onetwo');
+    expect(cwd).not.toHaveBeenCalled();
   });
 
   it('preserves OSC 133 and OSC 7 event order within one chunk', () => {
@@ -365,6 +390,12 @@ describe('stripOsc133', () => {
   it('strips multiple sequences', () => {
     const input = `${osc('A')}prompt${osc('B')}${osc('C')}out${osc('D', '0')}`;
     expect(stripOsc133(input)).toBe('promptout');
+  });
+
+  it('strips OSC 7 cwd sequences', () => {
+    expect(stripOsc133(`before${osc7('file://host/tmp/project')}after`)).toBe(
+      'beforeafter',
+    );
   });
 
   it('returns plain text unchanged', () => {

--- a/apps/browser/src/backend/services/toolbox/services/shell/osc-parser.ts
+++ b/apps/browser/src/backend/services/toolbox/services/shell/osc-parser.ts
@@ -12,11 +12,14 @@
  * single session cwd source of truth stays current for UI and smart approval.
  *
  * Trust boundary: command output is external content. A program can print OSC
- * 7 bytes that look like cwd metadata, but that must not update the shell cwd:
- * child commands do not change the parent shell's cwd. The parser therefore
- * strips OSC 7 from command output and only emits cwd events for metadata seen
- * outside the command-output region, where the shell prompt integration reports
- * the parent shell's latest cwd after builtins such as `cd` have run.
+ * 7 / OSC 133 bytes that look like shell-integration metadata, but that must
+ * not update the shell cwd: child commands do not change the parent shell's
+ * cwd. The parser therefore strips OSC 7 from command output and only accepts
+ * OSC 133 command-end markers carrying the per-session boundary token. That
+ * prevents command output from forging `133;D` to escape the command-output
+ * region before printing a fake cwd. Cwd events emitted outside the trusted
+ * command-output region are prompt metadata from the parent shell, reporting
+ * the latest cwd after builtins such as `cd` have run.
  *
  * Falls back to sentinel-based detection when shell integration is absent.
  */
@@ -27,7 +30,7 @@ import { EventEmitter } from 'node:events';
 // Matches both BEL (\x07) and ST (\x1b\\) terminators.
 const OSC_RE =
   // biome-ignore lint/suspicious/noControlCharactersInRegex: ESC/BEL control chars are the OSC protocol
-  /\x1b\](?:133;([ABCD])(?:;(-?\d+))?|7;file:\/\/[^/\x07\x1b]*(\/[^\x07\x1b]*))(?:\x07|\x1b\\)/g;
+  /\x1b\](?:133;([ABCD])(?:;(-?\d+)(?:;([A-Za-z0-9_-]+))?)?|7;file:\/\/[^/\x07\x1b]*(\/[^\x07\x1b]*))(?:\x07|\x1b\\)/g;
 
 // ─── Sentinel format ──────────────────────────────────────────────
 // __STAGE_DONE_<id>_<exitCode>__
@@ -36,7 +39,7 @@ const SENTINEL_RE = /__STAGE_DONE_([a-zA-Z0-9_-]+)_(-?\d+)__/;
 // ─── Strip all OSC 133 / OSC 7 sequences from text ────────────────
 const OSC_STRIP_RE =
   // biome-ignore lint/suspicious/noControlCharactersInRegex: ESC/BEL control chars are OSC protocol terminators
-  /\x1b\](?:133;[ABCD](?:;-?\d+)?|7;[^\x07\x1b]*)(?:\x07|\x1b\\)/g;
+  /\x1b\](?:133;[ABCD](?:;-?\d+(?:;[A-Za-z0-9_-]+)?)?|7;[^\x07\x1b]*)(?:\x07|\x1b\\)/g;
 
 // ─── Types ────────────────────────────────────────────────────────
 
@@ -91,6 +94,10 @@ declare interface OscParserEmitter {
 
 export class OscParser extends (EventEmitter as new () => OscParserEmitter) {
   private mode: ParserMode = 'detecting';
+
+  constructor(public readonly boundaryToken?: string) {
+    super();
+  }
 
   /** Buffer for partial escape sequences split across data chunks */
   private escBuffer = '';
@@ -200,7 +207,8 @@ export class OscParser extends (EventEmitter as new () => OscParserEmitter) {
       const beforeMatch = data.slice(lastIndex, match.index);
       const marker = match[1]; // A, B, C, or D for OSC 133
       const codeStr = match[2]; // exit code for OSC 133;D
-      const cwdPath = match[3]; // path payload for OSC 7
+      const boundaryToken = match[3]; // optional trust token for OSC 133;D
+      const cwdPath = match[4]; // path payload for OSC 7
 
       // Emit non-sequence text as output
       if (beforeMatch.length > 0) {
@@ -215,6 +223,18 @@ export class OscParser extends (EventEmitter as new () => OscParserEmitter) {
         if (!this._inCommandOutput) {
           const cwd = decodeFileUriPath(cwdPath);
           if (cwd) this.emit('cwd', cwd);
+        }
+        lastIndex = match.index + match[0].length;
+        continue;
+      }
+
+      if (this._inCommandOutput) {
+        // While a command is producing output, OSC bytes are command output
+        // unless they are the shell integration's authenticated command-end
+        // marker. This prevents output from forging 133;D, clearing the
+        // command-output flag, and then spoofing OSC 7 cwd metadata.
+        if (marker === 'D' && this.isTrustedBoundary(boundaryToken)) {
+          this.finishCommand(codeStr);
         }
         lastIndex = match.index + match[0].length;
         continue;
@@ -239,16 +259,9 @@ export class OscParser extends (EventEmitter as new () => OscParserEmitter) {
           this.emit('commandStart');
           break;
         case 'D': {
-          const exitCode =
-            codeStr != null ? Number.parseInt(codeStr, 10) : null;
-          const output = this.commandOutputBuf;
-          this._inCommandOutput = false;
-          this.commandOutputBuf = '';
-          this.emit('commandDone', {
-            output: stripOsc133(output),
-            exitCode:
-              exitCode != null && !Number.isNaN(exitCode) ? exitCode : null,
-          });
+          if (this.isTrustedBoundary(boundaryToken)) {
+            this.finishCommand(codeStr);
+          }
           break;
         }
       }
@@ -270,6 +283,23 @@ export class OscParser extends (EventEmitter as new () => OscParserEmitter) {
       this.commandOutputBuf += stripped;
     }
     this.emit('output', stripped);
+  }
+
+  private isTrustedBoundary(boundaryToken: string | undefined): boolean {
+    return this.boundaryToken === undefined
+      ? true
+      : boundaryToken === this.boundaryToken;
+  }
+
+  private finishCommand(codeStr: string | undefined): void {
+    const exitCode = codeStr != null ? Number.parseInt(codeStr, 10) : null;
+    const output = this.commandOutputBuf;
+    this._inCommandOutput = false;
+    this.commandOutputBuf = '';
+    this.emit('commandDone', {
+      output: stripOsc133(output),
+      exitCode: exitCode != null && !Number.isNaN(exitCode) ? exitCode : null,
+    });
   }
 
   private processSentinel(data: string): void {

--- a/apps/browser/src/backend/services/toolbox/services/shell/osc-parser.ts
+++ b/apps/browser/src/backend/services/toolbox/services/shell/osc-parser.ts
@@ -8,6 +8,16 @@
  *   133;C — Command output start
  *   133;D;{exitCode} — Command finished
  *
+ * Also detects OSC 7 cwd updates emitted by the shell integration so the
+ * single session cwd source of truth stays current for UI and smart approval.
+ *
+ * Trust boundary: command output is external content. A program can print OSC
+ * 7 bytes that look like cwd metadata, but that must not update the shell cwd:
+ * child commands do not change the parent shell's cwd. The parser therefore
+ * strips OSC 7 from command output and only emits cwd events for metadata seen
+ * outside the command-output region, where the shell prompt integration reports
+ * the parent shell's latest cwd after builtins such as `cd` have run.
+ *
  * Falls back to sentinel-based detection when shell integration is absent.
  */
 
@@ -130,15 +140,15 @@ export class OscParser extends (EventEmitter as new () => OscParserEmitter) {
     this.escBuffer = '';
 
     // Check for a trailing partial OSC sequence that might be split
-    // across chunks: buffer it for the next write. Only OSC prefixes
-    // are buffered so normal CSI sequences keep their old behavior.
+    // across chunks. Buffer a final ESC or OSC introducer so split OSC 133
+    // markers and long OSC 7 cwd payloads are reassembled on the next write.
     const lastEsc = input.lastIndexOf('\x1b');
     let processable: string;
     if (lastEsc >= 0) {
       const tail = input.slice(lastEsc);
       if (
         (tail === '\x1b' || tail.startsWith('\x1b]')) &&
-        tail.length <= 4096 &&
+        tail.length <= 65_536 &&
         !this.isCompleteSequence(tail)
       ) {
         processable = input.slice(0, lastEsc);
@@ -176,9 +186,8 @@ export class OscParser extends (EventEmitter as new () => OscParserEmitter) {
   private isCompleteSequence(s: string): boolean {
     // Quick check: does it contain a BEL or ST terminator after the OSC introducer?
     if (s.includes('\x07')) return true;
-    if (s.includes('\x1b\\') && s.indexOf('\x1b\\') > s.indexOf('\x1b]'))
-      return true;
-    return false;
+    const st = s.indexOf('\x1b\\');
+    return st > s.indexOf('\x1b]');
   }
 
   private processOsc(data: string): void {
@@ -199,8 +208,14 @@ export class OscParser extends (EventEmitter as new () => OscParserEmitter) {
       }
 
       if (cwdPath !== undefined) {
-        const cwd = decodeFileUriPath(cwdPath);
-        if (cwd) this.emit('cwd', cwd);
+        // OSC 7 printed while a command is producing output is untrusted
+        // command content, not parent-shell state. Strip it from visible output
+        // but do not emit a cwd event. Only prompt-integration OSC 7, emitted
+        // after the shell has regained control, may update SessionManager.cwd.
+        if (!this._inCommandOutput) {
+          const cwd = decodeFileUriPath(cwdPath);
+          if (cwd) this.emit('cwd', cwd);
+        }
         lastIndex = match.index + match[0].length;
         continue;
       }
@@ -312,11 +327,19 @@ function stripOscSequences(text: string): string {
 
 function decodeFileUriPath(pathname: string | undefined): string | null {
   if (!pathname) return null;
+  let decoded = pathname;
   try {
-    return decodeURIComponent(pathname);
+    decoded = decodeURIComponent(pathname);
   } catch {
-    return pathname;
+    // Some shells emit raw paths instead of percent-encoded file URLs.
   }
+
+  if (process.platform === 'win32') {
+    if (/^\/[A-Za-z]:\//.test(decoded)) decoded = decoded.slice(1);
+    decoded = decoded.replace(/\//g, '\\');
+  }
+
+  return decoded;
 }
 
 /**

--- a/apps/browser/src/backend/services/toolbox/services/shell/session-manager.test.ts
+++ b/apps/browser/src/backend/services/toolbox/services/shell/session-manager.test.ts
@@ -8,6 +8,7 @@ import {
   SessionManager,
   getCommandIdleMs,
   getCommandTimeoutMs,
+  injectBoundaryToken,
 } from './session-manager';
 import { detectShell } from './detect-shell';
 import { sanitizeEnv } from './sanitize-env';
@@ -70,6 +71,24 @@ describe('applyHeadTailCap', () => {
 });
 
 // ─── Section B: stripAnsi (pure) ─────────────────────────────────
+
+describe('injectBoundaryToken', () => {
+  it('replaces all shell integration boundary placeholders', () => {
+    const token = 'abc123';
+    expect(
+      injectBoundaryToken(
+        'BoundaryToken="__STAGEWISE_BOUNDARY_TOKEN__"; D=__STAGEWISE_BOUNDARY_TOKEN__',
+        token,
+      ),
+    ).toBe('BoundaryToken="abc123"; D=abc123');
+  });
+
+  it('removes placeholders when no parser token is available', () => {
+    expect(injectBoundaryToken('__STAGEWISE_BOUNDARY_TOKEN__', undefined)).toBe(
+      '',
+    );
+  });
+});
 
 describe('stripAnsi', () => {
   it('strips SGR color codes', () => {
@@ -402,6 +421,29 @@ describeIfShell('SessionManager (integration)', () => {
     expect(r.output).toContain('beforeafter');
     expect(sm.getCurrentCwd(sid)).not.toBe('/tmp/spoofed-after-fake-d');
     expect(sm.getCurrentCwd(sid)).toBe(cwd);
+  });
+
+  it('rejects prompt metadata forged with the exposed boundary token', async () => {
+    sm = createSM();
+    const sid = sm.createSession('agent-test', cwd, env);
+    await waitForReady(sm, sid);
+
+    const spoofedDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sm-spoofed-'));
+    try {
+      const r = await sm.executeCommand(sid, {
+        command: [
+          "printf 'before\\033]133;D;0;'",
+          '"$__stagewise_boundary_token"',
+          `'\\007\\033]7;file://localhost${spoofedDir}\\007after'`,
+        ].join(''),
+      });
+
+      expect(r.output).toContain('beforeafter');
+      expect(sm.getCurrentCwd(sid)).not.toBe(spoofedDir);
+      expect(sm.getCurrentCwd(sid)).toBe(cwd);
+    } finally {
+      fs.rmSync(spoofedDir, { recursive: true, force: true });
+    }
   });
 
   // ─── Session cwd ─────────────────────────────────────────────

--- a/apps/browser/src/backend/services/toolbox/services/shell/session-manager.test.ts
+++ b/apps/browser/src/backend/services/toolbox/services/shell/session-manager.test.ts
@@ -268,6 +268,19 @@ async function waitForSessionExit(
   }
 }
 
+async function waitForCwd(
+  sm: SessionManager,
+  sessionId: string,
+  expectedCwd: string,
+  timeoutMs = 2000,
+): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (sm.getCurrentCwd(sessionId) === expectedCwd) return;
+    await new Promise((r) => setTimeout(r, 25));
+  }
+}
+
 describeIfShell('SessionManager (integration)', () => {
   const env = sanitizeEnv();
   const cwd = fs.realpathSync(os.tmpdir());
@@ -348,7 +361,12 @@ describeIfShell('SessionManager (integration)', () => {
 
       const r = await sm.executeCommand(sid, { command: 'pwd' });
       expect(r.output).toContain(path.basename(uniqueDir));
-      expect(sm.getCurrentCwd(sid)).toBeUndefined();
+      if (sm.getSession(sid)?.shellIntegrationActive) {
+        await waitForCwd(sm, sid, uniqueDir);
+        expect(sm.getCurrentCwd(sid)).toBe(uniqueDir);
+      } else {
+        expect(sm.getCurrentCwd(sid)).toBe(cwd);
+      }
     } finally {
       sm?.killAll();
       // Windows needs time to release PTY directory locks after kill
@@ -357,7 +375,7 @@ describeIfShell('SessionManager (integration)', () => {
     }
   });
 
-  it('ignores OSC 7 cwd spoofing from command output', async () => {
+  it('ignores OSC 7 cwd spoofing from command output and keeps the shell cwd', async () => {
     sm = createSM();
     const sid = sm.createSession('agent-test', cwd, env);
     await waitForReady(sm, sid);
@@ -366,15 +384,13 @@ describeIfShell('SessionManager (integration)', () => {
       command: `printf '\\033]7;file://localhost/tmp/spoofed\\007'`,
     });
 
-    if (sm.getSession(sid)?.shellIntegrationActive) {
-      expect(sm.getCurrentCwd(sid)).not.toBe('/tmp/spoofed');
-      expect(sm.getCurrentCwd(sid)).toBeUndefined();
-    } else {
-      expect(sm.getCurrentCwd(sid)).toBeUndefined();
-    }
+    // Command output is external content. A child command printing OSC 7 must
+    // not affect the parent shell cwd used by smart approval.
+    expect(sm.getCurrentCwd(sid)).not.toBe('/tmp/spoofed');
+    expect(sm.getCurrentCwd(sid)).toBe(cwd);
   });
 
-  it('ignores cwd spoofing that fakes OSC 133 command completion first', async () => {
+  it('keeps the last valid shell cwd when command output tries to fake prompt metadata', async () => {
     sm = createSM();
     const sid = sm.createSession('agent-test', cwd, env);
     await waitForReady(sm, sid);
@@ -383,12 +399,8 @@ describeIfShell('SessionManager (integration)', () => {
       command: `printf '\\033]133;D;0\\007\\033]7;file://localhost/tmp/spoofed-after-fake-d\\007'`,
     });
 
-    if (sm.getSession(sid)?.shellIntegrationActive) {
-      expect(sm.getCurrentCwd(sid)).not.toBe('/tmp/spoofed-after-fake-d');
-      expect(sm.getCurrentCwd(sid)).toBeUndefined();
-    } else {
-      expect(sm.getCurrentCwd(sid)).toBeUndefined();
-    }
+    expect(sm.getCurrentCwd(sid)).not.toBe('/tmp/spoofed-after-fake-d');
+    expect(sm.getCurrentCwd(sid)).toBe(cwd);
   });
 
   // ─── Session cwd ─────────────────────────────────────────────

--- a/apps/browser/src/backend/services/toolbox/services/shell/session-manager.test.ts
+++ b/apps/browser/src/backend/services/toolbox/services/shell/session-manager.test.ts
@@ -395,10 +395,11 @@ describeIfShell('SessionManager (integration)', () => {
     const sid = sm.createSession('agent-test', cwd, env);
     await waitForReady(sm, sid);
 
-    await sm.executeCommand(sid, {
-      command: `printf '\\033]133;D;0\\007\\033]7;file://localhost/tmp/spoofed-after-fake-d\\007'`,
+    const r = await sm.executeCommand(sid, {
+      command: `printf 'before\\033]133;D;0\\007\\033]7;file://localhost/tmp/spoofed-after-fake-d\\007after'`,
     });
 
+    expect(r.output).toContain('beforeafter');
     expect(sm.getCurrentCwd(sid)).not.toBe('/tmp/spoofed-after-fake-d');
     expect(sm.getCurrentCwd(sid)).toBe(cwd);
   });

--- a/apps/browser/src/backend/services/toolbox/services/shell/session-manager.ts
+++ b/apps/browser/src/backend/services/toolbox/services/shell/session-manager.ts
@@ -114,13 +114,16 @@ __stagewise_file_uri_path() {
   done
   printf '%s' "$encoded"
 }
+__stagewise_emit_cwd() {
+  printf '\\033]7;file://%s%s\\007' "\${HOSTNAME:-localhost}" "$(__stagewise_file_uri_path "$PWD")"
+}
 __stagewise_prompt_command() {
   local exit_code=$?
   if [ "$__stagewise_command_executed" = "1" ]; then
     printf '\\033]133;D;%d\\007' "$exit_code"
     __stagewise_command_executed=0
   fi
-  printf '\\033]7;file://%s%s\\007' "\${HOSTNAME:-localhost}" "$(__stagewise_file_uri_path "$PWD")"
+  __stagewise_emit_cwd
   printf '\\033]133;A\\007'
 }
 __stagewise_pre_exec() {
@@ -135,7 +138,7 @@ if [ -z "$PROMPT_COMMAND" ]; then
 else
   PROMPT_COMMAND="__stagewise_prompt_command;\${PROMPT_COMMAND}"
 fi
-printf '\\033]7;file://%s%s\\007' "\${HOSTNAME:-localhost}" "$(__stagewise_file_uri_path "$PWD")"
+__stagewise_emit_cwd
 printf '\\033]133;A\\007'
 `.trim();
 
@@ -162,6 +165,9 @@ __stagewise_file_uri_path() {
   done
   printf '%s' "$encoded"
 }
+__stagewise_emit_cwd() {
+  printf '\\033]7;file://%s%s\\007' "\${HOST:-\${HOSTNAME:-localhost}}" "$(__stagewise_file_uri_path "$PWD")"
+}
 autoload -Uz add-zsh-hook 2>/dev/null
 __stagewise_precmd() {
   local exit_code=$?
@@ -169,7 +175,7 @@ __stagewise_precmd() {
     printf '\\033]133;D;%d\\007' "$exit_code"
     __stagewise_command_executed=0
   fi
-  printf '\\033]7;file://%s%s\\007' "\${HOST:-localhost}" "$(__stagewise_file_uri_path "$PWD")"
+  __stagewise_emit_cwd
   printf '\\033]133;A\\007'
 }
 __stagewise_preexec() {
@@ -184,7 +190,7 @@ else
   precmd_functions+=(__stagewise_precmd)
   preexec_functions+=(__stagewise_preexec)
 fi
-printf '\\033]7;file://%s%s\\007' "\${HOST:-localhost}" "$(__stagewise_file_uri_path "$PWD")"
+__stagewise_emit_cwd
 printf '\\033]133;A\\007'
 `.trim();
 
@@ -213,6 +219,9 @@ function Global:Prompt() {
       $Result += "$([char]0x1b)]133;D;$FakeCode\`a"
     }
   }
+  $Cwd = (Get-Location).ProviderPath.Replace('\\', '/')
+  if ($Cwd -match '^[A-Za-z]:/') { $Cwd = "/$Cwd" }
+  $Result += "$([char]0x1b)]7;file://localhost$Cwd\`a"
   $Result += "$([char]0x1b)]133;A\`a"
   if ($FakeCode -ne 0) { Write-Error "failure" -ea ignore }
   $Result += $Global:__StagewiseState.OriginalPrompt.Invoke()
@@ -409,11 +418,23 @@ export class SessionManager {
       this.handleSessionExit(sessionId, exitCode);
     });
 
-    // Wire parser events
-    parser.on('cwd', () => {
-      // OSC 7 is just terminal output. Commands can spoof both cwd metadata
-      // and OSC 133 boundaries, so agent sessions never trust in-band cwd
-      // updates for smart-approval cwd decisions.
+    // Trust model for cwd tracking:
+    // - `session.cwd` is the single source of truth used by UI and smart
+    //   approval.
+    // - It represents the parent shell process cwd, not cwd-like bytes printed
+    //   by child commands.
+    // - OscParser strips and ignores OSC 7 from command output. Cwd events here
+    //   are accepted only as shell-integration prompt metadata emitted after the
+    //   shell regains control, which captures real shell cwd changes such as
+    //   `cd` while preventing command-output spoofing from affecting approval
+    //   context.
+    parser.on('cwd', (cwd) => {
+      const normalizedCwd = path.resolve(cwd);
+      if (normalizedCwd === session.cwd) return;
+      session.cwd = normalizedCwd;
+      session.currentCwd = normalizedCwd;
+      session.lastActivityAt = Date.now();
+      this.onSessionStateChange?.(agentInstanceId);
     });
 
     parser.on('integrationDetected', () => {
@@ -594,15 +615,7 @@ export class SessionManager {
         // which will resolve any pending commands when the session exits.
       }
 
-      // Write the command to the PTY. Once bytes are sent to the shell, the
-      // cwd can change in ways we cannot verify securely from terminal output:
-      // commands can spoof OSC 7 and OSC 133 boundaries. Keep the initial cwd
-      // for first-command approval only, then fail closed for subsequent
-      // relative commands until a new session is created with an explicit cwd.
       const command = request.command;
-      if (command.length > 0) {
-        session.currentCwd = null;
-      }
 
       if (request.rawInput) {
         // Raw stdin: write bytes verbatim — no \r, no sentinel
@@ -612,8 +625,8 @@ export class SessionManager {
         // The agent is just waiting for output; the pending command will
         // resolve via timeout, pattern match, or session exit.
       } else if (session.shellIntegrationActive) {
-        // Shell integration handles output boundaries via OSC 133. Cwd updates
-        // from that same terminal stream are intentionally ignored above.
+        // Shell integration handles output boundaries via OSC 133 and emits
+        // OSC 7 cwd metadata at prompt time for session cwd tracking.
         session.pty.write(`${command}\r`);
       } else if (session.parser.currentMode === 'sentinel') {
         // Wrap with sentinel for exit code detection
@@ -723,9 +736,11 @@ export class SessionManager {
   }
 
   getCurrentCwd(sessionId: string): string | undefined {
-    const session = this.sessions.get(sessionId);
-    if (!session?.shellIntegrationActive) return undefined;
-    return session.currentCwd ?? undefined;
+    return this.getSessionCwd(sessionId);
+  }
+
+  getSessionCwd(sessionId: string): string | undefined {
+    return this.sessions.get(sessionId)?.cwd;
   }
 
   /**

--- a/apps/browser/src/backend/services/toolbox/services/shell/session-manager.ts
+++ b/apps/browser/src/backend/services/toolbox/services/shell/session-manager.ts
@@ -100,6 +100,7 @@ HISTSIZE=0 2>/dev/null
 HISTFILESIZE=0 2>/dev/null
 set +o history 2>/dev/null
 __stagewise_command_executed=0
+__stagewise_boundary_token="__STAGEWISE_BOUNDARY_TOKEN__"
 __stagewise_file_uri_path() {
   local path="$1"
   local encoded=''
@@ -120,7 +121,7 @@ __stagewise_emit_cwd() {
 __stagewise_prompt_command() {
   local exit_code=$?
   if [ "$__stagewise_command_executed" = "1" ]; then
-    printf '\\033]133;D;%d\\007' "$exit_code"
+    printf '\\033]133;D;%d;%s\\007' "$exit_code" "$__stagewise_boundary_token"
     __stagewise_command_executed=0
   fi
   __stagewise_emit_cwd
@@ -151,6 +152,7 @@ SAVEHIST=0 2>/dev/null
 unsetopt SHARE_HISTORY INC_APPEND_HISTORY APPEND_HISTORY 2>/dev/null
 PROMPT_EOL_MARK=''
 __stagewise_command_executed=0
+__stagewise_boundary_token="__STAGEWISE_BOUNDARY_TOKEN__"
 __stagewise_file_uri_path() {
   local path="$1"
   local encoded=''
@@ -172,7 +174,7 @@ autoload -Uz add-zsh-hook 2>/dev/null
 __stagewise_precmd() {
   local exit_code=$?
   if [[ "$__stagewise_command_executed" == "1" ]]; then
-    printf '\\033]133;D;%d\\007' "$exit_code"
+    printf '\\033]133;D;%d;%s\\007' "$exit_code" "$__stagewise_boundary_token"
     __stagewise_command_executed=0
   fi
   __stagewise_emit_cwd
@@ -205,6 +207,7 @@ $Global:__StagewiseState = @{
   OriginalPrompt = $function:Prompt
   LastHistoryId  = -1
   IsInExecution  = $false
+  BoundaryToken  = "__STAGEWISE_BOUNDARY_TOKEN__"
 }
 function Global:Prompt() {
   $FakeCode = [int]!$global:?
@@ -214,9 +217,9 @@ function Global:Prompt() {
   if ($Global:__StagewiseState.LastHistoryId -ne -1 -and ($Global:__StagewiseState.HasPSReadLine -eq $false -or $Global:__StagewiseState.IsInExecution -eq $true)) {
     $Global:__StagewiseState.IsInExecution = $false
     if ($LastHistoryEntry.Id -eq $Global:__StagewiseState.LastHistoryId) {
-      $Result += "$([char]0x1b)]133;D\`a"
+      $Result += "$([char]0x1b)]133;D;0;$($Global:__StagewiseState.BoundaryToken)\`a"
     } else {
-      $Result += "$([char]0x1b)]133;D;$FakeCode\`a"
+      $Result += "$([char]0x1b)]133;D;$FakeCode;$($Global:__StagewiseState.BoundaryToken)\`a"
     }
   }
   $Cwd = (Get-Location).ProviderPath.Replace('\\', '/')
@@ -359,7 +362,8 @@ export class SessionManager {
       ...this.ptySpawnOptions,
     });
 
-    const parser = new OscParser();
+    const boundaryToken = randomUUID().replace(/-/g, '');
+    const parser = new OscParser(boundaryToken);
 
     const session: PtySession = {
       id: sessionId,
@@ -423,11 +427,12 @@ export class SessionManager {
     //   approval.
     // - It represents the parent shell process cwd, not cwd-like bytes printed
     //   by child commands.
-    // - OscParser strips and ignores OSC 7 from command output. Cwd events here
-    //   are accepted only as shell-integration prompt metadata emitted after the
-    //   shell regains control, which captures real shell cwd changes such as
-    //   `cd` while preventing command-output spoofing from affecting approval
-    //   context.
+    // - OscParser strips and ignores OSC 7 from command output, and only trusts
+    //   OSC 133 command-end markers containing this session's unexposed boundary
+    //   token. Cwd events here are accepted only as shell-integration prompt
+    //   metadata emitted after the shell regains control, which captures real
+    //   shell cwd changes such as `cd` while preventing command-output spoofing
+    //   from affecting approval context.
     parser.on('cwd', (cwd) => {
       const normalizedCwd = path.resolve(cwd);
       if (normalizedCwd === session.cwd) return;
@@ -1143,7 +1148,14 @@ export class SessionManager {
       // timeout with rich prompt frameworks like starship/p10k).
       const nativeTempPath = path.join(tmpdir(), `sw-${session.id}.sh`);
       try {
-        fs.writeFileSync(nativeTempPath, script, { mode: 0o600 });
+        fs.writeFileSync(
+          nativeTempPath,
+          script.replaceAll(
+            '__STAGEWISE_BOUNDARY_TOKEN__',
+            session.parser.boundaryToken ?? '',
+          ),
+          { mode: 0o600 },
+        );
         session.initScriptPath = nativeTempPath;
         // Dot-source is POSIX (cannot be aliased). Cleanup handled by deactivateSession.
         // Single-quote to survive paths containing spaces (e.g. Windows
@@ -1154,7 +1166,14 @@ export class SessionManager {
         session.pty.write(`. '${shellPath}'\r`);
       } catch (_err) {
         // Temp file write failed — fall back to eval through the line editor.
-        session.pty.write(`eval $'${escapeForShell(script)}'\r`);
+        session.pty.write(
+          `eval $'${escapeForShell(
+            script.replaceAll(
+              '__STAGEWISE_BOUNDARY_TOKEN__',
+              session.parser.boundaryToken ?? '',
+            ),
+          )}'\r`,
+        );
       }
     }
   }

--- a/apps/browser/src/backend/services/toolbox/services/shell/session-manager.ts
+++ b/apps/browser/src/backend/services/toolbox/services/shell/session-manager.ts
@@ -1,4 +1,5 @@
 import * as pty from 'node-pty';
+import { execFileSync } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
 import fs from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -72,6 +73,54 @@ const ANSI_RE =
 
 export function stripAnsi(str: string): string {
   return str.replace(ANSI_RE, '');
+}
+
+function getProcessCwd(pid: number): string | null {
+  try {
+    if (process.platform === 'linux') {
+      return fs.readlinkSync(`/proc/${pid}/cwd`);
+    }
+
+    if (process.platform === 'darwin') {
+      const output = execFileSync(
+        'lsof',
+        ['-a', '-p', String(pid), '-d', 'cwd', '-Fn'],
+        {
+          encoding: 'utf8',
+          stdio: ['ignore', 'pipe', 'ignore'],
+          timeout: 250,
+        },
+      );
+      const cwdLine = output.split('\n').find((line) => line.startsWith('n'));
+      return cwdLine ? cwdLine.slice(1) : null;
+    }
+  } catch {
+    return null;
+  }
+
+  return null;
+}
+
+function realpathOrNull(cwd: string): string | null {
+  try {
+    return fs.realpathSync.native(cwd);
+  } catch {
+    return null;
+  }
+}
+
+function areSameShellCwd(a: string, b: string): boolean {
+  if (path.resolve(a) === path.resolve(b)) return true;
+  const realA = realpathOrNull(a);
+  const realB = realpathOrNull(b);
+  return realA != null && realB != null && realA === realB;
+}
+
+export function injectBoundaryToken(
+  script: string,
+  boundaryToken: string | undefined,
+): string {
+  return script.replaceAll('__STAGEWISE_BOUNDARY_TOKEN__', boundaryToken ?? '');
 }
 
 // ─── Head/tail output capping ────────────────────────────────────
@@ -352,7 +401,8 @@ export class SessionManager {
       sessionId = randomUUID();
     }
 
-    const spawnArgs = this.getSpawnArgs();
+    const boundaryToken = randomUUID().replace(/-/g, '');
+    const spawnArgs = this.getSpawnArgs(boundaryToken);
     const ptyProcess = pty.spawn(this.shell.path, spawnArgs, {
       name: 'xterm-256color',
       cols: DEFAULT_TERMINAL_COLS,
@@ -362,7 +412,6 @@ export class SessionManager {
       ...this.ptySpawnOptions,
     });
 
-    const boundaryToken = randomUUID().replace(/-/g, '');
     const parser = new OscParser(boundaryToken);
 
     const session: PtySession = {
@@ -428,14 +477,23 @@ export class SessionManager {
     // - It represents the parent shell process cwd, not cwd-like bytes printed
     //   by child commands.
     // - OscParser strips and ignores OSC 7 from command output, and only trusts
-    //   OSC 133 command-end markers containing this session's unexposed boundary
-    //   token. Cwd events here are accepted only as shell-integration prompt
-    //   metadata emitted after the shell regains control, which captures real
-    //   shell cwd changes such as `cd` while preventing command-output spoofing
-    //   from affecting approval context.
+    //   OSC 133 command-end markers containing this session's boundary token.
+    //   That token is a guardrail, not the trust root: shell state is still
+    //   same-user command-controlled, so a cwd update is accepted only when it
+    //   matches the OS-reported cwd of the parent shell process. If the OS cwd
+    //   cannot be read, keep the last trusted cwd rather than trusting PTY bytes.
+    //   This keeps real `cd` behavior where validation is available while
+    //   preventing forged prompt metadata from moving smart approval into a
+    //   command-controlled directory.
     parser.on('cwd', (cwd) => {
       const normalizedCwd = path.resolve(cwd);
       if (normalizedCwd === session.cwd) return;
+
+      const processCwd = getProcessCwd(session.pty.pid);
+      if (!processCwd || !areSameShellCwd(normalizedCwd, processCwd)) {
+        return;
+      }
+
       session.cwd = normalizedCwd;
       session.currentCwd = normalizedCwd;
       session.lastActivityAt = Date.now();
@@ -1150,10 +1208,7 @@ export class SessionManager {
       try {
         fs.writeFileSync(
           nativeTempPath,
-          script.replaceAll(
-            '__STAGEWISE_BOUNDARY_TOKEN__',
-            session.parser.boundaryToken ?? '',
-          ),
+          injectBoundaryToken(script, session.parser.boundaryToken),
           { mode: 0o600 },
         );
         session.initScriptPath = nativeTempPath;
@@ -1168,10 +1223,7 @@ export class SessionManager {
         // Temp file write failed — fall back to eval through the line editor.
         session.pty.write(
           `eval $'${escapeForShell(
-            script.replaceAll(
-              '__STAGEWISE_BOUNDARY_TOKEN__',
-              session.parser.boundaryToken ?? '',
-            ),
+            injectBoundaryToken(script, session.parser.boundaryToken),
           )}'\r`,
         );
       }
@@ -1185,9 +1237,13 @@ export class SessionManager {
     }
   }
 
-  private getSpawnArgs(): string[] {
+  private getSpawnArgs(boundaryToken: string): string[] {
     if (this.shell.type === 'powershell') {
-      return ['-NoExit', '-Command', POWERSHELL_INTEGRATION];
+      return [
+        '-NoExit',
+        '-Command',
+        injectBoundaryToken(POWERSHELL_INTEGRATION, boundaryToken),
+      ];
     }
     if (process.platform === 'win32' && this.shell.type === 'bash') {
       return ['--login', '-i'];

--- a/apps/browser/src/backend/services/toolbox/services/shell/types.ts
+++ b/apps/browser/src/backend/services/toolbox/services/shell/types.ts
@@ -149,9 +149,11 @@ export interface PtySession {
   /** Latest known working directory for the session. */
   cwd: string;
   /**
-   * Last trusted working directory. For agent sessions this is only the
-   * session creation cwd. Once input is written to the shell, terminal-emitted
-   * cwd metadata is not trusted because commands can spoof OSC 7 and OSC 133.
+   * Last trusted working directory for the parent shell process. Initialized
+   * from the session spawn cwd and updated only from prompt-time shell
+   * integration metadata. Command output is untrusted and must not affect this
+   * value, because child commands can print OSC bytes but cannot change the
+   * parent shell's cwd.
    */
   currentCwd: string | null;
   /** Path to the temp init script file, for cleanup. */

--- a/apps/browser/src/backend/services/toolbox/services/shell/types.ts
+++ b/apps/browser/src/backend/services/toolbox/services/shell/types.ts
@@ -146,7 +146,7 @@ export interface PtySession {
   onData: ((sessionId: string, data: string) => void) | null;
   /** Append-only log writer for the session's full output history. */
   logger: SessionLogger | null;
-  /** Working directory the session was started in. */
+  /** Latest known working directory for the session. */
   cwd: string;
   /**
    * Last trusted working directory. For agent sessions this is only the

--- a/apps/browser/src/backend/services/toolbox/tools/shell/execute-shell-command.ts
+++ b/apps/browser/src/backend/services/toolbox/tools/shell/execute-shell-command.ts
@@ -221,27 +221,41 @@ function resolveCwd(
   return homedir();
 }
 
-function toClassifierCwdPrefix(
+export function absoluteCwdToMountPrefix(
   absoluteCwd: string | undefined,
   getMountedPaths: MountedPathsGetter,
-): string {
-  if (!absoluteCwd) return '';
+): string | undefined {
+  if (!absoluteCwd) return undefined;
   const normalizedCwd = resolve(absoluteCwd);
+  let bestPrefix: string | undefined;
+  let bestRoot = '';
 
   for (const [prefix, mountRoot] of getMountedPaths()) {
     const resolvedRoot = resolve(mountRoot);
     if (
-      normalizedCwd !== resolvedRoot &&
-      !normalizedCwd.startsWith(`${resolvedRoot}${sep}`)
+      (normalizedCwd === resolvedRoot ||
+        normalizedCwd.startsWith(`${resolvedRoot}${sep}`)) &&
+      resolvedRoot.length > bestRoot.length
     ) {
-      continue;
+      bestPrefix = prefix;
+      bestRoot = resolvedRoot;
     }
-
-    const relativePath = normalizedCwd.slice(resolvedRoot.length + 1);
-    return relativePath ? `${prefix}/${relativePath}` : prefix;
   }
 
-  return '';
+  if (!bestPrefix) return undefined;
+  if (normalizedCwd === bestRoot) return bestPrefix;
+
+  return `${bestPrefix}/${normalizedCwd
+    .slice(bestRoot.length + 1)
+    .split(sep)
+    .join('/')}`;
+}
+
+function toClassifierCwdPrefix(
+  absoluteCwd: string | undefined,
+  getMountedPaths: MountedPathsGetter,
+): string {
+  return absoluteCwdToMountPrefix(absoluteCwd, getMountedPaths) ?? '';
 }
 
 export const createShellSession = (
@@ -314,12 +328,10 @@ export const executeShellCommand = (
             SMART_APPROVAL_TAIL_LINES,
           ) ?? '')
         : '';
-      const currentCwd = input.session_id
-        ? shellService.getSessionCurrentCwd(input.session_id)
-        : undefined;
+      const currentCwd = shellService.getSessionCurrentCwd(input.session_id);
       // If a session's current cwd is not verified by shell integration,
       // fail closed by requiring manual approval for non-read-only calls.
-      if (input.session_id && !currentCwd) {
+      if (!currentCwd) {
         const explanation =
           'Current terminal directory is unknown. Approving manually to stay safe.';
         smartApproval.recordPendingApproval(toolCallId, explanation);

--- a/apps/browser/src/shared/karton-contracts/ui/agent/metadata.ts
+++ b/apps/browser/src/shared/karton-contracts/ui/agent/metadata.ts
@@ -263,7 +263,7 @@ export const shellSessionSnapshotSchema = z.object({
   tailContent: z.string().optional(),
   /** Last visible terminal line, derived from headless xterm buffer. */
   lastLine: z.string().optional(),
-  /** Working directory the session was started in. */
+  /** Latest known working directory for the session. */
   cwd: z.string(),
   /** Unix ms timestamp of session creation. */
   createdAt: z.number(),


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes failing smart approvals by making the session cwd a verified source of truth from prompt-time `OSC 7`, cross-checked with the shell process cwd. Hardened OSC parsing with per-session boundary tokens so command output cannot spoof boundaries or cwd; approvals use the tracked cwd, falling back to manual only when cwd is unknown.

- **Bug Fixes**
  - Authenticate `OSC 133;D` with a per-session boundary token and ignore `OSC 7` inside command output; handle long/split sequences and normalize Windows paths.
  - Validate prompt-time `OSC 7` cwd against the parent shell’s actual cwd; keep the last trusted cwd if validation fails; expose via `getSessionCwd` and return it from `getCurrentCwd`.
  - Update bash/zsh/PowerShell to emit cwd at startup and prompt and include the boundary token; PowerShell now emits `OSC 7`.
  - Use the tracked cwd for smart approval and mount prefixes via `absoluteCwdToMountPrefix`; require manual approval only when cwd is unknown (e.g., no session).

<sup>Written for commit 06e79f9d178162e8fd47177be85f2be3ac15d004. Summary will update on new commits. <a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1194?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Consistent session cwd reporting and a new public way to read a session’s latest working directory.

* **Bug Fixes**
  * Rejects cwd updates from untrusted command output and tighter validation to prevent spoofing.
  * Improved cross‑platform path normalization and handling of very long/incomplete terminal escape sequences.

* **Tests**
  * Expanded coverage for cwd detection, stripping from output, multi‑write sequences, and spoofing resilience.

* **Chores**
  * Stricter behavior when the current working directory is unknown to tighten manual approval triggers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stagewise-io/stagewise/pull/1194?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->