### PR TITLE
fix(stagewise): fix browser-tab rendering in cmd-k center

### DIFF
--- a/apps/browser/src/ui/screens/main/command-center/command-center-hotkeys.tsx
+++ b/apps/browser/src/ui/screens/main/command-center/command-center-hotkeys.tsx
@@ -2,15 +2,25 @@ import { HotkeyActions } from '@shared/hotkeys';
 import { useHotKeyListener } from '@ui/hooks/use-hotkey-listener';
 import { useKartonProcedure, useKartonState } from '@ui/hooks/use-karton';
 import { useTabUIState } from '@ui/hooks/use-tab-ui-state';
+import { useOpenAgent } from '@ui/hooks/use-open-chat';
 import { useCommandCenter } from './command-center-context';
 
 export function CommandCenterHotkeys() {
   const { close, isOpen, open, restoreFocusOnClose } = useCommandCenter();
-  const activeTabId = useKartonState((s) => s.browser.activeTabId);
-  const { tabUiState } = useTabUIState();
-  const shouldRestoreFocusOnClose = activeTabId
-    ? tabUiState[activeTabId]?.focusedPanel === 'tab-content'
-    : false;
+  const [openAgent] = useOpenAgent();
+  const activeTabId = useKartonState((s) => s.contentTabs.activeTabId);
+  const activeTab = useKartonState((s) =>
+    activeTabId ? (s.contentTabs.tabs[activeTabId] ?? null) : null,
+  );
+  const { tabUiState, requestTerminalFocus } = useTabUIState();
+  const isActiveTabVisible =
+    !!activeTab &&
+    (activeTab.agentInstanceId === null ||
+      activeTab.agentInstanceId === openAgent);
+  const shouldRestoreFocusOnClose =
+    isActiveTabVisible && activeTabId
+      ? tabUiState[activeTabId]?.focusedPanel === 'tab-content'
+      : false;
   const movePanelToForeground = useKartonProcedure(
     (p) => p.browser.layout.movePanelToForeground,
   );
@@ -27,7 +37,11 @@ export function CommandCenterHotkeys() {
     close();
     if (!restoreFocusOnClose) return;
     void movePanelToForeground('tab-content');
-    void togglePanelKeyboardFocus('tab-content');
+    void togglePanelKeyboardFocus('tab-content').then(() => {
+      if (activeTab?.type === 'terminal' && activeTabId) {
+        requestTerminalFocus(activeTabId);
+      }
+    });
   }, HotkeyActions.OPEN_COMMAND_CENTER);
 
   return null;

--- a/apps/browser/src/ui/screens/main/command-center/command-center.tsx
+++ b/apps/browser/src/ui/screens/main/command-center/command-center.tsx
@@ -85,6 +85,10 @@ export function CommandCenter() {
       optimisticPinnedAgentIds,
       pendingRemovalAgentIds,
     });
+  const activeTabId = useKartonState((s) => s.contentTabs.activeTabId);
+  const activeTab = useKartonState((s) =>
+    activeTabId ? (s.contentTabs.tabs[activeTabId] ?? null) : null,
+  );
   const [openAgent, setOpenAgent] = useOpenAgent();
   const resumeAgent = useKartonProcedure((p) => p.agents.resume);
   const deleteAgent = useKartonProcedure((p) => p.agents.delete);
@@ -105,7 +109,7 @@ export function CommandCenter() {
   const setTabAgentInstance = useKartonProcedure(
     (p) => p.browser.setTabAgentInstance,
   );
-  const { removeTabUiState } = useTabUIState();
+  const { removeTabUiState, requestTerminalFocus } = useTabUIState();
   const pinnedAgentIds = useKartonState(
     useComparingSelector(
       (s) => s.preferences.sidebar.pinnedAgentIds,
@@ -142,8 +146,12 @@ export function CommandCenter() {
 
   const restoreTabContentFocus = useCallback(() => {
     void movePanelToForegroundRef.current('tab-content');
-    void togglePanelKeyboardFocusRef.current('tab-content');
-  }, []);
+    void togglePanelKeyboardFocusRef.current('tab-content').then(() => {
+      if (activeTab?.type === 'terminal' && activeTabId) {
+        requestTerminalFocus(activeTabId);
+      }
+    });
+  }, [activeTab, activeTabId]);
 
   const dismissCommandCenter = useCallback(() => {
     close();

--- a/apps/browser/src/ui/screens/main/command-center/sources/use-tab-command-items.tsx
+++ b/apps/browser/src/ui/screens/main/command-center/sources/use-tab-command-items.tsx
@@ -36,36 +36,42 @@ function tabTitle(tab: TabState) {
 export function useTabCommandItems(query: string) {
   const tabs = useKartonState(
     useComparingSelector((s): TabCommandItem[] => {
-      const activeTabId = s.browser.activeTabId;
-      return Object.values(s.browser.tabs).map((tab) => {
-        const title = tabTitle(tab);
+      const activeTabId = s.contentTabs.activeTabId;
+      return (
+        Object.values(s.contentTabs.tabs)
+          // Browser mode intentionally lists web tabs only. Terminal tab
+          // search/switching will be added later as its own command source.
+          .filter((tab) => tab.type === undefined || tab.type === 'browser')
+          .map((tab) => {
+            const title = tabTitle(tab);
 
-        return {
-          id: `tab:${tab.id}`,
-          kind: 'tab',
-          mode: 'browser',
-          title,
-          subtitle: tab.url,
-          keywords: ['tab', 'browser', tab.url],
-          icon: (
-            <CommandCenterTabFavicon
-              faviconUrls={tab.faviconUrls}
-              title={title}
-              url={tab.url}
-            />
-          ),
-          tabId: tab.id,
-          url: tab.url,
-          agentInstanceId: tab.agentInstanceId,
-          faviconUrls: tab.faviconUrls,
-          screenshot: tab.screenshot,
-          isActive: tab.id === activeTabId,
-          // In tab UI, the pin icon means “keep global”. Global tabs have no
-          // agent owner; agent-owned tabs are visually unpinned/scoped.
-          isPinned: tab.agentInstanceId === null,
-          lastFocusedAt: tab.lastFocusedAt,
-        };
-      });
+            return {
+              id: `tab:${tab.id}`,
+              kind: 'tab',
+              mode: 'browser',
+              title,
+              subtitle: tab.url,
+              keywords: ['tab', 'browser', tab.url],
+              icon: (
+                <CommandCenterTabFavicon
+                  faviconUrls={tab.faviconUrls}
+                  title={title}
+                  url={tab.url}
+                />
+              ),
+              tabId: tab.id,
+              url: tab.url,
+              agentInstanceId: tab.agentInstanceId,
+              faviconUrls: tab.faviconUrls,
+              screenshot: tab.screenshot,
+              isActive: tab.id === activeTabId,
+              // In tab UI, the pin icon means “keep global”. Global tabs have no
+              // agent owner; agent-owned tabs are visually unpinned/scoped.
+              isPinned: tab.agentInstanceId === null,
+              lastFocusedAt: tab.lastFocusedAt,
+            };
+          })
+      );
     }, tabsEqual),
   );
 

--- a/apps/browser/src/ui/screens/main/terminal-panel/_components/per-terminal-content.tsx
+++ b/apps/browser/src/ui/screens/main/terminal-panel/_components/per-terminal-content.tsx
@@ -319,7 +319,7 @@ export function PerTerminalContent({
       lastSentSizeRef.current = null;
       cancelAnimationFrame(fitTimer);
     };
-  }, [terminalId]);
+  }, [terminalId, markTerminalFocused, focusTerminalIfReady]);
 
   useEffect(() => {
     const mq = window.matchMedia('(prefers-color-scheme: dark)');


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes browser-tab rendering and focus handling in the Command Center (Cmd-K). Switches to `contentTabs` and reliably restores tab content focus, including terminals.

- **Bug Fixes**
  - Use `contentTabs` for active tab and tab list; show only browser tabs (exclude terminal/system).
  - Restore content focus only when the active tab is visible (global or owned by the open agent) and was previously focused; for terminal tabs, also request terminal focus so xterm regains input; update terminal effect deps to prevent lost focus.

<sup>Written for commit 7ca81ddc49310ebbd98d2f86f47fa18b32cb0301. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1222?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Command Center focus restoration now correctly uses the active content tab and only restores focus when that tab is visible.
  * Command Center tab commands no longer include terminal-style tabs, so only relevant content tabs are shown.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stagewise-io/stagewise/pull/1222?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->