### PR TITLE
fix(stagewise): fix missing sounds in packaged build and add workspace popup actions

### DIFF
--- a/apps/browser/CHANGELOG.md
+++ b/apps/browser/CHANGELOG.md
@@ -5,7 +5,6 @@
 ### Bug Fixes
 
 * reduce cross-icon size on workspace-select (72e6f11)
-
 ## 1.0.0 (2026-05-27)
 
 ### Features
@@ -13,8 +12,6 @@
 * show worktree main as workspacename (59e9b24)
 * prepare nightly release infrastructure (23d9b03)
 * add agent notification sounds (f894e4d)
-* add social-signins to login options (3e36df2)
-* add agent notification sounds (4693c72)
 * show new chat button and title in collapsed sidebar titlebar (e1072d1)
 * add user-controllable terminal tabs (c8d2046)
 * add more shortcut-controls and align design (1cbab15)

--- a/apps/browser/assets/icons/dev/icon.icon/icon.json
+++ b/apps/browser/assets/icons/dev/icon.icon/icon.json
@@ -1,39 +1,71 @@
 {
-  "fill-specializations": [
-    {
-      "value": {
-        "solid": "srgb:0.94902,0.94902,0.94118,1.00000"
-      }
-    },
-    {
-      "appearance": "dark",
-      "value": {
-        "solid": "srgb:0.11765,0.11765,0.11373,1.00000"
-      }
-    }
-  ],
+  "fill": {
+    "solid": "srgb:0.11765,0.11765,0.11373,1.00000"
+  },
   "groups": [
     {
+      "blend-mode": "normal",
+      "blur-material": null,
       "layers": [
         {
-          "fill": {
-            "solid": "srgb:0.97647,0.45098,0.08627,1.00000"
-          },
+          "blend-mode": "normal",
+          "fill-specializations": [
+            {
+              "value": {
+                "solid": "srgb:0.96078,0.61961,0.04314,1.00000"
+              }
+            },
+            {
+              "appearance": "tinted",
+              "value": {
+                "solid": "srgb:1.00000,1.00000,1.00000,0.70000"
+              }
+            }
+          ],
+          "glass-specializations": [
+            {
+              "value": false
+            },
+            {
+              "appearance": "tinted",
+              "value": true
+            }
+          ],
           "image-name": "logo.svg",
           "name": "logo",
           "position": {
-            "scale": 5.53,
-            "translation-in-points": [0, 0]
+            "scale": 6.2,
+            "translation-in-points": [-12, -12]
           }
         }
       ],
-      "shadow": {
-        "kind": "layer-color",
-        "opacity": 1
-      },
+      "name": "Group",
+      "shadow-specializations": [
+        {
+          "value": {
+            "kind": "neutral",
+            "opacity": 0.5
+          }
+        },
+        {
+          "appearance": "light",
+          "value": {
+            "kind": "neutral",
+            "opacity": 0.5
+          }
+        },
+        {
+          "appearance": "dark",
+          "value": {
+            "kind": "neutral",
+            "opacity": 0.1
+          }
+        }
+      ],
+      "specular": true,
       "translucency": {
         "enabled": true,
-        "value": 0.2
+        "value": 0.65
       }
     }
   ],

--- a/apps/browser/assets/icons/prerelease/icon.icon/icon.json
+++ b/apps/browser/assets/icons/prerelease/icon.icon/icon.json
@@ -1,17 +1,7 @@
 {
-  "fill-specializations": [
-    {
-      "value": {
-        "solid": "srgb:0.94902,0.94902,0.94118,1.00000"
-      }
-    },
-    {
-      "appearance": "dark",
-      "value": {
-        "solid": "srgb:0.11765,0.11765,0.11373,1.00000"
-      }
-    }
-  ],
+  "fill": {
+    "solid": "srgb:0.11765,0.11765,0.11373,1.00000"
+  },
   "groups": [
     {
       "blur-material": null,
@@ -25,24 +15,46 @@
             },
             {
               "appearance": "tinted",
-              "value": "automatic"
+              "value": {
+                "solid": "srgb:1.00000,1.00000,1.00000,0.70000"
+              }
+            }
+          ],
+          "glass-specializations": [
+            {
+              "value": false
+            },
+            {
+              "appearance": "tinted",
+              "value": true
             }
           ],
           "image-name": "logo.svg",
           "name": "logo",
           "position": {
-            "scale": 5.53,
-            "translation-in-points": [0, 0]
+            "scale": 6.2,
+            "translation-in-points": [-12, -12]
           }
         }
       ],
-      "shadow": {
-        "kind": "layer-color",
-        "opacity": 1
-      },
+      "shadow-specializations": [
+        {
+          "value": {
+            "kind": "neutral",
+            "opacity": 0.5
+          }
+        },
+        {
+          "appearance": "dark",
+          "value": {
+            "kind": "neutral",
+            "opacity": 0.1
+          }
+        }
+      ],
       "translucency": {
         "enabled": true,
-        "value": 0.2
+        "value": 0.65
       }
     },
     {
@@ -63,13 +75,13 @@
         }
       ],
       "shadow": {
-        "kind": "layer-color",
-        "opacity": 1
+        "kind": "neutral",
+        "opacity": 0.2
       },
       "specular": true,
       "translucency": {
         "enabled": true,
-        "value": 1
+        "value": 0.5
       }
     }
   ],

--- a/apps/browser/assets/icons/release/icon.icon/icon.json
+++ b/apps/browser/assets/icons/release/icon.icon/icon.json
@@ -2,18 +2,19 @@
   "fill-specializations": [
     {
       "value": {
-        "solid": "srgb:0.94902,0.94902,0.94118,1.00000"
+        "solid": "srgb:0.94902,0.94902,0.94510,1.00000"
       }
     },
     {
       "appearance": "dark",
       "value": {
-        "solid": "srgb:0.11765,0.11765,0.11373,1.00000"
+        "solid": "display-p3:0.11765,0.11765,0.11409,1.00000"
       }
     }
   ],
   "groups": [
     {
+      "blend-mode": "normal",
       "blur-material": null,
       "layers": [
         {
@@ -25,28 +26,62 @@
               }
             },
             {
+              "appearance": "dark",
+              "value": {
+                "solid": "srgb:0.19608,0.41176,1.00000,1.00000"
+              }
+            },
+            {
               "appearance": "tinted",
-              "value": "automatic"
+              "value": {
+                "solid": "srgb:1.00000,1.00000,1.00000,0.70000"
+              }
             }
           ],
-          "glass": true,
+          "glass-specializations": [
+            {
+              "value": false
+            },
+            {
+              "appearance": "tinted",
+              "value": true
+            }
+          ],
           "image-name": "logo.svg",
           "name": "logo",
           "position": {
-            "scale": 5.53,
-            "translation-in-points": [0, 0]
+            "scale": 6.2,
+            "translation-in-points": [-12, -12]
           }
         }
       ],
       "name": "Group",
-      "shadow": {
-        "kind": "layer-color",
-        "opacity": 1
-      },
+      "shadow-specializations": [
+        {
+          "value": {
+            "kind": "neutral",
+            "opacity": 0.5
+          }
+        },
+        {
+          "appearance": "light",
+          "value": {
+            "kind": "neutral",
+            "opacity": 0.5
+          }
+        },
+        {
+          "appearance": "dark",
+          "value": {
+            "kind": "neutral",
+            "opacity": 0.1
+          }
+        }
+      ],
       "specular": true,
       "translucency": {
         "enabled": true,
-        "value": 0.2
+        "value": 0.65
       }
     }
   ],

--- a/apps/browser/src/backend/main.ts
+++ b/apps/browser/src/backend/main.ts
@@ -201,9 +201,12 @@ export async function main({ launchOptions: { verbose } }: MainParameters) {
   );
 
   // Resolve the sounds directory.
-  // Packaged: resourcesPath is the asar root. Dev: app.getAppPath() = project root.
-  const appRoot = app.isPackaged ? process.resourcesPath! : app.getAppPath();
-  const soundsDir = path.join(appRoot, 'assets', 'sounds');
+  // Packaged: extraResource copies leaf dirs directly into Resources/.
+  // So ./assets/sounds → Resources/sounds/, NOT Resources/assets/sounds/.
+  // Dev: app.getAppPath() = project root where assets/sounds/ exists.
+  const soundsDir = app.isPackaged
+    ? path.join(process.resourcesPath!, 'sounds')
+    : path.join(app.getAppPath(), 'assets', 'sounds');
   const importedPacksDir = path.join(
     app.getPath('userData'),
     'imported-sound-packs',

--- a/apps/browser/src/backend/services/window-layout/browsing-tab-controller.ts
+++ b/apps/browser/src/backend/services/window-layout/browsing-tab-controller.ts
@@ -37,6 +37,7 @@ import type { TelemetryService } from '../telemetry';
 import {
   canBrowserHandleUrl,
   openFolderFirstFileInIde,
+  revealPathInFileManager,
 } from './protocol-utils';
 import { ContextMenuWebContent } from './utils/context-menu-web-content';
 import {
@@ -1310,13 +1311,13 @@ export class BrowsingTabController extends EventEmitter<TabControllerEventMap> {
     wc.on('will-navigate', (event, url) => {
       if (url.startsWith('stagewise://reveal-file/')) {
         event.preventDefault();
-        const filePath = url
-          .replace('stagewise://reveal-file/', '')
-          .replace(/:\d+$/, '');
+        const filePath = decodeURIComponent(
+          url.replace('stagewise://reveal-file/', '').replace(/:\d+$/, ''),
+        );
         this.logger.debug(
           `[TabController] Revealing file in folder: ${filePath}`,
         );
-        shell.showItemInFolder(filePath);
+        revealPathInFileManager(filePath);
         return;
       }
       if (url.startsWith('stagewise://open-folder-in-ide/')) {
@@ -1332,7 +1333,7 @@ export class BrowsingTabController extends EventEmitter<TabControllerEventMap> {
         );
         if (url.startsWith('file://')) {
           const filePath = fileURLToPath(url).replace(/:\d+$/, '');
-          shell.showItemInFolder(filePath);
+          revealPathInFileManager(filePath);
         } else shell.openExternal(url);
       }
     });
@@ -1580,13 +1581,15 @@ export class BrowsingTabController extends EventEmitter<TabControllerEventMap> {
     wc.setWindowOpenHandler((details) => {
       // Intercept stagewise://reveal-file/ to show file in native file manager
       if (details.url.startsWith('stagewise://reveal-file/')) {
-        const filePath = details.url
-          .replace('stagewise://reveal-file/', '')
-          .replace(/:\d+$/, '');
+        const filePath = decodeURIComponent(
+          details.url
+            .replace('stagewise://reveal-file/', '')
+            .replace(/:\d+$/, ''),
+        );
         this.logger.debug(
           `[TabController] Revealing file in folder: ${filePath}`,
         );
-        shell.showItemInFolder(filePath);
+        revealPathInFileManager(filePath);
         return { action: 'deny' };
       }
 
@@ -1605,7 +1608,7 @@ export class BrowsingTabController extends EventEmitter<TabControllerEventMap> {
         );
         if (details.url.startsWith('file://')) {
           const filePath = fileURLToPath(details.url).replace(/:\d+$/, '');
-          shell.showItemInFolder(filePath);
+          revealPathInFileManager(filePath);
         } else shell.openExternal(details.url);
 
         return { action: 'deny' };

--- a/apps/browser/src/backend/services/window-layout/protocol-utils.ts
+++ b/apps/browser/src/backend/services/window-layout/protocol-utils.ts
@@ -1,4 +1,5 @@
 import { session, shell } from 'electron';
+import fsSync from 'node:fs';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import type { Logger } from '../logger';
@@ -49,6 +50,27 @@ export function canBrowserHandleUrl(url: string): boolean {
  * in the requested IDE. Falls back to revealing the folder in
  * Finder / Explorer if no files exist.
  */
+/**
+ * Reveal a path in the native file manager.
+ * Directories are opened directly (openPath), files are shown in their
+ * parent folder (showItemInFolder).
+ */
+export function revealPathInFileManager(filePath: string): void {
+  try {
+    if (
+      fsSync.existsSync(filePath) &&
+      fsSync.statSync(filePath).isDirectory()
+    ) {
+      shell.openPath(filePath);
+    } else {
+      shell.showItemInFolder(filePath);
+    }
+  } catch {
+    // Fall back to showItemInFolder on any stat error
+    shell.showItemInFolder(filePath);
+  }
+}
+
 export async function openFolderFirstFileInIde(
   url: string,
   logger: Logger,
@@ -73,7 +95,7 @@ export async function openFolderFirstFileInIde(
       const ideUrl = getIDEFileUrl(target, ide);
       logger.debug(`[openFolderFirstFileInIde] Opening first file: ${target}`);
       if (ideUrl.startsWith('stagewise://reveal-file/')) {
-        shell.showItemInFolder(target);
+        revealPathInFileManager(target);
       } else {
         shell.openExternal(ideUrl);
       }
@@ -81,13 +103,13 @@ export async function openFolderFirstFileInIde(
       logger.debug(
         `[openFolderFirstFileInIde] Folder empty, revealing: ${folderPath}`,
       );
-      shell.showItemInFolder(folderPath);
+      revealPathInFileManager(folderPath);
     }
   } catch (err) {
     logger.error(
       `[openFolderFirstFileInIde] Failed to read folder: ${folderPath}`,
       err,
     );
-    shell.showItemInFolder(folderPath);
+    revealPathInFileManager(folderPath);
   }
 }

--- a/apps/browser/src/backend/services/window-layout/ui-controller.ts
+++ b/apps/browser/src/backend/services/window-layout/ui-controller.ts
@@ -15,6 +15,7 @@ import { fileURLToPath, pathToFileURL } from 'node:url';
 import {
   canBrowserHandleUrl,
   openFolderFirstFileInIde,
+  revealPathInFileManager,
 } from './protocol-utils';
 import {
   default as installExtension,
@@ -475,13 +476,13 @@ export class UIController extends EventEmitter<UIControllerEventMap> {
     view.webContents.on('will-navigate', (event, url) => {
       if (url.startsWith('stagewise://reveal-file/')) {
         event.preventDefault();
-        const filePath = url
-          .replace('stagewise://reveal-file/', '')
-          .replace(/:\d+$/, '');
+        const filePath = decodeURIComponent(
+          url.replace('stagewise://reveal-file/', '').replace(/:\d+$/, ''),
+        );
         this.logger.debug(
           `[UIController] Revealing file in folder: ${filePath}`,
         );
-        shell.showItemInFolder(filePath);
+        revealPathInFileManager(filePath);
         return;
       }
       if (url.startsWith('stagewise://open-folder-in-ide/')) {
@@ -493,13 +494,15 @@ export class UIController extends EventEmitter<UIControllerEventMap> {
     view.webContents.setWindowOpenHandler((details) => {
       // Intercept stagewise://reveal-file/ to show file in native file manager
       if (details.url.startsWith('stagewise://reveal-file/')) {
-        const filePath = details.url
-          .replace('stagewise://reveal-file/', '')
-          .replace(/:\d+$/, '');
+        const filePath = decodeURIComponent(
+          details.url
+            .replace('stagewise://reveal-file/', '')
+            .replace(/:\d+$/, ''),
+        );
         this.logger.debug(
           `[UIController] Revealing file in folder: ${filePath}`,
         );
-        shell.showItemInFolder(filePath);
+        revealPathInFileManager(filePath);
         return { action: 'deny' };
       }
 
@@ -518,7 +521,7 @@ export class UIController extends EventEmitter<UIControllerEventMap> {
         );
         if (details.url.startsWith('file://')) {
           const filePath = fileURLToPath(details.url).replace(/:\d+$/, '');
-          shell.showItemInFolder(filePath);
+          revealPathInFileManager(filePath);
         } else shell.openExternal(details.url);
 
         return { action: 'deny' };

--- a/apps/browser/src/shared/hotkeys.ts
+++ b/apps/browser/src/shared/hotkeys.ts
@@ -61,6 +61,7 @@ export enum HotkeyActions {
 
   // Tab & window navigation
   NEW_TAB = 'new_tab',
+  NEW_TERMINAL_TAB = 'new_terminal_tab',
   CLOSE_TAB = 'close_tab',
   NEXT_TAB = 'next_tab',
   PREV_TAB = 'prev_tab',
@@ -192,6 +193,10 @@ export const hotkeyDefinitions: Record<HotkeyActions, HotkeyDefinition> = {
   // Tab & window navigation
   [HotkeyActions.NEW_TAB]: {
     accelerator: 'Mod+T',
+    captureDominantly: true,
+  },
+  [HotkeyActions.NEW_TERMINAL_TAB]: {
+    accelerator: 'Mod+Alt+T',
     captureDominantly: true,
   },
   [HotkeyActions.CLOSE_TAB]: {

--- a/apps/browser/src/shared/ide-url.ts
+++ b/apps/browser/src/shared/ide-url.ts
@@ -1,7 +1,7 @@
 import type { OpenFilesInIde } from '@shared/karton-contracts/ui/shared-types';
 import { getCurrentPlatform } from '@shared/hotkeys';
 
-const nativeFileManagerLabel = (() => {
+export const nativeFileManagerLabel = (() => {
   const platform = getCurrentPlatform();
   if (platform === 'mac') return 'Finder';
   if (platform === 'windows') return 'Explorer';
@@ -60,7 +60,7 @@ export const getIDEFileUrl = (
       url = `kiro://file/${absFilePath}`;
       break;
     case 'other':
-      url = `stagewise://reveal-file/${absFilePath}`;
+      url = `stagewise://reveal-file/${encodeURIComponent(absFilePath)}`;
       break;
   }
   if (lineNumber) url += `:${lineNumber}`;

--- a/apps/browser/src/ui/screens/main/_components/agent-hotkey-bindings.tsx
+++ b/apps/browser/src/ui/screens/main/_components/agent-hotkey-bindings.tsx
@@ -14,8 +14,10 @@ import { useCommandCenter } from '../command-center';
  */
 export function AgentHotkeyBindings({
   onCreateTab,
+  onCreateTerminalTab,
 }: {
   onCreateTab: () => void;
+  onCreateTerminalTab: () => void;
 }) {
   // -- Content panel toggle (Mod+Alt+B) ----------------------------------
   const { collapsed: contentCollapsed, setCollapsed: setContentCollapsed } =
@@ -46,6 +48,16 @@ export function AgentHotkeyBindings({
       onCreateTab();
     },
     HotkeyActions.NEW_TAB,
+    agentHotkeysEnabled,
+  );
+
+  // Mod+Alt+T: new terminal tab
+  useHotKeyListener(
+    () => {
+      if (contentCollapsed) setContentCollapsed(false);
+      onCreateTerminalTab();
+    },
+    HotkeyActions.NEW_TERMINAL_TAB,
     agentHotkeysEnabled,
   );
 

--- a/apps/browser/src/ui/screens/main/_components/new-tab-buttons.tsx
+++ b/apps/browser/src/ui/screens/main/_components/new-tab-buttons.tsx
@@ -4,6 +4,8 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from '@stagewise/stage-ui/components/tooltip';
+import { HotkeyActions } from '@shared/hotkeys';
+import { HotkeyCombo } from '@ui/components/hotkey-combo';
 import { GlobePlusIcon } from './globe-plus-icon';
 import { WindowPlusIcon } from '../terminal-panel/_components/window-plus-icon';
 
@@ -32,7 +34,12 @@ export function NewTabButtons({
             <GlobePlusIcon className="size-4" />
           </Button>
         </TooltipTrigger>
-        <TooltipContent>Open browsing tab</TooltipContent>
+        <TooltipContent>
+          <span className="flex items-center gap-1.5">
+            <span>Open browsing tab</span>
+            <HotkeyCombo action={HotkeyActions.NEW_TAB} size="xs" />
+          </span>
+        </TooltipContent>
       </Tooltip>
       <Tooltip>
         <TooltipTrigger>
@@ -46,7 +53,12 @@ export function NewTabButtons({
             <WindowPlusIcon className="size-4" />
           </Button>
         </TooltipTrigger>
-        <TooltipContent>Open terminal tab</TooltipContent>
+        <TooltipContent>
+          <span className="flex items-center gap-1.5">
+            <span>Open terminal tab</span>
+            <HotkeyCombo action={HotkeyActions.NEW_TERMINAL_TAB} size="xs" />
+          </span>
+        </TooltipContent>
       </Tooltip>
     </div>
   );

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/workspace-select.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/workspace-select.tsx
@@ -30,7 +30,9 @@ import {
   IconCodeBranchOutline18,
   IconCopyOutline18,
   IconFolder5Outline18,
+  IconFolderOpenOutline18,
   IconPenDrawSparkleOutline18,
+  IconSquareTerminalOutline18,
 } from 'nucleo-ui-outline-18';
 import {
   Tooltip,
@@ -52,7 +54,11 @@ import { useScrollFadeMask } from '@ui/hooks/use-scroll-fade-mask';
 import { useTrack } from '@ui/hooks/use-track';
 import { useHotKeyListener } from '@ui/hooks/use-hotkey-listener';
 import { IdeLogo } from '@ui/components/ide-logo';
-import { getIDEFileUrl, IDE_SELECTION_ITEMS } from '@ui/utils';
+import {
+  getIDEFileUrl,
+  IDE_SELECTION_ITEMS,
+  nativeFileManagerLabel,
+} from '@ui/utils';
 import { HotkeyActions } from '@shared/hotkeys';
 import { getBaseName } from '@shared/path-utils';
 import { FileContextMenu } from '@ui/components/file-context-menu';
@@ -72,6 +78,7 @@ import {
 } from '@shared/karton-contracts/ui';
 import { AgentTypes } from '@shared/karton-contracts/ui/agent';
 import { useOpenAgent } from '@ui/hooks/use-open-chat';
+import { useContentCollapsed } from '@ui/screens/main/_components/content-collapsed-context';
 import {
   memo,
   useCallback,
@@ -932,12 +939,44 @@ function WorkspacePreviewCardContent({
   const hasSkills = mount.skills.length > 0;
   const gitRef = mount.git ? formatGitRef(mount.git) : null;
   const gitStatus = mount.git ? formatGitStatus(mount.git.status) : null;
+  const [openAgent] = useOpenAgent();
+  const createTerminal = useKartonProcedure((p) => p.browser.createTerminal);
+  const { collapsed: contentCollapsed, setCollapsed: setContentCollapsed } =
+    useContentCollapsed();
 
   const handleCopyPath = useCallback(
     (event: React.MouseEvent) => {
       event.stopPropagation();
       event.preventDefault();
       void navigator.clipboard?.writeText(mount.path);
+    },
+    [mount.path],
+  );
+
+  const handleOpenTerminal = useCallback(
+    (event: React.MouseEvent) => {
+      event.stopPropagation();
+      event.preventDefault();
+      if (contentCollapsed) setContentCollapsed(false);
+      void createTerminal(mount.path, openAgent);
+    },
+    [
+      mount.path,
+      openAgent,
+      createTerminal,
+      contentCollapsed,
+      setContentCollapsed,
+    ],
+  );
+
+  const handleRevealInFileManager = useCallback(
+    (event: React.MouseEvent) => {
+      event.stopPropagation();
+      event.preventDefault();
+      window.open(
+        `stagewise://reveal-file/${encodeURIComponent(mount.path)}`,
+        '_blank',
+      );
     },
     [mount.path],
   );
@@ -1011,7 +1050,37 @@ function WorkspacePreviewCardContent({
         </div>
       )}
 
-      <div className="flex justify-end gap-0.5 px-2.5 py-1.5">
+      <div className="flex justify-end gap-1.5 px-2 py-1.5">
+        <Tooltip>
+          <TooltipTrigger>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-2xs"
+              aria-label="Open terminal"
+              onClick={handleOpenTerminal}
+              className="text-muted-foreground hover:text-foreground focus-visible:text-foreground"
+            >
+              <IconSquareTerminalOutline18 className="size-3.5" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>Open terminal</TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-2xs"
+              aria-label={`Reveal in ${nativeFileManagerLabel}`}
+              onClick={handleRevealInFileManager}
+              className="text-muted-foreground hover:text-foreground focus-visible:text-foreground"
+            >
+              <IconFolderOpenOutline18 className="size-3.5" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>Reveal in {nativeFileManagerLabel}</TooltipContent>
+        </Tooltip>
         <Tooltip>
           <TooltipTrigger>
             <Button

--- a/apps/browser/src/ui/screens/main/index.tsx
+++ b/apps/browser/src/ui/screens/main/index.tsx
@@ -167,7 +167,12 @@ function DefaultLayoutInner({ show }: { show: boolean }) {
   return (
     <>
       {show && <GlobalHotkeyBindings />}
-      {show && <AgentHotkeyBindings onCreateTab={handleCreateTab} />}
+      {show && (
+        <AgentHotkeyBindings
+          onCreateTab={handleCreateTab}
+          onCreateTerminalTab={handleOpenTerminal}
+        />
+      )}
       {show && <CommandCenterHotkeys />}
       {show && <CommandCenter />}
       <div

--- a/apps/browser/src/ui/utils.tsx
+++ b/apps/browser/src/ui/utils.tsx
@@ -319,7 +319,11 @@ export const getTruncatedFileUrl = (
   return `${leadingSep || ''}${truncatedPath}`;
 };
 
-export { IDE_SELECTION_ITEMS, getIDEFileUrl } from '@shared/ide-url';
+export {
+  IDE_SELECTION_ITEMS,
+  getIDEFileUrl,
+  nativeFileManagerLabel,
+} from '@shared/ide-url';
 
 /**
  * Extract an image URL from drag-and-drop data transfer.


### PR DESCRIPTION
closes #1206 

- Fix sound path resolution in packaged builds — extraResource copies leaf directories directly into Resources/, so sounds live at Resources/sounds/ not Resources/assets/sounds/
- Add terminal button to workspace preview popup — opens a terminal with the worktree as cwd, expanding the content panel if collapsed
- Add reveal-in-Finder button to workspace preview popup
- Update macOS Tahoe icon designs across all release channels

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes notification sounds in packaged builds, improves file reveal handling, and adds quick workspace actions and a Mod+Alt+T shortcut for new terminal tabs. Also refreshes macOS Tahoe app icons across release channels.

- **Bug Fixes**
  - Correct sound asset path in packaged apps (Resources/sounds instead of Resources/assets/sounds) so notification sounds play.
  - Make “reveal file” robust: open folders directly, handle spaces/special characters via URL encoding, and centralize logic.

- **New Features**
  - Add “Open terminal” and “Reveal in native file manager” to the workspace preview; terminal opens with the worktree as cwd and expands the content panel if collapsed.
  - Add Mod+Alt+T to open a new terminal tab and show hotkey hints in new-tab tooltips.

<sup>Written for commit c01f3dac7c05ca2b600768fd582c4200b97b8924. Summary will update on new commits. <a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1209?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Open terminal" and "Reveal in Finder" action buttons to workspace preview cards
  * Introduced keyboard shortcut (Mod+Alt+T) to create new terminal tabs
  * Added hotkey tooltips to new tab buttons for improved discoverability

* **Bug Fixes**
  * Fixed file path handling when paths contain special characters
  * Corrected notification sounds directory path in packaged builds

* **Chores**
  * Updated application icon visual styling

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stagewise-io/stagewise/pull/1209?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->