### PR TITLE
fix(stagewise): apply release version before packaging

### DIFF
--- a/.github/workflows/_release-browser.yml
+++ b/.github/workflows/_release-browser.yml
@@ -175,6 +175,18 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
+      - name: Apply release version to package metadata
+        run: |
+          node -e '
+            const fs = require("node:fs");
+            const path = "apps/browser/package.json";
+            const pkg = JSON.parse(fs.readFileSync(path, "utf8"));
+            pkg.version = process.env.RELEASE_VERSION;
+            fs.writeFileSync(path, `${JSON.stringify(pkg, null, 2)}\n`);
+          '
+        env:
+          RELEASE_VERSION: ${{ inputs.version }}
+
       - name: Import macOS signing certs
         if: runner.os == 'macOS'
         uses: apple-actions/import-codesign-certs@v3


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Write the release version from the workflow input into `apps/browser/package.json` before packaging, ensuring the packaged browser app has the correct version. Fixes version mismatches in stagewise/nightly artifacts.

<sup>Written for commit 0231de8cf1dca7a002466e970aaf5488ed84d8e7. Summary will update on new commits. <a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1208?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release build process to ensure accurate version tracking during browser app deployments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stagewise-io/stagewise/pull/1208?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->