### PR TITLE
fix(stagewise): ignore prerelease tags for stable baseline

### DIFF
--- a/scripts/release/git-utils.ts
+++ b/scripts/release/git-utils.ts
@@ -33,10 +33,10 @@ export async function getLastStableTag(prefix: string): Promise<string | null> {
     );
     const tags = stdout.trim().split('\n').filter(Boolean);
 
-    // Find the first tag that doesn't contain alpha or beta
+    // Find the first tag without any prerelease suffix.
     for (const tag of tags) {
       const version = tag.replace(prefix, '');
-      if (!version.includes('-alpha') && !version.includes('-beta')) {
+      if (!version.includes('-')) {
         return tag;
       }
     }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix stagewise changelog baseline by skipping prerelease tags (e.g., -alpha, -beta, -rc). getLastStableTag now returns the first tag without a '-' in the version, ensuring we use the last stable tag.

<sup>Written for commit 55920b0f2a70384626639cba30561a0912c3f0cd. Summary will update on new commits. <a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1212?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release tagging process with improved version filtering logic for stable release identification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stagewise-io/stagewise/pull/1212?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->