### PR TITLE
feat(stagewise): add ctrl-backtick for terminal focus

### DIFF
--- a/apps/browser/src/backend/services/terminal/index.ts
+++ b/apps/browser/src/backend/services/terminal/index.ts
@@ -473,7 +473,7 @@ export class TerminalService extends DisposableService {
         cwd?: string,
         agentInstanceId?: string | null,
       ) => {
-        await this.handleCreateTerminal(cwd, agentInstanceId);
+        return await this.handleCreateTerminal(cwd, agentInstanceId);
       },
     );
 
@@ -558,8 +558,8 @@ export class TerminalService extends DisposableService {
   private async handleCreateTerminal(
     cwd?: string,
     agentInstanceId?: string | null,
-  ): Promise<void> {
-    if (this.disposed) return;
+  ): Promise<string | null> {
+    if (this.disposed) return null;
 
     const resolvedCwd = cwd ?? this.resolveDefaultCwd(agentInstanceId);
     this.terminalCounter++;
@@ -568,7 +568,7 @@ export class TerminalService extends DisposableService {
     const createdAt = Date.now();
 
     const actualCwd = this.createPty(terminalId, resolvedCwd);
-    if (!actualCwd) return;
+    if (!actualCwd) return null;
 
     // Insert the tab into contentTabs but do NOT set activeTabId here.
     // WindowLayoutService owns all active-tab transitions — it needs to
@@ -600,6 +600,8 @@ export class TerminalService extends DisposableService {
     this.logger.info(
       `[TerminalService] Created terminal ${terminalId} in ${actualCwd}`,
     );
+
+    return terminalId;
   }
 
   /** Compute the default CWD for a new terminal:

--- a/apps/browser/src/shared/hotkeys.ts
+++ b/apps/browser/src/shared/hotkeys.ts
@@ -62,6 +62,7 @@ export enum HotkeyActions {
   // Tab & window navigation
   NEW_TAB = 'new_tab',
   NEW_TERMINAL_TAB = 'new_terminal_tab',
+  FOCUS_OR_TOGGLE_TERMINAL = 'focus_or_toggle_terminal',
   CLOSE_TAB = 'close_tab',
   NEXT_TAB = 'next_tab',
   PREV_TAB = 'prev_tab',
@@ -197,6 +198,10 @@ export const hotkeyDefinitions: Record<HotkeyActions, HotkeyDefinition> = {
   },
   [HotkeyActions.NEW_TERMINAL_TAB]: {
     accelerator: 'Mod+Alt+T',
+    captureDominantly: true,
+  },
+  [HotkeyActions.FOCUS_OR_TOGGLE_TERMINAL]: {
+    accelerator: 'Ctrl+Backquote',
     captureDominantly: true,
   },
   [HotkeyActions.CLOSE_TAB]: {

--- a/apps/browser/src/shared/karton-contracts/ui/index.ts
+++ b/apps/browser/src/shared/karton-contracts/ui/index.ts
@@ -1280,7 +1280,7 @@ export type KartonContract = {
       createTerminal: (
         cwd?: string,
         agentInstanceId?: string | null,
-      ) => Promise<void>;
+      ) => Promise<string | null>;
       /** Write keystroke data to a terminal's PTY. */
       terminalInput: (terminalId: string, data: string) => Promise<void>;
       /** Resize a terminal's PTY dimensions. */

--- a/apps/browser/src/ui/hooks/use-tab-ui-state.tsx
+++ b/apps/browser/src/ui/hooks/use-tab-ui-state.tsx
@@ -6,17 +6,16 @@ import React, {
   useMemo,
 } from 'react';
 
-export type State =
-  | {
-      focusedPanel: 'tab-content';
-    }
-  | {
-      focusedPanel: 'stagewise-ui';
-    };
+export type State = {
+  focusedPanel?: 'tab-content' | 'stagewise-ui';
+  terminalFocusRequestId?: number;
+};
 
 export type TabStateUI = {
   tabUiState: Record<string, State>;
   setTabUiState: (tabId: string, state: State) => void;
+  requestTerminalFocus: (tabId: string) => void;
+  clearTerminalFocusRequest: (tabId: string) => void;
   removeTabUiState: (tabId: string) => void;
 };
 
@@ -46,6 +45,26 @@ export const TabStateUIProvider = ({
     }));
   }, []);
 
+  const requestTerminalFocus = useCallback((tabId: string) => {
+    setTabUiStateInternal((prev) => ({
+      ...prev,
+      [tabId]: {
+        ...prev[tabId],
+        terminalFocusRequestId: (prev[tabId]?.terminalFocusRequestId ?? 0) + 1,
+      },
+    }));
+  }, []);
+
+  const clearTerminalFocusRequest = useCallback((tabId: string) => {
+    setTabUiStateInternal((prev) => ({
+      ...prev,
+      [tabId]: {
+        ...prev[tabId],
+        terminalFocusRequestId: undefined,
+      },
+    }));
+  }, []);
+
   const removeTabUiState = useCallback((tabId: string) => {
     setTabUiStateInternal((prev) => {
       const { [tabId]: _, ...rest } = prev;
@@ -57,9 +76,17 @@ export const TabStateUIProvider = ({
     () => ({
       tabUiState,
       setTabUiState,
+      requestTerminalFocus,
+      clearTerminalFocusRequest,
       removeTabUiState,
     }),
-    [tabUiState, setTabUiState, removeTabUiState],
+    [
+      tabUiState,
+      setTabUiState,
+      requestTerminalFocus,
+      clearTerminalFocusRequest,
+      removeTabUiState,
+    ],
   );
 
   return (

--- a/apps/browser/src/ui/screens/main/_components/agent-hotkey-bindings.tsx
+++ b/apps/browser/src/ui/screens/main/_components/agent-hotkey-bindings.tsx
@@ -17,7 +17,7 @@ export function AgentHotkeyBindings({
   onCreateTerminalTab,
 }: {
   onCreateTab: () => void;
-  onCreateTerminalTab: () => void;
+  onCreateTerminalTab: () => Promise<string | null>;
 }) {
   // -- Content panel toggle (Mod+Alt+B) ----------------------------------
   const { collapsed: contentCollapsed, setCollapsed: setContentCollapsed } =
@@ -36,9 +36,12 @@ export function AgentHotkeyBindings({
   // -- Tab management (per-agent) ---------------------------------------
   const activeTabId = useKartonState((s) => s.contentTabs.activeTabId);
   const tabs = useKartonState((s) => s.contentTabs.tabs);
+  const globalOrder = useKartonState((s) => s.contentTabs.globalOrder);
+  const agentOrders = useKartonState((s) => s.contentTabs.agentOrders);
   const closeTab = useKartonProcedure((p) => p.browser.closeTab);
   const switchTab = useKartonProcedure((p) => p.browser.switchTab);
-  const { removeTabUiState } = useTabUIState();
+  const { tabUiState, requestTerminalFocus, removeTabUiState } =
+    useTabUIState();
 
   // Mod+T: new tab (attached to current agent, opens content panel)
   const [openAgent] = useOpenAgent();
@@ -51,11 +54,16 @@ export function AgentHotkeyBindings({
     agentHotkeysEnabled,
   );
 
+  const createTerminalTabSafely = useCallback(
+    () => onCreateTerminalTab().catch(() => null),
+    [onCreateTerminalTab],
+  );
+
   // Mod+Alt+T: new terminal tab
   useHotKeyListener(
     () => {
       if (contentCollapsed) setContentCollapsed(false);
-      onCreateTerminalTab();
+      void createTerminalTabSafely();
     },
     HotkeyActions.NEW_TERMINAL_TAB,
     agentHotkeysEnabled,
@@ -73,12 +81,41 @@ export function AgentHotkeyBindings({
   );
 
   // -- Content panel tab navigation (Mod+Alt+PageDown / Mod+Alt+PageUp) --
-  // Only tabs visible for the current agent (global + agent-attached).
-  const visibleTabIds = Object.keys(tabs).filter(
-    (id) =>
-      tabs[id]?.agentInstanceId === null ||
-      tabs[id]?.agentInstanceId === openAgent,
+  // Only tabs visible for the current agent (global + agent-attached), in
+  // the same order as the rendered tab bar.
+  const visibleTabIds = [
+    ...globalOrder.filter((id) => tabs[id]?.agentInstanceId === null),
+    ...(openAgent ? (agentOrders[openAgent] ?? []) : []).filter(
+      (id) => tabs[id]?.agentInstanceId === openAgent,
+    ),
+  ];
+  const visibleTerminalIds = visibleTabIds.filter(
+    (id) => tabs[id]?.type === 'terminal',
   );
+
+  const focusTerminal = useCallback(
+    (terminalId: string) => {
+      void switchTab(terminalId);
+      requestTerminalFocus(terminalId);
+    },
+    [requestTerminalFocus, switchTab],
+  );
+
+  const getNextTerminalId = useCallback(() => {
+    if (visibleTerminalIds.length === 0) return null;
+    if (!activeTabId) return visibleTerminalIds[0] ?? null;
+
+    const activeVisibleIndex = visibleTabIds.indexOf(activeTabId);
+    if (activeVisibleIndex === -1) return visibleTerminalIds[0] ?? null;
+
+    return (
+      visibleTerminalIds.find(
+        (terminalId) => visibleTabIds.indexOf(terminalId) > activeVisibleIndex,
+      ) ??
+      visibleTerminalIds[0] ??
+      null
+    );
+  }, [activeTabId, visibleTabIds, visibleTerminalIds]);
 
   const switchToTabByIndex = useCallback(
     (index: number) => {
@@ -86,6 +123,52 @@ export function AgentHotkeyBindings({
       if (id) void switchTab(id);
     },
     [visibleTabIds, switchTab],
+  );
+
+  useHotKeyListener(
+    () => {
+      const activeTab = activeTabId ? tabs[activeTabId] : undefined;
+      const activeTabIsVisibleTerminal =
+        !!activeTabId &&
+        activeTab?.type === 'terminal' &&
+        visibleTerminalIds.includes(activeTabId);
+      const activeTerminalFocused =
+        !!activeTabId &&
+        tabUiState[activeTabId]?.focusedPanel === 'tab-content';
+      const nextTerminalId = getNextTerminalId();
+
+      if (visibleTerminalIds.length === 0) {
+        if (contentCollapsed) setContentCollapsed(false);
+        void createTerminalTabSafely().then((terminalId) => {
+          if (terminalId) requestTerminalFocus(terminalId);
+        });
+        return;
+      }
+
+      if (contentCollapsed) {
+        setContentCollapsed(false);
+        focusTerminal(
+          activeTabIsVisibleTerminal
+            ? activeTabId
+            : (nextTerminalId ?? visibleTerminalIds[0]!),
+        );
+        return;
+      }
+
+      if (activeTabIsVisibleTerminal && activeTerminalFocused) {
+        setContentCollapsed(true);
+        return;
+      }
+
+      if (activeTabIsVisibleTerminal) {
+        requestTerminalFocus(activeTabId);
+        return;
+      }
+
+      if (nextTerminalId) focusTerminal(nextTerminalId);
+    },
+    HotkeyActions.FOCUS_OR_TOGGLE_TERMINAL,
+    agentHotkeysEnabled,
   );
 
   const cycleTab = useCallback(

--- a/apps/browser/src/ui/screens/main/content/index.tsx
+++ b/apps/browser/src/ui/screens/main/content/index.tsx
@@ -247,7 +247,7 @@ export function MainSection({
   // Ref-based reads prevent stale closures so the effect always sees
   // current Karton state even when lazily-created tabs land between
   // the agent switch and the next render.
-  const prevOpenAgentRef = useRef<string | null>(null);
+  const prevOpenAgentRef = useRef(openAgent);
   const tabsRef = useRef(tabs);
   tabsRef.current = tabs;
   const globalOrderRef = useRef(globalOrder);
@@ -259,64 +259,99 @@ export function MainSection({
   const lastActiveTabPerAgentRef = useRef(lastActiveTabPerAgent);
   lastActiveTabPerAgentRef.current = lastActiveTabPerAgent;
 
+  const isActiveTabVisibleForAgent = useCallback((agentId: string) => {
+    const curActiveId = activeTabIdRef.current;
+    if (!curActiveId) return false;
+
+    const currentTab = tabsRef.current[curActiveId];
+    if (!currentTab) return false;
+
+    return (
+      currentTab.agentInstanceId === null ||
+      currentTab.agentInstanceId === agentId
+    );
+  }, []);
+
+  const reconcileActiveTabForAgent = useCallback(
+    (agentId: string) => {
+      const curTabs = tabsRef.current;
+      const curActiveId = activeTabIdRef.current;
+      const curLastActive = lastActiveTabPerAgentRef.current;
+      const curGlobalOrder = globalOrderRef.current;
+      const curAgentOrders = agentOrdersRef.current;
+
+      // Bail only if the current tab is explicitly for this agent.
+      // A global tab is "visible" everywhere but we still want to
+      // switch to a remembered agent-specific tab when available.
+      if (curActiveId && curTabs[curActiveId]) {
+        const currentTab = curTabs[curActiveId];
+        if (currentTab.agentInstanceId === agentId) return;
+      }
+
+      // Need to switch — collect visible tab IDs for the agent
+      const visibleIds = [
+        ...curGlobalOrder.filter((id) => curTabs[id]?.agentInstanceId === null),
+        ...(curAgentOrders[agentId] ?? []).filter(
+          (id) => curTabs[id]?.agentInstanceId === agentId,
+        ),
+      ];
+
+      // Prefer previously active tab for this agent
+      const prevActive = curLastActive[agentId];
+      if (
+        prevActive &&
+        curTabs[prevActive] &&
+        visibleIds.includes(prevActive)
+      ) {
+        switchTab(prevActive);
+        return;
+      }
+
+      // Prefer any agent-specific tab
+      const agentTab = visibleIds.find(
+        (id) => curTabs[id]?.agentInstanceId === agentId,
+      );
+      if (agentTab) {
+        switchTab(agentTab);
+        return;
+      }
+
+      // Prefer any global tab
+      const globalTab = visibleIds.find(
+        (id) => curTabs[id]?.agentInstanceId === null,
+      );
+      if (globalTab) {
+        switchTab(globalTab);
+        return;
+      }
+
+      // No visible tabs for this agent — do nothing;
+      // effectiveActiveTabId derived below will show empty state.
+    },
+    [switchTab],
+  );
+
   useEffect(() => {
     const prevAgent = prevOpenAgentRef.current;
     prevOpenAgentRef.current = openAgent;
 
-    // Only react to actual agent changes
-    if (prevAgent === openAgent) return;
     if (!openAgent) return;
 
-    const curTabs = tabsRef.current;
-    const curActiveId = activeTabIdRef.current;
-    const curLastActive = lastActiveTabPerAgentRef.current;
-    const curGlobalOrder = globalOrderRef.current;
-    const curAgentOrders = agentOrdersRef.current;
-
-    // Bail only if the current tab is explicitly for this agent.
-    // A global tab is "visible" everywhere but we still want to
-    // switch to a remembered agent-specific tab when available.
-    if (curActiveId && curTabs[curActiveId]) {
-      const currentTab = curTabs[curActiveId];
-      if (currentTab.agentInstanceId === openAgent) return;
-    }
-
-    // Need to switch — collect visible tab IDs for the new agent
-    const visibleIds = [
-      ...curGlobalOrder.filter((id) => curTabs[id]?.agentInstanceId === null),
-      ...(openAgent ? (curAgentOrders[openAgent] ?? []) : []).filter(
-        (id) => curTabs[id]?.agentInstanceId === openAgent,
-      ),
-    ];
-
-    // Prefer previously active tab for this agent
-    const prevActive = curLastActive[openAgent];
-    if (prevActive && curTabs[prevActive] && visibleIds.includes(prevActive)) {
-      switchTab(prevActive);
+    if (prevAgent === openAgent) {
+      if (!isActiveTabVisibleForAgent(openAgent)) {
+        reconcileActiveTabForAgent(openAgent);
+      }
       return;
     }
 
-    // Prefer any agent-specific tab
-    const agentTab = visibleIds.find(
-      (id) => curTabs[id]?.agentInstanceId === openAgent,
-    );
-    if (agentTab) {
-      switchTab(agentTab);
-      return;
-    }
-
-    // Prefer any global tab
-    const globalTab = visibleIds.find(
-      (id) => curTabs[id]?.agentInstanceId === null,
-    );
-    if (globalTab) {
-      switchTab(globalTab);
-      return;
-    }
-
-    // No visible tabs for this agent — do nothing;
-    // effectiveActiveTabId derived below will show empty state.
-  }, [openAgent, switchTab, globalOrder, agentOrders]);
+    reconcileActiveTabForAgent(openAgent);
+  }, [
+    openAgent,
+    isActiveTabVisibleForAgent,
+    reconcileActiveTabForAgent,
+    globalOrder,
+    agentOrders,
+  ]);
 
   // ---------------------------------------------------------------------------
   // Optimistic tab order

--- a/apps/browser/src/ui/screens/main/index.tsx
+++ b/apps/browser/src/ui/screens/main/index.tsx
@@ -152,7 +152,7 @@ function DefaultLayoutInner({ show }: { show: boolean }) {
 
   const handleOpenTerminal = useCallback(() => {
     if (contentCollapsed) setContentCollapsed(false);
-    void createTerminal(undefined, openAgent);
+    return createTerminal(undefined, openAgent);
   }, [createTerminal, openAgent, contentCollapsed, setContentCollapsed]);
 
   const markStagewiseUiFocused = useCallback(() => {

--- a/apps/browser/src/ui/screens/main/terminal-panel/_components/per-terminal-content.tsx
+++ b/apps/browser/src/ui/screens/main/terminal-panel/_components/per-terminal-content.tsx
@@ -56,9 +56,11 @@ export function PerTerminalContent({
     (p) => p.browser.getTerminalSnapshot,
   );
   const updatePreferences = useKartonProcedure((p) => p.preferences.update);
-  const { tabUiState, setTabUiState } = useTabUIState();
-  const isTerminalFocused =
-    tabUiState[terminalId]?.focusedPanel === 'tab-content';
+  const { tabUiState, setTabUiState, clearTerminalFocusRequest } =
+    useTabUIState();
+  const terminalUiState = tabUiState[terminalId];
+  const isTerminalFocused = terminalUiState?.focusedPanel === 'tab-content';
+  const terminalFocusRequestId = terminalUiState?.terminalFocusRequestId;
 
   const terminalInputRef = useRef(terminalInput);
   terminalInputRef.current = terminalInput;
@@ -68,10 +70,22 @@ export function PerTerminalContent({
   getTerminalSnapshotRef.current = getTerminalSnapshot;
   const isActiveRef = useRef(isActive);
   isActiveRef.current = isActive;
+  const terminalFocusRequestIdRef = useRef(terminalFocusRequestId);
+  terminalFocusRequestIdRef.current = terminalFocusRequestId;
 
-  const markTerminalFocused = () => {
+  const markTerminalFocused = useCallback(() => {
     setTabUiState(terminalId, { focusedPanel: 'tab-content' });
-  };
+  }, [setTabUiState, terminalId]);
+
+  const focusTerminalIfReady = useCallback(() => {
+    const term = terminalRef.current;
+    if (!term) return false;
+
+    term.focus();
+    markTerminalFocused();
+    clearTerminalFocusRequest(terminalId);
+    return true;
+  }, [clearTerminalFocusRequest, markTerminalFocused, terminalId]);
 
   const updateTerminalZoom = useCallback(
     (nextZoomPercentage: number) => {
@@ -204,6 +218,11 @@ export function PerTerminalContent({
   };
 
   useEffect(() => {
+    if (!isActive || terminalFocusRequestId === undefined) return;
+    focusTerminalIfReady();
+  }, [focusTerminalIfReady, isActive, terminalFocusRequestId]);
+
+  useEffect(() => {
     const container = containerRef.current;
     if (!container) return;
 
@@ -255,6 +274,13 @@ export function PerTerminalContent({
       term.open(container);
       terminalRef.current = term;
 
+      if (
+        isActiveRef.current &&
+        terminalFocusRequestIdRef.current !== undefined
+      ) {
+        focusTerminalIfReady();
+      }
+
       term.onData((data: string) => {
         markTerminalFocused();
         terminalInputRef.current(terminalId, data);
@@ -264,7 +290,13 @@ export function PerTerminalContent({
         try {
           fitAddon.fit();
           sendResize(true);
-          if (isActiveRef.current) term.focus();
+          if (isActiveRef.current) {
+            if (terminalFocusRequestIdRef.current !== undefined) {
+              focusTerminalIfReady();
+            } else {
+              term.focus();
+            }
+          }
         } catch {
           // May fail during layout transitions.
         }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Ctrl+Backquote to focus or toggle the terminal for the current agent. Improves focus reliability after terminal creation, mount/resizes, and agent/tab layout changes.

- New Features
  - New hotkey: Ctrl+Backquote (`FOCUS_OR_TOGGLE_TERMINAL`).
    - No terminal: opens panel, creates one, and focuses it.
    - Panel collapsed: expands and focuses the active or next visible terminal (uses `globalOrder` + `agentOrders`).
    - Focused terminal: collapses the panel; otherwise focuses it.
  - Terminal focus is requested and applied after mount/resizes for consistent behavior.

- Refactors
  - `createTerminal` now returns the new terminal ID; Karton UI contract updated to `Promise<string | null>`.
  - Added per-tab UI state: `terminalFocusRequestId`, `requestTerminalFocus`, and `clearTerminalFocusRequest`.
  - Improved active-tab reconciliation when switching agents or after lazy tab creation; initialized `prevOpenAgentRef` with the current agent.

<sup>Written for commit e46f83a8a3a0e74953938aba34d75edd9a30533d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1218?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Ctrl+Backquote hotkey to focus or toggle the terminal panel; when no terminal exists the hotkey creates one and focuses it.

* **Bug Fixes**
  * Terminal creation now reliably returns an identifier so newly created terminals can be focused.
  * Improved terminal focus handling, deterministic terminal navigation, and smoother agent/tab switching to avoid stale focus or incorrect tab selection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stagewise-io/stagewise/pull/1218?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->