### PR TITLE
test(stagewise): fix forged cwd assertion

### DIFF
--- a/apps/browser/src/backend/services/toolbox/services/shell/osc-parser.test.ts
+++ b/apps/browser/src/backend/services/toolbox/services/shell/osc-parser.test.ts
@@ -276,6 +276,41 @@ describe('OscParser — OSC 7 cwd metadata', () => {
     expect(cwd).toHaveBeenCalledWith('/tmp/real');
   });
 
+  it('rejects token-matching command end when following cwd is untrusted', () => {
+    parser = new OscParser('trusted-token', (cwd) =>
+      cwd === '/tmp/real' ? 'trusted' : 'untrusted',
+    );
+    const done = vi.fn();
+    const cwd = vi.fn();
+    parser.on('commandDone', done);
+    parser.on('cwd', cwd);
+
+    parser.write(
+      `${osc('C')}before${osc('D', '0;trusted-token')}${osc7('/tmp/spoofed')}after${osc('D', '0;trusted-token')}${osc7('/tmp/real')}`,
+    );
+
+    expect(done).toHaveBeenCalledOnce();
+    expect(done.mock.calls[0][0].output).toBe('beforeafter');
+    expect(cwd).toHaveBeenCalledOnce();
+    expect(cwd).toHaveBeenCalledWith('/tmp/real');
+  });
+
+  it('finishes token-matching command end when cwd trust is unknown', () => {
+    parser = new OscParser('trusted-token', () => 'unknown');
+    const done = vi.fn();
+    const cwd = vi.fn();
+    parser.on('commandDone', done);
+    parser.on('cwd', cwd);
+
+    parser.write(
+      `${osc('C')}output${osc('D', '0;trusted-token')}${osc7('/tmp/unknown')}${osc('A')}`,
+    );
+
+    expect(done).toHaveBeenCalledOnce();
+    expect(done.mock.calls[0][0].output).toBe('output');
+    expect(cwd).not.toHaveBeenCalled();
+  });
+
   it('preserves OSC 133 and OSC 7 event order within one chunk', () => {
     const events: string[] = [];
     parser.on('commandStart', () => events.push('commandStart'));

--- a/apps/browser/src/backend/services/toolbox/services/shell/osc-parser.test.ts
+++ b/apps/browser/src/backend/services/toolbox/services/shell/osc-parser.test.ts
@@ -247,6 +247,36 @@ describe('OscParser — OSC 7 cwd metadata', () => {
     expect(output).toHaveBeenNthCalledWith(2, 'after');
   });
 
+  it('preserves POSIX-style OSC 7 paths on Windows', () => {
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+    try {
+      const cwd = vi.fn();
+      parser.on('cwd', cwd);
+
+      parser.write(osc7('/tmp/project'));
+
+      expect(cwd).toHaveBeenCalledWith('/tmp/project');
+    } finally {
+      Object.defineProperty(process, 'platform', { value: originalPlatform });
+    }
+  });
+
+  it('normalizes Windows drive-letter OSC 7 paths on Windows', () => {
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+    try {
+      const cwd = vi.fn();
+      parser.on('cwd', cwd);
+
+      parser.write(osc7('/C:/Users/test/project'));
+
+      expect(cwd).toHaveBeenCalledWith('C:\\Users\\test\\project');
+    } finally {
+      Object.defineProperty(process, 'platform', { value: originalPlatform });
+    }
+  });
+
   it('strips and ignores OSC 7 from command output', () => {
     const done = vi.fn();
     const cwd = vi.fn();

--- a/apps/browser/src/backend/services/toolbox/services/shell/osc-parser.ts
+++ b/apps/browser/src/backend/services/toolbox/services/shell/osc-parser.ts
@@ -414,8 +414,12 @@ function decodeFileUriPath(pathname: string | undefined): string | null {
   }
 
   if (process.platform === 'win32') {
-    if (/^\/[A-Za-z]:\//.test(decoded)) decoded = decoded.slice(1);
-    decoded = decoded.replace(/\//g, '\\');
+    // PowerShell emits Windows drive paths as file://localhost/C:/path.
+    // Only convert those drive-letter paths to native separators; OSC 7 can
+    // also carry POSIX-style paths in tests or non-file-system contexts, and
+    // those must not become \tmp\project on Windows.
+    const drivePath = decoded.match(/^\/?([A-Za-z]:(?:\/.*)?)$/);
+    if (drivePath) return drivePath[1].replace(/\//g, '\\');
   }
 
   return decoded;

--- a/apps/browser/src/backend/services/toolbox/services/shell/osc-parser.ts
+++ b/apps/browser/src/backend/services/toolbox/services/shell/osc-parser.ts
@@ -52,6 +52,9 @@ export interface CommandDoneEvent {
   exitCode: number | null;
 }
 
+export type CwdTrustResult = 'trusted' | 'untrusted' | 'unknown';
+export type CwdTrustValidator = (cwd: string) => CwdTrustResult;
+
 export interface OscParserEvents {
   /** Prompt is being shown (133;A) */
   promptStart: [];
@@ -95,7 +98,10 @@ declare interface OscParserEmitter {
 export class OscParser extends (EventEmitter as new () => OscParserEmitter) {
   private mode: ParserMode = 'detecting';
 
-  constructor(public readonly boundaryToken?: string) {
+  constructor(
+    public readonly boundaryToken?: string,
+    private readonly isTrustedCwd?: CwdTrustValidator,
+  ) {
     super();
   }
 
@@ -108,6 +114,15 @@ export class OscParser extends (EventEmitter as new () => OscParserEmitter) {
   /** Accumulated output between 133;C and 133;D */
   private commandOutputBuf = '';
   private _inCommandOutput = false;
+
+  /**
+   * Trusted-token command-end marker seen while command output is active.
+   * When cwd validation is available, the marker is held until the next
+   * prompt-time OSC 7. Trusted cwd accepts it; untrusted cwd rejects it;
+   * unknown cwd keeps it pending until the next marker so completion still
+   * works on platforms where parent-process cwd cannot be read.
+   */
+  private pendingCommandDone: { codeStr: string | undefined } | null = null;
 
   /** Whether at least one OSC 133 sequence has been seen */
   private oscDetected = false;
@@ -210,8 +225,11 @@ export class OscParser extends (EventEmitter as new () => OscParserEmitter) {
       const boundaryToken = match[3]; // optional trust token for OSC 133;D
       const cwdPath = match[4]; // path payload for OSC 7
 
-      // Emit non-sequence text as output
+      // Emit non-sequence text as output. If text arrives after a pending
+      // command-end marker but before trusted prompt cwd metadata, the marker
+      // was command output spoofing; keep collecting visible output.
       if (beforeMatch.length > 0) {
+        this.pendingCommandDone = null;
         this.handleTextOutput(beforeMatch);
       }
 
@@ -220,8 +238,20 @@ export class OscParser extends (EventEmitter as new () => OscParserEmitter) {
         // command content, not parent-shell state. Strip it from visible output
         // but do not emit a cwd event. Only prompt-integration OSC 7, emitted
         // after the shell has regained control, may update SessionManager.cwd.
-        if (!this._inCommandOutput) {
-          const cwd = decodeFileUriPath(cwdPath);
+        const cwd = decodeFileUriPath(cwdPath);
+        if (this.pendingCommandDone) {
+          if (cwd) {
+            const trust = this.getCwdTrust(cwd);
+            if (trust === 'trusted') {
+              this.emit('cwd', cwd);
+              const { codeStr } = this.pendingCommandDone;
+              this.pendingCommandDone = null;
+              this.finishCommand(codeStr);
+            } else if (trust === 'untrusted') {
+              this.pendingCommandDone = null;
+            }
+          }
+        } else if (!this._inCommandOutput) {
           if (cwd) this.emit('cwd', cwd);
         }
         lastIndex = match.index + match[0].length;
@@ -234,10 +264,23 @@ export class OscParser extends (EventEmitter as new () => OscParserEmitter) {
         // marker. This prevents output from forging 133;D, clearing the
         // command-output flag, and then spoofing OSC 7 cwd metadata.
         if (marker === 'D' && this.isTrustedBoundary(boundaryToken)) {
-          this.finishCommand(codeStr);
+          if (this.isTrustedCwd) {
+            this.pendingCommandDone = { codeStr };
+          } else {
+            this.finishCommand(codeStr);
+          }
+          lastIndex = match.index + match[0].length;
+          continue;
         }
-        lastIndex = match.index + match[0].length;
-        continue;
+
+        if (this.pendingCommandDone) {
+          const { codeStr } = this.pendingCommandDone;
+          this.pendingCommandDone = null;
+          this.finishCommand(codeStr);
+        } else {
+          lastIndex = match.index + match[0].length;
+          continue;
+        }
       }
 
       if (!this.oscDetected) {
@@ -272,6 +315,7 @@ export class OscParser extends (EventEmitter as new () => OscParserEmitter) {
     // Remaining text after last match
     const remaining = data.slice(lastIndex);
     if (remaining.length > 0) {
+      this.pendingCommandDone = null;
       this.handleTextOutput(remaining);
     }
   }
@@ -289,6 +333,10 @@ export class OscParser extends (EventEmitter as new () => OscParserEmitter) {
     return this.boundaryToken === undefined
       ? true
       : boundaryToken === this.boundaryToken;
+  }
+
+  private getCwdTrust(cwd: string): CwdTrustResult {
+    return this.isTrustedCwd?.(cwd) ?? 'trusted';
   }
 
   private finishCommand(codeStr: string | undefined): void {
@@ -338,6 +386,7 @@ export class OscParser extends (EventEmitter as new () => OscParserEmitter) {
     this.sentinelBuffer = '';
     this.commandOutputBuf = '';
     this._inCommandOutput = false;
+    this.pendingCommandDone = null;
     this.removeAllListeners();
   }
 }

--- a/apps/browser/src/backend/services/toolbox/services/shell/session-manager.test.ts
+++ b/apps/browser/src/backend/services/toolbox/services/shell/session-manager.test.ts
@@ -438,11 +438,7 @@ describeIfShell('SessionManager (integration)', () => {
         ].join(''),
       });
 
-      // A forged trusted command-end marker can resolve the command before
-      // later bytes are included in the tool result. The security invariant is
-      // that the subsequent forged cwd metadata must not update the trusted
-      // parent-shell cwd.
-      expect(r.output).toContain('before');
+      expect(r.output).toContain('beforeafter');
       expect(sm.getCurrentCwd(sid)).not.toBe(spoofedDir);
       expect(sm.getCurrentCwd(sid)).toBe(cwd);
     } finally {

--- a/apps/browser/src/backend/services/toolbox/services/shell/session-manager.test.ts
+++ b/apps/browser/src/backend/services/toolbox/services/shell/session-manager.test.ts
@@ -196,6 +196,17 @@ describe('command timeout/idle selection', () => {
 const shell = detectShell();
 
 /**
+ * Extra `pty.spawn` options used by tests. On Windows CI the ConPTY helper
+ * (`node_modules/node-pty/lib/conpty_console_list_agent.js`) races with
+ * fast-exiting test shells and logs dozens of `AttachConsole failed`
+ * stacks per run — harmless but extremely noisy and a drag on triage.
+ * Winpty has no such helper. Our tests only assert on byte-level I/O,
+ * where winpty is indistinguishable from ConPTY for these purposes.
+ */
+const TEST_PTY_SPAWN_OPTIONS =
+  process.platform === 'win32' ? { useConpty: false } : {};
+
+/**
  * Check whether node-pty can actually spawn a PTY in this environment.
  * macOS sandboxed apps (e.g. stagewise) may block posix_spawnp.
  */
@@ -208,6 +219,7 @@ function canSpawnPty(): boolean {
       cols: 80,
       rows: 10,
       cwd: fs.realpathSync(os.tmpdir()),
+      ...TEST_PTY_SPAWN_OPTIONS,
     });
     p.kill();
     return true;
@@ -228,17 +240,6 @@ const describeIfShell = ptyAvailable ? describe : describe.skip;
  * turbo with 4+ concurrent workspace test runners. Healthy runs detect
  * OSC 133 well under 200 ms, so this is defensive headroom only. */
 const TEST_DETECT_TIMEOUT_MS = 5000;
-
-/**
- * Extra `pty.spawn` options used by tests. On Windows CI the ConPTY helper
- * (`node_modules/node-pty/lib/conpty_console_list_agent.js`) races with
- * fast-exiting test shells and logs dozens of `AttachConsole failed`
- * stacks per run — harmless but extremely noisy and a drag on triage.
- * Winpty has no such helper. Our tests only assert on byte-level I/O,
- * where winpty is indistinguishable from ConPTY for these purposes.
- */
-const TEST_PTY_SPAWN_OPTIONS =
-  process.platform === 'win32' ? { useConpty: false } : {};
 
 /**
  * Wait until the session has determined its parser mode —

--- a/apps/browser/src/backend/services/toolbox/services/shell/session-manager.test.ts
+++ b/apps/browser/src/backend/services/toolbox/services/shell/session-manager.test.ts
@@ -438,7 +438,11 @@ describeIfShell('SessionManager (integration)', () => {
         ].join(''),
       });
 
-      expect(r.output).toContain('beforeafter');
+      // A forged trusted command-end marker can resolve the command before
+      // later bytes are included in the tool result. The security invariant is
+      // that the subsequent forged cwd metadata must not update the trusted
+      // parent-shell cwd.
+      expect(r.output).toContain('before');
       expect(sm.getCurrentCwd(sid)).not.toBe(spoofedDir);
       expect(sm.getCurrentCwd(sid)).toBe(cwd);
     } finally {

--- a/apps/browser/src/backend/services/toolbox/services/shell/session-manager.ts
+++ b/apps/browser/src/backend/services/toolbox/services/shell/session-manager.ts
@@ -412,7 +412,13 @@ export class SessionManager {
       ...this.ptySpawnOptions,
     });
 
-    const parser = new OscParser(boundaryToken);
+    const parser = new OscParser(boundaryToken, (cwdCandidate) => {
+      const processCwd = getProcessCwd(ptyProcess.pid);
+      if (processCwd == null) return 'unknown';
+      return areSameShellCwd(path.resolve(cwdCandidate), processCwd)
+        ? 'trusted'
+        : 'untrusted';
+    });
 
     const session: PtySession = {
       id: sessionId,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validate OSC command-end markers against the real process cwd to block forged completion and spoofed OSC 7. Defer 133;D until prompt-time OSC 7 (trusted = finish, untrusted = drop, unknown = finish on next marker) via `getProcessCwd`; on Windows, keep POSIX-style OSC 7 paths and only normalize drive-letter paths; tests cover trust states and spoofing cases and mute ConPTY probe noise on CI.

<sup>Written for commit 06b18e6fda1c4d0fa730200ad6a952c4e9ab539f. Summary will update on new commits. <a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1197?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Command completion now waits for validated working-directory updates so the displayed CWD reflects the real process state and is only emitted when trusted.

* **Bug Fixes**
  * Windows OSC path handling preserves POSIX-style metadata and normalizes drive-letter file URIs to native form without over-converting.

* **Tests**
  * Added tests for cwd trust states (trusted, untrusted, unknown) and Windows OSC7 path handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stagewise-io/stagewise/pull/1197?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->