### PR TITLE
Schedule nightly release

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -1,6 +1,10 @@
 name: "Nightly Release"
 
 on:
+  schedule:
+    # Run daily at 03:00 UTC. The workflow skips if main has not changed
+    # since the latest nightly tag reachable from main.
+    - cron: '0 3 * * *'
   workflow_dispatch:
     inputs:
       ref:
@@ -23,8 +27,54 @@ permissions:
   contents: read
 
 jobs:
+  should-release:
+    name: Check for main changes
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      should_release: ${{ steps.check.outputs.should_release }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          ref: ${{ inputs.ref || 'main' }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Check latest nightly tag
+        id: check
+        run: |
+          if [ "${{ github.event_name }}" != "schedule" ]; then
+            echo "should_release=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          latest_nightly_tag=$(git tag \
+            --list 'stagewise@*-nightly*' \
+            --merged HEAD \
+            --sort=-version:refname \
+            | head -n 1)
+
+          if [ -z "$latest_nightly_tag" ]; then
+            echo "should_release=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          latest_nightly_commit=$(git rev-list -n 1 "$latest_nightly_tag")
+          current_commit=$(git rev-parse HEAD)
+
+          if [ "$latest_nightly_commit" = "$current_commit" ]; then
+            echo "should_release=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "should_release=true" >> "$GITHUB_OUTPUT"
+          fi
+
   version:
     name: Compute nightly version
+    needs: should-release
+    if: needs.should-release.outputs.should_release == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -79,16 +79,16 @@ The counter is **capped at `999`**. Going beyond would break lexical ordering â€
 
 Nightly versions are generated dynamically by CI and are **not committed** to `apps/browser/package.json`.
 
-Format: `MAJOR.MINOR.PATCH-nightlyYYYYMMDDNNN` (e.g. `1.0.1-nightly20260525001`). The base version is the next patch after the current stable package version. For example, if `apps/browser/package.json` is `1.0.0`, the nightly base is `1.0.1`.
+Format: `MAJOR.MINOR.PATCH-nightlyYYYYMMDDcNNN` (e.g. `1.0.1-nightly20260525c001`). The base version is the next patch after the current stable package version. For example, if `apps/browser/package.json` is `1.0.0`, the nightly base is `1.0.1`.
 
-The nightly suffix is a single SemVer prerelease identifier so the version remains compatible with Squirrel.Windows. `YYYYMMDD` is the UTC date and `NNN` is a 3-digit per-day counter.
+The nightly suffix is a single SemVer prerelease identifier so the version remains compatible with Squirrel.Windows. `YYYYMMDD` is the UTC date and `NNN` is a 3-digit per-day counter. The `c` separator prevents Squirrel.Windows' embedded NuGet parser from reading `YYYYMMDDNNN` as one integer, which overflows Int32.
 
 Examples:
 
 - `1.0.1-alpha001` - First alpha for upcoming 1.0.1
 - `1.0.1-alpha002` - Second alpha
 - `1.0.1-beta001` - First beta (after alpha phase)
-- `1.0.1-nightly20260525001` - Nightly build for the 1.0.1 release line
+- `1.0.1-nightly20260525c001` - Nightly build for the 1.0.1 release line
 - `1.0.1` - Final release
 
 ### Version Transitions

--- a/apps/update-server/spec.md
+++ b/apps/update-server/spec.md
@@ -13,7 +13,7 @@ Build a auto-update / download server that responds to certain request paths wit
   - The app is released and files are hosted in a github repo. Make this configurable as well (`APP_GITHUB_ORG` and `APP_GITHUB_REPO`)
 - The server offers multiple update channels:
   - Release updates (returns only stable versions) under channel `release`.
-  - Nightly updates (returns only nightly versions such as `1.0.1-nightly20260525001`) under channel `nightly`.
+  - Nightly updates (returns only nightly versions such as `1.0.1-nightly20260525c001`) under channel `nightly`.
   - Legacy pre-release updates are kept during the migration window:
     - Alpha channel (returns the latest legacy pre-release, including pre-releases with alpha and beta version suffix) under channel `alpha`.
     - Beta channel (returns the latest legacy pre-release with beta version suffix, but no alpha versions) under channel `beta`.
@@ -36,9 +36,9 @@ Build a auto-update / download server that responds to certain request paths wit
 
 ## App release format
 
-The versioning of the app is in semver with optional suffixes for pre-release versions. Examples: `1.2.3`, `1.1.0-alpha001`, `2.2.0-beta005`, `1.0.1-nightly20260525001`.
+The versioning of the app is in semver with optional suffixes for pre-release versions. Examples: `1.2.3`, `1.1.0-alpha001`, `2.2.0-beta005`, `1.0.1-nightly20260525c001`.
 
-Release versions don't have suffixes. Legacy pre-releases use a suffix with either "alpha" or "beta". Nightly versions use a suffix in the form `nightlyYYYYMMDDNNN`, where `NNN` is a three-digit per-day counter.
+Release versions don't have suffixes. Legacy pre-releases use a suffix with either "alpha" or "beta". Nightly versions use a suffix in the form `nightlyYYYYMMDDcNNN`, where `NNN` is a three-digit per-day counter.
 
 The suffix name and counter are intentionally concatenated without dot separators so Squirrel.Windows' NuGet parser can read versions from update package filenames.
 

--- a/apps/update-server/src/version.ts
+++ b/apps/update-server/src/version.ts
@@ -46,7 +46,7 @@ export function parseVersion(version: string): ParsedVersion | null {
     // This is SemVer 1.0-compatible so Squirrel.Windows' embedded NuGet parser
     // (used client-side on Windows) can handle the filename-derived version.
     const concatenatedMatch = first.match(/^(alpha|beta)(\d+)$/);
-    const nightlyMatch = first.match(/^nightly(\d{8})(\d{3})$/);
+    const nightlyMatch = first.match(/^nightly(\d{8})c(\d{3})$/);
     if (concatenatedMatch) {
       prereleaseType = concatenatedMatch[1] as 'alpha' | 'beta';
       prereleaseNum = Number.parseInt(concatenatedMatch[2], 10);
@@ -95,7 +95,7 @@ export function matchesChannel(
 ): boolean {
   switch (channel) {
     case 'release':
-      return version.prereleaseType === null;
+      return version.prerelease === null;
     case 'nightly':
       return version.prereleaseType === 'nightly';
     case 'beta':

--- a/scripts/release/nightly-version.ts
+++ b/scripts/release/nightly-version.ts
@@ -60,7 +60,7 @@ async function getNextCounter(
   baseVersion: string,
   date: string,
 ): Promise<number> {
-  const tagPrefix = `stagewise@${baseVersion}-nightly${date}`;
+  const tagPrefix = `stagewise@${baseVersion}-nightly${date}c`;
   const { stdout } = await exec(
     `git tag --list "${tagPrefix}*" --sort=-version:refname`,
   );
@@ -68,7 +68,7 @@ async function getNextCounter(
     .split('\n')
     .map((tag) => tag.trim())
     .filter(Boolean)
-    .map((tag) => tag.match(/nightly\d{8}(\d{3})$/)?.[1])
+    .map((tag) => tag.match(/nightly\d{8}c(\d{3})$/)?.[1])
     .filter((counter): counter is string => Boolean(counter))
     .map((counter) => Number.parseInt(counter, 10))
     .filter((counter) => Number.isInteger(counter));
@@ -111,7 +111,7 @@ async function main(): Promise<void> {
   const counter = values.counter
     ? Number.parseInt(values.counter, 10)
     : await getNextCounter(baseVersion, date);
-  const version = `${baseVersion}-nightly${date}${formatCounter(counter)}`;
+  const version = `${baseVersion}-nightly${date}c${formatCounter(counter)}`;
   const tag = `stagewise@${version}`;
 
   if (!semver.valid(version)) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Schedules nightly releases at 03:00 UTC and skips if `main` hasn’t changed since the last nightly. Updates the nightly version format to `nightlyYYYYMMDDcNNN` for Squirrel.Windows compatibility and updates the update server and scripts.

- **New Features**
  - Nightly workflow runs daily at 03:00 UTC and skips when the latest nightly tag on `main` matches `HEAD`.
  - Manual runs still supported via `workflow_dispatch`.

- **Bug Fixes**
  - Switch nightly suffix to `YYYYMMDDcNNN` to prevent Squirrel.Windows/NuGet Int32 overflow; docs updated.
  - Update `apps/update-server` parsing and release script to use the new format; fix release channel check to use `prerelease === null`.

<sup>Written for commit 919bbb4d72ba5d4e12693eaedf2d0faf1e1bb48f. Summary will update on new commits. <a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1207?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Nightly builds now release automatically on a daily schedule, with safeguards to prevent unnecessary releases when code hasn't changed.

* **Documentation**
  * Updated nightly version format from `nightlyYYYYMMDDNNN` to `nightlyYYYYMMDDcNNN` for improved compatibility with update systems.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stagewise-io/stagewise/pull/1207?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->