### PR TITLE
ci(browser): trigger nightly after stable release

### DIFF
--- a/.github/workflows/_release-browser.yml
+++ b/.github/workflows/_release-browser.yml
@@ -307,3 +307,25 @@ jobs:
           files: release/*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  trigger-nightly-after-stable:
+    name: Trigger nightly after stable
+    needs: release
+    if: inputs.channel == 'release' && github.ref_name == 'main'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: read
+
+    steps:
+      - name: Dispatch nightly release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          curl -fsSL \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/workflows/nightly-release.yml/dispatches" \
+            -d '{"ref":"main","inputs":{"ref":"main"}}'

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -18,6 +18,7 @@ permissions:
   contents: write
   pull-requests: read
   id-token: write
+  actions: write
 
 jobs:
   # ---------------------------------------------------------------------------


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically triggers the nightly browser release after a stable release on main. Adds a CI job gated by inputs.channel == 'release' and github.ref_name == 'main' to dispatch `nightly-release.yml` via the GitHub API, and adds `actions: write` in `auto-release.yml` to allow the dispatch.

<sup>Written for commit 0660b8deb8d13a354c54e10e77579d13b11ecd6d. Summary will update on new commits. <a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1214?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a post-release job that dispatches the nightly release workflow when a release on the main branch completes, ensuring nightly workflow runs are initiated automatically.
  * Updated the auto-release workflow token permissions to grant workflow dispatch capabilities for the release automation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stagewise-io/stagewise/pull/1214?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->