### PR TITLE
fix(stagewise): reduce cross-icon size on workspace-select

### DIFF
--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/workspace-select.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/workspace-select.tsx
@@ -351,7 +351,7 @@ const WorkspaceBadge = memo(function WorkspaceBadge({
           ) : (
             <IconFolder5Outline18 className="size-3 shrink-0 group-hover/workspace:opacity-0 group-focus-visible/workspace:opacity-0" />
           )}
-          <IconXmarkFill18 className="absolute size-3.5 text-muted-foreground opacity-0 group-hover/unmount:text-foreground group-hover/workspace:opacity-100 group-focus-visible/workspace:opacity-100" />
+          <IconXmarkFill18 className="absolute size-3 text-muted-foreground opacity-0 group-hover/unmount:text-foreground group-hover/workspace:opacity-100 group-focus-visible/workspace:opacity-100" />
         </span>
       </TooltipTrigger>
       <TooltipContent>Disconnect workspace</TooltipContent>
@@ -2017,7 +2017,7 @@ const WorkspaceActionSelect = memo(function WorkspaceActionSelect({
                 ) : (
                   <IconCodeBranchOutline18 className="size-3 shrink-0 group-hover/workspace:opacity-0" />
                 )}
-                <IconXmarkFill18 className="absolute size-3.5 text-muted-foreground opacity-0 group-hover/unmount:text-foreground group-hover/workspace:opacity-100" />
+                <IconXmarkFill18 className="absolute size-3 text-muted-foreground opacity-0 group-hover/unmount:text-foreground group-hover/workspace:opacity-100" />
               </span>
             </TooltipTrigger>
             <TooltipContent>Disconnect workspace</TooltipContent>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Reduced the “X” disconnect icon size in the workspace selector for consistent sizing and cleaner hover states. Updated `IconXmarkFill18` from size-3.5 to size-3 in both the workspace badge and action select.

<sup>Written for commit 9cac58ed6bdbaffc026ec9d64265bf994ecc4d4f. Summary will update on new commits. <a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1200?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the disconnect icon sizing in workspace-related UI elements for improved visual consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stagewise-io/stagewise/pull/1200?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->