### PR TITLE
fix(stagewise): fix provider-thinking-signatures

### DIFF
--- a/apps/browser/src/backend/agents/model-provider.test.ts
+++ b/apps/browser/src/backend/agents/model-provider.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it } from 'vitest';
+import {
+  reasoningSignatureSourceSchema,
+  type ReasoningSignatureSource,
+} from '@shared/karton-contracts/ui/agent/metadata';
+import {
+  createReasoningSignatureSource,
+  getSemanticProviderForApiSpec,
+  reasoningSourcesMatch,
+} from './reasoning-signatures';
+
+describe('reasoning signature source helpers', () => {
+  it('maps custom endpoint API specs to semantic providers', () => {
+    expect(getSemanticProviderForApiSpec('anthropic')).toBe('anthropic');
+    expect(getSemanticProviderForApiSpec('amazon-bedrock')).toBe('anthropic');
+    expect(getSemanticProviderForApiSpec('google')).toBe('google');
+    expect(getSemanticProviderForApiSpec('google-vertex')).toBe('google');
+    expect(getSemanticProviderForApiSpec('openai-chat-completions')).toBe(
+      'openai',
+    );
+    expect(getSemanticProviderForApiSpec('openai-responses')).toBe('openai');
+    expect(getSemanticProviderForApiSpec('azure')).toBe('openai');
+  });
+
+  it('creates stagewise and official sources with provider and model id', () => {
+    expect(
+      createReasoningSignatureSource(
+        'stagewise',
+        'anthropic',
+        'anthropic/claude-sonnet-4.6',
+      ),
+    ).toEqual({
+      providerMode: 'stagewise',
+      provider: 'anthropic',
+      modelId: 'anthropic/claude-sonnet-4.6',
+    });
+
+    expect(
+      createReasoningSignatureSource('official', 'openai', 'gpt-5.4'),
+    ).toEqual({
+      providerMode: 'official',
+      provider: 'openai',
+      modelId: 'gpt-5.4',
+    });
+  });
+
+  it('creates custom sources with API spec and endpoint id', () => {
+    expect(
+      createReasoningSignatureSource('custom', 'google', 'gemini-custom', {
+        apiSpec: 'google-vertex',
+        endpointId: 'vertex-prod',
+      }),
+    ).toEqual({
+      providerMode: 'custom',
+      provider: 'google',
+      modelId: 'gemini-custom',
+      apiSpec: 'google-vertex',
+      endpointId: 'vertex-prod',
+    });
+  });
+
+  it('rejects incomplete or inconsistent custom source construction', () => {
+    expect(() =>
+      createReasoningSignatureSource('custom', 'google', 'gemini-custom', {
+        apiSpec: 'google-vertex',
+      } as any),
+    ).toThrow('apiSpec and endpointId');
+    expect(() =>
+      createReasoningSignatureSource('custom', 'google', 'gemini-custom', {
+        endpointId: 'vertex-prod',
+      } as any),
+    ).toThrow('apiSpec and endpointId');
+    expect(() =>
+      createReasoningSignatureSource('custom', 'google', 'gemini-custom', {
+        apiSpec: 'amazon-bedrock',
+        endpointId: 'bedrock-prod',
+      }),
+    ).toThrow('provider/apiSpec mismatch');
+  });
+
+  it('matches non-custom sources by provider mode and provider only', () => {
+    const a: ReasoningSignatureSource = {
+      providerMode: 'stagewise',
+      provider: 'anthropic',
+      modelId: 'anthropic/claude-a',
+    };
+    const b: ReasoningSignatureSource = {
+      providerMode: 'stagewise',
+      provider: 'anthropic',
+      modelId: 'anthropic/claude-b',
+    };
+    const c: ReasoningSignatureSource = {
+      providerMode: 'official',
+      provider: 'anthropic',
+      modelId: 'claude-a',
+    };
+
+    expect(reasoningSourcesMatch(a, b)).toBe(true);
+    expect(reasoningSourcesMatch(a, c)).toBe(false);
+  });
+
+  it('matches custom sources by provider, API spec, and endpoint id', () => {
+    const base: ReasoningSignatureSource = {
+      providerMode: 'custom',
+      provider: 'anthropic',
+      apiSpec: 'amazon-bedrock',
+      endpointId: 'bedrock-prod',
+      modelId: 'anthropic.claude-sonnet-4-6',
+    };
+
+    expect(
+      reasoningSourcesMatch(base, {
+        ...base,
+        modelId: 'anthropic.claude-opus-4-7',
+      }),
+    ).toBe(true);
+    expect(
+      reasoningSourcesMatch(base, { ...base, endpointId: 'bedrock-dev' }),
+    ).toBe(false);
+    expect(reasoningSourcesMatch(base, { ...base, apiSpec: 'anthropic' })).toBe(
+      false,
+    );
+    expect(reasoningSourcesMatch(base, { ...base, apiSpec: undefined })).toBe(
+      false,
+    );
+    expect(
+      reasoningSourcesMatch(base, { ...base, endpointId: undefined }),
+    ).toBe(false);
+  });
+
+  it('validates reasoning signature source schema invariants', () => {
+    expect(
+      reasoningSignatureSourceSchema.safeParse({
+        providerMode: 'stagewise',
+        provider: 'anthropic',
+        modelId: 'anthropic/claude-sonnet-4.6',
+      }).success,
+    ).toBe(true);
+    expect(
+      reasoningSignatureSourceSchema.safeParse({
+        providerMode: 'official',
+        provider: 'anthropic',
+        modelId: 'claude-sonnet-4.6',
+      }).success,
+    ).toBe(true);
+    expect(
+      reasoningSignatureSourceSchema.safeParse({
+        providerMode: 'stagewise',
+        provider: 'anthropic',
+      }).success,
+    ).toBe(false);
+    expect(
+      reasoningSignatureSourceSchema.safeParse({
+        providerMode: 'custom',
+        provider: 'google',
+        modelId: 'gemini-custom',
+        endpointId: 'vertex-prod',
+      }).success,
+    ).toBe(false);
+    expect(
+      reasoningSignatureSourceSchema.safeParse({
+        providerMode: 'custom',
+        provider: 'google',
+        modelId: 'gemini-custom',
+        apiSpec: 'google-vertex',
+      }).success,
+    ).toBe(false);
+    expect(
+      reasoningSignatureSourceSchema.safeParse({
+        providerMode: 'custom',
+        provider: 'google',
+        modelId: 'gemini-custom',
+        apiSpec: 'google-vertex',
+        endpointId: 'vertex-prod',
+      }).success,
+    ).toBe(true);
+  });
+});

--- a/apps/browser/src/backend/agents/model-provider.ts
+++ b/apps/browser/src/backend/agents/model-provider.ts
@@ -6,6 +6,12 @@ import type {
   CustomModel,
   CustomEndpoint,
 } from '@shared/karton-contracts/ui/shared-types';
+import type { ReasoningSignatureSource } from '@shared/karton-contracts/ui/agent/metadata';
+import {
+  createReasoningSignatureSource,
+  getSemanticProviderForApiSpec,
+  type ProviderMode,
+} from './reasoning-signatures';
 import type { LanguageModelV3 } from '@ai-sdk/provider';
 import { availableModels } from '@shared/available-models';
 import { createAnthropic } from '@ai-sdk/anthropic';
@@ -44,7 +50,7 @@ const stagewiseUrlPassthroughMiddleware: LanguageModelMiddleware = {
   }),
 };
 
-export type ProviderMode = 'stagewise' | 'official' | 'custom';
+export type { ProviderMode } from './reasoning-signatures';
 
 export type ModelWithOptions = {
   model: LanguageModelV3;
@@ -52,6 +58,7 @@ export type ModelWithOptions = {
   headers: Record<string, string>;
   contextWindowSize: number;
   providerMode: ProviderMode;
+  reasoningSignatureSource: ReasoningSignatureSource;
   /**
    * When true, the agent must strip the `strict` field from every tool
    * definition before passing them to `streamText`. Required for providers
@@ -347,15 +354,19 @@ export class ModelProviderService {
     };
 
     if (mode === 'stagewise') {
+      if (!officialProvider) {
+        throw new Error(
+          `Model ${modelSettings.modelId} has no officialProvider set`,
+        );
+      }
       const proxyBaseUrl =
         process.env.LLM_PROXY_URL || 'https://llm.stagewise.io';
       // OpenRouter uses different provider prefixes for some vendors
       const OPENROUTER_PROVIDER_MAP: Partial<Record<ModelProvider, string>> = {
         alibaba: 'qwen',
       };
-      const routerProvider = officialProvider
-        ? (OPENROUTER_PROVIDER_MAP[officialProvider] ?? officialProvider)
-        : officialProvider;
+      const routerProvider =
+        OPENROUTER_PROVIDER_MAP[officialProvider] ?? officialProvider;
       const prefixedModelId = `${routerProvider}/${modelSettings.modelId}`;
       const stagewiseProvider = createStagewise({
         apiKey: this.authService.accessToken ?? '',
@@ -375,6 +386,11 @@ export class ModelProviderService {
         >[0]['providerOptions'],
         contextWindowSize: modelSettings.modelContextRaw,
         providerMode: 'stagewise',
+        reasoningSignatureSource: createReasoningSignatureSource(
+          'stagewise',
+          officialProvider,
+          prefixedModelId,
+        ),
       };
     }
 
@@ -447,6 +463,12 @@ export class ModelProviderService {
       posthogProperties: Record<string, unknown>;
     },
   ): Omit<ModelWithOptions, 'providerMode'> {
+    const reasoningSignatureSource = createReasoningSignatureSource(
+      'official',
+      provider,
+      modelId,
+    );
+
     switch (provider) {
       case 'anthropic': {
         const p = createAnthropic({ apiKey, baseURL });
@@ -460,6 +482,7 @@ export class ModelProviderService {
             typeof streamText
           >[0]['providerOptions'],
           contextWindowSize,
+          reasoningSignatureSource,
         };
       }
       case 'openai': {
@@ -474,6 +497,7 @@ export class ModelProviderService {
             typeof streamText
           >[0]['providerOptions'],
           contextWindowSize,
+          reasoningSignatureSource,
         };
       }
       case 'google': {
@@ -488,6 +512,7 @@ export class ModelProviderService {
             typeof streamText
           >[0]['providerOptions'],
           contextWindowSize,
+          reasoningSignatureSource,
         };
       }
       case 'moonshotai': {
@@ -507,6 +532,7 @@ export class ModelProviderService {
             typeof streamText
           >[0]['providerOptions'],
           contextWindowSize,
+          reasoningSignatureSource,
         };
       }
       case 'alibaba': {
@@ -526,6 +552,7 @@ export class ModelProviderService {
             typeof streamText
           >[0]['providerOptions'],
           contextWindowSize,
+          reasoningSignatureSource,
         };
       }
       case 'deepseek': {
@@ -544,6 +571,7 @@ export class ModelProviderService {
             typeof streamText
           >[0]['providerOptions'],
           contextWindowSize,
+          reasoningSignatureSource,
         };
       }
       case 'z-ai': {
@@ -562,6 +590,7 @@ export class ModelProviderService {
             typeof streamText
           >[0]['providerOptions'],
           contextWindowSize,
+          reasoningSignatureSource,
         };
       }
       case 'minimax': {
@@ -580,6 +609,7 @@ export class ModelProviderService {
             typeof streamText
           >[0]['providerOptions'],
           contextWindowSize,
+          reasoningSignatureSource,
         };
       }
       default: {
@@ -608,6 +638,12 @@ export class ModelProviderService {
     );
     const baseURL = endpoint.baseUrl || undefined;
     const { apiSpec } = endpoint;
+    const reasoningSignatureSource = createReasoningSignatureSource(
+      'custom',
+      getSemanticProviderForApiSpec(apiSpec),
+      modelId,
+      { apiSpec, endpointId: endpoint.id },
+    );
 
     switch (apiSpec) {
       case 'anthropic': {
@@ -620,6 +656,7 @@ export class ModelProviderService {
           headers,
           providerOptions: modelProviderOptions as any,
           contextWindowSize,
+          reasoningSignatureSource,
         };
       }
 
@@ -633,6 +670,7 @@ export class ModelProviderService {
           headers,
           providerOptions: modelProviderOptions as any,
           contextWindowSize,
+          reasoningSignatureSource,
         };
       }
 
@@ -646,6 +684,7 @@ export class ModelProviderService {
           headers,
           providerOptions: modelProviderOptions as any,
           contextWindowSize,
+          reasoningSignatureSource,
         };
       }
 
@@ -659,6 +698,7 @@ export class ModelProviderService {
           headers,
           providerOptions: modelProviderOptions as any,
           contextWindowSize,
+          reasoningSignatureSource,
         };
       }
 
@@ -677,6 +717,7 @@ export class ModelProviderService {
           headers,
           providerOptions: modelProviderOptions as any,
           contextWindowSize,
+          reasoningSignatureSource,
         };
       }
 
@@ -690,6 +731,7 @@ export class ModelProviderService {
           headers,
           providerOptions: modelProviderOptions as any,
           contextWindowSize,
+          reasoningSignatureSource,
           stripStrictFromTools: true,
         };
       }
@@ -716,6 +758,7 @@ export class ModelProviderService {
           headers,
           providerOptions: modelProviderOptions as any,
           contextWindowSize,
+          reasoningSignatureSource,
         };
       }
       default: {
@@ -775,6 +818,12 @@ export class ModelProviderService {
     }
 
     const providerKey = apiSpec.startsWith('openai-') ? 'openai' : apiSpec;
+    const reasoningSignatureSource = createReasoningSignatureSource(
+      'custom',
+      getSemanticProviderForApiSpec(apiSpec),
+      customModel.modelId,
+      { apiSpec, endpointId: endpoint?.id ?? customModel.endpointId },
+    );
     const providerOptions =
       Object.keys(customModel.providerOptions).length > 0
         ? ({ [providerKey]: customModel.providerOptions } as any)
@@ -791,6 +840,7 @@ export class ModelProviderService {
           headers,
           providerOptions,
           contextWindowSize: customModel.contextWindowSize,
+          reasoningSignatureSource,
         };
       }
 
@@ -804,6 +854,7 @@ export class ModelProviderService {
           headers,
           providerOptions,
           contextWindowSize: customModel.contextWindowSize,
+          reasoningSignatureSource,
         };
       }
 
@@ -817,6 +868,7 @@ export class ModelProviderService {
           headers,
           providerOptions,
           contextWindowSize: customModel.contextWindowSize,
+          reasoningSignatureSource,
         };
       }
 
@@ -830,6 +882,7 @@ export class ModelProviderService {
           headers,
           providerOptions,
           contextWindowSize: customModel.contextWindowSize,
+          reasoningSignatureSource,
         };
       }
 
@@ -849,6 +902,7 @@ export class ModelProviderService {
           headers,
           providerOptions,
           contextWindowSize: customModel.contextWindowSize,
+          reasoningSignatureSource,
         };
       }
 
@@ -863,6 +917,7 @@ export class ModelProviderService {
           headers,
           providerOptions,
           contextWindowSize: customModel.contextWindowSize,
+          reasoningSignatureSource,
           stripStrictFromTools: true,
         };
       }
@@ -890,6 +945,7 @@ export class ModelProviderService {
           headers,
           providerOptions,
           contextWindowSize: customModel.contextWindowSize,
+          reasoningSignatureSource,
         };
       }
     }

--- a/apps/browser/src/backend/agents/reasoning-signatures.ts
+++ b/apps/browser/src/backend/agents/reasoning-signatures.ts
@@ -1,0 +1,90 @@
+import type {
+  ApiSpec,
+  ModelProvider,
+} from '@shared/karton-contracts/ui/shared-types';
+import type { ReasoningSignatureSource } from '@shared/karton-contracts/ui/agent/metadata';
+
+export type ProviderMode = 'stagewise' | 'official' | 'custom';
+
+export function getSemanticProviderForApiSpec(apiSpec: ApiSpec): ModelProvider {
+  switch (apiSpec) {
+    case 'anthropic':
+    case 'amazon-bedrock':
+      return 'anthropic';
+    case 'google':
+    case 'google-vertex':
+      return 'google';
+    case 'openai-chat-completions':
+    case 'openai-responses':
+    case 'azure':
+      return 'openai';
+  }
+}
+
+/**
+ * Matches the route owner of signed reasoning details.
+ *
+ * `modelId` is intentionally not part of the match today. It is stored for
+ * observability and future tightening, but current compatibility is scoped to
+ * provider route shape: non-custom sources match by provider mode and semantic
+ * provider, while custom sources additionally match `apiSpec` and `endpointId`
+ * so signatures never cross user-defined backends.
+ */
+export function reasoningSourcesMatch(
+  a: ReasoningSignatureSource,
+  b: ReasoningSignatureSource,
+): boolean {
+  if (a.providerMode !== b.providerMode) return false;
+  if (a.provider !== b.provider) return false;
+  if (a.providerMode !== 'custom') return true;
+  if (!a.apiSpec || !a.endpointId || !b.apiSpec || !b.endpointId) {
+    return false;
+  }
+  return a.apiSpec === b.apiSpec && a.endpointId === b.endpointId;
+}
+
+type NonCustomProviderMode = Exclude<ProviderMode, 'custom'>;
+type CustomReasoningSignatureSourceOptions = {
+  apiSpec: ApiSpec;
+  endpointId: string;
+};
+
+export function createReasoningSignatureSource(
+  providerMode: NonCustomProviderMode,
+  provider: ModelProvider,
+  modelId: string,
+): ReasoningSignatureSource;
+export function createReasoningSignatureSource(
+  providerMode: 'custom',
+  provider: ModelProvider,
+  modelId: string,
+  opts: CustomReasoningSignatureSourceOptions,
+): ReasoningSignatureSource;
+export function createReasoningSignatureSource(
+  providerMode: ProviderMode,
+  provider: ModelProvider,
+  modelId: string,
+  opts?: Partial<CustomReasoningSignatureSourceOptions>,
+): ReasoningSignatureSource {
+  if (providerMode === 'custom' && (!opts?.apiSpec || !opts.endpointId)) {
+    throw new Error(
+      'Custom reasoning signature sources require apiSpec and endpointId',
+    );
+  }
+  if (providerMode === 'custom' && opts?.apiSpec) {
+    const expectedProvider = getSemanticProviderForApiSpec(opts.apiSpec);
+    if (expectedProvider !== provider) {
+      throw new Error(
+        `Custom reasoning signature source provider/apiSpec mismatch: provider "${provider}" does not match apiSpec "${opts.apiSpec}" (expected "${expectedProvider}")`,
+      );
+    }
+  }
+
+  return {
+    providerMode,
+    provider,
+    modelId,
+    ...(opts?.apiSpec ? { apiSpec: opts.apiSpec } : {}),
+    ...(opts?.endpointId ? { endpointId: opts.endpointId } : {}),
+  };
+}

--- a/apps/browser/src/backend/agents/shared/base-agent/base-agent.ts
+++ b/apps/browser/src/backend/agents/shared/base-agent/base-agent.ts
@@ -17,7 +17,10 @@ import type {
   AgentState,
   AgentRuntimeError,
 } from '@shared/karton-contracts/ui/agent';
-import type { FullEnvironmentSnapshot } from '@shared/karton-contracts/ui/agent/metadata';
+import type {
+  FullEnvironmentSnapshot,
+  ReasoningSignatureSource,
+} from '@shared/karton-contracts/ui/agent/metadata';
 import type { ModelCapabilities } from '@shared/karton-contracts/ui/shared-types';
 import { type ModelId, getModelCapabilities } from '@shared/available-models';
 import type { z } from 'zod';
@@ -60,6 +63,7 @@ import { clearPendingApproval } from './pending-approvals-cleanup';
 import type { StagewiseToolSet } from '@shared/karton-contracts/ui/agent/tools/types';
 import { stripStrictFromToolSet } from './strip-strict-from-tools';
 import type { StagewiseProviderMetadata } from '../../stagewise-provider';
+import { reasoningSourcesMatch } from '../../reasoning-signatures';
 import type { AgentToolUIPart } from '@shared/karton-contracts/ui/agent';
 import { AgentsMap } from '../../agents-map';
 
@@ -1183,27 +1187,21 @@ export abstract class BaseAgent<
   protected async transformMessagesToModelMessages(
     messages: AgentMessage[],
     systemPrompt: string,
+    modelId: ModelId,
+    modelContextWindowSize: number,
+    reasoningSignatureSource?: ReasoningSignatureSource,
   ): Promise<ModelMessage[]> {
-    const activeModelId = this.state.get().activeModelId;
     const fileReadCache = await this.getFileReadCache();
-    const capabilities = getModelCapabilities(activeModelId);
+    const capabilities = getModelCapabilities(modelId);
 
-    // Derive per-request content limits from the model's context window
-    // so the transformer pipeline uses explicit values instead of
-    // module-level globals.
-    let contentLimits: ContentLimits | undefined;
-    try {
-      const { contextWindowSize } =
-        this.modelProviderService.getModelWithOptions(activeModelId, '');
-      contentLimits = {
-        maxReadChars: deriveMaxReadChars(contextWindowSize),
-        maxPreviewLines: 30,
-      };
-    } catch {
-      // Model lookup can fail when the provider is misconfigured.
-      // Fall through — undefined contentLimits lets transformers use
-      // their built-in defaults.
-    }
+    // Derive per-request content limits from the already-resolved model route
+    // for this step. Do not re-read `state.activeModelId` here: users may
+    // switch models while a step is preparing, and the context transformer must
+    // stay aligned with the same model/options object passed to `streamText`.
+    const contentLimits: ContentLimits = {
+      maxReadChars: deriveMaxReadChars(modelContextWindowSize),
+      maxPreviewLines: 30,
+    };
 
     const shellInfo = this.toolbox.getShellInfo();
     const skills = await this.toolbox.getSkillsList(this.instanceId);
@@ -1261,6 +1259,7 @@ export abstract class BaseAgent<
       fileReadCache,
       this.toolbox.getMountedPathsForAgent(this.instanceId),
       contentLimits,
+      reasoningSignatureSource,
     );
   }
 
@@ -1574,6 +1573,9 @@ export abstract class BaseAgent<
     try {
       modelMessages = await this.generateContextForNewStep(
         queueFlushIndex >= 0 ? queueFlushIndex : undefined,
+        stepModelId,
+        modelWithOptions.contextWindowSize,
+        modelWithOptions.reasoningSignatureSource,
       );
       tools = await this.getToolsForStep();
       this._toolCallDurations.clear();
@@ -1841,7 +1843,10 @@ export abstract class BaseAgent<
       // populateReasoningDetailsOnAssistantMessage for details.
       if (finishedResult && this._stepGeneration === stepGen) {
         try {
-          this.populateReasoningDetailsOnAssistantMessage(finishedResult);
+          this.populateReasoningDetailsOnAssistantMessage(
+            finishedResult,
+            modelWithOptions.reasoningSignatureSource,
+          );
         } catch (err) {
           this.logger.debug(
             `[BaseAgent:${this.instanceId}] Failed to populate reasoningDetails: ${this.formatError(err as Error)}`,
@@ -2331,7 +2336,10 @@ export abstract class BaseAgent<
    * rather than at the end — env-changes appear before user content.
    */
   private async generateContextForNewStep(
-    queueFlushStart?: number,
+    queueFlushStart: number | undefined,
+    modelId: ModelId,
+    modelContextWindowSize: number,
+    reasoningSignatureSource?: ReasoningSignatureSource,
   ): Promise<ModelMessage[]> {
     // ─── Capture & attach snapshot to last message ────────────────────
     const fullSnapshot = (await this.toolbox.captureEnvironmentSnapshot(
@@ -2377,6 +2385,9 @@ export abstract class BaseAgent<
     const modelMessages = await this.transformMessagesToModelMessages(
       filteredUIMsgs,
       systemPrompt,
+      modelId,
+      modelContextWindowSize,
+      reasoningSignatureSource,
     );
 
     // Then, we allow another step to modify the final model messages
@@ -2539,19 +2550,19 @@ export abstract class BaseAgent<
 
   /**
    * Persist the provider's signed `reasoning_details` array into the
-   * last assistant message's metadata so it can be re-injected on
-   * subsequent requests.
+   * last assistant message's metadata with the semantic route that
+   * produced it so conversion can re-inject it only for compatible
+   * future requests.
    *
    * Context: OpenRouter / Bedrock-hosted Claude refuses to extend a
    * thinking process when the conversation carries unsigned reasoning
    * blocks. We capture the per-step signatures here (extracted by the
-   * stagewise metadata extractor under
-   * `providerMetadata.openaiCompatible.reasoningDetails`) and later
-   * spread them back onto the outbound assistant message via
-   * `providerOptions.openaiCompatible.reasoning_details`.
+   * stagewise metadata extractor under the OpenAI-compatible transport
+   * metadata key) and later spread matching groups back onto outbound
+   * assistant messages via `providerOptions.openaiCompatible.reasoning_details`.
    *
-   * Multi-step continuations append to the existing array so the full
-   * thinking history stays intact across tool-call rounds.
+   * Multi-step continuations append to the existing source-owned group
+   * so the full thinking history stays intact across tool-call rounds.
    *
    * Must be called AFTER `handleUiStream` has drained. `handleUiStream`
    * is the only site that pushes the assistant message into
@@ -2566,6 +2577,7 @@ export abstract class BaseAgent<
    */
   private populateReasoningDetailsOnAssistantMessage(
     step: StepResult<StagewiseToolSet>,
+    reasoningSignatureSource: ReasoningSignatureSource,
   ): void {
     const meta = step.providerMetadata as StagewiseProviderMetadata | undefined;
     const details = meta?.openaiCompatible?.reasoningDetails;
@@ -2582,11 +2594,28 @@ export abstract class BaseAgent<
         createdAt: new Date(),
         partsMetadata: [],
       };
-      const existing = target.metadata.reasoningDetails ?? [];
-      target.metadata.reasoningDetails = [
-        ...existing,
-        ...(details as Record<string, unknown>[]),
-      ];
+      const detailRecords = details as Record<string, unknown>[];
+      const existing = target.metadata.ownedReasoningDetails ?? [];
+      const matchingIdx = existing.findIndex((group) =>
+        reasoningSourcesMatch(group.source, reasoningSignatureSource),
+      );
+
+      if (matchingIdx >= 0) {
+        const group = existing[matchingIdx]!;
+        target.metadata.ownedReasoningDetails = existing.map((entry, idx) =>
+          idx === matchingIdx
+            ? { ...group, details: [...group.details, ...detailRecords] }
+            : entry,
+        );
+      } else {
+        target.metadata.ownedReasoningDetails = [
+          ...existing,
+          {
+            source: reasoningSignatureSource,
+            details: detailRecords,
+          },
+        ];
+      }
     });
   }
 

--- a/apps/browser/src/backend/agents/shared/base-agent/history-compression/index.test.ts
+++ b/apps/browser/src/backend/agents/shared/base-agent/history-compression/index.test.ts
@@ -64,6 +64,11 @@ function makeMockModelProviderService(): ModelProviderService {
       headers: {},
       contextWindowSize: 100_000,
       providerMode: 'stagewise',
+      reasoningSignatureSource: {
+        providerMode: 'stagewise',
+        provider: 'anthropic',
+        modelId: 'anthropic/claude-sonnet-4.6',
+      },
     }),
   } as unknown as ModelProviderService;
 }

--- a/apps/browser/src/backend/agents/shared/base-agent/title-generation.test.ts
+++ b/apps/browser/src/backend/agents/shared/base-agent/title-generation.test.ts
@@ -40,6 +40,11 @@ function makeMockModelProviderService(): ModelProviderService {
       headers: {},
       contextWindowSize: 100_000,
       providerMode: 'stagewise',
+      reasoningSignatureSource: {
+        providerMode: 'stagewise',
+        provider: 'anthropic',
+        modelId: 'anthropic/claude-sonnet-4.6',
+      },
     }),
   } as unknown as ModelProviderService;
 }

--- a/apps/browser/src/backend/agents/shared/base-agent/utils.test.ts
+++ b/apps/browser/src/backend/agents/shared/base-agent/utils.test.ts
@@ -7,8 +7,12 @@ import type {
   EnvironmentSnapshot,
   FullEnvironmentSnapshot,
 } from '@shared/karton-contracts/ui/agent/metadata';
-import type { UserMessageMetadata } from '@shared/karton-contracts/ui/agent/metadata';
+import type {
+  ReasoningSignatureSource,
+  UserMessageMetadata,
+} from '@shared/karton-contracts/ui/agent/metadata';
 import type { AgentMessage } from '@shared/karton-contracts/ui/agent';
+import type { ModelMessage } from 'ai';
 import { convertAgentMessagesToModelMessages } from './utils';
 import {
   resolveEffectiveSnapshot,
@@ -76,24 +80,136 @@ function makeAssistantMsg(
   } as AgentMessage;
 }
 
+function makeReasoningAssistantMsg(
+  metadata: Partial<UserMessageMetadata>,
+): AgentMessage {
+  return {
+    id: 'a-reasoning',
+    role: 'assistant',
+    parts: [
+      { type: 'step-start' },
+      { type: 'reasoning', text: 'private thought', state: 'done' },
+      { type: 'text', text: 'visible answer', state: 'done' },
+    ],
+    metadata: {
+      ...makeMetadata(),
+      ...metadata,
+    },
+  } as AgentMessage;
+}
+
+const stagewiseAnthropicSource: ReasoningSignatureSource = {
+  providerMode: 'stagewise',
+  provider: 'anthropic',
+  modelId: 'anthropic/claude-sonnet-4.6',
+};
+
+const stagewiseOpenAISource: ReasoningSignatureSource = {
+  providerMode: 'stagewise',
+  provider: 'openai',
+  modelId: 'openai/gpt-5.4',
+};
+
+const stagewiseGoogleSource: ReasoningSignatureSource = {
+  providerMode: 'stagewise',
+  provider: 'google',
+  modelId: 'google/gemini-3.1-pro-preview',
+};
+
+const officialAnthropicSource: ReasoningSignatureSource = {
+  providerMode: 'official',
+  provider: 'anthropic',
+  modelId: 'claude-sonnet-4.6',
+};
+
+const customAnthropicSource: ReasoningSignatureSource = {
+  providerMode: 'custom',
+  provider: 'anthropic',
+  apiSpec: 'amazon-bedrock',
+  endpointId: 'bedrock-prod',
+  modelId: 'anthropic.claude-sonnet-4-6',
+};
+
+type AssistantModelMessage = Extract<ModelMessage, { role: 'assistant' }>;
+
+type TextLikePart = {
+  type: string;
+  text?: string;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isTextLikePart(value: unknown): value is TextLikePart {
+  return isRecord(value) && typeof value.type === 'string';
+}
+
+function getAssistantMessages(
+  messages: ModelMessage[],
+): AssistantModelMessage[] {
+  return messages.filter(
+    (message): message is AssistantModelMessage => message.role === 'assistant',
+  );
+}
+
+function getContentParts(message: ModelMessage): TextLikePart[] {
+  const { content } = message;
+  if (Array.isArray(content)) return content.filter(isTextLikePart);
+  if (typeof content === 'string') return [{ type: 'text', text: content }];
+  return [];
+}
+
+function hasReasoningPart(message: AssistantModelMessage): boolean {
+  return getContentParts(message).some((part) => part.type === 'reasoning');
+}
+
+function getReasoningDetails(message: ModelMessage): unknown {
+  const providerOptions = message.providerOptions;
+  if (!isRecord(providerOptions)) return undefined;
+  const openaiCompatible = providerOptions.openaiCompatible;
+  if (!isRecord(openaiCompatible)) return undefined;
+  return openaiCompatible.reasoning_details;
+}
+
+function convertWithReasoningSource(
+  messages: AgentMessage[],
+  source?: ReasoningSignatureSource,
+) {
+  return convertAgentMessagesToModelMessages(
+    messages,
+    '',
+    {},
+    'agent-1',
+    noopBlobReader,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    source,
+  );
+}
+
 /**
  * Extract all text from a user model message's content array.
  */
-function getUserMsgTexts(msg: any): string[] {
-  const content = Array.isArray(msg.content)
-    ? msg.content
-    : [{ type: 'text', text: msg.content }];
-  return content
-    .filter((p: any) => p.type === 'text' && typeof p.text === 'string')
-    .map((p: any) => p.text as string);
+function getUserMsgTexts(msg: ModelMessage): string[] {
+  return getContentParts(msg)
+    .filter((part) => part.type === 'text' && typeof part.text === 'string')
+    .map((part) => part.text!);
 }
 
-function hasEnvSnapshot(msg: any): boolean {
-  return getUserMsgTexts(msg).some((t) => t.includes('<env-snapshot>'));
+function hasEnvSnapshot(msg: ModelMessage): boolean {
+  return getUserMsgTexts(msg).some((text) => text.includes('<env-snapshot>'));
 }
 
-function hasEnvChanges(msg: any): boolean {
-  return getUserMsgTexts(msg).some((t) => t.includes('<env-changes>'));
+function hasEnvChanges(msg: ModelMessage): boolean {
+  return getUserMsgTexts(msg).some((text) => text.includes('<env-changes>'));
 }
 
 const noopBlobReader = async () => Buffer.alloc(0);
@@ -120,6 +236,247 @@ describe('convertAgentMessagesToModelMessages – env context injection', () => 
     expect(hasEnvSnapshot(userMessages[0])).toBe(true);
     expect(hasEnvChanges(userMessages[0])).toBe(false);
   });
+});
+
+describe('convertAgentMessagesToModelMessages – reasoning signatures', () => {
+  it('attaches matching owned Anthropic stagewise reasoning details', async () => {
+    const details = [
+      {
+        type: 'reasoning.text',
+        text: 'private thought',
+        signature: 'anthropic-signature',
+      },
+    ];
+    const messages = [
+      makeReasoningAssistantMsg({
+        ownedReasoningDetails: [{ source: stagewiseAnthropicSource, details }],
+      }),
+    ];
+
+    const result = await convertWithReasoningSource(
+      messages,
+      stagewiseAnthropicSource,
+    );
+    const assistant = getAssistantMessages(result)[0];
+
+    expect(getReasoningDetails(assistant)).toEqual(details);
+    expect(hasReasoningPart(assistant)).toBe(false);
+  });
+
+  it('attaches matching non-stagewise details and strips reasoning parts', async () => {
+    const details = [
+      {
+        type: 'reasoning.text',
+        text: 'private thought',
+        signature: 'anthropic-signature',
+      },
+    ];
+    const messages = [
+      makeReasoningAssistantMsg({
+        ownedReasoningDetails: [{ source: customAnthropicSource, details }],
+      }),
+    ];
+
+    const result = await convertWithReasoningSource(
+      messages,
+      customAnthropicSource,
+    );
+    const assistant = getAssistantMessages(result)[0];
+
+    expect(getReasoningDetails(assistant)).toEqual(details);
+    expect(hasReasoningPart(assistant)).toBe(false);
+  });
+
+  it('strips mismatched non-stagewise owned details', async () => {
+    const messages = [
+      makeReasoningAssistantMsg({
+        ownedReasoningDetails: [
+          {
+            source: customAnthropicSource,
+            details: [
+              {
+                type: 'reasoning.text',
+                text: 'private thought',
+                signature: 'anthropic-signature',
+              },
+            ],
+          },
+        ],
+      }),
+    ];
+
+    const result = await convertWithReasoningSource(
+      messages,
+      stagewiseOpenAISource,
+    );
+    const assistant = getAssistantMessages(result)[0];
+
+    expect(getReasoningDetails(assistant)).toBeUndefined();
+    expect(hasReasoningPart(assistant)).toBe(false);
+  });
+
+  it('does not attach mismatched owned details for OpenAI', async () => {
+    const messages = [
+      makeReasoningAssistantMsg({
+        ownedReasoningDetails: [
+          {
+            source: stagewiseAnthropicSource,
+            details: [
+              {
+                type: 'reasoning.text',
+                text: 'private thought',
+                signature: 'anthropic-signature',
+              },
+            ],
+          },
+        ],
+      }),
+    ];
+
+    const result = await convertWithReasoningSource(
+      messages,
+      stagewiseOpenAISource,
+    );
+    const assistant = getAssistantMessages(result)[0];
+
+    expect(getReasoningDetails(assistant)).toBeUndefined();
+    expect(hasReasoningPart(assistant)).toBe(false);
+  });
+
+  it('replays legacy Anthropic-shaped details only for stagewise Anthropic', async () => {
+    const details = [
+      {
+        type: 'reasoning.text',
+        text: 'private thought',
+        signature: 'anthropic-signature',
+      },
+    ];
+    const messages = [makeReasoningAssistantMsg({ reasoningDetails: details })];
+
+    const matching = await convertWithReasoningSource(
+      messages,
+      stagewiseAnthropicSource,
+    );
+    const mismatched = await convertWithReasoningSource(
+      messages,
+      stagewiseGoogleSource,
+    );
+
+    expect(getReasoningDetails(getAssistantMessages(matching)[0])).toEqual(
+      details,
+    );
+    expect(
+      getReasoningDetails(getAssistantMessages(mismatched)[0]),
+    ).toBeUndefined();
+  });
+
+  it('replays legacy Google-shaped details only for stagewise Google', async () => {
+    const details = [
+      {
+        type: 'reasoning.encrypted',
+        text: 'private thought',
+        thought_signature: 'google-signature',
+      },
+    ];
+    const messages = [makeReasoningAssistantMsg({ reasoningDetails: details })];
+
+    const matching = await convertWithReasoningSource(
+      messages,
+      stagewiseGoogleSource,
+    );
+    const mismatched = await convertWithReasoningSource(
+      messages,
+      stagewiseAnthropicSource,
+    );
+
+    expect(getReasoningDetails(getAssistantMessages(matching)[0])).toEqual(
+      details,
+    );
+    expect(
+      getReasoningDetails(getAssistantMessages(mismatched)[0]),
+    ).toBeUndefined();
+  });
+
+  it('does not replay legacy details with ambiguous signature fields', async () => {
+    const messages = [
+      makeReasoningAssistantMsg({
+        reasoningDetails: [
+          {
+            type: 'reasoning.text',
+            text: 'private thought',
+            signature: 'anthropic-signature',
+            thought_signature: 'google-signature',
+          },
+        ],
+      }),
+    ];
+
+    const result = await convertWithReasoningSource(
+      messages,
+      stagewiseGoogleSource,
+    );
+    const assistant = getAssistantMessages(result)[0];
+
+    expect(getReasoningDetails(assistant)).toBeUndefined();
+    expect(hasReasoningPart(assistant)).toBe(false);
+  });
+
+  it('does not replay legacy unknown-shaped details', async () => {
+    const messages = [
+      makeReasoningAssistantMsg({
+        reasoningDetails: [{ type: 'reasoning.text', text: 'private thought' }],
+      }),
+    ];
+
+    const result = await convertWithReasoningSource(
+      messages,
+      stagewiseAnthropicSource,
+    );
+    const assistant = getAssistantMessages(result)[0];
+
+    expect(getReasoningDetails(assistant)).toBeUndefined();
+    expect(hasReasoningPart(assistant)).toBe(false);
+  });
+
+  it('strips unmatched legacy reasoning on non-stagewise routes', async () => {
+    const messages = [
+      makeReasoningAssistantMsg({
+        reasoningDetails: [
+          {
+            type: 'reasoning.text',
+            text: 'private thought',
+            signature: 'anthropic-signature',
+          },
+        ],
+      }),
+    ];
+
+    const result = await convertWithReasoningSource(
+      messages,
+      officialAnthropicSource,
+    );
+    const assistant = getAssistantMessages(result)[0];
+
+    expect(getReasoningDetails(assistant)).toBeUndefined();
+    expect(hasReasoningPart(assistant)).toBe(false);
+  });
+
+  it('preserves native reasoning parts when no stagewise metadata exists', async () => {
+    const messages = [makeReasoningAssistantMsg({})];
+
+    const result = await convertWithReasoningSource(
+      messages,
+      officialAnthropicSource,
+    );
+    const assistant = getAssistantMessages(result)[0];
+
+    expect(getReasoningDetails(assistant)).toBeUndefined();
+    expect(hasReasoningPart(assistant)).toBe(true);
+  });
+});
+
+describe('convertAgentMessagesToModelMessages – env context changes', () => {
+  const agentId = 'agent-1';
 
   it('does not inject env-changes when snapshots are identical', async () => {
     const snap = makeSnapshot();

--- a/apps/browser/src/backend/agents/shared/base-agent/utils.ts
+++ b/apps/browser/src/backend/agents/shared/base-agent/utils.ts
@@ -12,6 +12,7 @@ import type { AgentMessage } from '@shared/karton-contracts/ui/agent';
 import type { SkillDefinition } from '@shared/skills';
 import type {
   FullEnvironmentSnapshot,
+  ReasoningSignatureSource,
   TabMentionMeta,
 } from '@shared/karton-contracts/ui/agent/metadata';
 
@@ -26,6 +27,7 @@ import {
 } from '../prompts/utils/environment-renderer';
 import type { SkillInfo } from '../prompts/utils/skills';
 import { deepMergeProviderOptions } from '@/agents/model-provider';
+import { reasoningSourcesMatch } from '@/agents/reasoning-signatures';
 import {
   extractSlashIdsFromText,
   inlineSlashLinksAsText,
@@ -157,6 +159,7 @@ export const convertAgentMessagesToModelMessages = async (
   fileReadCache?: FileReadCacheService,
   mountPaths?: Map<string, string>,
   contentLimits?: ContentLimits,
+  reasoningSignatureSource?: ReasoningSignatureSource,
 ): Promise<ModelMessage[]> => {
   // ─── Step 1: Find compression boundary ──────────────────────────────
 
@@ -258,7 +261,11 @@ export const convertAgentMessagesToModelMessages = async (
         });
       }
 
-      const assistantMsgs = await convertAssistantMessage(message, tools);
+      const assistantMsgs = await convertAssistantMessage(
+        message,
+        tools,
+        reasoningSignatureSource,
+      );
       modelMessages.push(...assistantMsgs);
 
       // Inject file contents from pathReferences (from readFile tool calls).
@@ -737,26 +744,96 @@ function buildCompressedHistoryPart(
  * Returns only the assistant-role message(s). Sandbox file attachments
  * are handled by the main loop alongside env-changes.
  *
- * Also round-trips signed `reasoning_details` through the outbound
- * `providerOptions.openaiCompatible.reasoning_details` hook that the
- * SDK spreads onto the OpenAI-compatible request body. Without this,
- * Bedrock-hosted Claude silently refuses to extend the thinking
- * process because the history carries unsigned `reasoning_content`
- * strings. See `plans/rehydrate-reasoning-signatures-openrouter.md`.
+ * Also round-trips matching provider-owned signed `reasoning_details`
+ * through the outbound `providerOptions.openaiCompatible.reasoning_details`
+ * transport hook that the SDK spreads onto the OpenAI-compatible request
+ * body. Semantic ownership lives in assistant metadata and is checked here
+ * before replay so signatures are never sent across provider boundaries.
  */
+// Legacy flat `reasoningDetails` predate source ownership and were only
+// captured from the stagewise OpenAI-compatible gateway. Replay them only when
+// their signature shape clearly identifies the current stagewise provider;
+// unknown or mixed shapes are unsafe and must be dropped.
+function inferLegacyReasoningProvider(
+  details: Record<string, unknown>[],
+): ReasoningSignatureSource['provider'] | null {
+  let inferred: ReasoningSignatureSource['provider'] | null = null;
+  for (const detail of details) {
+    const hasGoogleSignature = typeof detail.thought_signature === 'string';
+    const hasAnthropicSignature = typeof detail.signature === 'string';
+    const provider =
+      hasGoogleSignature === hasAnthropicSignature
+        ? null
+        : hasGoogleSignature
+          ? 'google'
+          : 'anthropic';
+    if (!provider) return null;
+    if (inferred && inferred !== provider) return null;
+    inferred = provider;
+  }
+  return inferred;
+}
+
+function selectReasoningDetailsForSource(
+  message: AgentMessage,
+  reasoningSignatureSource?: ReasoningSignatureSource,
+): {
+  signedDetails: Record<string, unknown>[];
+  shouldStripReasoningParts: boolean;
+} {
+  const ownedGroups = message.metadata?.ownedReasoningDetails ?? [];
+  const hasOwnedReasoningDetails = ownedGroups.some(
+    (group) => group.details.length > 0,
+  );
+
+  if (reasoningSignatureSource) {
+    const matchingOwned = ownedGroups.filter(
+      (group) =>
+        group.details.length > 0 &&
+        reasoningSourcesMatch(group.source, reasoningSignatureSource),
+    );
+    if (matchingOwned.length > 0) {
+      return {
+        signedDetails: matchingOwned.flatMap((group) => group.details),
+        shouldStripReasoningParts: true,
+      };
+    }
+  }
+
+  const legacyDetails = message.metadata?.reasoningDetails ?? [];
+  if (legacyDetails.length === 0) {
+    return {
+      signedDetails: [],
+      shouldStripReasoningParts: hasOwnedReasoningDetails,
+    };
+  }
+
+  const legacyProvider = inferLegacyReasoningProvider(legacyDetails);
+  const canReplayLegacy =
+    reasoningSignatureSource?.providerMode === 'stagewise' &&
+    legacyProvider === reasoningSignatureSource.provider;
+
+  return {
+    signedDetails: canReplayLegacy ? legacyDetails : [],
+    shouldStripReasoningParts: true,
+  };
+}
+
 async function convertAssistantMessage(
   message: AgentMessage,
   tools: ToolSet,
+  reasoningSignatureSource?: ReasoningSignatureSource,
 ): Promise<ModelMessage[]> {
-  const signedDetails = message.metadata?.reasoningDetails ?? [];
+  const { signedDetails, shouldStripReasoningParts } =
+    selectReasoningDetailsForSource(message, reasoningSignatureSource);
   const hasSignatures = signedDetails.length > 0;
 
   const cleanedMessage = {
     ...message,
     parts: message.parts
-      // Drop `reasoning` UI parts from the outbound conversion ONLY
-      // when we have signed `reasoning_details` to replace them with
-      // (the stagewise / OpenRouter path).
+      // Drop `reasoning` UI parts from the outbound conversion when
+      // provider-signed reasoning details are being replayed or when
+      // stagewise/legacy signature metadata makes UI reasoning unsafe.
       //
       // Rationale: for the openai-compatible SDK path,
       // `convertToOpenAICompatibleChatMessages` concatenates reasoning
@@ -766,26 +843,30 @@ async function convertAssistantMessage(
       // `reasoning_details` array causes Anthropic/Bedrock to reject
       // the turn with `thinking blocks ... cannot be modified`.
       //
-      // When signatures ARE present, we rely purely on
+      // When matching signatures ARE present, we rely purely on
       // `providerOptions.openaiCompatible.reasoning_details` (attached
-      // below) to round-trip signed reasoning. OpenRouter reconstructs
-      // Anthropic `thinking` / Gemini `thought` blocks from that
-      // structured array.
+      // below) to round-trip signed reasoning. When only mismatched
+      // stagewise or legacy signatures exist, we still drop UI reasoning
+      // parts so unsigned or foreign-provider reasoning content is not
+      // sent. UI reasoning text is not a safe substitute for the provider
+      // signed details.
       //
-      // When signatures are NOT present we leave reasoning parts
-      // alone. This matters for BYOK with native SDKs
+      // When no stagewise/legacy signature metadata exists we leave
+      // reasoning parts alone. This matters for BYOK with native SDKs
       // (@ai-sdk/anthropic, @ai-sdk/google) which consume reasoning
       // parts via their own signature mechanism
       // (`providerMetadata.anthropic.signature`,
       // `providerMetadata.google.thoughtSignature`) and would
       // otherwise lose cross-turn chain-of-thought. It also preserves
-      // pre-fix stagewise messages' reasoning text in outbound history
+      // legacy messages without captured signatures in outbound history
       // — no worse than before.
       //
       // UI visibility is unaffected — this filter only touches the
       // throwaway copy used for model conversion; persisted UI parts
       // still carry reasoning for transcript display.
-      .filter((part) => !(hasSignatures && part.type === 'reasoning'))
+      .filter(
+        (part) => !(shouldStripReasoningParts && part.type === 'reasoning'),
+      )
       .map((part) => {
         const isToolPart =
           part.type.startsWith('tool-') || part.type === 'dynamic-tool';
@@ -845,10 +926,10 @@ async function convertAssistantMessage(
   //    modified. These blocks must remain as they were in the
   //    original response.`
   //
-  // The UI parts and the accumulated `reasoningDetails` array are both
-  // ordered by (step, position-in-step), so counting reasoning parts
-  // per step block and slicing the details array the same way keeps
-  // them aligned.
+  // The UI parts and the selected provider-owned details array are both
+  // ordered by (step, position-in-step), so counting reasoning parts per
+  // step block and slicing the details array the same way keeps them
+  // aligned.
   if (hasSignatures) {
     const reasoningCountsPerStep = countReasoningPartsPerStep(message.parts);
     const totalReasoningParts = reasoningCountsPerStep.reduce(

--- a/apps/browser/src/backend/agents/stagewise-provider.ts
+++ b/apps/browser/src/backend/agents/stagewise-provider.ts
@@ -107,9 +107,10 @@ function extractReasoningDetailsFromMessage(
  *     reasoning details array OR returns on the response. Required for
  *     Anthropic (Bedrock) and Google models to validate chain-of-thought
  *     signatures on subsequent turns. The SDK does not map this field
- *     natively (see vercel/ai#11342), so we capture it here and
- *     `base-agent` re-injects it via `providerOptions.openaiCompatible`
- *     on each outgoing assistant message.
+ *     natively (see vercel/ai#11342), so we capture it here. The key is
+ *     the transport hook, not the semantic owner; `base-agent` stores the
+ *     current route alongside these details and only re-injects matching
+ *     groups via `providerOptions.openaiCompatible` on future requests.
  *
  *  2. `stagewise` — any `provider_metadata` riding on the response
  *     message/delta. Preserved as-is for existing usage-limit/plan
@@ -233,12 +234,13 @@ export type StagewiseProviderSettings = {
  * chat completions endpoints.
  *
  * Provider options are forwarded under the `stagewise` key and
- * response metadata is extracted under the same key.
+ * response metadata is extracted from gateway responses.
  *
  * Message-level metadata (e.g. `cache_control`, signed
  * `reasoning_details`) is forwarded via the built-in
- * `openaiCompatible` providerOptions key which the SDK spreads
- * directly onto each message in the request body.
+ * `openaiCompatible` providerOptions transport key which the SDK spreads
+ * directly onto each message in the request body. Semantic ownership for
+ * signed reasoning details is tracked separately in assistant metadata.
  */
 export function createStagewise(
   settings: StagewiseProviderSettings,

--- a/apps/browser/src/shared/karton-contracts/ui/agent/metadata.ts
+++ b/apps/browser/src/shared/karton-contracts/ui/agent/metadata.ts
@@ -1,5 +1,10 @@
 import { z } from 'zod';
-import { environmentDiffSnapshotSchema } from '../shared-types';
+import {
+  apiSpecSchema,
+  environmentDiffSnapshotSchema,
+  modelProviderSchema,
+  providerEndpointModeSchema,
+} from '../shared-types';
 
 /**
  * A path-based attachment on a user message.
@@ -49,6 +54,43 @@ export const textClipAttachmentSchema = z.object({
 
 /** @deprecated Use file-based `.textclip` attachments instead. */
 export type TextClipAttachment = z.infer<typeof textClipAttachmentSchema>;
+
+export const reasoningSignatureSourceSchema = z
+  .object({
+    providerMode: providerEndpointModeSchema,
+    provider: modelProviderSchema,
+    apiSpec: apiSpecSchema.optional(),
+    endpointId: z.string().optional(),
+    modelId: z.string(),
+  })
+  .superRefine((source, ctx) => {
+    if (source.providerMode !== 'custom') return;
+    if (!source.apiSpec) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Custom reasoning signature sources require apiSpec',
+        path: ['apiSpec'],
+      });
+    }
+    if (!source.endpointId) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Custom reasoning signature sources require endpointId',
+        path: ['endpointId'],
+      });
+    }
+  });
+
+export type ReasoningSignatureSource = z.infer<
+  typeof reasoningSignatureSourceSchema
+>;
+
+export const ownedReasoningDetailsSchema = z.object({
+  source: reasoningSignatureSourceSchema,
+  details: z.array(z.record(z.string(), z.unknown())).min(1),
+});
+
+export type OwnedReasoningDetails = z.infer<typeof ownedReasoningDetailsSchema>;
 
 export const browserTabSnapshotSchema = z.object({
   id: z.string(),
@@ -343,19 +385,21 @@ const metadataSchema = z.object({
    */
   pathReferences: z.record(z.string(), z.string()).optional(),
   /**
-   * Signed `reasoning_details` captured from the provider response.
-   * Re-injected into outbound assistant messages on subsequent requests
-   * so providers (Anthropic via Bedrock/OpenRouter, Google) can verify
-   * chain-of-thought signatures and keep extending the thinking process.
+   * Provider-owned signed `reasoning_details` captured from the provider
+   * response. Re-injected only when the outbound model route matches the
+   * semantic owner so Anthropic/Google/OpenAI signatures are never replayed
+   * across provider boundaries.
    *
    * Shape is provider-defined (`reasoning.text`, `reasoning.encrypted`,
    * `reasoning.summary`, etc., each carrying `signature` /
    * `thought_signature` / `format`). We store entries verbatim so
    * forward-compat is preserved — do NOT tighten this schema.
-   *
-   * Populated by `populateReasoningDetailsOnAssistantMessage` at step end.
-   * Consumed by `convertAssistantMessage` when building ModelMessages
-   * (attached under `providerOptions.openaiCompatible.reasoning_details`).
+   */
+  ownedReasoningDetails: z.array(ownedReasoningDetailsSchema).optional(),
+  /**
+   * @deprecated Legacy flat signed `reasoning_details` captured before
+   * provider ownership was tracked. Kept readable for existing DB rows;
+   * conversion consumes it via conservative source inference only.
    */
   reasoningDetails: z.array(z.record(z.string(), z.unknown())).optional(),
 });


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents cross‑provider reuse of thinking signatures by storing provider‑owned signatures with their route and only replaying on matching routes. Also derives per‑request content limits from the resolved model and clarifies when reasoning parts are stripped vs kept.

- **Bug Fixes**
  - Store signed reasoning as `ownedReasoningDetails` with a `ReasoningSignatureSource`; match non‑custom by mode+provider and custom by `apiSpec`+`endpointId`.
  - Replay only matching groups via `providerOptions.openaiCompatible.reasoning_details`; strip `reasoning` UI parts when replaying or when legacy/stagewise metadata exists; keep them otherwise (native SDK routes).
  - Legacy back‑compat: infer provider from signature shape (`signature` vs `thought_signature`); replay only on matching stagewise routes; drop ambiguous/unknown shapes.
  - Thread the source through all provider routes (stagewise/official/custom), map API specs to semantic providers, require `officialProvider` in stagewise, derive per‑request content limits from the active route, and append new signatures to the matching group; added tests for mapping, matching, and replay behavior.

<sup>Written for commit 35b62f8b0755e807bceede4e56acc24512e0fbb5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1227?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added reasoning-signature sources to record provider/model/endpoint ownership and map API specs to semantic providers; custom sources now require API spec + endpoint.

* **Refactor**
  * Thread reasoning-signature sources through model selection, per-step context, message conversion, and persisted assistant metadata.
  * Persist owned reasoning details grouped by source instead of a single flat array.

* **Tests**
  * New and extended tests validating creation, validation, matching, and replay behavior.

* **Documentation**
  * Updated metadata contracts and docs describing source-owned reasoning details.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stagewise-io/stagewise/pull/1227?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->