### PR TITLE
feat(stagewise): add worktree setup lifecycle

### DIFF
--- a/apps/browser/src/backend/services/git/index.ts
+++ b/apps/browser/src/backend/services/git/index.ts
@@ -577,6 +577,7 @@ export class GitService extends DisposableService {
     return {
       ok: true,
       path: targetPath,
+      branchName: worktreeName,
       git: await this.getMountedWorkspaceSummary(targetPath),
     };
   }

--- a/apps/browser/src/backend/services/git/types.ts
+++ b/apps/browser/src/backend/services/git/types.ts
@@ -94,7 +94,12 @@ export type GitMutationResult =
   | GitActionFailure;
 
 export type GitCreateWorktreeResult =
-  | { ok: true; path: string; git: MountedWorkspaceGitSummary | null }
+  | {
+      ok: true;
+      path: string;
+      branchName: string;
+      git: MountedWorkspaceGitSummary | null;
+    }
   | GitActionFailure;
 
 export type GitCreateBranchOptions = {

--- a/apps/browser/src/backend/services/toolbox/services/mount-manager/git-path-actions.test.ts
+++ b/apps/browser/src/backend/services/toolbox/services/mount-manager/git-path-actions.test.ts
@@ -20,6 +20,9 @@ import type { Logger } from '@/services/logger';
 import type { TelemetryService } from '@/services/telemetry';
 import type { UserExperienceService } from '@/services/experience';
 import { getWorktreesDir } from '@/utils/paths';
+import type { WorkspaceGitSetupRun } from '@shared/karton-contracts/ui';
+
+const services: MountManagerService[] = [];
 
 beforeEach(async () => {
   mockHomeDir = await fs.mkdtemp(
@@ -28,6 +31,7 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
+  await Promise.all(services.splice(0).map((service) => service.teardown()));
   await fs.rm(mockHomeDir, { recursive: true, force: true });
 });
 
@@ -52,6 +56,9 @@ function createHarness({ recentPaths = [] }: { recentPaths?: string[] } = {}) {
       },
     },
     agents: { instances: { agent1: { type: 'regular' } } },
+    workspaceGitSetup: {
+      runsByPath: {} as Record<string, WorkspaceGitSetupRun>,
+    },
   };
 
   const uiKarton = {
@@ -92,11 +99,23 @@ function createHarness({ recentPaths = [] }: { recentPaths?: string[] } = {}) {
         },
       ],
     })),
+    getWorkspaceRepositoryInfo: vi.fn(async (workspacePath: string) => ({
+      repositoryId: path.join(workspacePath, '.git'),
+      repoRoot: workspacePath,
+      commonGitDir: path.join(workspacePath, '.git'),
+    })),
+    getWorkspaceMainWorktreePath: vi.fn(async (workspacePath: string) =>
+      workspacePath.includes('linked-worktree')
+        ? workspacePath.replace('linked-worktree', 'main-worktree')
+        : workspacePath,
+    ),
+    getMountedWorkspaceSummary: vi.fn(async () => null),
     switchBranch: vi.fn(async () => ({ ok: true, git: null })),
     createBranch: vi.fn(async () => ({ ok: true, git: null })),
-    createWorktree: vi.fn(async (workspacePath: string) => ({
+    createWorktree: vi.fn(async (workspacePath: string, options) => ({
       ok: true,
       path: path.join(workspacePath, '..', 'created-worktree'),
+      branchName: options.worktreeName.trim(),
       git: null,
     })),
   } as unknown as GitService;
@@ -121,14 +140,24 @@ function createHarness({ recentPaths = [] }: { recentPaths?: string[] } = {}) {
   };
 
   const service = new MountManagerService(
-    { warn: vi.fn() } as unknown as Logger,
+    {
+      debug: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      isDebugEnabled: false,
+    } as unknown as Logger,
     {} as FilePickerService,
     userExperienceService,
     uiKarton,
-    { capture: vi.fn() } as unknown as TelemetryService,
+    {
+      capture: vi.fn(),
+      captureException: vi.fn(),
+    } as unknown as TelemetryService,
     gitService,
     preferencesService as never,
   );
+
+  services.push(service);
 
   return { service, procedureHandlers, state, gitService };
 }
@@ -293,5 +322,171 @@ describe('MountManagerService path-based Git actions', () => {
       worktreeName: 'feature-a',
       sourceBranch: 'main',
     });
+  });
+
+  it('creates worktrees from the main worktree when called from a linked worktree', async () => {
+    const repoDir = path.join(getWorktreesDir(), 'repo-hash');
+    await fs.mkdir(repoDir, { recursive: true });
+    const linkedPath = await fs.mkdtemp(path.join(repoDir, 'linked-worktree-'));
+    const mainPath = linkedPath.replace('linked-worktree', 'main-worktree');
+    await fs.mkdir(mainPath, { recursive: true });
+    const { service, procedureHandlers, gitService } = createHarness({
+      recentPaths: [linkedPath],
+    });
+    await initializeService(service);
+
+    const handler = procedureHandlers.get('toolbox.createGitWorktreeByPath');
+    await expect(
+      handler?.('client1', linkedPath, {
+        worktreeName: 'feature-a',
+        sourceBranch: 'main',
+      }),
+    ).resolves.toMatchObject({ ok: true });
+
+    expect(gitService.createWorktree).toHaveBeenCalledWith(mainPath, {
+      worktreeName: 'feature-a',
+      sourceBranch: 'main',
+    });
+  });
+
+  it('rejects worktree creation when the derived main worktree is untrusted', async () => {
+    const repoDir = path.join(getWorktreesDir(), 'repo-hash');
+    await fs.mkdir(repoDir, { recursive: true });
+    const linkedPath = await fs.mkdtemp(path.join(repoDir, 'linked-worktree-'));
+    const untrustedMainPath = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'untrusted-main-worktree-'),
+    );
+    const { service, procedureHandlers, gitService } = createHarness();
+    vi.mocked(gitService.getWorkspaceMainWorktreePath).mockResolvedValueOnce(
+      untrustedMainPath,
+    );
+    vi.mocked(gitService.getWorkspaceRepositoryInfo).mockImplementation(
+      async (workspacePath: string) => {
+        if (workspacePath === untrustedMainPath) return null;
+        return {
+          repositoryId: path.join(linkedPath, '.git'),
+          repoRoot: linkedPath,
+          commonGitDir: path.join(linkedPath, '.git'),
+        };
+      },
+    );
+    await initializeService(service);
+
+    const handler = procedureHandlers.get('toolbox.createGitWorktreeByPath');
+    await expect(
+      handler?.('client1', linkedPath, {
+        worktreeName: 'feature-a',
+        sourceBranch: 'main',
+      }),
+    ).resolves.toMatchObject({
+      ok: false,
+      reason: 'not-git-repo',
+    });
+
+    expect(gitService.createWorktree).not.toHaveBeenCalled();
+  });
+
+  it('starts pending setup only after mounting the created worktree', async () => {
+    const recentPath = await fs.mkdtemp(path.join(os.tmpdir(), 'recent-repo-'));
+    const createdPath = path.join(recentPath, '..', 'created-worktree');
+    const scriptPath = path.join(
+      createdPath,
+      '.stagewise',
+      'worktree-setup.sh',
+    );
+    await fs.mkdir(path.dirname(scriptPath), { recursive: true });
+    await fs.writeFile(scriptPath, 'exit 0');
+    const { service, procedureHandlers, state } = createHarness({
+      recentPaths: [recentPath],
+    });
+    await initializeService(service);
+
+    const createHandler = procedureHandlers.get(
+      'toolbox.createGitWorktreeByPath',
+    );
+    await createHandler?.('client1', recentPath, {
+      worktreeName: 'feature-a',
+      sourceBranch: 'main',
+    });
+    expect(state.workspaceGitSetup.runsByPath[createdPath]).toBeUndefined();
+
+    const mountHandler = procedureHandlers.get('toolbox.mountWorkspace');
+    await mountHandler?.('client1', 'agent1', createdPath);
+
+    await vi.waitFor(() => {
+      expect(state.workspaceGitSetup.runsByPath[createdPath]).toBeDefined();
+    });
+  });
+
+  it('does not start setup for manually mounted worktrees', async () => {
+    const manualPath = await fs.mkdtemp(path.join(os.tmpdir(), 'manual-repo-'));
+    const scriptPath = path.join(manualPath, '.stagewise', 'worktree-setup.sh');
+    await fs.mkdir(path.dirname(scriptPath), { recursive: true });
+    await fs.writeFile(scriptPath, 'exit 0');
+    const { service, procedureHandlers, state } = createHarness();
+    await initializeService(service);
+
+    const mountHandler = procedureHandlers.get('toolbox.mountWorkspace');
+    await mountHandler?.('client1', 'agent1', manualPath);
+
+    expect(state.workspaceGitSetup.runsByPath[manualPath]).toBeUndefined();
+  });
+
+  it('does not create setup state when the setup script is missing', async () => {
+    const recentPath = await fs.mkdtemp(path.join(os.tmpdir(), 'recent-repo-'));
+    const createdPath = path.join(recentPath, '..', 'created-worktree');
+    const { service, procedureHandlers, state } = createHarness({
+      recentPaths: [recentPath],
+    });
+    await initializeService(service);
+
+    const createHandler = procedureHandlers.get(
+      'toolbox.createGitWorktreeByPath',
+    );
+    await createHandler?.('client1', recentPath, {
+      worktreeName: 'feature-a',
+      sourceBranch: 'main',
+    });
+    const mountHandler = procedureHandlers.get('toolbox.mountWorkspace');
+    await mountHandler?.('client1', 'agent1', createdPath);
+
+    expect(state.workspaceGitSetup.runsByPath[createdPath]).toBeUndefined();
+  });
+
+  it('keeps failed setup worktrees mounted', async () => {
+    const recentPath = await fs.mkdtemp(path.join(os.tmpdir(), 'recent-repo-'));
+    const createdPath = path.join(recentPath, '..', 'created-worktree');
+    const scriptPath = path.join(
+      createdPath,
+      '.stagewise',
+      'worktree-setup.sh',
+    );
+    await fs.mkdir(path.dirname(scriptPath), { recursive: true });
+    await fs.writeFile(scriptPath, 'echo failed >&2\nexit 1');
+    const { service, procedureHandlers, state } = createHarness({
+      recentPaths: [recentPath],
+    });
+    await initializeService(service);
+
+    const createHandler = procedureHandlers.get(
+      'toolbox.createGitWorktreeByPath',
+    );
+    await createHandler?.('client1', recentPath, {
+      worktreeName: 'feature-a',
+      sourceBranch: 'main',
+    });
+    const mountHandler = procedureHandlers.get('toolbox.mountWorkspace');
+    await mountHandler?.('client1', 'agent1', createdPath);
+
+    await vi.waitFor(() => {
+      expect(state.workspaceGitSetup.runsByPath[createdPath]?.status).toBe(
+        'failed',
+      );
+    });
+    expect(
+      state.toolbox.agent1.workspace.mounts.some(
+        (mount) => mount.path === createdPath,
+      ),
+    ).toBe(true);
   });
 });

--- a/apps/browser/src/backend/services/toolbox/services/mount-manager/index.ts
+++ b/apps/browser/src/backend/services/toolbox/services/mount-manager/index.ts
@@ -17,6 +17,8 @@ import type {
   MountedWorkspaceGitSummary,
   WorkspaceGitCleanupCandidate,
   WorkspaceGitCleanupResult,
+  WorkspaceGitCleanupState,
+  MountEntry,
   WorkspaceGitCreateBranchOptions,
   WorkspaceGitCreateWorktreeOptions,
   WorkspaceGitCreateWorktreeResult,
@@ -35,15 +37,34 @@ import {
 import { readAgentsMd } from '@/agents/shared/prompts/utils/read-agents-md';
 import { getSkills } from '@/agents/shared/prompts/utils/get-skills';
 import { getRipgrepBasePath, getWorktreesDir } from '@/utils/paths';
+import {
+  WorktreeSetupRunner,
+  type WorktreeSetupMetadata,
+} from './worktree-setup-runner';
+
+type KartonStateDraft = {
+  workspaceGitCleanup: WorkspaceGitCleanupState;
+  toolbox: Record<
+    string,
+    {
+      workspace: { mounts: MountEntry[] };
+      pendingFileDiffs: unknown[];
+      editSummary: unknown[];
+      pendingUserQuestion: unknown;
+    }
+  >;
+};
 
 const WORKTREE_CLEANUP_UNUSED_DAYS = 7;
 const WORKTREE_CLEANUP_UNUSED_MS =
   WORKTREE_CLEANUP_UNUSED_DAYS * 24 * 60 * 60 * 1000;
 const WORKTREE_CLEANUP_DISMISS_MS = 7 * 24 * 60 * 60 * 1000;
+const PENDING_WORKTREE_SETUP_TTL_MS = 10 * 60 * 1000;
 
 type AgentInstanceId = string;
 type MountPrefix = string;
 type WorkspacePath = string;
+type PendingWorktreeSetup = WorktreeSetupMetadata & { createdAt: number };
 
 async function safeRealpath(targetPath: string): Promise<string | null> {
   try {
@@ -82,6 +103,11 @@ export class MountManagerService extends DisposableService {
   private readonly preferencesService: PreferencesService;
   private readonly mentionSearch: MentionSearchService;
   private readonly resolvedEnvPromise: Promise<Record<string, string> | null>;
+  private readonly worktreeSetupRunner: WorktreeSetupRunner;
+  private readonly pendingWorktreeSetups = new Map<
+    string,
+    PendingWorktreeSetup
+  >();
   private onMountsChanged?: (agentInstanceId: string) => void;
   private getWorkspaceLastUsedAtByPath: (
     workspacePaths: string[],
@@ -125,6 +151,12 @@ export class MountManagerService extends DisposableService {
     this.gitService = gitService;
     this.preferencesService = preferencesService;
     this.resolvedEnvPromise = resolvedEnvPromise ?? Promise.resolve(null);
+    this.worktreeSetupRunner = new WorktreeSetupRunner({
+      logger,
+      telemetryService,
+      uiKarton,
+      resolvedEnvPromise: this.resolvedEnvPromise,
+    });
 
     const searchCtx: MentionSearchContext = {
       getWorkspacePathForPrefix: (prefix) =>
@@ -355,12 +387,12 @@ export class MountManagerService extends DisposableService {
       'toolbox.dismissWorkspaceGitCleanupPrompt',
       async () => {
         const paths = this.uiKarton.state.workspaceGitCleanup.candidates.map(
-          (candidate) => candidate.path,
+          (candidate: WorkspaceGitCleanupCandidate) => candidate.path,
         );
         await this.preferencesService.snoozeWorkspaceGitCleanupCandidates(
           paths,
         );
-        this.uiKarton.setState((draft) => {
+        this.uiKarton.setState((draft: KartonStateDraft) => {
           draft.workspaceGitCleanup.dismissed = true;
         });
       },
@@ -391,7 +423,7 @@ export class MountManagerService extends DisposableService {
   ): { prefix: string; path: string } | null {
     const mount = this.uiKarton.state.toolbox[
       agentInstanceId
-    ]?.workspace.mounts.find((item) => item.prefix === mountPrefix);
+    ]?.workspace.mounts.find((item: MountEntry) => item.prefix === mountPrefix);
     if (!mount) return null;
     return { prefix: mount.prefix, path: mount.path };
   }
@@ -410,6 +442,15 @@ export class MountManagerService extends DisposableService {
       reason: 'not-git-repo',
       message: 'Workspace is not a Git repo.',
     };
+  }
+
+  private isPathInside(parentPath: string, childPath: string): boolean {
+    const relativePath = path.relative(parentPath, childPath);
+    return (
+      relativePath.length > 0 &&
+      !relativePath.startsWith('..') &&
+      !path.isAbsolute(relativePath)
+    );
   }
 
   private async isTrustedGitPath(workspacePath: string): Promise<boolean> {
@@ -431,12 +472,32 @@ export class MountManagerService extends DisposableService {
     const worktreesDir = await safeRealpath(getWorktreesDir());
     if (!worktreesDir) return false;
 
-    const relativeToWorktrees = path.relative(worktreesDir, resolvedPath);
-    return (
-      relativeToWorktrees.length > 0 &&
-      !relativeToWorktrees.startsWith('..') &&
-      !path.isAbsolute(relativeToWorktrees)
-    );
+    return this.isPathInside(worktreesDir, resolvedPath);
+  }
+
+  private async isTrustedMainWorktreePath(
+    workspacePath: string,
+    mainWorktreePath: string,
+  ): Promise<boolean> {
+    if (await this.isTrustedGitPath(mainWorktreePath)) return true;
+
+    const [resolvedWorkspacePath, resolvedMainWorktreePath, worktreesDir] =
+      await Promise.all([
+        safeRealpath(workspacePath),
+        safeRealpath(mainWorktreePath),
+        safeRealpath(getWorktreesDir()),
+      ]);
+    if (!resolvedWorkspacePath || !resolvedMainWorktreePath || !worktreesDir) {
+      return false;
+    }
+    if (!this.isPathInside(worktreesDir, resolvedWorkspacePath)) return false;
+
+    const repositoryInfo =
+      await this.gitService.getWorkspaceRepositoryInfo(mainWorktreePath);
+    if (!repositoryInfo) return false;
+
+    const resolvedRepoRoot = await safeRealpath(repositoryInfo.repoRoot);
+    return resolvedRepoRoot === resolvedMainWorktreePath;
   }
 
   private async listGitBranchesByPath(workspacePath: string) {
@@ -476,7 +537,34 @@ export class MountManagerService extends DisposableService {
     if (!(await this.isTrustedGitPath(workspacePath))) {
       return this.notGitRepoCreateWorktreeResult();
     }
-    return this.gitService.createWorktree(workspacePath, options);
+
+    const [repositoryInfo, mainWorktreePath] = await Promise.all([
+      this.gitService.getWorkspaceRepositoryInfo(workspacePath),
+      this.gitService.getWorkspaceMainWorktreePath(workspacePath),
+    ]);
+    if (!repositoryInfo || !mainWorktreePath) {
+      return this.notGitRepoCreateWorktreeResult();
+    }
+    if (
+      !(await this.isTrustedMainWorktreePath(workspacePath, mainWorktreePath))
+    ) {
+      return this.notGitRepoCreateWorktreeResult();
+    }
+
+    const result = await this.gitService.createWorktree(
+      mainWorktreePath,
+      options,
+    );
+    if (result.ok) {
+      await this.setPendingWorktreeSetup(result.path, {
+        workspacePath: result.path,
+        mainWorktreePath,
+        repositoryId: repositoryInfo.repositoryId,
+        sourceBranch: options.sourceBranch,
+        worktreeBranch: result.branchName,
+      });
+    }
+    return result;
   }
 
   private updateMountedWorkspaceGit(
@@ -484,9 +572,9 @@ export class MountManagerService extends DisposableService {
     mountPrefix: string,
     git: MountedWorkspaceGitSummary | null,
   ): void {
-    this.uiKarton.setState((draft) => {
+    this.uiKarton.setState((draft: KartonStateDraft) => {
       const mount = draft.toolbox[agentInstanceId]?.workspace.mounts.find(
-        (item) => item.prefix === mountPrefix,
+        (item: MountEntry) => item.prefix === mountPrefix,
       );
       if (mount) mount.git = git;
     });
@@ -547,7 +635,7 @@ export class MountManagerService extends DisposableService {
     });
 
     if (!this.uiKarton.state.toolbox[agentInstanceId]) {
-      this.uiKarton.setState((draft) => {
+      this.uiKarton.setState((draft: KartonStateDraft) => {
         draft.toolbox[agentInstanceId] = {
           workspace: { mounts: [] },
           pendingFileDiffs: [],
@@ -584,7 +672,7 @@ export class MountManagerService extends DisposableService {
       resolvedWorkspacePath,
     );
 
-    this.uiKarton.setState((draft) => {
+    this.uiKarton.setState((draft: KartonStateDraft) => {
       draft.toolbox[agentInstanceId].workspace.mounts.push({
         prefix,
         path: resolvedWorkspacePath,
@@ -599,6 +687,13 @@ export class MountManagerService extends DisposableService {
     });
 
     this.onMountsChanged?.(agentInstanceId);
+
+    const pendingSetup = await this.takePendingWorktreeSetup(
+      resolvedWorkspacePath,
+    );
+    if (pendingSetup) {
+      void this.worktreeSetupRunner.start(pendingSetup);
+    }
 
     const agentType =
       this.uiKarton.state.agents.instances[agentInstanceId]?.type ?? 'unknown';
@@ -620,10 +715,10 @@ export class MountManagerService extends DisposableService {
     mounts.delete(mountPrefix);
     this.releaseMountIfUnused(mountPrefix);
 
-    this.uiKarton.setState((draft) => {
+    this.uiKarton.setState((draft: KartonStateDraft) => {
       draft.toolbox[agentInstanceId].workspace.mounts = draft.toolbox[
         agentInstanceId
-      ].workspace.mounts.filter((m) => m.prefix !== mountPrefix);
+      ].workspace.mounts.filter((m: MountEntry) => m.prefix !== mountPrefix);
     });
 
     this.onMountsChanged?.(agentInstanceId);
@@ -730,7 +825,7 @@ export class MountManagerService extends DisposableService {
           now - dismissedAt >= WORKTREE_CLEANUP_DISMISS_MS
         );
       });
-      this.uiKarton.setState((draft) => {
+      this.uiKarton.setState((draft: KartonStateDraft) => {
         draft.workspaceGitCleanup.checkedAt = now;
         draft.workspaceGitCleanup.dismissed = promptableCandidates.length === 0;
         draft.workspaceGitCleanup.cleaning = false;
@@ -738,7 +833,9 @@ export class MountManagerService extends DisposableService {
         draft.workspaceGitCleanup.lastResult = null;
       });
       await this.preferencesService.pruneWorkspaceGitCleanupSnoozes(
-        candidates.map((candidate) => candidate.path),
+        candidates.map(
+          (candidate: WorkspaceGitCleanupCandidate) => candidate.path,
+        ),
         WORKTREE_CLEANUP_DISMISS_MS,
         now,
       );
@@ -746,7 +843,7 @@ export class MountManagerService extends DisposableService {
       this.logger.warn(
         `[MountManager] Failed to scan worktree cleanup candidates: ${error instanceof Error ? error.message : String(error)}`,
       );
-      this.uiKarton.setState((draft) => {
+      this.uiKarton.setState((draft: KartonStateDraft) => {
         draft.workspaceGitCleanup.checkedAt = Date.now();
         draft.workspaceGitCleanup.cleaning = false;
       });
@@ -757,7 +854,7 @@ export class MountManagerService extends DisposableService {
     paths: string[],
   ): Promise<WorkspaceGitCleanupResult> {
     const uniquePaths = Array.from(new Set(paths));
-    this.uiKarton.setState((draft) => {
+    this.uiKarton.setState((draft: KartonStateDraft) => {
       draft.workspaceGitCleanup.cleaning = true;
     });
 
@@ -789,7 +886,7 @@ export class MountManagerService extends DisposableService {
           message: 'Unable to verify worktree usage data.',
         })),
       } satisfies WorkspaceGitCleanupResult;
-      this.uiKarton.setState((draft) => {
+      this.uiKarton.setState((draft: KartonStateDraft) => {
         draft.workspaceGitCleanup.cleaning = false;
         draft.workspaceGitCleanup.lastResult = result;
       });
@@ -829,12 +926,13 @@ export class MountManagerService extends DisposableService {
 
     const removedPaths = new Set(removed.map((item) => item.path));
     const result = { removed, failed };
-    this.uiKarton.setState((draft) => {
+    this.uiKarton.setState((draft: KartonStateDraft) => {
       draft.workspaceGitCleanup.cleaning = false;
       draft.workspaceGitCleanup.lastResult = result;
       draft.workspaceGitCleanup.candidates =
         draft.workspaceGitCleanup.candidates.filter(
-          (candidate) => !removedPaths.has(candidate.path),
+          (candidate: WorkspaceGitCleanupCandidate) =>
+            !removedPaths.has(candidate.path),
         );
       if (draft.workspaceGitCleanup.candidates.length === 0) {
         draft.workspaceGitCleanup.dismissed = true;
@@ -844,7 +942,9 @@ export class MountManagerService extends DisposableService {
       const remainingCleanupCandidates =
         await this.getWorkspaceGitCleanupCandidates();
       await this.preferencesService.pruneWorkspaceGitCleanupSnoozes(
-        remainingCleanupCandidates.map((candidate) => candidate.path),
+        remainingCleanupCandidates.map(
+          (candidate: WorkspaceGitCleanupCandidate) => candidate.path,
+        ),
         WORKTREE_CLEANUP_DISMISS_MS,
       );
     } catch (error) {
@@ -1055,7 +1155,7 @@ export class MountManagerService extends DisposableService {
     workspacePath: string,
     content: string | null,
   ): void {
-    this.uiKarton.setState((draft) => {
+    this.uiKarton.setState((draft: KartonStateDraft) => {
       for (const agentId in draft.toolbox) {
         const mounts = draft.toolbox[agentId].workspace.mounts;
         for (const mount of mounts)
@@ -1256,7 +1356,7 @@ export class MountManagerService extends DisposableService {
 
       const git = await this.gitService.getMountedWorkspaceSummary(wsPath);
 
-      this.uiKarton.setState((draft) => {
+      this.uiKarton.setState((draft: KartonStateDraft) => {
         for (const agentId in draft.toolbox) {
           for (const mount of draft.toolbox[agentId].workspace.mounts) {
             if (mount.path !== wsPath) continue;
@@ -1290,6 +1390,47 @@ export class MountManagerService extends DisposableService {
     }
   }
 
+  private async getPendingWorktreeSetupKey(
+    workspacePath: string,
+  ): Promise<string> {
+    return (await safeRealpath(workspacePath)) ?? workspacePath;
+  }
+
+  private pruneExpiredPendingWorktreeSetups(now = Date.now()): void {
+    for (const [key, setup] of this.pendingWorktreeSetups) {
+      if (now - setup.createdAt > PENDING_WORKTREE_SETUP_TTL_MS) {
+        this.pendingWorktreeSetups.delete(key);
+      }
+    }
+  }
+
+  private async setPendingWorktreeSetup(
+    workspacePath: string,
+    setup: WorktreeSetupMetadata,
+  ): Promise<void> {
+    this.pruneExpiredPendingWorktreeSetups();
+    this.pendingWorktreeSetups.set(
+      await this.getPendingWorktreeSetupKey(workspacePath),
+      {
+        ...setup,
+        createdAt: Date.now(),
+      },
+    );
+  }
+
+  private async takePendingWorktreeSetup(
+    workspacePath: string,
+  ): Promise<WorktreeSetupMetadata | null> {
+    this.pruneExpiredPendingWorktreeSetups();
+    const key = await this.getPendingWorktreeSetupKey(workspacePath);
+    const setup = this.pendingWorktreeSetups.get(key);
+    if (!setup) return null;
+    this.pendingWorktreeSetups.delete(key);
+
+    const { createdAt: _createdAt, ...metadata } = setup;
+    return metadata;
+  }
+
   private report(
     error: Error,
     operation: string,
@@ -1303,6 +1444,9 @@ export class MountManagerService extends DisposableService {
   }
 
   protected async onTeardown(): Promise<void> {
+    this.pendingWorktreeSetups.clear();
+    this.worktreeSetupRunner.teardown();
+
     for (const wsPath of this.watchersPerPath.keys())
       this.stopWorkspaceWatcher(wsPath);
 

--- a/apps/browser/src/backend/services/toolbox/services/mount-manager/worktree-setup-runner.test.ts
+++ b/apps/browser/src/backend/services/toolbox/services/mount-manager/worktree-setup-runner.test.ts
@@ -1,0 +1,475 @@
+import { EventEmitter } from 'node:events';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { PassThrough } from 'node:stream';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { KartonService } from '@/services/karton';
+import type { Logger } from '@/services/logger';
+import type { TelemetryService } from '@/services/telemetry';
+import { WorktreeSetupRunner } from './worktree-setup-runner';
+
+let tempDir: string;
+
+beforeEach(async () => {
+  tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'worktree-setup-runner-'));
+});
+
+afterEach(async () => {
+  vi.useRealTimers();
+  await fs.rm(tempDir, { recursive: true, force: true });
+});
+
+function createKarton() {
+  const state = { workspaceGitSetup: { runsByPath: {} } } as {
+    workspaceGitSetup: {
+      runsByPath: Record<
+        string,
+        {
+          status: string;
+          scriptPath: string;
+          stdoutTail: string;
+          stderrTail: string;
+          finishedAt: number | null;
+          exitCode: number | null;
+          message: string | null;
+        }
+      >;
+    };
+  };
+
+  return {
+    state,
+    uiKarton: {
+      state,
+      setState: vi.fn((recipe: (draft: typeof state) => void) => recipe(state)),
+    } as unknown as KartonService,
+  };
+}
+
+function metadata(mainWorktreePath: string, workspacePath: string) {
+  return {
+    workspacePath,
+    mainWorktreePath,
+    repositoryId: path.join(mainWorktreePath, '.git'),
+    sourceBranch: 'main',
+    worktreeBranch: 'feature-a',
+  };
+}
+
+async function writeSetupScript(worktreePath: string, content = 'exit 0') {
+  const scriptPath = path.join(worktreePath, '.stagewise', 'worktree-setup.sh');
+  await fs.mkdir(path.dirname(scriptPath), { recursive: true });
+  await fs.writeFile(scriptPath, content);
+  return scriptPath;
+}
+
+function createProcess() {
+  const child = new EventEmitter() as EventEmitter & {
+    stdout: PassThrough;
+    stderr: PassThrough;
+    kill: ReturnType<typeof vi.fn>;
+  };
+  child.stdout = new PassThrough();
+  child.stderr = new PassThrough();
+  child.kill = vi.fn();
+  return child;
+}
+
+type TestSpawnProcess = ReturnType<typeof createProcess>;
+
+type TestRunnerDeps = {
+  logger: Logger;
+  telemetryService: TelemetryService;
+  uiKarton: KartonService;
+  resolvedEnvPromise: Promise<Record<string, string> | null>;
+  spawnProcess?: (
+    command: string,
+    args: string[],
+    options: {
+      cwd: string;
+      env: NodeJS.ProcessEnv;
+      stdio: ['ignore', 'pipe', 'pipe'];
+    },
+  ) => TestSpawnProcess;
+  timeoutMs?: number;
+  platform?: NodeJS.Platform;
+};
+
+function createRunner(deps: TestRunnerDeps) {
+  return new WorktreeSetupRunner({
+    platform: 'darwin',
+    ...deps,
+  });
+}
+
+describe('WorktreeSetupRunner', () => {
+  it('does not create setup state when the script is missing', async () => {
+    const mainWorktreePath = path.join(tempDir, 'main');
+    const workspacePath = path.join(tempDir, 'worktree');
+    await fs.mkdir(workspacePath, { recursive: true });
+    const { state, uiKarton } = createKarton();
+    const spawnProcess = vi.fn();
+    const runner = createRunner({
+      logger: { warn: vi.fn() } as unknown as Logger,
+      telemetryService: {
+        captureException: vi.fn(),
+      } as unknown as TelemetryService,
+      uiKarton,
+      resolvedEnvPromise: Promise.resolve(null),
+      spawnProcess,
+    });
+
+    await runner.start(metadata(mainWorktreePath, workspacePath));
+
+    expect(spawnProcess).not.toHaveBeenCalled();
+    expect(state.workspaceGitSetup.runsByPath[workspacePath]).toBeUndefined();
+  });
+
+  it('ignores setup scripts that exist only in the main worktree', async () => {
+    const mainWorktreePath = path.join(tempDir, 'main');
+    const workspacePath = path.join(tempDir, 'worktree');
+    await fs.mkdir(workspacePath, { recursive: true });
+    await writeSetupScript(mainWorktreePath);
+    const { state, uiKarton } = createKarton();
+    const spawnProcess = vi.fn();
+    const runner = createRunner({
+      logger: { warn: vi.fn() } as unknown as Logger,
+      telemetryService: {
+        captureException: vi.fn(),
+      } as unknown as TelemetryService,
+      uiKarton,
+      resolvedEnvPromise: Promise.resolve(null),
+      spawnProcess,
+    });
+
+    await runner.start(metadata(mainWorktreePath, workspacePath));
+
+    expect(spawnProcess).not.toHaveBeenCalled();
+    expect(state.workspaceGitSetup.runsByPath[workspacePath]).toBeUndefined();
+  });
+
+  it('spawns the setup script with expected cwd and environment', async () => {
+    const mainWorktreePath = path.join(tempDir, 'main');
+    const workspacePath = path.join(tempDir, 'worktree');
+    await fs.mkdir(workspacePath, { recursive: true });
+    const scriptPath = await writeSetupScript(workspacePath);
+    const child = createProcess();
+    const spawnProcess = vi.fn(() => child);
+    const { state, uiKarton } = createKarton();
+    const runner = createRunner({
+      logger: { warn: vi.fn() } as unknown as Logger,
+      telemetryService: {
+        captureException: vi.fn(),
+      } as unknown as TelemetryService,
+      uiKarton,
+      resolvedEnvPromise: Promise.resolve({ PATH: '/custom/bin' }),
+      spawnProcess,
+    });
+
+    await runner.start(metadata(mainWorktreePath, workspacePath));
+
+    expect(spawnProcess).toHaveBeenCalledWith('/bin/sh', [scriptPath], {
+      cwd: workspacePath,
+      env: expect.objectContaining({
+        PATH: '/custom/bin',
+        STAGEWISE_MAIN_WORKTREE: mainWorktreePath,
+        STAGEWISE_NEW_WORKTREE: workspacePath,
+        STAGEWISE_WORKTREE: workspacePath,
+        STAGEWISE_SOURCE_BRANCH: 'main',
+        STAGEWISE_WORKTREE_BRANCH: 'feature-a',
+        STAGEWISE_REPOSITORY_ID: path.join(mainWorktreePath, '.git'),
+        STAGEWISE_SETUP_SCRIPT: scriptPath,
+      }),
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    expect(state.workspaceGitSetup.runsByPath[workspacePath]?.status).toBe(
+      'running',
+    );
+  });
+
+  it('updates state to succeeded on zero exit', async () => {
+    const mainWorktreePath = path.join(tempDir, 'main');
+    const workspacePath = path.join(tempDir, 'worktree');
+    await fs.mkdir(workspacePath, { recursive: true });
+    await writeSetupScript(workspacePath);
+    const child = createProcess();
+    const { state, uiKarton } = createKarton();
+    const runner = createRunner({
+      logger: { warn: vi.fn() } as unknown as Logger,
+      telemetryService: {
+        captureException: vi.fn(),
+      } as unknown as TelemetryService,
+      uiKarton,
+      resolvedEnvPromise: Promise.resolve(null),
+      spawnProcess: vi.fn(() => child),
+    });
+
+    await runner.start(metadata(mainWorktreePath, workspacePath));
+    child.stdout.write('installed');
+    child.emit('close', 0);
+
+    expect(state.workspaceGitSetup.runsByPath[workspacePath]).toMatchObject({
+      status: 'succeeded',
+      exitCode: 0,
+      message: null,
+      stdoutTail: 'installed',
+    });
+  });
+
+  it('updates state to failed on non-zero exit', async () => {
+    const mainWorktreePath = path.join(tempDir, 'main');
+    const workspacePath = path.join(tempDir, 'worktree');
+    await fs.mkdir(workspacePath, { recursive: true });
+    await writeSetupScript(workspacePath);
+    const child = createProcess();
+    const { state, uiKarton } = createKarton();
+    const captureException = vi.fn();
+    const runner = createRunner({
+      logger: { warn: vi.fn() } as unknown as Logger,
+      telemetryService: {
+        captureException,
+      } as unknown as TelemetryService,
+      uiKarton,
+      resolvedEnvPromise: Promise.resolve(null),
+      spawnProcess: vi.fn(() => child),
+    });
+
+    await runner.start(metadata(mainWorktreePath, workspacePath));
+    child.stderr.write('failed badly');
+    child.emit('close', 1);
+
+    expect(state.workspaceGitSetup.runsByPath[workspacePath]).toMatchObject({
+      status: 'failed',
+      exitCode: 1,
+      message: 'Worktree setup exited with code 1.',
+      stderrTail: 'failed badly',
+    });
+    expect(captureException).not.toHaveBeenCalled();
+  });
+
+  it('does not spawn the setup script on Windows', async () => {
+    const mainWorktreePath = path.join(tempDir, 'main');
+    const workspacePath = path.join(tempDir, 'worktree');
+    await fs.mkdir(workspacePath, { recursive: true });
+    await writeSetupScript(workspacePath);
+    const { state, uiKarton } = createKarton();
+    const spawnProcess = vi.fn();
+    const captureException = vi.fn();
+    const runner = createRunner({
+      logger: { warn: vi.fn() } as unknown as Logger,
+      telemetryService: {
+        captureException,
+      } as unknown as TelemetryService,
+      uiKarton,
+      resolvedEnvPromise: Promise.resolve(null),
+      spawnProcess,
+      platform: 'win32',
+    });
+
+    await runner.start(metadata(mainWorktreePath, workspacePath));
+
+    expect(spawnProcess).not.toHaveBeenCalled();
+    expect(state.workspaceGitSetup.runsByPath[workspacePath]).toMatchObject({
+      status: 'failed',
+      exitCode: null,
+      message: 'Worktree setup scripts are not supported on Windows yet.',
+    });
+    expect(captureException).not.toHaveBeenCalled();
+  });
+
+  it('marks setup failed if environment resolution times out', async () => {
+    const mainWorktreePath = path.join(tempDir, 'main');
+    const workspacePath = path.join(tempDir, 'worktree');
+    await fs.mkdir(workspacePath, { recursive: true });
+    await writeSetupScript(workspacePath);
+    const { state, uiKarton } = createKarton();
+    const spawnProcess = vi.fn();
+    const captureException = vi.fn();
+    const runner = createRunner({
+      logger: { warn: vi.fn() } as unknown as Logger,
+      telemetryService: {
+        captureException,
+      } as unknown as TelemetryService,
+      uiKarton,
+      resolvedEnvPromise: new Promise(() => {}),
+      spawnProcess,
+      timeoutMs: 10,
+    });
+
+    void runner.start(metadata(mainWorktreePath, workspacePath));
+
+    await vi.waitFor(() => {
+      expect(state.workspaceGitSetup.runsByPath[workspacePath]?.status).toBe(
+        'failed',
+      );
+    });
+    expect(spawnProcess).not.toHaveBeenCalled();
+    expect(state.workspaceGitSetup.runsByPath[workspacePath]).toMatchObject({
+      exitCode: null,
+      message: 'Worktree setup timed out.',
+    });
+    expect(captureException).not.toHaveBeenCalled();
+  });
+
+  it('flushes pending output when the process exits', async () => {
+    vi.useFakeTimers();
+    const mainWorktreePath = path.join(tempDir, 'main');
+    const workspacePath = path.join(tempDir, 'worktree');
+    await fs.mkdir(workspacePath, { recursive: true });
+    await writeSetupScript(workspacePath);
+    const child = createProcess();
+    const { state, uiKarton } = createKarton();
+    const runner = createRunner({
+      logger: { warn: vi.fn() } as unknown as Logger,
+      telemetryService: {
+        captureException: vi.fn(),
+      } as unknown as TelemetryService,
+      uiKarton,
+      resolvedEnvPromise: Promise.resolve(null),
+      spawnProcess: vi.fn(() => child),
+    });
+
+    await runner.start(metadata(mainWorktreePath, workspacePath));
+    child.stdout.write('first');
+    child.stdout.write('second');
+    expect(state.workspaceGitSetup.runsByPath[workspacePath]?.stdoutTail).toBe(
+      '',
+    );
+
+    child.emit('close', 0);
+
+    expect(state.workspaceGitSetup.runsByPath[workspacePath]).toMatchObject({
+      status: 'succeeded',
+      stdoutTail: 'firstsecond',
+    });
+  });
+
+  it('preserves captured output when interrupted during teardown', async () => {
+    const mainWorktreePath = path.join(tempDir, 'main');
+    const workspacePath = path.join(tempDir, 'worktree');
+    await fs.mkdir(workspacePath, { recursive: true });
+    await writeSetupScript(workspacePath);
+    const child = createProcess();
+    const { state, uiKarton } = createKarton();
+    const captureException = vi.fn();
+    const runner = createRunner({
+      logger: { warn: vi.fn() } as unknown as Logger,
+      telemetryService: {
+        captureException,
+      } as unknown as TelemetryService,
+      uiKarton,
+      resolvedEnvPromise: Promise.resolve(null),
+      spawnProcess: vi.fn(() => child),
+    });
+
+    await runner.start(metadata(mainWorktreePath, workspacePath));
+    child.stdout.write('partial output');
+    child.stderr.write('partial error');
+    runner.teardown();
+
+    expect(child.kill).toHaveBeenCalledOnce();
+    expect(state.workspaceGitSetup.runsByPath[workspacePath]).toMatchObject({
+      status: 'failed',
+      message: 'Worktree setup was interrupted.',
+      stdoutTail: 'partial output',
+      stderrTail: 'partial error',
+    });
+
+    child.emit('close', 1);
+
+    expect(state.workspaceGitSetup.runsByPath[workspacePath]).toMatchObject({
+      status: 'failed',
+      message: 'Worktree setup was interrupted.',
+      stdoutTail: 'partial output',
+      stderrTail: 'partial error',
+    });
+    expect(captureException).not.toHaveBeenCalled();
+  });
+
+  it('marks setup failed and kills the process on timeout', async () => {
+    vi.useFakeTimers();
+    const mainWorktreePath = path.join(tempDir, 'main');
+    const workspacePath = path.join(tempDir, 'worktree');
+    await fs.mkdir(workspacePath, { recursive: true });
+    await writeSetupScript(workspacePath);
+    const child = createProcess();
+    const { state, uiKarton } = createKarton();
+    const captureException = vi.fn();
+    const runner = createRunner({
+      logger: { warn: vi.fn() } as unknown as Logger,
+      telemetryService: {
+        captureException,
+      } as unknown as TelemetryService,
+      uiKarton,
+      resolvedEnvPromise: Promise.resolve(null),
+      spawnProcess: vi.fn(() => child),
+      timeoutMs: 100,
+    });
+
+    await runner.start(metadata(mainWorktreePath, workspacePath));
+    vi.advanceTimersByTime(100);
+
+    expect(child.kill).toHaveBeenCalledOnce();
+    expect(state.workspaceGitSetup.runsByPath[workspacePath]).toMatchObject({
+      status: 'failed',
+      exitCode: null,
+      message: 'Worktree setup timed out.',
+    });
+
+    child.emit('close', 1);
+
+    expect(state.workspaceGitSetup.runsByPath[workspacePath]).toMatchObject({
+      status: 'failed',
+      exitCode: null,
+      message: 'Worktree setup timed out.',
+    });
+    expect(captureException).not.toHaveBeenCalled();
+  });
+
+  it('does not spawn after teardown if environment resolves late', async () => {
+    const mainWorktreePath = path.join(tempDir, 'main');
+    const workspacePath = path.join(tempDir, 'worktree');
+    await fs.mkdir(workspacePath, { recursive: true });
+    await writeSetupScript(workspacePath);
+    let resolveEnv!: (env: Record<string, string> | null) => void;
+    const resolvedEnvPromise = new Promise<Record<string, string> | null>(
+      (resolve) => {
+        resolveEnv = resolve;
+      },
+    );
+    const { state, uiKarton } = createKarton();
+    const spawnProcess = vi.fn();
+    const captureException = vi.fn();
+    const runner = createRunner({
+      logger: { warn: vi.fn() } as unknown as Logger,
+      telemetryService: {
+        captureException,
+      } as unknown as TelemetryService,
+      uiKarton,
+      resolvedEnvPromise,
+      spawnProcess,
+    });
+
+    const startPromise = runner.start(
+      metadata(mainWorktreePath, workspacePath),
+    );
+    await vi.waitFor(() => {
+      expect(state.workspaceGitSetup.runsByPath[workspacePath]?.status).toBe(
+        'running',
+      );
+    });
+
+    runner.teardown();
+    resolveEnv(null);
+    await startPromise;
+
+    expect(spawnProcess).not.toHaveBeenCalled();
+    expect(state.workspaceGitSetup.runsByPath[workspacePath]).toMatchObject({
+      status: 'failed',
+      exitCode: null,
+      message: 'Worktree setup was interrupted.',
+    });
+    expect(captureException).not.toHaveBeenCalled();
+  });
+});

--- a/apps/browser/src/backend/services/toolbox/services/mount-manager/worktree-setup-runner.test.ts
+++ b/apps/browser/src/backend/services/toolbox/services/mount-manager/worktree-setup-runner.test.ts
@@ -186,6 +186,9 @@ describe('WorktreeSetupRunner', () => {
     expect(state.workspaceGitSetup.runsByPath[workspacePath]?.status).toBe(
       'running',
     );
+
+    child.emit('close', 0);
+    runner.teardown();
   });
 
   it('updates state to succeeded on zero exit', async () => {
@@ -286,18 +289,26 @@ describe('WorktreeSetupRunner', () => {
     const { state, uiKarton } = createKarton();
     const spawnProcess = vi.fn();
     const captureException = vi.fn();
+    let resolveEnv!: (env: Record<string, string> | null) => void;
+    const resolvedEnvPromise = new Promise<Record<string, string> | null>(
+      (resolve) => {
+        resolveEnv = resolve;
+      },
+    );
     const runner = createRunner({
       logger: { warn: vi.fn() } as unknown as Logger,
       telemetryService: {
         captureException,
       } as unknown as TelemetryService,
       uiKarton,
-      resolvedEnvPromise: new Promise(() => {}),
+      resolvedEnvPromise,
       spawnProcess,
       timeoutMs: 10,
     });
 
-    void runner.start(metadata(mainWorktreePath, workspacePath));
+    const startPromise = runner.start(
+      metadata(mainWorktreePath, workspacePath),
+    );
 
     await vi.waitFor(() => {
       expect(state.workspaceGitSetup.runsByPath[workspacePath]?.status).toBe(
@@ -310,6 +321,9 @@ describe('WorktreeSetupRunner', () => {
       message: 'Worktree setup timed out.',
     });
     expect(captureException).not.toHaveBeenCalled();
+
+    resolveEnv(null);
+    await startPromise;
   });
 
   it('flushes pending output when the process exits', async () => {

--- a/apps/browser/src/backend/services/toolbox/services/mount-manager/worktree-setup-runner.ts
+++ b/apps/browser/src/backend/services/toolbox/services/mount-manager/worktree-setup-runner.ts
@@ -1,0 +1,364 @@
+import { randomUUID } from 'node:crypto';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { spawn } from 'node:child_process';
+import type { Readable } from 'node:stream';
+import type { KartonService } from '@/services/karton';
+import type { AppState } from '@shared/karton-contracts/ui';
+import type { Logger } from '@/services/logger';
+import type { TelemetryService } from '@/services/telemetry';
+
+const WORKTREE_SETUP_SCRIPT_RELATIVE_PATH = path.join(
+  '.stagewise',
+  'worktree-setup.sh',
+);
+const WORKTREE_SETUP_TIMEOUT_MS = 20 * 60 * 1000;
+const OUTPUT_TAIL_MAX_LENGTH = 12_000;
+const OUTPUT_UPDATE_INTERVAL_MS = 150;
+
+const WORKTREE_SETUP_TIMEOUT_MESSAGE = 'Worktree setup timed out.';
+const WORKTREE_SETUP_WINDOWS_UNSUPPORTED_MESSAGE =
+  'Worktree setup scripts are not supported on Windows yet.';
+
+const EXPECTED_FAILURE_MESSAGES = new Set([
+  WORKTREE_SETUP_TIMEOUT_MESSAGE,
+  WORKTREE_SETUP_WINDOWS_UNSUPPORTED_MESSAGE,
+  'Worktree setup was interrupted.',
+]);
+
+type SpawnProcess = {
+  stdout: Readable;
+  stderr: Readable;
+  kill: () => boolean | undefined;
+  on(event: 'error', listener: (error: Error) => void): SpawnProcess;
+  on(event: 'close', listener: (code: number | null) => void): SpawnProcess;
+};
+
+type SpawnFn = (
+  command: string,
+  args: string[],
+  options: {
+    cwd: string;
+    env: NodeJS.ProcessEnv;
+    stdio: ['ignore', 'pipe', 'pipe'];
+  },
+) => SpawnProcess;
+
+export type WorktreeSetupMetadata = {
+  workspacePath: string;
+  mainWorktreePath: string;
+  repositoryId: string;
+  sourceBranch: string;
+  worktreeBranch: string;
+};
+
+type WorktreeSetupRunnerDeps = {
+  logger: Logger;
+  telemetryService: TelemetryService;
+  uiKarton: KartonService;
+  resolvedEnvPromise: Promise<Record<string, string> | null>;
+  spawnProcess?: SpawnFn;
+  timeoutMs?: number;
+  platform?: NodeJS.Platform;
+};
+
+type ActiveRun = {
+  child: SpawnProcess | null;
+  timeout: ReturnType<typeof setTimeout>;
+  outputFlushTimer: ReturnType<typeof setTimeout> | null;
+  stdoutTail: string;
+  stderrTail: string;
+  settled: boolean;
+};
+
+function appendTail(current: string, chunk: Buffer): string {
+  const next = current + chunk.toString('utf8');
+  if (next.length <= OUTPUT_TAIL_MAX_LENGTH) return next;
+  return next.slice(next.length - OUTPUT_TAIL_MAX_LENGTH);
+}
+
+export class WorktreeSetupRunner {
+  private readonly logger: Logger;
+  private readonly telemetryService: TelemetryService;
+  private readonly uiKarton: KartonService;
+  private readonly resolvedEnvPromise: Promise<Record<string, string> | null>;
+  private readonly spawnProcess: SpawnFn;
+  private readonly timeoutMs: number;
+  private readonly platform: NodeJS.Platform;
+  private readonly activeRuns = new Map<string, ActiveRun>();
+
+  public constructor({
+    logger,
+    telemetryService,
+    uiKarton,
+    resolvedEnvPromise,
+    spawnProcess = (command, args, options) =>
+      spawn(command, args, options) as SpawnProcess,
+    timeoutMs = WORKTREE_SETUP_TIMEOUT_MS,
+    platform = process.platform,
+  }: WorktreeSetupRunnerDeps) {
+    this.logger = logger;
+    this.telemetryService = telemetryService;
+    this.uiKarton = uiKarton;
+    this.resolvedEnvPromise = resolvedEnvPromise;
+    this.spawnProcess = spawnProcess;
+    this.timeoutMs = timeoutMs;
+    this.platform = platform;
+  }
+
+  public async start(metadata: WorktreeSetupMetadata): Promise<void> {
+    if (this.activeRuns.has(metadata.workspacePath)) return;
+
+    const scriptPath = path.join(
+      metadata.workspacePath,
+      WORKTREE_SETUP_SCRIPT_RELATIVE_PATH,
+    );
+    if (!(await this.pathExists(scriptPath))) return;
+
+    const runId = randomUUID();
+    const startedAt = Date.now();
+    this.uiKarton.setState((draft: AppState) => {
+      draft.workspaceGitSetup.runsByPath[metadata.workspacePath] = {
+        id: runId,
+        workspacePath: metadata.workspacePath,
+        mainWorktreePath: metadata.mainWorktreePath,
+        repositoryId: metadata.repositoryId,
+        sourceBranch: metadata.sourceBranch,
+        worktreeBranch: metadata.worktreeBranch,
+        scriptPath,
+        status: 'running',
+        startedAt,
+        finishedAt: null,
+        exitCode: null,
+        message: null,
+        stdoutTail: '',
+        stderrTail: '',
+      };
+    });
+
+    const activeRun: ActiveRun = {
+      child: null,
+      timeout: setTimeout(() => {
+        if (activeRun.settled) return;
+        try {
+          activeRun.child?.kill();
+        } catch {
+          // ignore kill failures; the run is already marked failed below.
+        }
+        finish('failed', null, WORKTREE_SETUP_TIMEOUT_MESSAGE);
+      }, this.timeoutMs),
+      outputFlushTimer: null,
+      stdoutTail: '',
+      stderrTail: '',
+      settled: false,
+    };
+    this.activeRuns.set(metadata.workspacePath, activeRun);
+
+    const flushOutput = () => {
+      if (activeRun.outputFlushTimer) {
+        clearTimeout(activeRun.outputFlushTimer);
+        activeRun.outputFlushTimer = null;
+      }
+      this.updateOutput(
+        metadata.workspacePath,
+        activeRun.stdoutTail,
+        activeRun.stderrTail,
+      );
+    };
+
+    const scheduleOutputFlush = () => {
+      if (activeRun.outputFlushTimer) return;
+      activeRun.outputFlushTimer = setTimeout(() => {
+        activeRun.outputFlushTimer = null;
+        this.updateOutput(
+          metadata.workspacePath,
+          activeRun.stdoutTail,
+          activeRun.stderrTail,
+        );
+      }, OUTPUT_UPDATE_INTERVAL_MS);
+    };
+
+    const finish = (
+      status: 'succeeded' | 'failed',
+      exitCode: number | null,
+      message: string | null,
+      error?: Error,
+    ) => {
+      if (activeRun.settled) return;
+      activeRun.settled = true;
+      clearTimeout(activeRun.timeout);
+      flushOutput();
+      this.activeRuns.delete(metadata.workspacePath);
+      this.finishRun(metadata.workspacePath, {
+        status,
+        exitCode,
+        message,
+        stdoutTail: activeRun.stdoutTail,
+        stderrTail: activeRun.stderrTail,
+        error,
+      });
+    };
+
+    if (this.platform === 'win32') {
+      finish('failed', null, WORKTREE_SETUP_WINDOWS_UNSUPPORTED_MESSAGE);
+      return;
+    }
+
+    let resolvedEnv: Record<string, string> | null;
+    try {
+      resolvedEnv = await this.resolvedEnvPromise;
+    } catch (error) {
+      finish(
+        'failed',
+        null,
+        error instanceof Error
+          ? `Failed to resolve worktree setup environment: ${error.message}`
+          : 'Failed to resolve worktree setup environment.',
+        error instanceof Error ? error : undefined,
+      );
+      return;
+    }
+    if (activeRun.settled) return;
+
+    const env: NodeJS.ProcessEnv = {
+      ...process.env,
+      ...(resolvedEnv ?? {}),
+      STAGEWISE_MAIN_WORKTREE: metadata.mainWorktreePath,
+      STAGEWISE_NEW_WORKTREE: metadata.workspacePath,
+      STAGEWISE_WORKTREE: metadata.workspacePath,
+      STAGEWISE_SOURCE_BRANCH: metadata.sourceBranch,
+      STAGEWISE_WORKTREE_BRANCH: metadata.worktreeBranch,
+      STAGEWISE_REPOSITORY_ID: metadata.repositoryId,
+      STAGEWISE_SETUP_SCRIPT: scriptPath,
+    };
+
+    try {
+      activeRun.child = this.spawnProcess('/bin/sh', [scriptPath], {
+        cwd: metadata.workspacePath,
+        env,
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+    } catch (error) {
+      finish(
+        'failed',
+        null,
+        error instanceof Error
+          ? `Failed to start worktree setup: ${error.message}`
+          : 'Failed to start worktree setup.',
+        error instanceof Error ? error : undefined,
+      );
+      return;
+    }
+
+    activeRun.child.stdout.on('data', (chunk: Buffer) => {
+      activeRun.stdoutTail = appendTail(activeRun.stdoutTail, chunk);
+      scheduleOutputFlush();
+    });
+    activeRun.child.stderr.on('data', (chunk: Buffer) => {
+      activeRun.stderrTail = appendTail(activeRun.stderrTail, chunk);
+      scheduleOutputFlush();
+    });
+
+    activeRun.child.on('error', (error: Error) => {
+      finish('failed', null, `Worktree setup failed: ${error.message}`, error);
+    });
+    activeRun.child.on('close', (code: number | null) => {
+      if (code === 0) {
+        finish('succeeded', 0, null);
+        return;
+      }
+      finish(
+        'failed',
+        code,
+        `Worktree setup exited with code ${code ?? 'null'}.`,
+      );
+    });
+  }
+
+  public teardown(): void {
+    for (const [workspacePath, run] of this.activeRuns) {
+      run.settled = true;
+      clearTimeout(run.timeout);
+      if (run.outputFlushTimer) {
+        clearTimeout(run.outputFlushTimer);
+        run.outputFlushTimer = null;
+      }
+      try {
+        run.child?.kill();
+      } catch {
+        // ignore
+      }
+      this.finishRun(workspacePath, {
+        status: 'failed',
+        exitCode: null,
+        message: 'Worktree setup was interrupted.',
+        stdoutTail: run.stdoutTail,
+        stderrTail: run.stderrTail,
+      });
+    }
+    this.activeRuns.clear();
+  }
+
+  private async pathExists(targetPath: string): Promise<boolean> {
+    try {
+      const stat = await fs.stat(targetPath);
+      return stat.isFile();
+    } catch {
+      return false;
+    }
+  }
+
+  private updateOutput(
+    workspacePath: string,
+    stdoutTail: string,
+    stderrTail: string,
+  ): void {
+    this.uiKarton.setState((draft: AppState) => {
+      const run = draft.workspaceGitSetup.runsByPath[workspacePath];
+      if (!run || run.status !== 'running') return;
+      run.stdoutTail = stdoutTail;
+      run.stderrTail = stderrTail;
+    });
+  }
+
+  private finishRun(
+    workspacePath: string,
+    result: {
+      status: 'succeeded' | 'failed';
+      exitCode: number | null;
+      message: string | null;
+      stdoutTail: string;
+      stderrTail: string;
+      error?: Error;
+    },
+  ): void {
+    this.uiKarton.setState((draft: AppState) => {
+      const run = draft.workspaceGitSetup.runsByPath[workspacePath];
+      if (!run) return;
+      run.status = result.status;
+      run.finishedAt = Date.now();
+      run.exitCode = result.exitCode;
+      run.message = result.message;
+      run.stdoutTail = result.stdoutTail;
+      run.stderrTail = result.stderrTail;
+    });
+
+    if (result.status === 'failed') {
+      this.logger.warn('[WorktreeSetupRunner] Worktree setup failed', {
+        workspacePath,
+        message: result.message,
+        exitCode: result.exitCode,
+      });
+
+      if (
+        result.error &&
+        !EXPECTED_FAILURE_MESSAGES.has(result.message ?? '')
+      ) {
+        this.telemetryService.captureException(result.error, {
+          service: 'worktree-setup-runner',
+          operation: 'runSetup',
+        });
+      }
+    }
+  }
+}

--- a/apps/browser/src/shared/karton-contracts/ui/index.ts
+++ b/apps/browser/src/shared/karton-contracts/ui/index.ts
@@ -126,6 +126,29 @@ export type WorkspaceGitCleanupState = {
   lastResult: WorkspaceGitCleanupResult | null;
 };
 
+export type WorkspaceGitSetupStatus = 'running' | 'succeeded' | 'failed';
+
+export type WorkspaceGitSetupRun = {
+  id: string;
+  workspacePath: string;
+  mainWorktreePath: string;
+  repositoryId: string;
+  sourceBranch: string;
+  worktreeBranch: string;
+  scriptPath: string;
+  status: WorkspaceGitSetupStatus;
+  startedAt: number;
+  finishedAt: number | null;
+  exitCode: number | null;
+  message: string | null;
+  stdoutTail: string;
+  stderrTail: string;
+};
+
+export type WorkspaceGitSetupState = {
+  runsByPath: Record<string, WorkspaceGitSetupRun>;
+};
+
 export type WorkspaceGitFailureReason =
   | 'not-git-repo'
   | 'branch-not-found'
@@ -147,7 +170,12 @@ export type WorkspaceGitMutationResult =
   | WorkspaceGitFailure;
 
 export type WorkspaceGitCreateWorktreeResult =
-  | { ok: true; path: string; git: WorkspaceGitSummary | null }
+  | {
+      ok: true;
+      path: string;
+      branchName: string;
+      git: WorkspaceGitSummary | null;
+    }
   | WorkspaceGitFailure;
 
 export type WorkspaceGitCreateBranchOptions = {
@@ -621,6 +649,7 @@ export type AppState = {
     };
   };
   workspaceGitCleanup: WorkspaceGitCleanupState;
+  workspaceGitSetup: WorkspaceGitSetupState;
   toolbox: {
     [agentInstanceId: string]: {
       workspace: {
@@ -1378,6 +1407,9 @@ export const defaultState: KartonContract['state'] = {
     cleaning: false,
     candidates: [],
     lastResult: null,
+  },
+  workspaceGitSetup: {
+    runsByPath: {},
   },
   toolbox: {},
   userAccount: {

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/workspace-select.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/workspace-select.tsx
@@ -47,7 +47,7 @@ import {
 import { Switch } from '@stagewise/stage-ui/components/switch';
 import { OverlayScrollbar } from '@stagewise/stage-ui/components/overlay-scrollbar';
 import { cn } from '@stagewise/stage-ui/lib/utils';
-import { CheckIcon, XIcon, Loader2Icon } from 'lucide-react';
+import { CheckIcon, Loader2Icon, XIcon } from 'lucide-react';
 
 import { useKartonProcedure, useKartonState } from '@ui/hooks/use-karton';
 import { useScrollFadeMask } from '@ui/hooks/use-scroll-fade-mask';
@@ -75,6 +75,8 @@ import {
   type WorkspaceGitCreateWorktreeOptions,
   type WorkspaceGitCreateWorktreeResult,
   type WorkspaceGitMutationResult,
+  type WorkspaceGitSetupRun,
+  type KartonContract,
 } from '@shared/karton-contracts/ui';
 import { AgentTypes } from '@shared/karton-contracts/ui/agent';
 import { useOpenAgent } from '@ui/hooks/use-open-chat';
@@ -91,8 +93,14 @@ import {
 import { Button } from '@stagewise/stage-ui/components/button';
 import { applyWorkspaceGitActionPreferences } from './workspace-action-preferences';
 import { hydrateWorkspaceActionConfigWithDefaults } from './workspace-action-config-utils';
+import {
+  SetupRunSidePanel,
+  WorkspaceSetupStatusIndicator,
+} from './workspace-setup-status';
 
 const EMPTY_SKILLS: string[] = [];
+type KartonState = KartonContract['state'];
+type KartonProcedures = KartonContract['serverProcedures'];
 
 function formatGitRef(git: MountedWorkspaceGitSummary): string | null {
   return git.branch ?? git.headSha?.slice(0, 7) ?? null;
@@ -123,19 +131,35 @@ const WorkspaceBadge = memo(function WorkspaceBadge({
 }) {
   const display = getWorkspaceDisplayInfo(mount);
   const gitRef = mount.git ? formatGitRef(mount.git) : null;
+  const setupRun = useKartonState(
+    (s: KartonState) => s.workspaceGitSetup.runsByPath[mount.path],
+  );
+  const [open, setOpen] = useState(false);
+  const [seenSucceededSetupRunIds, setSeenSucceededSetupRunIds] = useState<
+    ReadonlySet<string>
+  >(() => new Set());
+  const showSucceededSetupReceipt =
+    setupRun?.status === 'succeeded' &&
+    !seenSucceededSetupRunIds.has(setupRun.id);
+  const showSetupRunDetails =
+    setupRun?.status === 'running' ||
+    setupRun?.status === 'failed' ||
+    showSucceededSetupReceipt;
 
   const respectAgentsMd = useKartonState(
-    (s) =>
+    (s: KartonState) =>
       s.preferences?.agent?.workspaceSettings?.[mount.path]?.respectAgentsMd ??
       false,
   );
-  const preferences = useKartonState((s) => s.preferences);
-  const preferencesUpdate = useKartonProcedure((p) => p.preferences.update);
+  const preferences = useKartonState((s: KartonState) => s.preferences);
+  const preferencesUpdate = useKartonProcedure(
+    (p: KartonProcedures) => p.preferences.update,
+  );
   const generateWorkspaceMd = useKartonProcedure(
-    (p) => p.toolbox.generateWorkspaceMd,
+    (p: KartonProcedures) => p.toolbox.generateWorkspaceMd,
   );
 
-  const isGeneratingWorkspaceMd = useKartonState((s) => {
+  const isGeneratingWorkspaceMd = useKartonState((s: KartonState) => {
     for (const id in s.agents.instances) {
       const inst = s.agents.instances[id];
       if (!inst) continue;
@@ -181,7 +205,7 @@ const WorkspaceBadge = memo(function WorkspaceBadge({
   );
 
   const disabledSkills = useKartonState(
-    (s) =>
+    (s: KartonState) =>
       s.preferences?.agent?.workspaceSettings?.[mount.path]?.disabledSkills ??
       EMPTY_SKILLS,
   );
@@ -192,7 +216,7 @@ const WorkspaceBadge = memo(function WorkspaceBadge({
         preferences?.agent?.workspaceSettings?.[mount.path];
       const current = currentSettings?.disabledSkills ?? [];
       const next = enabled
-        ? current.filter((s) => s !== skillName)
+        ? current.filter((s: string) => s !== skillName)
         : [...current, skillName];
 
       const patches = currentSettings
@@ -221,7 +245,7 @@ const WorkspaceBadge = memo(function WorkspaceBadge({
   );
 
   const openInIdeSelection = useKartonState(
-    (s) => s.globalConfig.openFilesInIde,
+    (s: KartonState) => s.globalConfig.openFilesInIde,
   );
 
   const resolveAbsolute = useCallback((p: string) => p, []);
@@ -263,6 +287,23 @@ const WorkspaceBadge = memo(function WorkspaceBadge({
     }, 150);
   }, [cancelPendingClear, cancelPendingOpen]);
 
+  const handleOpenChange = useCallback(
+    (next: boolean) => {
+      setOpen(next);
+      if (next) return;
+      cancelPendingOpen();
+      setSidePanelContent(null);
+      if (setupRun?.status !== 'succeeded' || !showSucceededSetupReceipt) {
+        return;
+      }
+      setSeenSucceededSetupRunIds((current) => {
+        if (current.has(setupRun.id)) return current;
+        return new Set([...Array.from(current), setupRun.id]);
+      });
+    },
+    [cancelPendingOpen, setupRun, showSucceededSetupReceipt],
+  );
+
   useEffect(
     () => () => {
       cancelPendingClear();
@@ -284,7 +325,7 @@ const WorkspaceBadge = memo(function WorkspaceBadge({
     fadeDistance: 24,
   });
 
-  useLayoutEffect(() => {
+  const updateSidePanelOffset = useCallback(() => {
     if (!sidePanelContent || !sidePanelRef.current || !containerRef.current)
       return;
     const panelHeight = sidePanelRef.current.offsetHeight;
@@ -296,6 +337,24 @@ const WorkspaceBadge = memo(function WorkspaceBadge({
 
     setSidePanelOffset(offset);
   }, [sidePanelContent, itemCenterY]);
+
+  useLayoutEffect(() => {
+    updateSidePanelOffset();
+  }, [updateSidePanelOffset]);
+
+  useEffect(() => {
+    if (!sidePanelContent || !sidePanelRef.current || !containerRef.current)
+      return;
+
+    const observer = new ResizeObserver(() => {
+      updateSidePanelOffset();
+    });
+    observer.observe(sidePanelRef.current);
+    observer.observe(containerRef.current);
+    updateSidePanelOffset();
+
+    return () => observer.disconnect();
+  }, [sidePanelContent, updateSidePanelOffset]);
 
   const handleItemHover = useCallback(
     (content: SidePanelContent, event: React.MouseEvent<HTMLElement>) => {
@@ -366,7 +425,7 @@ const WorkspaceBadge = memo(function WorkspaceBadge({
   );
 
   return (
-    <Popover>
+    <Popover open={open} onOpenChange={handleOpenChange}>
       <FileContextMenu relativePath={mount.path} resolvePath={resolveAbsolute}>
         <PopoverTrigger>
           <Button
@@ -388,6 +447,10 @@ const WorkspaceBadge = memo(function WorkspaceBadge({
                 {gitRef}
               </span>
             )}
+            <WorkspaceSetupStatusIndicator
+              setupRun={setupRun}
+              failedClassName="text-muted-foreground group-hover/workspace:text-foreground group-focus-visible/workspace:text-foreground group-has-[[data-unmount]:hover]/workspace:text-muted-foreground"
+            />
             <IconChevronDownFill18 className="size-3 shrink-0 text-subtle-foreground group-hover/workspace:text-muted-foreground group-focus-visible/workspace:text-muted-foreground group-has-[[data-unmount]:hover]/workspace:text-subtle-foreground" />
           </Button>
         </PopoverTrigger>
@@ -424,6 +487,8 @@ const WorkspaceBadge = memo(function WorkspaceBadge({
               <WorkspacePreviewCardContent
                 mount={mount}
                 name={display.label}
+                setupRun={setupRun}
+                showSetupRunDetails={showSetupRunDetails}
                 onItemHover={handleItemHover}
                 onItemLeave={cancelPendingOpen}
                 activeRow={
@@ -431,7 +496,9 @@ const WorkspaceBadge = memo(function WorkspaceBadge({
                     ? 'contextFiles'
                     : sidePanelContent?.type === 'skillsList'
                       ? 'skillsList'
-                      : null
+                      : sidePanelContent?.type === 'setupRun'
+                        ? 'setupRun'
+                        : null
                 }
               />
             </PopoverBase.Popup>
@@ -470,6 +537,8 @@ const WorkspaceBadge = memo(function WorkspaceBadge({
                     onGenerateWorkspaceMd={handleGenerateWorkspaceMd}
                     openInIdeSelection={openInIdeSelection}
                   />
+                ) : sidePanelContent.type === 'setupRun' && setupRun ? (
+                  <SetupRunSidePanel setupRun={setupRun} />
                 ) : (
                   <SkillsListSidePanel
                     skills={mount.skills}
@@ -566,7 +635,8 @@ type SidePanelContent =
   | { type: 'workspaceMd'; content: string; workspacePath: string }
   | { type: 'agentsMd'; content: string; workspacePath: string }
   | { type: 'contextFiles' }
-  | { type: 'skillsList' };
+  | { type: 'skillsList' }
+  | { type: 'setupRun' };
 
 function ContextFilesSidePanel({
   mount,
@@ -921,12 +991,16 @@ function SkillsListSidePanel({
 function WorkspacePreviewCardContent({
   mount,
   name,
+  setupRun,
+  showSetupRunDetails,
   onItemHover,
   onItemLeave,
   activeRow,
 }: {
   mount: MountEntry;
   name: string;
+  setupRun?: WorkspaceGitSetupRun;
+  showSetupRunDetails: boolean;
   onItemHover: (
     content: SidePanelContent,
     event: React.MouseEvent<HTMLElement>,
@@ -934,15 +1008,24 @@ function WorkspacePreviewCardContent({
   /** Cancels a pending open if the cursor leaves the row before the
    * open delay elapses. */
   onItemLeave: () => void;
-  activeRow: 'contextFiles' | 'skillsList' | null;
+  activeRow: 'contextFiles' | 'skillsList' | 'setupRun' | null;
 }) {
   const hasSkills = mount.skills.length > 0;
   const gitRef = mount.git ? formatGitRef(mount.git) : null;
   const gitStatus = mount.git ? formatGitStatus(mount.git.status) : null;
   const [openAgent] = useOpenAgent();
-  const createTerminal = useKartonProcedure((p) => p.browser.createTerminal);
+  const createTerminal = useKartonProcedure(
+    (p: KartonProcedures) => p.browser.createTerminal,
+  );
   const { collapsed: contentCollapsed, setCollapsed: setContentCollapsed } =
     useContentCollapsed();
+  const setupTitle = setupRun
+    ? setupRun.status === 'running'
+      ? 'Worktree setup running'
+      : setupRun.status === 'failed'
+        ? 'Worktree setup failed'
+        : 'Worktree setup done'
+    : null;
 
   const handleCopyPath = useCallback(
     (event: React.MouseEvent) => {
@@ -1019,6 +1102,25 @@ function WorkspacePreviewCardContent({
       </div>
 
       <div className="mx-2.5 border-border-subtle border-t" />
+
+      {setupRun && showSetupRunDetails && setupTitle && (
+        <div
+          data-active={activeRow === 'setupRun' ? '' : undefined}
+          className={cn(
+            'group/row flex cursor-default items-center gap-1.5 px-2.5 py-1.5 text-muted-foreground',
+            'hover:text-foreground data-[active]:text-foreground',
+            setupRun.status === 'succeeded' &&
+              'text-subtle-foreground hover:text-muted-foreground data-[active]:text-muted-foreground',
+          )}
+          onMouseEnter={(e) => onItemHover({ type: 'setupRun' }, e)}
+          onMouseLeave={onItemLeave}
+        >
+          <span className="min-w-0 flex-1 truncate font-medium text-xs">
+            {setupTitle}
+          </span>
+          <IconChevronRightOutline18 className="ml-auto size-3 shrink-0" />
+        </div>
+      )}
 
       {/* Context files row — opens side panel on hover */}
       <div
@@ -1648,24 +1750,29 @@ const WorkspaceActionSelect = memo(function WorkspaceActionSelect({
     () => (mount.git ? formatGitRef(mount.git) : null),
     [mount.git],
   );
+  const setupRun = useKartonState(
+    (s: KartonState) => s.workspaceGitSetup.runsByPath[mount.path],
+  );
   const listWorkspaceGitBranches = useKartonProcedure(
-    (p) => p.toolbox.listWorkspaceGitBranches,
+    (p: KartonProcedures) => p.toolbox.listWorkspaceGitBranches,
   );
   const listWorkspaceGitWorktrees = useKartonProcedure(
-    (p) => p.toolbox.listWorkspaceGitWorktrees,
+    (p: KartonProcedures) => p.toolbox.listWorkspaceGitWorktrees,
   );
   const createWorkspaceGitWorktree = useKartonProcedure(
-    (p) => p.toolbox.createWorkspaceGitWorktree,
+    (p: KartonProcedures) => p.toolbox.createWorkspaceGitWorktree,
   );
   const createWorkspaceGitBranch = useKartonProcedure(
-    (p) => p.toolbox.createWorkspaceGitBranch,
+    (p: KartonProcedures) => p.toolbox.createWorkspaceGitBranch,
   );
   const switchWorkspaceGitBranch = useKartonProcedure(
-    (p) => p.toolbox.switchWorkspaceGitBranch,
+    (p: KartonProcedures) => p.toolbox.switchWorkspaceGitBranch,
   );
-  const mountWorkspace = useKartonProcedure((p) => p.toolbox.mountWorkspace);
+  const mountWorkspace = useKartonProcedure(
+    (p: KartonProcedures) => p.toolbox.mountWorkspace,
+  );
   const unmountWorkspace = useKartonProcedure(
-    (p) => p.toolbox.unmountWorkspace,
+    (p: KartonProcedures) => p.toolbox.unmountWorkspace,
   );
   const [actionError, setActionError] = useState<string | null>(null);
   const [branchesResult, setBranchesResult] =
@@ -1696,16 +1803,20 @@ const WorkspaceActionSelect = memo(function WorkspaceActionSelect({
     () => getCurrentBranchValue(branchesResult, gitRef),
     [branchesResult, gitRef],
   );
-  const preferencesUpdate = useKartonProcedure((p) => p.preferences.update);
-  const generalWorkspaceGitActionPreference = useKartonState(
-    (s) => s.preferences.agent.workspaceGitActionPreferences.general,
+  const preferencesUpdate = useKartonProcedure(
+    (p: KartonProcedures) => p.preferences.update,
   );
-  const repositoryWorkspaceGitActionPreference = useKartonState((s) =>
-    mount.git?.repositoryId
-      ? s.preferences.agent.workspaceGitActionPreferences.repositories[
-          mount.git.repositoryId
-        ]
-      : undefined,
+  const generalWorkspaceGitActionPreference = useKartonState(
+    (s: KartonState) =>
+      s.preferences.agent.workspaceGitActionPreferences.general,
+  );
+  const repositoryWorkspaceGitActionPreference = useKartonState(
+    (s: KartonState) =>
+      mount.git?.repositoryId
+        ? s.preferences.agent.workspaceGitActionPreferences.repositories[
+            mount.git.repositoryId
+          ]
+        : undefined,
   );
 
   const [open, setOpen] = useState(false);
@@ -2119,6 +2230,10 @@ const WorkspaceActionSelect = memo(function WorkspaceActionSelect({
               <span className="min-w-0 truncate text-subtle-foreground group-hover/action:text-muted-foreground group-has-[[data-popup-open]]/action:text-muted-foreground">
                 {triggerSummary}
               </span>
+              <WorkspaceSetupStatusIndicator
+                setupRun={setupRun}
+                failedClassName="text-muted-foreground group-hover/action:text-foreground group-focus-visible/action:text-foreground"
+              />
               <IconChevronDownFill18 className="size-3 shrink-0 text-subtle-foreground group-hover/action:text-muted-foreground group-has-[[data-popup-open]]/action:text-muted-foreground" />
             </Button>
           </PopoverTrigger>
@@ -2682,14 +2797,17 @@ const ConnectWorkspaceSelect = memo(function ConnectWorkspaceSelectInner({
 }: ConnectWorkspaceSelectProps) {
   const track = useTrack();
   const listGitBranchesByPath = useKartonProcedure(
-    (p) => p.toolbox.listGitBranchesByPath,
+    (p: KartonProcedures) => p.toolbox.listGitBranchesByPath,
   );
   const listGitWorktreesByPath = useKartonProcedure(
-    (p) => p.toolbox.listGitWorktreesByPath,
+    (p: KartonProcedures) => p.toolbox.listGitWorktreesByPath,
   );
-  const preferencesUpdate = useKartonProcedure((p) => p.preferences.update);
+  const preferencesUpdate = useKartonProcedure(
+    (p: KartonProcedures) => p.preferences.update,
+  );
   const workspaceGitActionGeneralPreference = useKartonState(
-    (s) => s.preferences.agent.workspaceGitActionPreferences.general,
+    (s: KartonState) =>
+      s.preferences.agent.workspaceGitActionPreferences.general,
   );
   const fallbackBranchItems = useMemo(() => getBranchSelectItems(null), []);
   const fallbackWorktreeItems = useMemo(() => getWorktreeSelectItems(), []);
@@ -3376,29 +3494,32 @@ export const WorkspaceSelect = memo(function WorkspaceSelect({
   const [openAgent] = useOpenAgent();
 
   const recentlyOpenedWorkspaces = useKartonState(
-    (s) => s.userExperience.storedExperienceData.recentlyOpenedWorkspaces,
+    (s: KartonState) =>
+      s.userExperience.storedExperienceData.recentlyOpenedWorkspaces,
   );
-  const mountWorkspace = useKartonProcedure((p) => p.toolbox.mountWorkspace);
+  const mountWorkspace = useKartonProcedure(
+    (p: KartonProcedures) => p.toolbox.mountWorkspace,
+  );
   const createGitWorktreeByPath = useKartonProcedure(
-    (p) => p.toolbox.createGitWorktreeByPath,
+    (p: KartonProcedures) => p.toolbox.createGitWorktreeByPath,
   );
   const createGitBranchByPath = useKartonProcedure(
-    (p) => p.toolbox.createGitBranchByPath,
+    (p: KartonProcedures) => p.toolbox.createGitBranchByPath,
   );
   const switchGitBranchByPath = useKartonProcedure(
-    (p) => p.toolbox.switchGitBranchByPath,
+    (p: KartonProcedures) => p.toolbox.switchGitBranchByPath,
   );
   const unmountWorkspace = useKartonProcedure(
-    (p) => p.toolbox.unmountWorkspace,
+    (p: KartonProcedures) => p.toolbox.unmountWorkspace,
   );
   const track = useTrack();
-  const allMounts = useKartonState((s) =>
+  const allMounts = useKartonState((s: KartonState) =>
     openAgent
       ? (s.toolbox[openAgent]?.workspace?.mounts ?? EMPTY_MOUNTS)
       : EMPTY_MOUNTS,
   );
   const mountedPaths = useMemo(
-    () => new Set(allMounts.map((mount) => mount.path)),
+    () => new Set<string>(allMounts.map((mount: MountEntry) => mount.path)),
     [allMounts],
   );
   const pendingConnectActionConfigsRef = useRef<
@@ -3469,7 +3590,9 @@ export const WorkspaceSelect = memo(function WorkspaceSelect({
 
       track('workspace-connect-started');
 
-      const previousPrefixes = new Set(allMounts.map((mount) => mount.prefix));
+      const previousPrefixes = new Set<string>(
+        allMounts.map((mount: MountEntry) => mount.prefix),
+      );
 
       // Connect-new is picker-first because there is no workspace path until
       // the native picker resolves. Carry the selected config into the
@@ -3639,7 +3762,7 @@ export const WorkspaceSelect = memo(function WorkspaceSelect({
   return (
     <div className="scrollbar-none flex min-w-0 shrink-0 items-center gap-7 overflow-x-auto px-1 py-0.5">
       {/* Connected workspaces */}
-      {allMounts.map((mount) => {
+      {allMounts.map((mount: MountEntry) => {
         const useActionSelect = chatIsEmpty && !!mount.git;
         return useActionSelect ? (
           <WorkspaceActionSelect

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/workspace-setup-status.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/workspace-setup-status.tsx
@@ -1,0 +1,270 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Button } from '@stagewise/stage-ui/components/button';
+import { OverlayScrollbar } from '@stagewise/stage-ui/components/overlay-scrollbar';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@stagewise/stage-ui/components/tooltip';
+import { cn } from '@stagewise/stage-ui/lib/utils';
+import { FileContextMenu } from '@ui/components/file-context-menu';
+import { FileIcon } from '@ui/components/file-icon';
+import { useKartonState } from '@ui/hooks/use-karton';
+import { useScrollFadeMask } from '@ui/hooks/use-scroll-fade-mask';
+import { getIDEFileUrl } from '@ui/utils';
+import { getBaseName } from '@shared/path-utils';
+import type {
+  AppState,
+  WorkspaceGitSetupRun,
+} from '@shared/karton-contracts/ui';
+import { IconTriangleWarningOutline18 } from 'nucleo-ui-outline-18';
+import { Loader2Icon } from 'lucide-react';
+
+function formatSetupDuration(ms: number): string {
+  const seconds = Math.max(0, Math.round(ms / 1000));
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  const remainingSeconds = seconds % 60;
+  if (minutes < 60) return `${minutes}m ${remainingSeconds}s`;
+  const hours = Math.floor(minutes / 60);
+  const remainingMinutes = minutes % 60;
+  return `${hours}h ${remainingMinutes}m`;
+}
+
+function formatSetupTimestamp(timestamp: number): string {
+  return new Date(timestamp).toLocaleTimeString([], {
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  });
+}
+
+export function WorkspaceSetupStatusIndicator({
+  setupRun,
+  failedClassName = 'text-foreground',
+}: {
+  setupRun?: WorkspaceGitSetupRun;
+  failedClassName?: string;
+}) {
+  if (!setupRun) return null;
+
+  if (setupRun.status === 'running') {
+    return (
+      <>
+        <Loader2Icon
+          aria-hidden
+          className="size-3 shrink-0 animate-spin text-muted-foreground"
+        />
+        <span role="status" aria-live="polite" className="sr-only">
+          Setup running
+        </span>
+      </>
+    );
+  }
+
+  if (setupRun.status === 'failed') {
+    return (
+      <>
+        <IconTriangleWarningOutline18
+          aria-hidden
+          className={cn('size-3 shrink-0', failedClassName)}
+        />
+        <span role="status" aria-live="polite" className="sr-only">
+          Setup failed
+        </span>
+      </>
+    );
+  }
+
+  return null;
+}
+
+export function SetupRunSidePanel({
+  setupRun,
+}: {
+  setupRun: WorkspaceGitSetupRun;
+}) {
+  const [scrollViewport, setScrollViewport] = useState<HTMLElement | null>(
+    null,
+  );
+  const [now, setNow] = useState(() => Date.now());
+  const scrollViewportRef = useMemo(
+    () => ({ current: scrollViewport }),
+    [scrollViewport],
+  ) as React.RefObject<HTMLElement>;
+  const { maskStyle } = useScrollFadeMask(scrollViewportRef, {
+    axis: 'vertical',
+    fadeDistance: 16,
+  });
+
+  useEffect(() => {
+    if (setupRun.status !== 'running') return;
+    setNow(Date.now());
+    const interval = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(interval);
+  }, [setupRun.status]);
+
+  const finishedAt = setupRun.finishedAt ?? now;
+  const duration = formatSetupDuration(finishedAt - setupRun.startedAt);
+  const title =
+    setupRun.status === 'running'
+      ? 'Worktree setup running'
+      : setupRun.status === 'failed'
+        ? 'Worktree setup failed'
+        : 'Worktree setup done';
+  const hasOutput = setupRun.stdoutTail || setupRun.stderrTail;
+  const globalConfig = useKartonState((s: AppState) => s.globalConfig);
+  const scriptName = getBaseName(setupRun.scriptPath) || setupRun.scriptPath;
+  const resolveScriptPath = useCallback(
+    (filePath: string) => (filePath === setupRun.scriptPath ? filePath : null),
+    [setupRun.scriptPath],
+  );
+  const handleOpenScript = useCallback(() => {
+    window.open(
+      getIDEFileUrl(setupRun.scriptPath, globalConfig.openFilesInIde),
+      '_blank',
+    );
+  }, [globalConfig.openFilesInIde, setupRun.scriptPath]);
+
+  return (
+    <>
+      <div className="border-derived-subtle border-b px-2.5 py-2">
+        <div className="flex items-center gap-1.5">
+          <WorkspaceSetupStatusIndicator setupRun={setupRun} />
+          <span className="font-semibold">{title}</span>
+        </div>
+        <div className="mt-1 text-2xs text-subtle-foreground">
+          {setupRun.status === 'running'
+            ? `Started at ${formatSetupTimestamp(setupRun.startedAt)} · ${duration}`
+            : `Finished in ${duration}`}
+        </div>
+      </div>
+      <OverlayScrollbar
+        className="mask-alpha max-h-80"
+        style={maskStyle}
+        options={{ overflow: { x: 'hidden', y: 'scroll' } }}
+        onViewportRef={setScrollViewport}
+      >
+        <div className="grid grid-cols-[auto_minmax(0,1fr)] items-start gap-x-2 gap-y-1.5 px-2.5 py-2 text-2xs">
+          <span className="pt-0.5 text-subtle-foreground leading-none">
+            Script
+          </span>
+          <FileContextMenu
+            relativePath={setupRun.scriptPath}
+            resolvePath={resolveScriptPath}
+          >
+            <Tooltip>
+              <TooltipTrigger>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="xs"
+                  className="h-auto min-w-0 items-center justify-start gap-1 px-0 py-0 text-muted-foreground"
+                  onClick={handleOpenScript}
+                >
+                  <FileIcon filePath={scriptName} className="size-4" />
+                  <span className="truncate font-mono leading-none">
+                    {scriptName}
+                  </span>
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>{setupRun.scriptPath}</TooltipContent>
+            </Tooltip>
+          </FileContextMenu>
+          {setupRun.exitCode !== null && (
+            <>
+              <span className="text-subtle-foreground leading-none">Exit</span>
+              <span className="font-mono text-muted-foreground leading-none">
+                {setupRun.exitCode}
+              </span>
+            </>
+          )}
+          {setupRun.message && (
+            <>
+              <span className="text-subtle-foreground leading-none">
+                Status
+              </span>
+              <span className="text-muted-foreground leading-normal">
+                {setupRun.message}
+              </span>
+            </>
+          )}
+
+          {setupRun.stdoutTail && (
+            <SetupOutputBlock label="Output" output={setupRun.stdoutTail} />
+          )}
+          {setupRun.stderrTail && (
+            <SetupOutputBlock label="Errors" output={setupRun.stderrTail} />
+          )}
+          {!hasOutput && (
+            <>
+              <span className="text-subtle-foreground leading-none">
+                Output
+              </span>
+              <span className="text-muted-foreground leading-none">
+                No output captured yet.
+              </span>
+            </>
+          )}
+        </div>
+      </OverlayScrollbar>
+    </>
+  );
+}
+
+function SetupOutputBlock({
+  label,
+  output,
+}: {
+  label: string;
+  output: string;
+}) {
+  const shouldStickToBottomRef = useRef(true);
+  const [scrollViewport, setScrollViewport] = useState<HTMLElement | null>(
+    null,
+  );
+  const scrollViewportRef = useMemo(
+    () => ({ current: scrollViewport }),
+    [scrollViewport],
+  ) as React.RefObject<HTMLElement>;
+  const { maskStyle } = useScrollFadeMask(scrollViewportRef, {
+    axis: 'vertical',
+    fadeDistance: 16,
+  });
+
+  useEffect(() => {
+    if (!scrollViewport) return;
+    const handleScroll = () => {
+      const distanceFromBottom =
+        scrollViewport.scrollHeight -
+        scrollViewport.scrollTop -
+        scrollViewport.clientHeight;
+      shouldStickToBottomRef.current = distanceFromBottom <= 24;
+    };
+    scrollViewport.addEventListener('scroll', handleScroll);
+    return () => scrollViewport.removeEventListener('scroll', handleScroll);
+  }, [scrollViewport]);
+
+  useEffect(() => {
+    if (!scrollViewport || !shouldStickToBottomRef.current) return;
+    scrollViewport.scrollTop = scrollViewport.scrollHeight;
+  }, [output, scrollViewport]);
+
+  return (
+    <>
+      <span className="pt-0.5 text-subtle-foreground leading-none">
+        {label}
+      </span>
+      <OverlayScrollbar
+        className="mask-alpha scrollbar-subtle max-h-40 min-w-0 overflow-y-auto"
+        style={maskStyle}
+        options={{ overflow: { x: 'hidden', y: 'scroll' } }}
+        onViewportRef={setScrollViewport}
+      >
+        <pre className="whitespace-pre-wrap break-words font-mono text-[11px] text-muted-foreground leading-relaxed">
+          {output}
+        </pre>
+      </OverlayScrollbar>
+    </>
+  );
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a worktree setup lifecycle that runs .stagewise/worktree-setup.sh for app‑created worktrees after they’re mounted. Shows live status and logs in the UI, with a 20‑min timeout and clear failure states; Windows is not supported yet.

- **New Features**
  - `WorktreeSetupRunner` executes the script with STAGEWISE_* env vars, batches stdout/stderr updates, limits tails, flushes output on exit, times out/kills on deadline or teardown, and reports success/failure (telemetry only on unexpected errors). Scripts missing in the new worktree or only present in the main worktree are skipped.
  - `MountManager` queues setup on `createWorktree` (10‑min TTL) and starts it only after the created worktree is mounted and the script exists in that worktree; manual mounts are ignored and failed setups keep the worktree mounted. Safety: creating from a linked worktree resolves and validates the trusted main worktree path (inside `getWorktreesDir` and matching repo root) and rejects if untrusted.
  - Creating a worktree from a linked worktree now targets the main worktree; `createWorktree` returns the created `branchName`.
  - UI: workspace badges and actions show a spinner or warning; a side panel shows script path, exit code, start/finish time, duration, and live output tails, with a link to open the script. Succeeded runs show a one‑time receipt until viewed.
  - State additions in `@shared/karton-contracts/ui`: `workspaceGitSetup` store and `WorkspaceGitSetupRun` types. Tests cover runner lifecycle, output updates, teardown/timeout behavior, Windows guard, trust checks, and the pending‑setup flow.

<sup>Written for commit 5aa34c6583373e7042ad8ebeaebb6c4a73cf56af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1217?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Live worktree setup indicators in workspace selector and action trigger (running / succeeded / failed).
  * Setup details side panel showing script name, duration, exit code, and captured stdout/stderr with auto-scroll.
  * Deferred worktree setup processing: created worktrees record pending setup and start setup when mounted.
  * Background runner to execute and monitor per-workspace setup scripts with lifecycle and timeout handling.

* **Improvements**
  * Git worktree creation now returns the created branch name alongside existing info.

* **Tests**
  * Expanded tests covering worktree creation flows and setup-run behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stagewise-io/stagewise/pull/1217?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->