### PR TITLE
fix(stagewise): make hotkeys QWERTZ-compatible

### DIFF
--- a/apps/browser/src/shared/hotkeys.test.ts
+++ b/apps/browser/src/shared/hotkeys.test.ts
@@ -177,6 +177,42 @@ describe('isEventMatch', () => {
       expect(isEventMatch(ev, def, 'windows')).toBe(true);
     });
   });
+
+  describe('layout-dependent symbol keys', () => {
+    it('matches Slash by produced character', () => {
+      const def: HotkeyDefinition = { accelerator: 'Mod+Slash' };
+      const ev = createKeyboardEvent({
+        code: 'Digit7',
+        key: '/',
+        metaKey: true,
+      });
+      expect(isEventMatch(ev, def, 'mac')).toBe(true);
+    });
+
+    it('does NOT match Slash by physical key when it produces minus', () => {
+      const def: HotkeyDefinition = { accelerator: 'Mod+Slash' };
+      const ev = createKeyboardEvent({
+        code: 'Slash',
+        key: '-',
+        metaKey: true,
+      });
+      expect(isEventMatch(ev, def, 'mac')).toBe(false);
+    });
+
+    it('matches shifted Slash aliases on QWERTZ-style layouts', () => {
+      const def: HotkeyDefinition = {
+        accelerator: 'Mod+Slash',
+        aliases: ['Mod+Shift+Slash'],
+      };
+      const ev = createKeyboardEvent({
+        code: 'Digit7',
+        key: '/',
+        metaKey: true,
+        shiftKey: true,
+      });
+      expect(isEventMatch(ev, def, 'mac')).toBe(true);
+    });
+  });
 });
 
 describe('getDisplayString', () => {

--- a/apps/browser/src/shared/hotkeys.ts
+++ b/apps/browser/src/shared/hotkeys.ts
@@ -151,6 +151,7 @@ export const hotkeyDefinitions: Record<HotkeyActions, HotkeyDefinition> = {
   },
   [HotkeyActions.OPEN_MODEL_SELECT]: {
     accelerator: 'Mod+Slash',
+    aliases: ['Mod+Shift+Slash'],
     captureDominantly: true,
   },
   [HotkeyActions.OPEN_COMMAND_CENTER]: {
@@ -522,7 +523,7 @@ function matchKeyToken(ev: KeyboardEvent, token: string): boolean {
     case 'PERIOD':
       return ev.code === 'Period';
     case 'SLASH':
-      return ev.code === 'Slash';
+      return ev.key === '/' || ev.code === 'NumpadDivide';
 
     // Function keys (F1-F24)
     default:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix slash-based hotkeys so they work on QWERTZ and other layouts. We now match the produced '/' (including `NumpadDivide`) and add a `Mod+Shift+Slash` alias for model select; tests cover layout-dependent cases.

<sup>Written for commit 44faf0820e8472f68c384b937bc3e2341d093484. Summary will update on new commits. <a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1198?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Mod+Shift+Slash keyboard shortcut for opening model select.

* **Bug Fixes**
  * Improved slash key recognition across different keyboard layouts, including better support for QWERTZ-style keyboards and numpad input.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stagewise-io/stagewise/pull/1198?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->