### PR TITLE
ci(stagewise): add correct tag-name for prerelease releases

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -96,6 +96,7 @@ jobs:
       version: ${{ needs.detect.outputs.stagewise-version }}
       tag: ${{ needs.detect.outputs.stagewise-tag }}
       channel: ${{ needs.detect.outputs.stagewise-channel }}
+      ref: ${{ github.sha }}
     secrets: inherit
 
   # ---------------------------------------------------------------------------


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix prerelease tagging in the auto-release workflow by passing the current commit SHA to the `stagewise` release step via its `ref` input. This ensures prereleases are published with the correct tag for the triggering commit.

<sup>Written for commit 883c1ec575fa000a6b3e0777cb19df9d2280f281. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1223?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow configuration to improve build traceability during the deployment process.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stagewise-io/stagewise/pull/1223?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->