### PR TITLE
Hotkey behavior fixes

### DIFF
--- a/apps/browser/src/backend/services/window-layout/index.ts
+++ b/apps/browser/src/backend/services/window-layout/index.ts
@@ -2001,8 +2001,22 @@ export class WindowLayoutService extends DisposableService {
     percentage: number,
     tabId?: string,
   ) => {
-    const tab = tabId ? this.tabs[tabId] : this.activeTab;
-    tab?.setZoomPercentage(percentage);
+    const resolvedTabId = tabId ?? this.activeTabId;
+    const tab = resolvedTabId ? this.tabs[resolvedTabId] : undefined;
+    if (tab) {
+      tab.setZoomPercentage(percentage);
+    } else if (resolvedTabId) {
+      // Terminal tabs have no BrowsingTabController — update state directly.
+      const isTerminal =
+        this.uiKarton.state.contentTabs.tabs[resolvedTabId]?.type ===
+        'terminal';
+      if (isTerminal) {
+        this.uiKarton.setState((draft) => {
+          const t = draft.contentTabs.tabs[resolvedTabId];
+          if (t) t.zoomPercentage = percentage;
+        });
+      }
+    }
   };
 
   private handleSetTabAgentInstance = async (

--- a/apps/browser/src/backend/services/window-layout/index.ts
+++ b/apps/browser/src/backend/services/window-layout/index.ts
@@ -14,6 +14,7 @@ import type { FaviconService } from '../favicon';
 import type { PagesService } from '../pages';
 import type { PreferencesService } from '../preferences';
 import type { PageTransition } from '@shared/karton-contracts/pages-api/types';
+import type { UserPreferences } from '@shared/karton-contracts/ui/shared-types';
 import { UIController } from './ui-controller';
 import {
   BrowsingTabController,
@@ -395,6 +396,10 @@ export class WindowLayoutService extends DisposableService {
       ) => void)
     | null = null;
 
+  private uiZoomPreferenceListener:
+    | ((newPrefs: UserPreferences, oldPrefs: UserPreferences) => void)
+    | null = null;
+
   private constructor(
     logger: Logger,
     historyService: HistoryService,
@@ -462,6 +467,10 @@ export class WindowLayoutService extends DisposableService {
     this.uiController.setCaptureAndStoreElementScreenshotHandler(
       this.handleCaptureAndStoreElementScreenshot.bind(this),
     );
+    this.applyUiZoomPercentage(
+      this.preferencesService.get().general.uiZoomPercentage,
+    );
+    this.setupUiZoomPreferenceListener();
 
     const savedState = this.loadWindowState();
     const defaultWidth = 1200;
@@ -651,6 +660,11 @@ export class WindowLayoutService extends DisposableService {
     if (this.syncThemeColorsListener) {
       ipcMain.removeListener('sync-theme-colors', this.syncThemeColorsListener);
       this.syncThemeColorsListener = null;
+    }
+
+    if (this.uiZoomPreferenceListener) {
+      this.preferencesService.removeListener(this.uiZoomPreferenceListener);
+      this.uiZoomPreferenceListener = null;
     }
 
     ipcMain.removeHandler('request-turnstile-token');
@@ -1081,10 +1095,39 @@ export class WindowLayoutService extends DisposableService {
         width: bounds.width,
         height: bounds.height,
       });
+      this.applyUiZoomPercentage(
+        this.preferencesService.get().general.uiZoomPercentage,
+      );
 
       // Restore correct z-layering (UI on top of tabs or vice versa)
       this.updateZOrder();
     });
+  }
+
+  private applyUiZoomPercentage(percentage: number): void {
+    if (!this.uiController) return;
+
+    const view = this.uiController.getView();
+    if (view.webContents.isDestroyed()) return;
+
+    const factor = Math.max(0.1, percentage / 100);
+    view.webContents.setZoomFactor(factor);
+    this.logger.debug(
+      `[WindowLayoutService] Applied UI webContents zoom factor: ${factor}`,
+    );
+  }
+
+  private setupUiZoomPreferenceListener(): void {
+    if (this.uiZoomPreferenceListener) return;
+
+    this.uiZoomPreferenceListener = (newPrefs, oldPrefs) => {
+      const nextZoom = newPrefs.general.uiZoomPercentage;
+      if (nextZoom === oldPrefs.general.uiZoomPercentage) return;
+
+      this.applyUiZoomPercentage(nextZoom);
+    };
+
+    this.preferencesService.addListener(this.uiZoomPreferenceListener);
   }
 
   private setupPagesServiceHandlers() {
@@ -2003,20 +2046,7 @@ export class WindowLayoutService extends DisposableService {
   ) => {
     const resolvedTabId = tabId ?? this.activeTabId;
     const tab = resolvedTabId ? this.tabs[resolvedTabId] : undefined;
-    if (tab) {
-      tab.setZoomPercentage(percentage);
-    } else if (resolvedTabId) {
-      // Terminal tabs have no BrowsingTabController — update state directly.
-      const isTerminal =
-        this.uiKarton.state.contentTabs.tabs[resolvedTabId]?.type ===
-        'terminal';
-      if (isTerminal) {
-        this.uiKarton.setState((draft) => {
-          const t = draft.contentTabs.tabs[resolvedTabId];
-          if (t) t.zoomPercentage = percentage;
-        });
-      }
-    }
+    tab?.setZoomPercentage(percentage);
   };
 
   private handleSetTabAgentInstance = async (

--- a/apps/browser/src/shared/hotkeys.ts
+++ b/apps/browser/src/shared/hotkeys.ts
@@ -186,7 +186,7 @@ export const hotkeyDefinitions: Record<HotkeyActions, HotkeyDefinition> = {
   },
   [HotkeyActions.STOP_AGENT]: {
     accelerator: 'Ctrl+C',
-    captureDominantly: true,
+    captureDominantly: false,
   },
 
   // Tab & window navigation

--- a/apps/browser/src/shared/karton-contracts/ui/shared-types.ts
+++ b/apps/browser/src/shared/karton-contracts/ui/shared-types.ts
@@ -527,11 +527,14 @@ export const userPreferencesSchema = z.object({
       startupPage: pageSettingSchema.default({ type: 'home' }),
       /** UI zoom percentage applied to the Stagewise interface (70-130) */
       uiZoomPercentage: z.number().min(70).max(130).default(100),
+      /** Global terminal zoom percentage applied to all terminal tabs (50-150) */
+      terminalZoomPercentage: z.number().min(50).max(150).default(100),
     })
     .default({
       newTabPage: { type: 'home' },
       startupPage: { type: 'home' },
       uiZoomPercentage: 100,
+      terminalZoomPercentage: 100,
     }),
   /** Website permission settings (defaults and host-specific overrides) */
   permissions: z.lazy(() => permissionsPreferencesSchema),
@@ -667,6 +670,7 @@ export const defaultUserPreferences: UserPreferences = {
     newTabPage: { type: 'home' },
     startupPage: { type: 'home' },
     uiZoomPercentage: 100,
+    terminalZoomPercentage: 100,
   },
   permissions: defaultPermissionsForUserPrefs,
   devToolbar: defaultDevToolbarForUserPrefs,

--- a/apps/browser/src/ui/components/web-contents-bounds-syncer.tsx
+++ b/apps/browser/src/ui/components/web-contents-bounds-syncer.tsx
@@ -3,7 +3,7 @@ import {
   useKartonProcedure,
   useKartonState,
 } from '@ui/hooks/use-karton';
-import { useLayoutEffect } from 'react';
+import { useLayoutEffect, useRef } from 'react';
 
 type Bounds = { x: number; y: number; width: number; height: number };
 
@@ -14,6 +14,11 @@ export const WebContentsBoundsSyncer = () => {
   const movePanelToForeground = useKartonProcedure(
     (p) => p.browser.layout.movePanelToForeground,
   );
+  const uiZoomPercentage = useKartonState(
+    (s) => s.preferences.general.uiZoomPercentage,
+  );
+  const uiZoomPercentageRef = useRef(uiZoomPercentage);
+  const sendBoundsUpdateRef = useRef<(() => void) | null>(null);
 
   useLayoutEffect(() => {
     // Don't set up observers if Karton isn't connected yet. Bounds fired
@@ -52,6 +57,7 @@ export const WebContentsBoundsSyncer = () => {
       }
 
       const rect = containerElement.getBoundingClientRect();
+      const uiZoomFactor = uiZoomPercentageRef.current / 100;
 
       if (rect.width <= 0 || rect.height <= 0) {
         // Element exists but hasn't been laid out yet (common during Electron
@@ -68,11 +74,16 @@ export const WebContentsBoundsSyncer = () => {
         return;
       }
 
+      // Electron WebContentsView bounds are in native window coordinates,
+      // while getBoundingClientRect() is reported in renderer CSS pixels.
+      // With UI zoom now applied via webContents.setZoomFactor(), convert
+      // the CSS-pixel rect back to visual/native coordinates before sending
+      // it to the backend.
       const newBounds: Bounds = {
-        x: rect.x,
-        y: rect.y,
-        width: rect.width,
-        height: rect.height,
+        x: Math.round(rect.x * uiZoomFactor),
+        y: Math.round(rect.y * uiZoomFactor),
+        width: Math.round(rect.width * uiZoomFactor),
+        height: Math.round(rect.height * uiZoomFactor),
       };
 
       const boundsChanged =
@@ -87,6 +98,8 @@ export const WebContentsBoundsSyncer = () => {
         lastBounds = newBounds;
       }
     };
+
+    sendBoundsUpdateRef.current = sendBoundsUpdate;
 
     // --- Hover detection logic (driven by mousemove, not polling) ---
 
@@ -244,8 +257,16 @@ export const WebContentsBoundsSyncer = () => {
       }
       // Clean up by hiding
       updateLayout.fire(null);
+      if (sendBoundsUpdateRef.current === sendBoundsUpdate) {
+        sendBoundsUpdateRef.current = null;
+      }
     };
   }, [activeTabId, connected]);
+
+  useLayoutEffect(() => {
+    uiZoomPercentageRef.current = uiZoomPercentage;
+    sendBoundsUpdateRef.current?.();
+  }, [uiZoomPercentage]);
 
   return null;
 };

--- a/apps/browser/src/ui/hooks/use-hotkey-listener.tsx
+++ b/apps/browser/src/ui/hooks/use-hotkey-listener.tsx
@@ -45,8 +45,15 @@ export function useHotKeyListener(
       if (!enabled) return;
 
       // For non-dominant hotkeys, check if a native editable element should consume the event
-      // This allows standard text editing behavior to work (e.g., Cmd+ArrowLeft in inputs)
-      if (!definition.captureDominantly && shouldNativeInputConsumeEvent(ev))
+      // This allows standard text editing behavior to work (e.g., Cmd+ArrowLeft in inputs).
+      // STOP_AGENT is selection-aware at the call site: Ctrl+C should still stop
+      // the agent from chat input when there is no selected text, but preserve
+      // native copy when there is a selection.
+      if (
+        hotKeyAction !== HotkeyActions.STOP_AGENT &&
+        !definition.captureDominantly &&
+        shouldNativeInputConsumeEvent(ev)
+      )
         return;
 
       // The first matching hotkey action will be executed and abort further processing of other hotkey actions.

--- a/apps/browser/src/ui/hooks/use-ui-zoom-counter-scale.ts
+++ b/apps/browser/src/ui/hooks/use-ui-zoom-counter-scale.ts
@@ -5,11 +5,11 @@ import { useKartonState } from './use-karton';
  * Returns the inverse zoom factor for counter-scaling elements that must
  * remain at native pixel size regardless of the UI zoom level.
  *
- * CSS `zoom` scales EVERYTHING including layout boxes, but the macOS
- * traffic lights are OS-drawn at native pixel positions. Elements that
- * align against them (traffic light gutter, titlebar row, toggle button)
- * need to be counter-scaled so their rendered pixel dimensions match the
- * native OS chrome.
+ * Electron renderer zoom scales the Stagewise UI, but the macOS traffic
+ * lights are OS-drawn at native pixel positions. Elements that align against
+ * them (traffic light gutter, titlebar row, toggle button) need to be
+ * counter-scaled so their rendered pixel dimensions match the native OS
+ * chrome.
  *
  * Usage: multiply native pixel values by this factor.
  *

--- a/apps/browser/src/ui/screens/index.tsx
+++ b/apps/browser/src/ui/screens/index.tsx
@@ -15,17 +15,9 @@ export function ScreenRouter() {
   const hasSeenOnboarding = useKartonState(
     (s) => s.userExperience.storedExperienceData.hasSeenOnboardingFlow,
   );
-  const uiZoomPercentage = useKartonState(
-    (s) => s.preferences.general.uiZoomPercentage,
-  );
 
   return (
-    <div
-      className="fixed inset-0"
-      style={{
-        zoom: uiZoomPercentage / 100,
-      }}
-    >
+    <div className="fixed inset-0">
       {!connected || hasSeenOnboarding === null ? (
         <div className="absolute inset-0 flex size-full flex-col items-center justify-center gap-4">
           <Logo

--- a/apps/browser/src/ui/screens/main/_components/global-hotkey-bindings.tsx
+++ b/apps/browser/src/ui/screens/main/_components/global-hotkey-bindings.tsx
@@ -242,8 +242,8 @@ export function GlobalHotkeyBindings() {
 
   // -- UI zoom (Mod+=, Mod+-, Mod+0) ------------------------------------
   // Only applies when keyboard focus is on stagewise UI chrome.
-  // When tab-content has focus, returns false so BrowserTabHotkeys
-  // (which registers later in the same capture phase) handles it.
+  // When tab-content has focus, returns false so browser-tab or terminal
+  // scoped zoom handlers can handle the same zoom hotkey.
   const preferences = useKartonState((s) => s.preferences);
   const updatePreferences = useKartonProcedure((p) => p.preferences.update);
   const uiZoomPercentage = useKartonState(
@@ -255,32 +255,34 @@ export function GlobalHotkeyBindings() {
     ? (tabUiState[activeTabId]?.focusedPanel ?? 'stagewise-ui')
     : 'stagewise-ui';
 
+  const shouldDeferToTabZoom = focusedPanel === 'tab-content';
+
   const handleUiZoomIn = useCallback(() => {
-    if (focusedPanel === 'tab-content') return false;
+    if (shouldDeferToTabZoom) return false;
     if (uiZoomPercentage >= 130) return;
     const [, patches] = produceWithPatches(preferences, (draft) => {
       draft.general.uiZoomPercentage = Math.min(uiZoomPercentage + 10, 130);
     });
     void updatePreferences(patches);
-  }, [focusedPanel, uiZoomPercentage, preferences, updatePreferences]);
+  }, [shouldDeferToTabZoom, uiZoomPercentage, preferences, updatePreferences]);
 
   const handleUiZoomOut = useCallback(() => {
-    if (focusedPanel === 'tab-content') return false;
+    if (shouldDeferToTabZoom) return false;
     if (uiZoomPercentage <= 70) return;
     const [, patches] = produceWithPatches(preferences, (draft) => {
       draft.general.uiZoomPercentage = Math.max(uiZoomPercentage - 10, 70);
     });
     void updatePreferences(patches);
-  }, [focusedPanel, uiZoomPercentage, preferences, updatePreferences]);
+  }, [shouldDeferToTabZoom, uiZoomPercentage, preferences, updatePreferences]);
 
   const handleUiZoomReset = useCallback(() => {
-    if (focusedPanel === 'tab-content') return false;
+    if (shouldDeferToTabZoom) return false;
     if (uiZoomPercentage === 100) return;
     const [, patches] = produceWithPatches(preferences, (draft) => {
       draft.general.uiZoomPercentage = 100;
     });
     void updatePreferences(patches);
-  }, [focusedPanel, uiZoomPercentage, preferences, updatePreferences]);
+  }, [shouldDeferToTabZoom, uiZoomPercentage, preferences, updatePreferences]);
 
   useHotKeyListener(
     handleUiZoomIn,

--- a/apps/browser/src/ui/screens/main/_components/global-hotkey-bindings.tsx
+++ b/apps/browser/src/ui/screens/main/_components/global-hotkey-bindings.tsx
@@ -6,11 +6,15 @@ import {
 } from '@shared/hotkeys';
 import { SETTINGS_PAGE_URL } from '@shared/internal-urls';
 import { useHotKeyListener } from '@ui/hooks/use-hotkey-listener';
-import { useKartonProcedure } from '@ui/hooks/use-karton';
+import { useKartonProcedure, useKartonState } from '@ui/hooks/use-karton';
+import { useTabUIState } from '@ui/hooks/use-tab-ui-state';
 import { useAgentSwitcher } from '@ui/hooks/use-open-chat';
 import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { produceWithPatches, enablePatches } from 'immer';
 import { useSidebarCollapsed } from './sidebar-collapsed-context';
 import { useCommandCenter } from '../command-center';
+
+enablePatches();
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -233,6 +237,64 @@ export function GlobalHotkeyBindings() {
   useHotKeyListener(
     () => toggleSidebar(),
     HotkeyActions.TOGGLE_SIDEBAR,
+    globalHotkeysEnabled,
+  );
+
+  // -- UI zoom (Mod+=, Mod+-, Mod+0) ------------------------------------
+  // Only applies when keyboard focus is on stagewise UI chrome.
+  // When tab-content has focus, returns false so BrowserTabHotkeys
+  // (which registers later in the same capture phase) handles it.
+  const preferences = useKartonState((s) => s.preferences);
+  const updatePreferences = useKartonProcedure((p) => p.preferences.update);
+  const uiZoomPercentage = useKartonState(
+    (s) => s.preferences.general.uiZoomPercentage,
+  );
+  const activeTabId = useKartonState((s) => s.contentTabs.activeTabId);
+  const { tabUiState } = useTabUIState();
+  const focusedPanel = activeTabId
+    ? (tabUiState[activeTabId]?.focusedPanel ?? 'stagewise-ui')
+    : 'stagewise-ui';
+
+  const handleUiZoomIn = useCallback(() => {
+    if (focusedPanel === 'tab-content') return false;
+    if (uiZoomPercentage >= 130) return;
+    const [, patches] = produceWithPatches(preferences, (draft) => {
+      draft.general.uiZoomPercentage = Math.min(uiZoomPercentage + 10, 130);
+    });
+    void updatePreferences(patches);
+  }, [focusedPanel, uiZoomPercentage, preferences, updatePreferences]);
+
+  const handleUiZoomOut = useCallback(() => {
+    if (focusedPanel === 'tab-content') return false;
+    if (uiZoomPercentage <= 70) return;
+    const [, patches] = produceWithPatches(preferences, (draft) => {
+      draft.general.uiZoomPercentage = Math.max(uiZoomPercentage - 10, 70);
+    });
+    void updatePreferences(patches);
+  }, [focusedPanel, uiZoomPercentage, preferences, updatePreferences]);
+
+  const handleUiZoomReset = useCallback(() => {
+    if (focusedPanel === 'tab-content') return false;
+    if (uiZoomPercentage === 100) return;
+    const [, patches] = produceWithPatches(preferences, (draft) => {
+      draft.general.uiZoomPercentage = 100;
+    });
+    void updatePreferences(patches);
+  }, [focusedPanel, uiZoomPercentage, preferences, updatePreferences]);
+
+  useHotKeyListener(
+    handleUiZoomIn,
+    HotkeyActions.ZOOM_IN,
+    globalHotkeysEnabled,
+  );
+  useHotKeyListener(
+    handleUiZoomOut,
+    HotkeyActions.ZOOM_OUT,
+    globalHotkeysEnabled,
+  );
+  useHotKeyListener(
+    handleUiZoomReset,
+    HotkeyActions.ZOOM_RESET,
     globalHotkeysEnabled,
   );
 

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/panel-footer.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/panel-footer.tsx
@@ -27,7 +27,6 @@ import {
 } from '@ui/hooks/use-karton';
 import { useHotKeyListener } from '@ui/hooks/use-hotkey-listener';
 import { useEventListener } from '@ui/hooks/use-event-listener';
-import { useTabUIState } from '@ui/hooks/use-tab-ui-state';
 import { useTrack } from '@ui/hooks/use-track';
 import {
   ChatInput,
@@ -300,15 +299,6 @@ export const ChatPanelFooter = memo(function ChatPanelFooter() {
   );
 
   const activeTabId = useKartonState((s) => s.contentTabs.activeTabId);
-  const activeTabIsTerminal = useKartonState((s) =>
-    activeTabId ? s.contentTabs.tabs[activeTabId]?.type === 'terminal' : false,
-  );
-  const { tabUiState } = useTabUIState();
-  const activeFocusedPanel = activeTabId
-    ? (tabUiState[activeTabId]?.focusedPanel ?? 'stagewise-ui')
-    : 'stagewise-ui';
-  const terminalHasFocus =
-    activeTabIsTerminal && activeFocusedPanel === 'tab-content';
 
   const elementSelectionActive = useMemo(() => {
     if (activeEditMessageId) return false;
@@ -1248,11 +1238,10 @@ export const ChatPanelFooter = memo(function ChatPanelFooter() {
   useHotKeyListener(
     useCallback(
       (event: KeyboardEvent) => {
-        if (terminalHasFocus) return false;
         if (shouldPreserveNativeCopy(event)) return false;
         void abortAgentRef.current();
       },
-      [shouldPreserveNativeCopy, terminalHasFocus],
+      [shouldPreserveNativeCopy],
     ),
     HotkeyActions.STOP_AGENT,
     isWorking && !hasPendingQuestion,

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/panel-footer.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/panel-footer.tsx
@@ -27,6 +27,7 @@ import {
 } from '@ui/hooks/use-karton';
 import { useHotKeyListener } from '@ui/hooks/use-hotkey-listener';
 import { useEventListener } from '@ui/hooks/use-event-listener';
+import { useTabUIState } from '@ui/hooks/use-tab-ui-state';
 import { useTrack } from '@ui/hooks/use-track';
 import {
   ChatInput,
@@ -299,6 +300,15 @@ export const ChatPanelFooter = memo(function ChatPanelFooter() {
   );
 
   const activeTabId = useKartonState((s) => s.contentTabs.activeTabId);
+  const activeTabIsTerminal = useKartonState((s) =>
+    activeTabId ? s.contentTabs.tabs[activeTabId]?.type === 'terminal' : false,
+  );
+  const { tabUiState } = useTabUIState();
+  const activeFocusedPanel = activeTabId
+    ? (tabUiState[activeTabId]?.focusedPanel ?? 'stagewise-ui')
+    : 'stagewise-ui';
+  const terminalHasFocus =
+    activeTabIsTerminal && activeFocusedPanel === 'tab-content';
 
   const elementSelectionActive = useMemo(() => {
     if (activeEditMessageId) return false;
@@ -1238,10 +1248,11 @@ export const ChatPanelFooter = memo(function ChatPanelFooter() {
   useHotKeyListener(
     useCallback(
       (event: KeyboardEvent) => {
+        if (terminalHasFocus) return false;
         if (shouldPreserveNativeCopy(event)) return false;
         void abortAgentRef.current();
       },
-      [shouldPreserveNativeCopy],
+      [shouldPreserveNativeCopy, terminalHasFocus],
     ),
     HotkeyActions.STOP_AGENT,
     isWorking && !hasPendingQuestion,

--- a/apps/browser/src/ui/screens/main/content/_components/browser-tab-hotkeys.tsx
+++ b/apps/browser/src/ui/screens/main/content/_components/browser-tab-hotkeys.tsx
@@ -47,19 +47,18 @@ export function BrowserTabHotkeys({
     activeTabIdRef.current = activeTabId;
   }, [activeTabId]);
 
-  // Tab-content zoom — applies to both browser and terminal tabs.
-  // When keyboard focus is inside the tab content (not stagewise UI).
-  // Returns false when stagewise-ui has focus so GlobalHotkeyBindings
-  // (registered earlier in the same capture phase) handles UI zoom.
+  // Browser tab-content zoom. Terminal zoom is handled locally in
+  // PerTerminalContent so it can mark/require terminal focus explicitly.
   useHotKeyListener(() => {
+    if (isTerminalTab) return false;
     if (focusedPanel !== 'tab-content') return false;
     if (!activeTabId || !currentZoomPercentage) return;
-    const max = isTerminalTab ? 150 : 500;
-    if (currentZoomPercentage >= max) return;
+    if (currentZoomPercentage >= 500) return;
     setZoomPercentage(currentZoomPercentage + 10, activeTabId);
   }, HotkeyActions.ZOOM_IN);
 
   useHotKeyListener(() => {
+    if (isTerminalTab) return false;
     if (focusedPanel !== 'tab-content') return false;
     if (!activeTabId || !currentZoomPercentage) return;
     if (currentZoomPercentage <= 50) return;
@@ -67,6 +66,7 @@ export function BrowserTabHotkeys({
   }, HotkeyActions.ZOOM_OUT);
 
   useHotKeyListener(() => {
+    if (isTerminalTab) return false;
     if (focusedPanel !== 'tab-content') return false;
     if (!activeTabId) return;
     setZoomPercentage(100, activeTabId);

--- a/apps/browser/src/ui/screens/main/content/_components/browser-tab-hotkeys.tsx
+++ b/apps/browser/src/ui/screens/main/content/_components/browser-tab-hotkeys.tsx
@@ -2,15 +2,12 @@ import { useHotKeyListener } from '@ui/hooks/use-hotkey-listener';
 import { HotkeyActions } from '@shared/hotkeys';
 import { useKartonState, useKartonProcedure } from '@ui/hooks/use-karton';
 import { useTabUIState } from '@ui/hooks/use-tab-ui-state';
-import { produceWithPatches, enablePatches } from 'immer';
 import { useEffect, useRef } from 'react';
-
-enablePatches();
 
 /**
  * Browser-tab–scoped hotkeys — mounted per content panel. Handles
  * per-tab web actions: history navigation, page reload, find, dev tools,
- * zoom, and URL bar focus.
+ * tab-content zoom, and URL bar focus.
  */
 export function BrowserTabHotkeys({
   onFocusUrlBar,
@@ -37,12 +34,6 @@ export function BrowserTabHotkeys({
     (p) => p.browser.setZoomPercentage,
   );
 
-  const preferences = useKartonState((s) => s.preferences);
-  const updatePreferences = useKartonProcedure((p) => p.preferences.update);
-  const uiZoomPercentage = useKartonState(
-    (s) => s.preferences.general.uiZoomPercentage,
-  );
-
   const currentZoomPercentage = useKartonState((s) =>
     activeTabId ? s.contentTabs.tabs[activeTabId]?.zoomPercentage : 100,
   );
@@ -56,46 +47,28 @@ export function BrowserTabHotkeys({
     activeTabIdRef.current = activeTabId;
   }, [activeTabId]);
 
-  // Zoom helpers
+  // Tab-content zoom — only applies when keyboard focus is inside a
+  // web page. Returns false when stagewise-ui has focus so the
+  // GlobalHotkeyBindings UI zoom handler (registered earlier in the
+  // same capture phase) can handle it.
   useHotKeyListener(() => {
-    if (focusedPanel === 'tab-content') {
-      if (!activeTabId || !currentZoomPercentage || isTerminalTab) return;
-      if (currentZoomPercentage >= 500) return;
-      setZoomPercentage(currentZoomPercentage + 10, activeTabId);
-    } else {
-      if (uiZoomPercentage >= 130) return;
-      const [, patches] = produceWithPatches(preferences, (draft) => {
-        draft.general.uiZoomPercentage = Math.min(uiZoomPercentage + 10, 130);
-      });
-      void updatePreferences(patches);
-    }
+    if (focusedPanel !== 'tab-content') return false;
+    if (!activeTabId || !currentZoomPercentage || isTerminalTab) return;
+    if (currentZoomPercentage >= 500) return;
+    setZoomPercentage(currentZoomPercentage + 10, activeTabId);
   }, HotkeyActions.ZOOM_IN);
 
   useHotKeyListener(() => {
-    if (focusedPanel === 'tab-content') {
-      if (!activeTabId || !currentZoomPercentage || isTerminalTab) return;
-      if (currentZoomPercentage <= 50) return;
-      setZoomPercentage(currentZoomPercentage - 10, activeTabId);
-    } else {
-      if (uiZoomPercentage <= 70) return;
-      const [, patches] = produceWithPatches(preferences, (draft) => {
-        draft.general.uiZoomPercentage = Math.max(uiZoomPercentage - 10, 70);
-      });
-      void updatePreferences(patches);
-    }
+    if (focusedPanel !== 'tab-content') return false;
+    if (!activeTabId || !currentZoomPercentage || isTerminalTab) return;
+    if (currentZoomPercentage <= 50) return;
+    setZoomPercentage(currentZoomPercentage - 10, activeTabId);
   }, HotkeyActions.ZOOM_OUT);
 
   useHotKeyListener(() => {
-    if (focusedPanel === 'tab-content') {
-      if (!activeTabId || isTerminalTab) return;
-      setZoomPercentage(100, activeTabId);
-    } else {
-      if (uiZoomPercentage === 100) return;
-      const [, patches] = produceWithPatches(preferences, (draft) => {
-        draft.general.uiZoomPercentage = 100;
-      });
-      void updatePreferences(patches);
-    }
+    if (focusedPanel !== 'tab-content') return false;
+    if (!activeTabId || isTerminalTab) return;
+    setZoomPercentage(100, activeTabId);
   }, HotkeyActions.ZOOM_RESET);
 
   // URL bar (Mod+Alt+L): always focus the omnibox.

--- a/apps/browser/src/ui/screens/main/content/_components/browser-tab-hotkeys.tsx
+++ b/apps/browser/src/ui/screens/main/content/_components/browser-tab-hotkeys.tsx
@@ -47,27 +47,27 @@ export function BrowserTabHotkeys({
     activeTabIdRef.current = activeTabId;
   }, [activeTabId]);
 
-  // Tab-content zoom — only applies when keyboard focus is inside a
-  // web page. Returns false when stagewise-ui has focus so the
-  // GlobalHotkeyBindings UI zoom handler (registered earlier in the
-  // same capture phase) can handle it.
+  // Tab-content zoom — applies to both browser and terminal tabs.
+  // When keyboard focus is inside the tab content (not stagewise UI).
+  // Returns false when stagewise-ui has focus so GlobalHotkeyBindings
+  // (registered earlier in the same capture phase) handles UI zoom.
   useHotKeyListener(() => {
     if (focusedPanel !== 'tab-content') return false;
-    if (!activeTabId || !currentZoomPercentage || isTerminalTab) return;
+    if (!activeTabId || !currentZoomPercentage) return;
     if (currentZoomPercentage >= 500) return;
     setZoomPercentage(currentZoomPercentage + 10, activeTabId);
   }, HotkeyActions.ZOOM_IN);
 
   useHotKeyListener(() => {
     if (focusedPanel !== 'tab-content') return false;
-    if (!activeTabId || !currentZoomPercentage || isTerminalTab) return;
+    if (!activeTabId || !currentZoomPercentage) return;
     if (currentZoomPercentage <= 50) return;
     setZoomPercentage(currentZoomPercentage - 10, activeTabId);
   }, HotkeyActions.ZOOM_OUT);
 
   useHotKeyListener(() => {
     if (focusedPanel !== 'tab-content') return false;
-    if (!activeTabId || isTerminalTab) return;
+    if (!activeTabId) return;
     setZoomPercentage(100, activeTabId);
   }, HotkeyActions.ZOOM_RESET);
 

--- a/apps/browser/src/ui/screens/main/content/_components/browser-tab-hotkeys.tsx
+++ b/apps/browser/src/ui/screens/main/content/_components/browser-tab-hotkeys.tsx
@@ -54,7 +54,8 @@ export function BrowserTabHotkeys({
   useHotKeyListener(() => {
     if (focusedPanel !== 'tab-content') return false;
     if (!activeTabId || !currentZoomPercentage) return;
-    if (currentZoomPercentage >= 500) return;
+    const max = isTerminalTab ? 150 : 500;
+    if (currentZoomPercentage >= max) return;
     setZoomPercentage(currentZoomPercentage + 10, activeTabId);
   }, HotkeyActions.ZOOM_IN);
 

--- a/apps/browser/src/ui/screens/main/index.tsx
+++ b/apps/browser/src/ui/screens/main/index.tsx
@@ -24,6 +24,7 @@ import {
   ContentCollapsedProvider,
   useContentCollapsed,
 } from './_components/content-collapsed-context';
+import { useTabUIState } from '@ui/hooks/use-tab-ui-state';
 import { ContentToggleButton } from './_components/content-toggle-button';
 import { GlobalHotkeyBindings } from './_components/global-hotkey-bindings';
 import { AgentHotkeyBindings } from './_components/agent-hotkey-bindings';
@@ -58,6 +59,7 @@ function DefaultLayoutInner({ show }: { show: boolean }) {
   const isFullScreen = useKartonState((s) => s.appInfo.isFullScreen);
   const tabs = useKartonState((s) => s.contentTabs.tabs);
   const activeTabId = useKartonState((s) => s.contentTabs.activeTabId);
+  const { setTabUiState } = useTabUIState();
   const [openAgent] = useOpenAgent();
   const { collapsed: sidebarCollapsed } = useSidebarCollapsed();
   const { collapsed: contentCollapsed, setCollapsed: setContentCollapsed } =
@@ -153,6 +155,11 @@ function DefaultLayoutInner({ show }: { show: boolean }) {
     void createTerminal(undefined, openAgent);
   }, [createTerminal, openAgent, contentCollapsed, setContentCollapsed]);
 
+  const markStagewiseUiFocused = useCallback(() => {
+    if (!activeTabId) return;
+    setTabUiState(activeTabId, { focusedPanel: 'stagewise-ui' });
+  }, [activeTabId, setTabUiState]);
+
   // Headless: keeps `openAgent` valid regardless of whether the sidebar
   // (which used to own this effect) is mounted.
   useAutoSelectFirstAgent();
@@ -168,6 +175,8 @@ function DefaultLayoutInner({ show }: { show: boolean }) {
           'root pointer-events-auto relative inset-0 flex size-full flex-row items-stretch justify-between transition-[opacity,filter] delay-150 duration-300 ease-out',
           !show && 'pointer-events-none opacity-0 blur-lg',
         )}
+        onFocusCapture={markStagewiseUiFocused}
+        onPointerDownCapture={markStagewiseUiFocused}
       >
         {/* Single global drag zone for macOS titlebar — sits behind everything */}
         {isMacOs && !isFullScreen && (

--- a/apps/browser/src/ui/screens/main/terminal-panel/_components/per-terminal-content.tsx
+++ b/apps/browser/src/ui/screens/main/terminal-panel/_components/per-terminal-content.tsx
@@ -1,8 +1,11 @@
-import { useEffect, useMemo, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import { Terminal } from '@xterm/xterm';
 import { FitAddon } from '@xterm/addon-fit';
 import { WebglAddon } from '@xterm/addon-webgl';
 import { useKartonProcedure, useKartonState } from '@ui/hooks/use-karton';
+import { useTabUIState } from '@ui/hooks/use-tab-ui-state';
+import { useHotKeyListener } from '@ui/hooks/use-hotkey-listener';
+import { HotkeyActions } from '@shared/hotkeys';
 import '@xterm/xterm/css/xterm.css';
 
 const BASE_FONT_SIZE = 13;
@@ -26,17 +29,17 @@ export function PerTerminalContent({
   /** Absolute backend output offset consumed by this renderer. */
   const consumedOffsetRef = useRef(0);
 
-  // Tab-level zoom (Cmd+=, Cmd+-, Cmd+0).  Terminal tabs use the
-  // same zoomPercentage field as browser tabs; the backend updates
-  // it directly in karton state for terminal-type tabs.
-  const zoomPercentage = useKartonState((s) => {
-    const tab = s.contentTabs.tabs[terminalId];
-    return tab?.zoomPercentage ?? 100;
-  });
-  const fontSize = useMemo(
-    () => Math.round(BASE_FONT_SIZE * (zoomPercentage / 100)),
-    [zoomPercentage],
+  // Global terminal zoom (Cmd+=, Cmd+-, Cmd+0 when terminal has focus).
+  // Persisted in user preferences so it survives app restarts and applies
+  // consistently across all terminal tabs.
+  const zoomPercentage = useKartonState(
+    (s) => s.preferences.general.terminalZoomPercentage,
   );
+  const terminalScale = zoomPercentage / 100;
+
+  // Terminal lives in the normal DOM. UI zoom affects it like any other UI,
+  // while terminal-specific zoom adjusts xterm's own font size.
+  const fontSize = BASE_FONT_SIZE * terminalScale;
 
   const outputBuffer = useKartonState(
     (s) => s.terminals.outputBuffers[terminalId] ?? '',
@@ -52,6 +55,10 @@ export function PerTerminalContent({
   const getTerminalSnapshot = useKartonProcedure(
     (p) => p.browser.getTerminalSnapshot,
   );
+  const updatePreferences = useKartonProcedure((p) => p.preferences.update);
+  const { tabUiState, setTabUiState } = useTabUIState();
+  const isTerminalFocused =
+    tabUiState[terminalId]?.focusedPanel === 'tab-content';
 
   const terminalInputRef = useRef(terminalInput);
   terminalInputRef.current = terminalInput;
@@ -61,6 +68,53 @@ export function PerTerminalContent({
   getTerminalSnapshotRef.current = getTerminalSnapshot;
   const isActiveRef = useRef(isActive);
   isActiveRef.current = isActive;
+
+  const markTerminalFocused = () => {
+    setTabUiState(terminalId, { focusedPanel: 'tab-content' });
+  };
+
+  const updateTerminalZoom = useCallback(
+    (nextZoomPercentage: number) => {
+      void updatePreferences([
+        {
+          op: 'replace',
+          path: ['general', 'terminalZoomPercentage'],
+          value: nextZoomPercentage,
+        },
+      ]);
+    },
+    [updatePreferences],
+  );
+
+  useHotKeyListener(
+    () => {
+      if (!isActive || !isTerminalFocused) return false;
+      if (zoomPercentage >= 150) return;
+      updateTerminalZoom(Math.min(zoomPercentage + 10, 150));
+    },
+    HotkeyActions.ZOOM_IN,
+    isActive,
+  );
+
+  useHotKeyListener(
+    () => {
+      if (!isActive || !isTerminalFocused) return false;
+      if (zoomPercentage <= 50) return;
+      updateTerminalZoom(Math.max(zoomPercentage - 10, 50));
+    },
+    HotkeyActions.ZOOM_OUT,
+    isActive,
+  );
+
+  useHotKeyListener(
+    () => {
+      if (!isActive || !isTerminalFocused) return false;
+      if (zoomPercentage === 100) return;
+      updateTerminalZoom(100);
+    },
+    HotkeyActions.ZOOM_RESET,
+    isActive,
+  );
 
   const sendResize = (immediate = false) => {
     const term = terminalRef.current;
@@ -174,7 +228,7 @@ export function PerTerminalContent({
     try {
       term.loadAddon(new WebglAddon());
     } catch {
-      // Fall back to canvas renderer if WebGL is unavailable.
+      // Fall back to the default renderer if WebGL is unavailable.
     }
 
     let aborted = false;
@@ -202,6 +256,7 @@ export function PerTerminalContent({
       terminalRef.current = term;
 
       term.onData((data: string) => {
+        markTerminalFocused();
         terminalInputRef.current(terminalId, data);
       });
 
@@ -265,23 +320,32 @@ export function PerTerminalContent({
     }
   }, [outputBuffer, baseOffset, endOffset]);
 
-  // Re-fit when font size changes (zoom) or tab becomes active.
+  // Re-fit when terminal zoom or active state changes.
   useEffect(() => {
     if (!isActive) return;
     const term = terminalRef.current;
     const fit = fitAddonRef.current;
     if (!term || !fit) return;
-    const tid = setTimeout(() => {
-      try {
-        term.options.fontSize = fontSize;
-        fit.fit();
-        sendResize(true);
-        term.focus();
-      } catch {
-        // ignore
-      }
-    }, 0);
-    return () => clearTimeout(tid);
+
+    term.options.fontSize = fontSize;
+
+    let frame2 = 0;
+    const frame1 = requestAnimationFrame(() => {
+      frame2 = requestAnimationFrame(() => {
+        try {
+          fit.fit();
+          sendResize(true);
+          term.focus();
+        } catch {
+          // ignore
+        }
+      });
+    });
+
+    return () => {
+      cancelAnimationFrame(frame1);
+      if (frame2) cancelAnimationFrame(frame2);
+    };
   }, [isActive, terminalId, fontSize]);
 
   useEffect(() => {
@@ -308,9 +372,11 @@ export function PerTerminalContent({
 
   return (
     <div
-      ref={containerRef}
-      className="size-full bg-background"
+      className="size-full overflow-hidden bg-background p-1"
       style={{ display: isActive ? undefined : 'none' }}
-    />
+      onPointerDown={markTerminalFocused}
+    >
+      <div ref={containerRef} className="size-full overflow-hidden" />
+    </div>
   );
 }

--- a/apps/browser/src/ui/screens/main/terminal-panel/_components/per-terminal-content.tsx
+++ b/apps/browser/src/ui/screens/main/terminal-panel/_components/per-terminal-content.tsx
@@ -1,9 +1,11 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import { Terminal } from '@xterm/xterm';
 import { FitAddon } from '@xterm/addon-fit';
 import { WebglAddon } from '@xterm/addon-webgl';
 import { useKartonProcedure, useKartonState } from '@ui/hooks/use-karton';
 import '@xterm/xterm/css/xterm.css';
+
+const BASE_FONT_SIZE = 13;
 
 interface PerTerminalContentProps {
   terminalId: string;
@@ -23,6 +25,18 @@ export function PerTerminalContent({
   const lastSentSizeRef = useRef<{ cols: number; rows: number } | null>(null);
   /** Absolute backend output offset consumed by this renderer. */
   const consumedOffsetRef = useRef(0);
+
+  // Tab-level zoom (Cmd+=, Cmd+-, Cmd+0).  Terminal tabs use the
+  // same zoomPercentage field as browser tabs; the backend updates
+  // it directly in karton state for terminal-type tabs.
+  const zoomPercentage = useKartonState((s) => {
+    const tab = s.contentTabs.tabs[terminalId];
+    return tab?.zoomPercentage ?? 100;
+  });
+  const fontSize = useMemo(
+    () => Math.round(BASE_FONT_SIZE * (zoomPercentage / 100)),
+    [zoomPercentage],
+  );
 
   const outputBuffer = useKartonState(
     (s) => s.terminals.outputBuffers[terminalId] ?? '',
@@ -146,7 +160,7 @@ export function PerTerminalContent({
       theme: getTheme(),
       fontFamily:
         "'Roboto Mono', Menlo, Monaco, stagewise-builtin-roboto-mono, 'Noto Sans Mono', ui-monospace, 'SF Mono', 'Segoe UI Mono', 'Ubuntu Mono', 'Noto Mono', 'Liberation Mono', 'Inter Mono', Consolas, monospace",
-      fontSize: 13,
+      fontSize,
       fontWeight: 'normal',
       fontWeightBold: 'bold',
       letterSpacing: 0,
@@ -251,6 +265,7 @@ export function PerTerminalContent({
     }
   }, [outputBuffer, baseOffset, endOffset]);
 
+  // Re-fit when font size changes (zoom) or tab becomes active.
   useEffect(() => {
     if (!isActive) return;
     const term = terminalRef.current;
@@ -258,6 +273,7 @@ export function PerTerminalContent({
     if (!term || !fit) return;
     const tid = setTimeout(() => {
       try {
+        term.options.fontSize = fontSize;
         fit.fit();
         sendResize(true);
         term.focus();
@@ -266,7 +282,7 @@ export function PerTerminalContent({
       }
     }, 0);
     return () => clearTimeout(tid);
-  }, [isActive, terminalId]);
+  }, [isActive, terminalId, fontSize]);
 
   useEffect(() => {
     const container = containerRef.current;
@@ -293,7 +309,7 @@ export function PerTerminalContent({
   return (
     <div
       ref={containerRef}
-      className="size-full bg-background p-1"
+      className="size-full bg-background"
       style={{ display: isActive ? undefined : 'none' }}
     />
   );

--- a/apps/browser/src/ui/screens/main/terminal-panel/_components/per-terminal-content.tsx
+++ b/apps/browser/src/ui/screens/main/terminal-panel/_components/per-terminal-content.tsx
@@ -374,6 +374,7 @@ export function PerTerminalContent({
     <div
       className="size-full overflow-hidden bg-background p-1"
       style={{ display: isActive ? undefined : 'none' }}
+      onFocusCapture={markTerminalFocused}
       onPointerDown={markTerminalFocused}
     >
       <div ref={containerRef} className="size-full overflow-hidden" />


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes zoom hotkeys and focus so Cmd+=/−/0 act on the right target. UI zoom uses Electron webContents zoom, works with no content panel open, and terminals have a separate persistent zoom. Ctrl+C now respects text selection and terminal focus while still stopping the agent when appropriate.

- New Features
  - Terminal zoom: Cmd+=/−/0 when a terminal is focused updates `general.terminalZoomPercentage` (50–150), scales xterm font size, and persists across tabs/sessions.
  - Global UI zoom: Cmd+=/−/0 when Stagewise UI is focused updates `general.uiZoomPercentage` (70–130). Applied via `webContents.setZoomFactor`, works with no content panel open, and applies on startup and preference changes.

- Bug Fixes
  - Correct focus gating for zoom hotkeys: tab-content and terminal handle zoom only when they have focus; otherwise UI zoom runs. Stagewise UI marks focus on pointer/focus capture.
  - Bounds syncing converts CSS px to native coords and re-sends on zoom changes, fixing misaligned `webContents` overlays.
  - Removed root CSS zoom and terminal container padding to eliminate white space/blur; z-order and resizing behave correctly on zoom and window resize.
  - `setZoomPercentage` resolves the active tab when no `tabId` is provided.
  - Ctrl+C is selection-aware in inputs: copies when text is selected; otherwise the STOP_AGENT hotkey runs. Focused terminals still receive Ctrl+C.

<sup>Written for commit bcb93d6dd681cc0dfa432e4089d506c7eeeb2dfe. Summary will update on new commits. <a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1204?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Persistent UI zoom that is applied on startup and kept in sync with preferences.
  * Persistent terminal zoom (50–150%, default 100%) that restores across restarts and adjusts terminal font/fit.

* **Improvements**
  * Global zoom hotkeys (zoom in/out/reset) wired with focus-aware behavior so tab- or terminal-scoped zoom wins when appropriate.
  * Bounds reporting now accounts for UI zoom for more accurate layout.

* **Bug Fixes**
  * Stop-agent and other hotkeys better respect native input and focus state.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stagewise-io/stagewise/pull/1204?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->