### PR TITLE
feat(stagewise): add opus 4.8

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -55,7 +55,7 @@ Für maximale Einfachheit und sofortigen Zugriff auf eine große Modellbibliothe
 
 Enthaltene Modelle:
 
-- **Anthropic**: Opus 4.7, Opus 4.6, Sonnet 4.6, Haiku 4.5
+- **Anthropic**: Opus 4.8, Opus 4.7, Opus 4.6, Sonnet 4.6, Haiku 4.5
 - **OpenAI**: GPT-5.5, GPT-5.4, GPT-5.3 Codex, GPT-5.3 Instant, GPT-5.4 mini, GPT-5.4 nano
 - **Google**: Gemini 3.1 Pro (Preview), Gemini 3 Flash, Gemini 3.1 Flash Lite
 - **Moonshot AI**: Kimi K2.6, Kimi K2.5

--- a/README.es.md
+++ b/README.es.md
@@ -55,7 +55,7 @@ Para mayor comodidad y acceso inmediato a una amplia biblioteca de modelos, simp
 
 Modelos incluidos:
 
-- **Anthropic**: Opus 4.7, Opus 4.6, Sonnet 4.6, Haiku 4.5
+- **Anthropic**: Opus 4.8, Opus 4.7, Opus 4.6, Sonnet 4.6, Haiku 4.5
 - **OpenAI**: GPT-5.5, GPT-5.4, GPT-5.3 Codex, GPT-5.3 Instant, GPT-5.4 mini, GPT-5.4 nano
 - **Google**: Gemini 3.1 Pro (Preview), Gemini 3 Flash, Gemini 3.1 Flash Lite
 - **Moonshot AI**: Kimi K2.6, Kimi K2.5

--- a/README.ja.md
+++ b/README.ja.md
@@ -55,7 +55,7 @@
 
 利用可能なモデル:
 
-- **Anthropic**: Opus 4.7, Opus 4.6, Sonnet 4.6, Haiku 4.5
+- **Anthropic**: Opus 4.8, Opus 4.7, Opus 4.6, Sonnet 4.6, Haiku 4.5
 - **OpenAI**: GPT-5.5, GPT-5.4, GPT-5.3 Codex, GPT-5.3 Instant, GPT-5.4 mini, GPT-5.4 nano
 - **Google**: Gemini 3.1 Pro (Preview), Gemini 3 Flash, Gemini 3.1 Flash Lite
 - **Moonshot AI**: Kimi K2.6, Kimi K2.5

--- a/README.ko.md
+++ b/README.ko.md
@@ -55,7 +55,7 @@
 
 포함된 모델:
 
-- **Anthropic**: Opus 4.7, Opus 4.6, Sonnet 4.6, Haiku 4.5
+- **Anthropic**: Opus 4.8, Opus 4.7, Opus 4.6, Sonnet 4.6, Haiku 4.5
 - **OpenAI**: GPT-5.5, GPT-5.4, GPT-5.3 Codex, GPT-5.3 Instant, GPT-5.4 mini, GPT-5.4 nano
 - **Google**: Gemini 3.1 Pro (Preview), Gemini 3 Flash, Gemini 3.1 Flash Lite
 - **Moonshot AI**: Kimi K2.6, Kimi K2.5

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ For ease of use and immediate access to a large library of models, you can simpl
 
 Included models:
 
-- **Anthropic**: Opus 4.7, Opus 4.6, Sonnet 4.6, Haiku 4.5
+- **Anthropic**: Opus 4.8, Opus 4.7, Opus 4.6, Sonnet 4.6, Haiku 4.5
 - **OpenAI**: GPT-5.5, GPT-5.4, GPT-5.3 Codex, GPT-5.3 Instant, GPT-5.4 mini, GPT-5.4 nano
 - **Google**: Gemini 3.1 Pro (Preview), Gemini 3 Flash, Gemini 3.1 Flash Lite
 - **Moonshot AI**: Kimi K2.6, Kimi K2.5

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -55,7 +55,7 @@
 
 包含模型：
 
-- **Anthropic**：Opus 4.7、Opus 4.6、Sonnet 4.6、Haiku 4.5
+- **Anthropic**：Opus 4.8、Opus 4.7、Opus 4.6、Sonnet 4.6、Haiku 4.5
 - **OpenAI**：GPT-5.5、GPT-5.4、GPT-5.3 Codex、GPT-5.3 Instant、GPT-5.4 mini、GPT-5.4 nano
 - **Google**：Gemini 3.1 Pro（预览）、Gemini 3 Flash、Gemini 3.1 Flash Lite（预览）
 - **Moonshot AI**：Kimi K2.6、Kimi K2.5

--- a/apps/browser/src/backend/agents/model-provider.ts
+++ b/apps/browser/src/backend/agents/model-provider.ts
@@ -31,8 +31,8 @@ type ProviderOptions = Parameters<typeof streamText>[0]['providerOptions'];
 
 /**
  * Converts an OpenRouter-style Anthropic model ID (dots in version, e.g.
- * `claude-opus-4.7`) to the native Anthropic API format (hyphens, e.g.
- * `claude-opus-4-7`). Idempotent on IDs that already use hyphens.
+ * `claude-opus-4.8`) to the native Anthropic API format (hyphens, e.g.
+ * `claude-opus-4-8`). Idempotent on IDs that already use hyphens.
  */
 function toNativeAnthropicModelId(modelId: string): string {
   return modelId.replace(/\./g, '-');

--- a/apps/browser/src/shared/available-models.ts
+++ b/apps/browser/src/shared/available-models.ts
@@ -111,10 +111,51 @@ export const availableModels = [
   // Anthropic Models
   {
     officialProvider: 'anthropic',
+    modelId: 'claude-opus-4.8',
+    modelDisplayName: 'Opus 4.8',
+    modelDescription:
+      "Anthropic's most capable model, excels at complex reasoning and architectural decisions.",
+    modelContext: '1M context',
+    modelContextRaw: 1000000,
+    headers: anthropicHeaders,
+    providerOptions: {
+      stagewise: { reasoning: { enabled: true, effort: 'medium' } },
+      anthropic: {
+        thinking: { type: 'adaptive' },
+        effort: 'medium',
+      },
+    },
+    thinkingEnabled: true,
+    pricing: {
+      inputPerMillion: 5.0,
+      outputPerMillion: 25.0,
+      relativeMultiplier: 5.3,
+    },
+    capabilities: {
+      inputModalities: {
+        text: true,
+        audio: false,
+        image: true,
+        video: false,
+        file: true,
+      },
+      outputModalities: {
+        text: true,
+        audio: false,
+        image: false,
+        video: false,
+        file: false,
+      },
+      inputConstraints: ANTHROPIC_INPUT_CONSTRAINTS,
+      toolCalling: true,
+    },
+  },
+  {
+    officialProvider: 'anthropic',
     modelId: 'claude-opus-4.7',
     modelDisplayName: 'Opus 4.7',
     modelDescription:
-      "Anthropic's most capable model, excels at complex reasoning and architectural decisions.",
+      'Previous-generation Opus model. Still highly capable for complex reasoning tasks.',
     modelContext: '1M context',
     modelContextRaw: 1000000,
     headers: anthropicHeaders,

--- a/apps/browser/src/shared/karton-contracts/ui/shared-types.ts
+++ b/apps/browser/src/shared/karton-contracts/ui/shared-types.ts
@@ -678,6 +678,7 @@ export const defaultUserPreferences: UserPreferences = {
   agent: {
     workspaceSettings: {},
     disabledModelIds: [
+      'claude-opus-4.7',
       'claude-opus-4.6',
       'kimi-k2.5',
       'gpt-5.4',

--- a/apps/browser/src/ui/screens/settings/sections/custom-providers-section.tsx
+++ b/apps/browser/src/ui/screens/settings/sections/custom-providers-section.tsx
@@ -136,13 +136,14 @@ function resolveEffectiveBedrockRegion(args: {
  * inference profile identifiers as published in Anthropic's Bedrock
  * reference (docs.anthropic.com → Models overview → Bedrock column).
  *
- * Note: the 4.6/4.7 generation uses short-form IDs without a date or
+ * Note: the 4.6/4.7/4.8 generation uses short-form IDs without a date or
  * `-v1:0` suffix — that is intentional on Anthropic's side, not a
  * placeholder. Older models (4.5 and earlier) still carry the dated,
  * versioned form.
  */
 function buildSuggestedBedrockMapping(prefix: string): string {
   const mapping: Record<string, string> = {
+    'claude-opus-4.8': `${prefix}anthropic.claude-opus-4-8`,
     'claude-opus-4.7': `${prefix}anthropic.claude-opus-4-7`,
     'claude-opus-4.6': `${prefix}anthropic.claude-opus-4-6-v1`,
     'claude-sonnet-4.6': `${prefix}anthropic.claude-sonnet-4-6`,
@@ -976,7 +977,7 @@ function CustomEndpointDialog({
             <textarea
               className="scrollbar-subtle w-full resize-y rounded-lg border border-derived p-2 font-mono text-foreground text-xs focus:outline-none focus:ring-1 focus:ring-muted-foreground/35"
               rows={8}
-              placeholder='{"claude-opus-4.7": "anthropic.claude-opus-4-7"}'
+              placeholder='{"claude-opus-4.8": "anthropic.claude-opus-4-8"}'
               value={modelIdMappingJson}
               onChange={(e) => {
                 setModelIdMappingJson(e.target.value);

--- a/apps/website/src/app/(home)/_components/model-provider-showcase.tsx
+++ b/apps/website/src/app/(home)/_components/model-provider-showcase.tsx
@@ -48,6 +48,7 @@ const PROVIDERS: ProviderInfo[] = [
     description:
       'Best-in-class instruction following and long-context reasoning.',
     models: [
+      { name: 'Opus 4.8', tier: 'frontier' },
       { name: 'Opus 4.7', tier: 'frontier' },
       { name: 'Opus 4.6', tier: 'frontier' },
       { name: 'Sonnet 4.6', tier: 'general' },


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds Anthropic Opus 4.8 across the app and makes it the preferred Opus tier with stagewise reasoning. Updates model lists, Bedrock mapping, and docs to surface the new model.

- **New Features**
  - Added `claude-opus-4.8` with 1M context, adaptive thinking, and stagewise reasoning (effort: medium).
  - Added Bedrock mapping `claude-opus-4.8` → `anthropic.claude-opus-4-8` and updated the JSON placeholder in settings.
  - Updated available models, website showcase, and all READMEs to include Opus 4.8; marked 4.7 as previous-gen.
  - Default preferences now disable `claude-opus-4.7` to prefer 4.8.

<sup>Written for commit c5a71fd7fbd3dd76abe4f0004382f71271b1b347. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1228?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Anthropic Opus 4.8 model with full capabilities (1M context window, pricing, extended thinking).

* **Documentation**
  * Updated READMEs in multiple languages (English, German, Spanish, Japanese, Korean, Chinese) to reflect available models.

* **Updates**
  * Updated model descriptions to reflect Opus 4.8 as the latest Anthropic model; Opus 4.7 marked as previous-generation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stagewise-io/stagewise/pull/1228?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->