### PR TITLE
feat(stagewise): show worktree main as workspacename

### DIFF
--- a/apps/browser/src/backend/services/git/index.test.ts
+++ b/apps/browser/src/backend/services/git/index.test.ts
@@ -130,6 +130,7 @@ describe('GitService', () => {
       repositoryId: repoGitDir,
       worktreeId: repoPath,
       repoRoot: repoPath,
+      mainWorktreePath: repoPath,
       commonGitDir: repoGitDir,
       isWorktree: false,
       branch: 'main',
@@ -161,6 +162,7 @@ describe('GitService', () => {
     await expect(
       service.getMountedWorkspaceSummary('/repo'),
     ).resolves.toMatchObject({
+      mainWorktreePath: repoPath,
       branch: null,
       headSha: 'abc123',
     });
@@ -229,6 +231,7 @@ describe('GitService', () => {
     ).resolves.toMatchObject({
       repositoryId: repoGitDir,
       worktreeId: repoLinkedPath,
+      mainWorktreePath: repoPath,
       isWorktree: true,
       branch: 'feature/test',
       headSha: 'def456',

--- a/apps/browser/src/backend/services/git/index.ts
+++ b/apps/browser/src/backend/services/git/index.ts
@@ -144,13 +144,18 @@ export class GitService extends DisposableService {
     const repositoryInfo = await this.getWorkspaceRepositoryInfo(workspacePath);
     if (!repositoryInfo) return null;
 
-    const worktreeInfo = await this.getWorktreeInfo(workspacePath);
+    const worktrees = await this.listWorktrees(workspacePath);
+    const worktreeInfo = await this.getWorktreeInfo(workspacePath, worktrees);
     if (!worktreeInfo) return null;
+
+    const mainWorktreePath =
+      worktrees.find((worktree) => worktree.isMainWorktree)?.path ?? null;
 
     return {
       repositoryId: repositoryInfo.repositoryId,
       worktreeId: worktreeInfo.worktreeId,
       repoRoot: repositoryInfo.repoRoot,
+      mainWorktreePath,
       commonGitDir: repositoryInfo.commonGitDir,
       isWorktree: !worktreeInfo.isMainWorktree,
       branch: worktreeInfo.branch,
@@ -214,6 +219,7 @@ export class GitService extends DisposableService {
 
   public async getWorktreeInfo(
     workspacePath: string,
+    knownWorktrees?: GitWorktreeInfo[],
   ): Promise<GitWorktreeInfo | null> {
     const result = await this.runGit(workspacePath, [
       'rev-parse',
@@ -232,7 +238,8 @@ export class GitService extends DisposableService {
 
     const worktreePath = path.resolve(worktreePathRaw);
     const normalizedWorktreePath = normalizeGitPath(worktreePath);
-    const worktrees = await this.listWorktrees(workspacePath);
+    const worktrees =
+      knownWorktrees ?? (await this.listWorktrees(workspacePath));
     const matchedWorktree = worktrees.find(
       (worktree) => normalizeGitPath(worktree.path) === normalizedWorktreePath,
     );

--- a/apps/browser/src/pages/routes/_internal-app/agent-settings.skills-context.tsx
+++ b/apps/browser/src/pages/routes/_internal-app/agent-settings.skills-context.tsx
@@ -13,10 +13,11 @@ import {
 } from 'react';
 import { cn } from '@pages/utils';
 import type { ContextFilesResult } from '@shared/karton-contracts/pages-api/types';
+import type { MountEntry } from '@shared/karton-contracts/ui';
 import type { Patch } from '@shared/karton-contracts/ui/shared-types';
 import { Button } from '@stagewise/stage-ui/components/button';
 import { Loader2Icon, RefreshCwIcon } from 'lucide-react';
-import { getBaseName } from '@shared/path-utils';
+import { getWorkspaceDisplayLabel } from '@ui/utils/workspace-display';
 import {
   Tooltip,
   TooltipTrigger,
@@ -69,17 +70,14 @@ function useIsOverflowing(ref: RefObject<HTMLElement | null>) {
 // Workspace Subheader
 // =============================================================================
 
-function WorkspaceSubheader({ workspacePath }: { workspacePath: string }) {
-  const folderName = useMemo(
-    () => getBaseName(workspacePath) || workspacePath,
-    [workspacePath],
-  );
+function WorkspaceSubheader({ mount }: { mount: MountEntry }) {
+  const displayName = useMemo(() => getWorkspaceDisplayLabel(mount), [mount]);
 
   return (
     <div className="flex flex-col">
-      <span className="font-medium text-foreground text-sm">{folderName}</span>
+      <span className="font-medium text-foreground text-sm">{displayName}</span>
       <span className="truncate text-subtle-foreground text-xs">
-        {workspacePath}
+        {mount.path}
       </span>
     </div>
   );
@@ -231,14 +229,7 @@ function SkillRow({
   );
 }
 
-function SkillsSection({
-  workspaceMounts,
-}: {
-  workspaceMounts: Array<{
-    path: string;
-    skills: Array<{ name: string; description: string }>;
-  }>;
-}) {
+function SkillsSection({ workspaceMounts }: { workspaceMounts: MountEntry[] }) {
   const hasSkills = workspaceMounts.some((m) => m.skills.length > 0);
 
   return (
@@ -255,7 +246,7 @@ function SkillsSection({
             .filter((mount) => mount.skills.length > 0)
             .map((mount) => (
               <div key={mount.path} className="space-y-2">
-                <WorkspaceSubheader workspacePath={mount.path} />
+                <WorkspaceSubheader mount={mount} />
                 <WorkspaceSkillsList
                   workspacePath={mount.path}
                   skills={mount.skills}
@@ -415,11 +406,7 @@ function ContextFilesSection({
   workspaceMounts,
   contextFiles,
 }: {
-  workspaceMounts: Array<{
-    path: string;
-    workspaceMdContent: string | null;
-    agentsMdContent: string | null;
-  }>;
+  workspaceMounts: MountEntry[];
   contextFiles: ContextFilesResult | null;
 }) {
   return (
@@ -434,7 +421,7 @@ function ContextFilesSection({
         <div className="space-y-4">
           {workspaceMounts.map((mount) => (
             <div key={mount.path} className="space-y-2">
-              <WorkspaceSubheader workspacePath={mount.path} />
+              <WorkspaceSubheader mount={mount} />
               <WorkspaceContextFilesList
                 workspacePath={mount.path}
                 workspaceMd={

--- a/apps/browser/src/shared/karton-contracts/ui/index.ts
+++ b/apps/browser/src/shared/karton-contracts/ui/index.ts
@@ -50,6 +50,7 @@ export type WorkspaceGitSummary = {
   repositoryId: string;
   worktreeId: string;
   repoRoot: string;
+  mainWorktreePath: string | null;
   commonGitDir: string;
   isWorktree: boolean;
   branch: string | null;

--- a/apps/browser/src/ui/components/file-reference-badge.tsx
+++ b/apps/browser/src/ui/components/file-reference-badge.tsx
@@ -14,6 +14,7 @@ import { useMountedPaths } from '@ui/hooks/use-mounted-paths';
 import { useKartonState } from '@ui/hooks/use-karton';
 import { useOpenAgent } from '@ui/hooks/use-open-chat';
 import { getBaseName } from '@shared/path-utils';
+import { getWorkspaceDisplayLabel } from '@ui/utils/workspace-display';
 
 // ─── Path classification ─────────────────────────────────────────────────────
 
@@ -53,7 +54,7 @@ function useWorkspaceData(prefix: string): WorkspaceData | null {
   return useMemo(() => {
     if (liveMount) {
       return {
-        name: getBaseName(liveMount.path) || liveMount.path,
+        name: getWorkspaceDisplayLabel(liveMount),
         path: liveMount.path,
         hasGit: liveMount.git !== null,
         isMounted: true,

--- a/apps/browser/src/ui/components/streamdown/attachment-links.tsx
+++ b/apps/browser/src/ui/components/streamdown/attachment-links.tsx
@@ -32,6 +32,7 @@ import { inferMimeType } from '@shared/mime-utils';
 import { getBaseName } from '@shared/path-utils';
 import { useMountedPaths } from '@ui/hooks/use-mounted-paths';
 import { FileReferenceBadge } from '@ui/components/file-reference-badge';
+import { getWorkspaceDisplayLabel } from '@ui/utils/workspace-display';
 
 // ─── Shared helpers ──────────────────────────────────────────────────────────
 
@@ -50,11 +51,12 @@ function useWorkspaceName(filePath: string): string | null {
     const slashIdx = filePath.indexOf('/');
     if (slashIdx <= 0) return null;
     const prefix = filePath.slice(0, slashIdx);
-    const mounts =
-      (historicalMounts?.length ? historicalMounts : null) ?? liveMounts ?? [];
-    const mount = mounts.find((m) => m.prefix === prefix);
-    if (!mount) return null;
-    return getBaseName(mount.path) || mount.path;
+    const liveMount = liveMounts?.find((m) => m.prefix === prefix);
+    if (liveMount) return getWorkspaceDisplayLabel(liveMount);
+
+    const historicalMount = historicalMounts?.find((m) => m.prefix === prefix);
+    if (!historicalMount) return null;
+    return getBaseName(historicalMount.path) || historicalMount.path;
   }, [filePath, historicalMounts, liveMounts]);
 }
 

--- a/apps/browser/src/ui/screens/main/_components/agent-preview-panel.tsx
+++ b/apps/browser/src/ui/screens/main/_components/agent-preview-panel.tsx
@@ -9,6 +9,7 @@ import { getBaseName, getParentPath } from '@shared/path-utils';
 import type { MountedWorkspaceGitSummary } from '@shared/karton-contracts/ui';
 import type { StoredAgentPreview } from '@shared/karton-contracts/ui/agent';
 import { FileIcon } from '@ui/components/file-icon';
+import { getWorkspaceDisplayInfo } from '@ui/utils/workspace-display';
 import { OverlayScrollbar } from '@stagewise/stage-ui/components/overlay-scrollbar';
 import { useScrollFadeMask } from '@ui/hooks/use-scroll-fade-mask';
 import {
@@ -401,7 +402,7 @@ function WorkspacePathBadge({
   path: string;
   git: MountedWorkspaceGitSummary | null;
 }) {
-  const name = getBaseName(path) || path;
+  const display = getWorkspaceDisplayInfo({ path, git });
   const gitRef = git?.branch ?? git?.headSha?.slice(0, 7) ?? null;
   const tooltip = gitRef ? `${path} (${gitRef})` : path;
   return (
@@ -418,7 +419,7 @@ function WorkspacePathBadge({
       ) : (
         <IconFolder5Outline18 className="size-3 shrink-0" />
       )}
-      <span className="max-w-28 truncate">{name}</span>
+      <span className="max-w-28 truncate">{display.label}</span>
     </span>
   );
 }

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/footer-status-card/file-diff-section.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/footer-status-card/file-diff-section.tsx
@@ -12,7 +12,9 @@ import {
 import { getBaseName, getParentPath, normalizePath } from '@shared/path-utils';
 import { useFileIDEHref } from '@ui/hooks/use-file-ide-href';
 import { FileContextMenu } from '@ui/components/file-context-menu';
+import type { MountEntry } from '@shared/karton-contracts/ui';
 import type { Mount } from '@shared/karton-contracts/ui/agent/metadata';
+import { getWorkspaceDisplayLabel } from '@ui/utils/workspace-display';
 import {
   type StatusCardSection,
   type FormattedFileDiff,
@@ -26,6 +28,8 @@ export interface FileDiffSectionProps {
   diffSummary: FormattedFileDiff[];
   /** All mounts ever seen (resolved from env snapshots). */
   resolvedMounts: Mount[];
+  /** Currently connected mounts with live Git metadata for display labels. */
+  activeMounts: MountEntry[];
   /** Paths of currently connected mounts. */
   activeMountPaths: Set<string>;
   onRejectAll: (hunkIds: string[]) => void;
@@ -66,6 +70,7 @@ function getRelativeDir(absoluteFilePath: string, mounts: Mount[]): string {
 function groupDiffsByMount(
   diffs: FormattedFileDiff[],
   mounts: Mount[],
+  activeMounts: MountEntry[],
   activeMountPaths: Set<string>,
 ): {
   label: string;
@@ -77,11 +82,17 @@ function groupDiffsByMount(
     string,
     { label: string; isDisconnected: boolean; diffs: FormattedFileDiff[] }
   >();
+  const activeMountsByPath = new Map(
+    activeMounts.map((mount) => [mount.path, mount]),
+  );
 
   // Pre-create groups in mount order
   for (const mount of mounts) {
+    const activeMount = activeMountsByPath.get(mount.path);
     groups.set(mount.path, {
-      label: getBaseName(mount.path) || mount.path,
+      label: activeMount
+        ? getWorkspaceDisplayLabel(activeMount)
+        : getBaseName(mount.path) || mount.path,
       isDisconnected: !activeMountPaths.has(mount.path),
       diffs: [],
     });
@@ -196,17 +207,20 @@ export function FileDiffFileItem({
 function FileDiffList({
   diffs,
   resolvedMounts,
+  activeMounts,
   activeMountPaths,
   onOpenDiffReview,
 }: {
   diffs: FormattedFileDiff[];
   resolvedMounts: Mount[];
+  activeMounts: MountEntry[];
   activeMountPaths: Set<string>;
   onOpenDiffReview: (fileId: string) => void;
 }) {
   const groups = useMemo(
-    () => groupDiffsByMount(diffs, resolvedMounts, activeMountPaths),
-    [diffs, resolvedMounts, activeMountPaths],
+    () =>
+      groupDiffsByMount(diffs, resolvedMounts, activeMounts, activeMountPaths),
+    [diffs, resolvedMounts, activeMounts, activeMountPaths],
   );
 
   // Show group labels when the agent ever had more than one workspace connected
@@ -262,6 +276,7 @@ export function FileDiffSection(
     pendingDiffs,
     diffSummary,
     resolvedMounts,
+    activeMounts,
     activeMountPaths,
     onRejectAll,
     onAcceptAll,
@@ -338,6 +353,7 @@ export function FileDiffSection(
         <FileDiffList
           diffs={pendingDiffs}
           resolvedMounts={resolvedMounts}
+          activeMounts={activeMounts}
           activeMountPaths={activeMountPaths}
           onOpenDiffReview={onOpenDiffReview}
         />
@@ -345,6 +361,7 @@ export function FileDiffSection(
         <FileDiffList
           diffs={filteredSummary}
           resolvedMounts={resolvedMounts}
+          activeMounts={activeMounts}
           activeMountPaths={activeMountPaths}
           onOpenDiffReview={onOpenDiffReview}
         />

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/footer-status-card/index.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/footer-status-card/index.tsx
@@ -34,8 +34,8 @@ import {
   type WorkspaceMdStatus,
 } from './workspace-md-section';
 import { UserQuestionSection } from './user-question-section';
-import { getBaseName } from '@shared/path-utils';
 import { getAgentOwnedPlanPaths, PLANS_PREFIX } from '@shared/plan-ownership';
+import { getWorkspaceDisplayLabel } from '@ui/utils/workspace-display';
 import { getAgentOwnedLogPaths, LOGS_PREFIX } from '@shared/log-ownership';
 import { buildPlanSections, type PlanEntry } from './plan-section';
 import {
@@ -390,7 +390,7 @@ export function StatusCard() {
 
     for (const mount of workspaceMounts) {
       const agent = agentByPath.get(mount.path);
-      const folderName = getBaseName(mount.path) || mount.path;
+      const folderName = getWorkspaceDisplayLabel(mount);
 
       let status: WorkspaceMdStatus;
       let errorMessage: string | null = null;
@@ -599,6 +599,7 @@ export function StatusCard() {
       pendingDiffs: effectivePendingDiffs,
       diffSummary: formattedDiffSummary,
       resolvedMounts,
+      activeMounts: workspaceMounts,
       activeMountPaths,
       onRejectAll: (hunkIds: string[]) => {
         setOptimisticHunkIds((prev) => {

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/panel-footer.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/panel-footer.tsx
@@ -66,6 +66,7 @@ import {
   enrichTipTapContent,
 } from '@ui/utils/tiptap-content-utils';
 import { getCurrentDraftAnswers } from './footer-status-card/user-question-section';
+import { getWorkspaceDisplayLabel } from '@ui/utils/workspace-display';
 import {
   Tooltip,
   TooltipContent,
@@ -83,10 +84,6 @@ const CHAT_INPUT_FOCUS_REQUESTED_EVENT = 'chat-input-focus-requested';
 
 function formatWorkspaceGitRef(git: MountEntry['git']): string | null {
   return git?.branch ?? git?.headSha?.slice(0, 7) ?? null;
-}
-
-function getWorkspaceDisplayName(mount: MountEntry): string {
-  return mount.path.split(/[\\/]/).filter(Boolean).at(-1) ?? mount.path;
 }
 
 function formatWorkspaceActionError(message: string): string {
@@ -812,7 +809,7 @@ export const ChatPanelFooter = memo(function ChatPanelFooter() {
         if (!result.ok) {
           return {
             ok: false as const,
-            message: `${getWorkspaceDisplayName(mount)}: ${result.message}`,
+            message: `${getWorkspaceDisplayLabel(mount)}: ${result.message}`,
           };
         }
 
@@ -827,7 +824,7 @@ export const ChatPanelFooter = memo(function ChatPanelFooter() {
       } catch (error) {
         return {
           ok: false as const,
-          message: `${getWorkspaceDisplayName(mount)}: ${
+          message: `${getWorkspaceDisplayLabel(mount)}: ${
             error instanceof Error
               ? error.message
               : 'Failed to execute workspace action.'

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/rich-text/mentions/providers/workspace-provider.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/rich-text/mentions/providers/workspace-provider.tsx
@@ -2,7 +2,7 @@ import { IconFolder5Outline18 } from 'nucleo-ui-outline-18';
 import { cn } from '@stagewise/stage-ui/lib/utils';
 import type { MentionProvider, MentionContext } from './types';
 import type { WorkspaceMentionItem } from '../types';
-import { getBaseName } from '@shared/path-utils';
+import { getWorkspaceDisplayLabel } from '@ui/utils/workspace-display';
 
 export const workspaceProvider: MentionProvider = {
   type: 'workspace',
@@ -13,11 +13,12 @@ export const workspaceProvider: MentionProvider = {
   ),
   query: (_input: string, ctx: MentionContext): WorkspaceMentionItem[] => {
     return ctx.mounts.map((mount) => {
-      const name = getBaseName(mount.path) || mount.path;
+      const name = getWorkspaceDisplayLabel(mount);
       return {
         id: mount.prefix,
         label: name,
         description: mount.path,
+        searchText: `${name} ${mount.path}`,
         descriptionTruncation: 'start' as const,
         providerType: 'workspace' as const,
         relevance: 0.4,

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/rich-text/mentions/suggestion-popup.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/rich-text/mentions/suggestion-popup.tsx
@@ -24,7 +24,7 @@ import type {
 import { MentionIcon } from './mention-icon';
 import { FilePathTree } from './file-path-tree';
 import { WorkspacePreviewSummary } from './workspace-preview-summary';
-import { getBaseName } from '@shared/path-utils';
+import { getWorkspaceDisplayLabel } from '@ui/utils/workspace-display';
 
 type SidePanelContent =
   | {
@@ -82,7 +82,7 @@ function deriveSidePanel(
     const meta = (item as FileMentionItem).meta;
     const mount = mounts.find((m) => m.prefix === meta.mountPrefix);
     const workspaceName = mount
-      ? getBaseName(mount.path) || mount.path
+      ? getWorkspaceDisplayLabel(mount)
       : meta.mountPrefix;
 
     if (meta.isDirectory) {
@@ -129,7 +129,7 @@ function deriveSidePanel(
       type: 'workspace',
       key: `workspace:${meta.prefix}`,
       mount,
-      name: meta.name,
+      name: getWorkspaceDisplayLabel(mount) || meta.name,
     };
   }
 

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/workspace-select.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/workspace-select.tsx
@@ -56,6 +56,7 @@ import { getIDEFileUrl, IDE_SELECTION_ITEMS } from '@ui/utils';
 import { HotkeyActions } from '@shared/hotkeys';
 import { getBaseName } from '@shared/path-utils';
 import { FileContextMenu } from '@ui/components/file-context-menu';
+import { getWorkspaceDisplayInfo } from '@ui/utils/workspace-display';
 import type { OpenFilesInIde } from '@shared/karton-contracts/ui/shared-types';
 import {
   type MountEntry,
@@ -113,7 +114,7 @@ const WorkspaceBadge = memo(function WorkspaceBadge({
   onUnmount: (prefix: string) => void;
   agentInstanceId: string;
 }) {
-  const name = getBaseName(mount.path) || mount.path;
+  const display = getWorkspaceDisplayInfo(mount);
   const gitRef = mount.git ? formatGitRef(mount.git) : null;
 
   const respectAgentsMd = useKartonState(
@@ -373,7 +374,7 @@ const WorkspaceBadge = memo(function WorkspaceBadge({
           >
             {unmountIcon}
             <span className="min-w-0 truncate group-hover/workspace:text-foreground group-focus-visible/workspace:text-foreground group-has-[[data-unmount]:hover]/workspace:text-muted-foreground">
-              {name}
+              {display.title}
             </span>
             {gitRef && (
               <span className="min-w-0 truncate text-subtle-foreground group-hover/workspace:text-muted-foreground group-focus-visible/workspace:text-muted-foreground group-has-[[data-unmount]:hover]/workspace:text-subtle-foreground">
@@ -415,7 +416,7 @@ const WorkspaceBadge = memo(function WorkspaceBadge({
             >
               <WorkspacePreviewCardContent
                 mount={mount}
-                name={name}
+                name={display.label}
                 onItemHover={handleItemHover}
                 onItemLeave={cancelPendingOpen}
                 activeRow={
@@ -455,7 +456,7 @@ const WorkspaceBadge = memo(function WorkspaceBadge({
                 ) : sidePanelContent.type === 'contextFiles' ? (
                   <ContextFilesSidePanel
                     mount={mount}
-                    name={name}
+                    name={display.label}
                     respectAgentsMd={respectAgentsMd}
                     onToggleAgentsMd={handleToggleAgentsMd}
                     isGeneratingWorkspaceMd={isGeneratingWorkspaceMd}
@@ -1573,7 +1574,7 @@ const WorkspaceActionSelect = memo(function WorkspaceActionSelect({
   agentInstanceId: string;
 }) {
   const track = useTrack();
-  const name = getBaseName(mount.path) || mount.path;
+  const display = getWorkspaceDisplayInfo(mount);
   const gitRef = useMemo(
     () => (mount.git ? formatGitRef(mount.git) : null),
     [mount.git],
@@ -2022,8 +2023,13 @@ const WorkspaceActionSelect = memo(function WorkspaceActionSelect({
             <TooltipContent>Disconnect workspace</TooltipContent>
           </Tooltip>
           <span className="shrink-0 truncate text-muted-foreground">
-            {name}
+            {display.title}
           </span>
+          {display.qualifier && (
+            <span className="min-w-0 truncate text-subtle-foreground">
+              {display.qualifier}
+            </span>
+          )}
           <span
             aria-hidden
             className="shrink-0 select-none text-subtle-foreground"

--- a/apps/browser/src/ui/utils/workspace-display.test.ts
+++ b/apps/browser/src/ui/utils/workspace-display.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getWorkspaceDisplayInfo,
+  getWorkspaceDisplayLabel,
+  type WorkspaceDisplaySource,
+} from './workspace-display';
+
+describe('workspace display helpers', () => {
+  it('uses the folder basename for non-Git workspaces', () => {
+    expect(
+      getWorkspaceDisplayLabel({
+        path: '/Users/test/projects/plain-workspace',
+        git: null,
+      }),
+    ).toBe('plain-workspace');
+  });
+
+  it('uses the mounted folder basename for main Git workspaces', () => {
+    expect(
+      getWorkspaceDisplayLabel({
+        path: '/Users/test/projects/stagewise',
+        git: gitSummary({ isWorktree: false }),
+      }),
+    ).toBe('stagewise');
+  });
+
+  it('combines the main worktree folder and branch for linked worktrees', () => {
+    expect(
+      getWorkspaceDisplayInfo({
+        path: '/Users/test/projects/stagewise-worktrees/seedable-eventloop',
+        git: gitSummary({
+          isWorktree: true,
+          mainWorktreePath: '/Users/test/projects/stagewise',
+          branch: 'seedable-eventloop',
+        }),
+      }),
+    ).toEqual({
+      title: 'stagewise',
+      qualifier: 'seedable-eventloop',
+      label: 'stagewise seedable-eventloop',
+    });
+  });
+
+  it('uses a short head SHA for detached linked worktrees', () => {
+    expect(
+      getWorkspaceDisplayLabel({
+        path: '/Users/test/projects/stagewise-worktrees/detached',
+        git: gitSummary({
+          isWorktree: true,
+          mainWorktreePath: '/Users/test/projects/stagewise',
+          branch: null,
+          headSha: '1234567890abcdef',
+        }),
+      }),
+    ).toBe('stagewise 1234567');
+  });
+
+  it('falls back to the linked worktree folder when no branch or SHA exists', () => {
+    expect(
+      getWorkspaceDisplayLabel({
+        path: '/Users/test/projects/stagewise-worktrees/local-folder',
+        git: gitSummary({
+          isWorktree: true,
+          mainWorktreePath: '/Users/test/projects/stagewise',
+          branch: null,
+          headSha: null,
+        }),
+      }),
+    ).toBe('stagewise local-folder');
+  });
+
+  it('uses the worktree folder as qualifier when the branch equals the repo folder', () => {
+    expect(
+      getWorkspaceDisplayInfo({
+        path: '/Users/test/projects/worktrees/stagewise-linked',
+        git: gitSummary({
+          isWorktree: true,
+          mainWorktreePath: '/Users/test/projects/stagewise',
+          branch: 'stagewise',
+        }),
+      }),
+    ).toEqual({
+      title: 'stagewise',
+      qualifier: 'stagewise-linked',
+      label: 'stagewise stagewise-linked',
+    });
+  });
+});
+
+function gitSummary(
+  overrides: Partial<NonNullable<WorkspaceDisplaySource['git']>> = {},
+): NonNullable<WorkspaceDisplaySource['git']> {
+  return {
+    branch: 'main',
+    headSha: 'abcdef1234567890',
+    isWorktree: false,
+    mainWorktreePath: null,
+    repositoryId: 'repo-id',
+    worktreeId: 'worktree-id',
+    repoRoot: '/Users/test/projects/stagewise',
+    commonGitDir: '/Users/test/projects/stagewise/.git',
+    status: {
+      dirty: false,
+      stagedCount: 0,
+      unstagedCount: 0,
+      untrackedCount: 0,
+    },
+    ...overrides,
+  };
+}

--- a/apps/browser/src/ui/utils/workspace-display.ts
+++ b/apps/browser/src/ui/utils/workspace-display.ts
@@ -1,0 +1,42 @@
+import type { MountedWorkspaceGitSummary } from '@shared/karton-contracts/ui';
+import { getBaseName } from '@shared/path-utils';
+
+export type WorkspaceDisplaySource = {
+  path: string;
+  git: MountedWorkspaceGitSummary | null;
+};
+
+export type WorkspaceDisplayInfo = {
+  title: string;
+  qualifier: string | null;
+  label: string;
+};
+
+export function getWorkspaceDisplayInfo(
+  workspace: WorkspaceDisplaySource,
+): WorkspaceDisplayInfo {
+  const pathName = getBaseName(workspace.path) || workspace.path;
+
+  if (!workspace.git?.isWorktree || !workspace.git.mainWorktreePath) {
+    return { title: pathName, qualifier: null, label: pathName };
+  }
+
+  const repoName =
+    getBaseName(workspace.git.mainWorktreePath) ||
+    workspace.git.mainWorktreePath;
+  const worktreeRef =
+    workspace.git.branch ?? workspace.git.headSha?.slice(0, 7) ?? pathName;
+  const qualifier = worktreeRef === repoName ? pathName : worktreeRef;
+
+  return {
+    title: repoName,
+    qualifier,
+    label: `${repoName} ${qualifier}`,
+  };
+}
+
+export function getWorkspaceDisplayLabel(
+  workspace: WorkspaceDisplaySource,
+): string {
+  return getWorkspaceDisplayInfo(workspace).label;
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the main worktree folder as the workspace name for Git worktrees, and include the branch or short SHA for linked worktrees so labels are clear and consistent across the app.

- New Features
  - Backend `GitService`: list worktrees, pass them to `getWorktreeInfo`, compute `mainWorktreePath`, and include it in the mounted workspace summary.
  - Contracts: add `mainWorktreePath` to `WorkspaceGitSummary`.
  - UI: add `getWorkspaceDisplayInfo`/`getWorkspaceDisplayLabel` and use them across badges, workspace select (with qualifier), status card (file diff grouping uses live mounts), mentions and suggestion popup, attachment links (prefer live mounts, fallback for historical), agent preview, skills/context sections, and footer errors to standardize workspace labels.

<sup>Written for commit ea4414798169e20b6a5606dd902fa98b0f7e0973. Summary will update on new commits. <a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1196?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workspace names and badges now use richer display info (includes primary worktree path and a qualifier) for clearer, consistent labels across previews, mentions, tooltips, and diffs.

* **Bug Fixes**
  * Naming logic handles detached or unnamed worktrees and avoids duplicate/confusing labels.

* **Tests**
  * Added tests covering display label behavior for Git and non-Git workspace scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stagewise-io/stagewise/pull/1196?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->