### PR TITLE
feat(stagewise): add rust and clang lsp

### DIFF
--- a/apps/browser/src/backend/services/toolbox/services/lsp/client.test.ts
+++ b/apps/browser/src/backend/services/toolbox/services/lsp/client.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import type { Diagnostic } from 'vscode-languageserver-types';
+import { LspClient } from './client';
+import type { LspServerInfo } from './types';
+
+/**
+ * Construct an LspClient without spawning a server. The constructor is private
+ * at the type level only (JS does not enforce it at runtime), so we bypass it
+ * via a cast. `waitForDiagnostics` / `updateDiagnostics` depend solely on the
+ * internal maps, the EventEmitter, and the static timeouts — no live
+ * connection — so this is sufficient to exercise the wait/receipt logic.
+ */
+interface TestClient {
+  waitForDiagnostics(filePath: string, minVersion?: number): Promise<void>;
+  updateDiagnostics(
+    filePath: string,
+    diagnostics: Diagnostic[],
+    version?: number,
+  ): void;
+  on(event: string, listener: (...args: unknown[]) => void): unknown;
+  emit(event: string, ...args: unknown[]): boolean;
+}
+
+function makeClient(): TestClient {
+  const serverInfo: LspServerInfo = {
+    id: 'test',
+    name: 'test',
+    extensions: ['.x'],
+    shouldActivate: async () => true,
+    spawn: async () => undefined,
+  };
+  const logger = {
+    debug() {},
+    warn() {},
+    error() {},
+    info() {},
+  };
+  const Ctor = LspClient as unknown as new (
+    serverInfo: LspServerInfo,
+    logger: unknown,
+    root: string,
+    resolvedEnv?: Record<string, string> | null,
+  ) => unknown;
+  return new Ctor(serverInfo, logger, '/tmp/project', null) as TestClient;
+}
+
+const FILE = '/tmp/project/a.x';
+
+function diag(message = 'warning'): Diagnostic {
+  return {
+    range: {
+      start: { line: 0, character: 0 },
+      end: { line: 0, character: 1 },
+    },
+    message,
+  };
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('LspClient.updateDiagnostics (receipt vs. change event)', () => {
+  it('emits a receipt with the version on every publish but the change event only when the set changes', () => {
+    const client = makeClient();
+    const received: Array<[string, number | undefined]> = [];
+    const changed: string[] = [];
+    client.on('diagnosticsReceived', (p, v) =>
+      received.push([p as string, v as number | undefined]),
+    );
+    client.on('diagnostics', (p) => changed.push(p as string));
+
+    client.updateDiagnostics(FILE, [diag()], 1);
+    client.updateDiagnostics(FILE, [diag()], 2); // identical content -> deduped
+
+    // Receipt fires for both publishes (so a re-lint never hangs), carrying
+    // the document version...
+    expect(received).toEqual([
+      [FILE, 1],
+      [FILE, 2],
+    ]);
+    // ...but the deduped change event only fires once.
+    expect(changed).toEqual([FILE]);
+  });
+});
+
+describe('LspClient.waitForDiagnostics', () => {
+  it('resolves shortly after a fresh receipt (debounce window)', async () => {
+    vi.useFakeTimers();
+    const client = makeClient();
+
+    const p = client.waitForDiagnostics(FILE, 1);
+    let resolved = false;
+    void p.then(() => {
+      resolved = true;
+    });
+
+    client.emit('diagnosticsReceived', FILE, 1);
+    await vi.advanceTimersByTimeAsync(149);
+    expect(resolved).toBe(false);
+    await vi.advanceTimersByTimeAsync(2);
+    expect(resolved).toBe(true);
+  });
+
+  it('ignores a stale lower-version publish and waits for the current version', async () => {
+    vi.useFakeTimers();
+    const client = makeClient();
+
+    // Waiting for diagnostics produced for document version 5.
+    const p = client.waitForDiagnostics(FILE, 5);
+    let resolved = false;
+    void p.then(() => {
+      resolved = true;
+    });
+
+    // A delayed publish from an earlier analysis (version 3) must NOT complete
+    // the wait — that would read stale diagnostics.
+    client.emit('diagnosticsReceived', FILE, 3);
+    await vi.advanceTimersByTimeAsync(200);
+    expect(resolved).toBe(false);
+
+    // The publish for the current content (version 5) completes it.
+    client.emit('diagnosticsReceived', FILE, 5);
+    await vi.advanceTimersByTimeAsync(150);
+    expect(resolved).toBe(true);
+  });
+
+  it('fast-path resolves immediately when the current version was already published', async () => {
+    vi.useFakeTimers();
+    const client = makeClient();
+    // Server already published version 7 for this file (cached, current).
+    client.updateDiagnostics(FILE, [diag()], 7);
+
+    // An unchanged re-lint asks to wait for version 7 (the cached version):
+    // the fast path resolves without waiting for a new publish that the server
+    // will not send.
+    let resolved = false;
+    void client.waitForDiagnostics(FILE, 7).then(() => {
+      resolved = true;
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(resolved).toBe(true);
+  });
+
+  it('accepts version-less receipts (servers that do not echo a version)', async () => {
+    vi.useFakeTimers();
+    const client = makeClient();
+
+    const p = client.waitForDiagnostics(FILE, 4);
+    let resolved = false;
+    void p.then(() => {
+      resolved = true;
+    });
+
+    // No version on the receipt -> cannot correlate -> accepted as best effort.
+    client.emit('diagnosticsReceived', FILE, undefined);
+    await vi.advanceTimersByTimeAsync(150);
+    expect(resolved).toBe(true);
+  });
+
+  it('falls back to the full timeout when no qualifying publish ever arrives', async () => {
+    vi.useFakeTimers();
+    const client = makeClient();
+
+    const p = client.waitForDiagnostics(FILE, 9);
+    let resolved = false;
+    void p.then(() => {
+      resolved = true;
+    });
+
+    await vi.advanceTimersByTimeAsync(2999);
+    expect(resolved).toBe(false);
+    await vi.advanceTimersByTimeAsync(2);
+    expect(resolved).toBe(true);
+  });
+});

--- a/apps/browser/src/backend/services/toolbox/services/lsp/client.ts
+++ b/apps/browser/src/backend/services/toolbox/services/lsp/client.ts
@@ -1,4 +1,5 @@
 import * as fs from 'node:fs';
+import { createHash } from 'node:crypto';
 import { EventEmitter } from 'node:events';
 import { pathToFileURL, fileURLToPath } from 'node:url';
 import { getBaseName } from '@shared/path-utils';
@@ -62,6 +63,11 @@ export class LspClient extends EventEmitter {
   public readonly root: string;
 
   private static readonly DIAGNOSTICS_DEBOUNCE_MS = 150;
+  /**
+   * Default safety-net cap for `waitForDiagnostics`. Individual servers can
+   * override it via `LspServerInfo.diagnosticsTimeoutMs` (e.g. rust-analyzer,
+   * whose cargo-backed flycheck is slower than this default on a cold cache).
+   */
   private static readonly DIAGNOSTICS_TIMEOUT_MS = 3000;
   private static readonly CLIENT_INIT_TIMEOUT_MS = 15_000;
   private static readonly SHUTDOWN_TIMEOUT_MS = 5_000;
@@ -72,6 +78,8 @@ export class LspClient extends EventEmitter {
   private openDocuments = new Map<string, number>(); // uri -> version
   private diagnostics = new Map<string, Diagnostic[]>(); // absoluteFilePath -> diagnostics
   private diagnosticsHash = new Map<string, string>(); // absoluteFilePath -> hash for deduplication
+  private lastDiagnosticsVersion = new Map<string, number>(); // absoluteFilePath -> last published document version
+  private sentContentHash = new Map<string, string>(); // uri -> hash of the last content sent to the server
   private initializePromise: Promise<void> | null = null;
   private initializationOptions: Record<string, unknown> | undefined;
   private disposed = false;
@@ -92,21 +100,44 @@ export class LspClient extends EventEmitter {
   }
 
   /**
+   * Compute a hash of file content for change detection between re-lints.
+   */
+  private computeContentHash(content: string): string {
+    return createHash('sha1').update(content).digest('hex');
+  }
+
+  /**
    * Update diagnostics and emit event only if they changed
    */
   private updateDiagnostics(
     filePath: string,
     newDiagnostics: Diagnostic[],
+    version?: number,
   ): void {
     const newHash = this.computeDiagnosticsHash(newDiagnostics);
     const oldHash = this.diagnosticsHash.get(filePath);
 
-    // Only emit if diagnostics actually changed
+    // Only emit the (deduped) 'diagnostics' change event if the set actually
+    // changed — downstream consumers use it for change propagation.
     if (newHash !== oldHash) {
       this.diagnostics.set(filePath, newDiagnostics);
       this.diagnosticsHash.set(filePath, newHash);
       this.emit('diagnostics', filePath, newDiagnostics);
     }
+
+    // Track the document version these diagnostics were computed against, when
+    // the server reports it (clangd and rust-analyzer both do). waitForDiagnostics
+    // uses this to ignore stale publishes from an earlier analysis.
+    if (typeof version === 'number') {
+      this.lastDiagnosticsVersion.set(filePath, version);
+    }
+
+    // Always signal that the server delivered a fresh diagnostic set for this
+    // file, even when the content was identical and the change event above was
+    // suppressed by dedup. waitForDiagnostics relies on this receipt (paired
+    // with the version) so it can resolve on an actual server response rather
+    // than guessing with a timer.
+    this.emit('diagnosticsReceived', filePath, version);
   }
 
   private readonly resolvedEnv: Record<string, string> | null;
@@ -231,7 +262,7 @@ export class LspClient extends EventEmitter {
       PublishDiagnosticsNotification.type,
       (params) => {
         const filePath = fileURLToPath(params.uri);
-        this.updateDiagnostics(filePath, params.diagnostics);
+        this.updateDiagnostics(filePath, params.diagnostics, params.version);
       },
     );
 
@@ -347,32 +378,12 @@ export class LspClient extends EventEmitter {
       return;
     }
 
-    for (const [uri, _version] of this.openDocuments) {
+    for (const uri of this.openDocuments.keys()) {
       const filePath = fileURLToPath(uri);
-
-      const requestPullDiagnostics = async () => {
-        // Snapshot the connection so a concurrent dispose() that nulls
-        // `this.connection` mid-flight cannot cause a null-deref here.
-        const conn = this.connection;
-        if (!conn || this.disposed) return;
-
-        try {
-          const diagResult = await conn.sendRequest('textDocument/diagnostic', {
-            textDocument: { uri },
-          });
-          if (this.disposed) return;
-          const items = (diagResult as { items?: Diagnostic[] })?.items ?? [];
-          this.updateDiagnostics(filePath, items);
-        } catch (error) {
-          this.logger.debug(
-            `[LspClient:${this.serverID}] Pull diagnostics failed during refresh for ${filePath}:`,
-            error,
-          );
-        }
-      };
-
-      // Small delay to avoid overwhelming the server
-      requestPullDiagnostics().catch(() => {});
+      // Re-pull through the shared helper: it snapshots and tags the current
+      // document version, so a refresh racing a concurrent change cannot emit a
+      // version-less receipt that resolves a wait with stale data.
+      this.schedulePullDiagnostics(uri, filePath, [0]);
     }
   }
 
@@ -450,7 +461,7 @@ export class LspClient extends EventEmitter {
         workspaceFolders: [
           {
             uri: pathToFileURL(this.root).toString(),
-            name: this.root.split('/').pop() || 'workspace',
+            name: getBaseName(this.root) || 'workspace',
           },
         ],
       };
@@ -481,10 +492,62 @@ export class LspClient extends EventEmitter {
   }
 
   /**
+   * Request pull diagnostics (`textDocument/diagnostic`) for a pull-model
+   * server (one advertising `diagnosticProvider`, e.g. ESLint) and feed the
+   * result through updateDiagnostics. Several delayed attempts give the server
+   * time to validate after an open/change.
+   *
+   * Each result is tagged with the document version current at send time. The
+   * server processes messages in order, so the response reflects at least that
+   * version; a pull issued before a newer change is therefore tagged with the
+   * older version and gated out by waitForDiagnostics instead of resolving a
+   * wait with stale data.
+   */
+  private schedulePullDiagnostics(
+    uri: string,
+    filePath: string,
+    delays: number[],
+  ): void {
+    if (!(this.capabilities as Record<string, unknown>)?.diagnosticProvider) {
+      return;
+    }
+    for (const delay of delays) {
+      void (async () => {
+        if (this.disposed) return;
+        await new Promise((resolve) => setTimeout(resolve, delay));
+        // Snapshot the connection after the timeout so dispose() nulling
+        // `this.connection` mid-flight cannot cause a null-deref here.
+        const conn = this.connection;
+        if (!conn || this.disposed) return;
+        // Read the document version at send time (see method doc).
+        const version = this.openDocuments.get(uri);
+        try {
+          const diagResult = await conn.sendRequest('textDocument/diagnostic', {
+            textDocument: { uri },
+          });
+          if (this.disposed) return;
+          const items = (diagResult as { items?: Diagnostic[] })?.items ?? [];
+          // Always update (even when empty) to clear stale diagnostics and emit
+          // a receipt so a clean file's wait resolves promptly.
+          this.updateDiagnostics(filePath, items, version);
+        } catch (pullError) {
+          // Server may not support pull diagnostics despite advertising, or
+          // dispose() may have torn the connection down between the timeout and
+          // the sendRequest resolving.
+          this.logger.debug(
+            `[LspClient:${this.serverID}] Pull diagnostics failed for ${filePath}:`,
+            pullError,
+          );
+        }
+      })();
+    }
+  }
+
+  /**
    * Open a document in the LSP server
    */
-  public async openDocument(filePath: string): Promise<void> {
-    if (!this.connection || this.disposed) return;
+  public async openDocument(filePath: string): Promise<number | undefined> {
+    if (!this.connection || this.disposed) return undefined;
 
     const uri = pathToFileURL(filePath).toString();
 
@@ -497,19 +560,37 @@ export class LspClient extends EventEmitter {
         // dispose() (which synchronously nulls `this.connection`) cannot
         // cause a null-deref on the sendNotification below.
         const conn = this.connection;
-        if (!conn || this.disposed) return;
+        if (!conn || this.disposed) return undefined;
         const currentVersion = this.openDocuments.get(uri)!;
         const newVersion = currentVersion + 1;
         this.openDocuments.set(uri, newVersion);
+        const contentHash = this.computeContentHash(content);
+        const contentChanged = this.sentContentHash.get(uri) !== contentHash;
+        this.sentContentHash.set(uri, contentHash);
         await conn.sendNotification(DidChangeTextDocumentNotification.type, {
           textDocument: { uri, version: newVersion },
           contentChanges: [{ text: content }],
         });
+        // Pull-model servers don't push on didChange — request a refresh when
+        // the content actually changed so new diagnostics are produced (and
+        // tagged with the new version).
+        if (contentChanged) {
+          this.schedulePullDiagnostics(uri, filePath, [100, 500]);
+        }
+        // If the on-disk content is unchanged, the server may not re-publish
+        // (clangd, for one, skips identical re-analyses) and the cached
+        // diagnostics are already current — so wait against the last published
+        // version, which the fast path in waitForDiagnostics satisfies
+        // immediately. Only when the content actually changed do we wait for a
+        // publish at the new version.
+        return contentChanged
+          ? newVersion
+          : this.lastDiagnosticsVersion.get(filePath);
       } catch {
         // File may have been deleted between open and re-read, or the
         // connection was disposed while we were reading.
+        return undefined;
       }
-      return;
     }
 
     try {
@@ -518,8 +599,9 @@ export class LspClient extends EventEmitter {
       // dispose() (which synchronously nulls `this.connection`) cannot
       // cause a null-deref on the sendNotification calls below.
       const conn = this.connection;
-      if (!conn || this.disposed) return;
+      if (!conn || this.disposed) return undefined;
       const languageId = getLanguageId(filePath);
+      this.sentContentHash.set(uri, this.computeContentHash(content));
 
       const textDocument: TextDocumentItem = {
         uri,
@@ -532,68 +614,33 @@ export class LspClient extends EventEmitter {
       const params: DidOpenTextDocumentParams = { textDocument };
       await conn.sendNotification(DidOpenTextDocumentNotification.type, params);
 
-      // ESLint's run: "onType" setting responds to changes, not just opens
-      // Send a no-op change to trigger validation
-      const changeParams: DidChangeTextDocumentParams = {
-        textDocument: {
-          uri,
-          version: 2,
-        },
-        contentChanges: [{ text: content }],
-      };
-      this.openDocuments.set(uri, 2);
-      await conn.sendNotification(
-        DidChangeTextDocumentNotification.type,
-        changeParams,
-      );
+      const isPullServer = !!(this.capabilities as Record<string, unknown>)
+        ?.diagnosticProvider;
 
-      // If server supports pull diagnostics (diagnosticProvider), request diagnostics
-      // ESLint uses pull diagnostics - we need to explicitly request them
-      if (
-        (this.capabilities as Record<string, unknown>)?.diagnosticProvider &&
-        !this.disposed
-      ) {
-        const requestPullDiagnostics = async (delay: number) => {
-          if (this.disposed) return;
-          await new Promise((resolve) => setTimeout(resolve, delay));
-          // Snapshot the connection after the timeout so dispose() nulling
-          // `this.connection` mid-flight cannot cause a null-deref here.
-          const conn = this.connection;
-          if (!conn || this.disposed) return;
-
-          try {
-            const diagResult = await conn.sendRequest(
-              'textDocument/diagnostic',
-              {
-                textDocument: { uri },
-              },
-            );
-            if (this.disposed) return;
-            // Process pull diagnostics result (deduplication handled by updateDiagnostics)
-            const items = (diagResult as { items?: Diagnostic[] })?.items ?? [];
-            if (items.length > 0) {
-              this.updateDiagnostics(filePath, items);
-            }
-          } catch (pullError) {
-            // Server may not support pull diagnostics despite advertising,
-            // or dispose() may have torn the connection down between the
-            // timeout and the sendRequest resolving.
-            this.logger.debug(
-              `[LspClient:${this.serverID}] Pull diagnostics failed for ${filePath}:`,
-              pullError,
-            );
-          }
-        };
-        // Request pull diagnostics after delays to give ESLint time to validate
-        requestPullDiagnostics(500).catch(() => {});
-        requestPullDiagnostics(2000).catch(() => {});
-        requestPullDiagnostics(5000).catch(() => {});
+      // Pull-model servers (e.g. ESLint with run: "onType") validate in
+      // response to changes, not bare opens, so nudge them with a no-op change
+      // and request diagnostics explicitly. Push servers publish on didOpen, so
+      // we deliberately do NOT advance them to a second version: clangd
+      // suppresses re-analysis of byte-identical changes and would never
+      // publish that version, which would hang the wait below until timeout.
+      if (isPullServer) {
+        this.openDocuments.set(uri, 2);
+        await conn.sendNotification(DidChangeTextDocumentNotification.type, {
+          textDocument: { uri, version: 2 },
+          contentChanges: [{ text: content }],
+        });
+        this.schedulePullDiagnostics(uri, filePath, [500, 2000, 5000]);
       }
+
+      // Wait for diagnostics at the latest version we actually sent: 1 for push
+      // servers (didOpen only) or 2 for pull servers (didOpen + no-op change).
+      return this.openDocuments.get(uri);
     } catch (error) {
       this.logger.error(
         `[LspClient:${this.serverID}] Failed to open document: ${filePath}`,
         error,
       );
+      return undefined;
     }
   }
 
@@ -603,20 +650,20 @@ export class LspClient extends EventEmitter {
   public async updateDocument(
     filePath: string,
     content: string,
-  ): Promise<void> {
-    if (!this.connection || this.disposed) return;
+  ): Promise<number | undefined> {
+    if (!this.connection || this.disposed) return undefined;
 
     const uri = pathToFileURL(filePath).toString();
     const currentVersion = this.openDocuments.get(uri);
 
     if (currentVersion === undefined) {
       // Document not open, open it instead
-      await this.openDocument(filePath);
-      return;
+      return await this.openDocument(filePath);
     }
 
     const newVersion = currentVersion + 1;
     this.openDocuments.set(uri, newVersion);
+    this.sentContentHash.set(uri, this.computeContentHash(content));
 
     const params: DidChangeTextDocumentParams = {
       textDocument: {
@@ -630,39 +677,12 @@ export class LspClient extends EventEmitter {
       params,
     );
 
-    // Request pull diagnostics after update for servers that use pull model (e.g., ESLint)
-    // Without this, servers with diagnosticProvider won't re-validate after content changes
-    if (
-      (this.capabilities as Record<string, unknown>)?.diagnosticProvider &&
-      this.connection
-    ) {
-      const requestPullDiagnostics = async (delay: number) => {
-        if (this.disposed) return;
-        await new Promise((resolve) => setTimeout(resolve, delay));
-        // Snapshot the connection after the timeout so dispose() nulling
-        // `this.connection` mid-flight cannot cause a null-deref here.
-        const conn = this.connection;
-        if (!conn || this.disposed) return;
+    // Pull-model servers (e.g. ESLint) won't re-validate on didChange — request
+    // diagnostics explicitly so the change is reflected (tagged with the new
+    // version).
+    this.schedulePullDiagnostics(uri, filePath, [100, 500]);
 
-        try {
-          const diagResult = await conn.sendRequest('textDocument/diagnostic', {
-            textDocument: { uri },
-          });
-          if (this.disposed) return;
-          const items = (diagResult as { items?: Diagnostic[] })?.items ?? [];
-          // Always update diagnostics (even if empty) to clear stale ones
-          this.updateDiagnostics(filePath, items);
-        } catch (pullError) {
-          this.logger.debug(
-            `[LspClient:${this.serverID}] Pull diagnostics failed after update for ${filePath}:`,
-            pullError,
-          );
-        }
-      };
-      // Request pull diagnostics with delays to give the server time to process the change
-      requestPullDiagnostics(100).catch(() => {});
-      requestPullDiagnostics(500).catch(() => {});
-    }
+    return newVersion;
   }
 
   /**
@@ -678,6 +698,8 @@ export class LspClient extends EventEmitter {
     this.openDocuments.delete(uri);
     this.diagnostics.delete(filePath);
     this.diagnosticsHash.delete(filePath);
+    this.lastDiagnosticsVersion.delete(filePath);
+    this.sentContentHash.delete(uri);
 
     const params: DidCloseTextDocumentParams = {
       textDocument: { uri },
@@ -692,20 +714,66 @@ export class LspClient extends EventEmitter {
    * Wait for diagnostics to be received for a file.
    * Uses debouncing to handle multiple rapid diagnostic updates.
    */
-  public async waitForDiagnostics(filePath: string): Promise<void> {
+  /**
+   * Wait for diagnostics produced by the current open/change of `filePath`.
+   *
+   * `minVersion` is the document version dispatched by the open/change that
+   * preceded this call (returned by openDocument/updateDocument). We resolve
+   * on a diagnostics *receipt* whose published document version is at least
+   * `minVersion`, which ties the wait to the current touch:
+   *
+   *  - A delayed publish from an earlier analysis carries a lower version and
+   *    is ignored, so we never resolve against a stale cache.
+   *  - Servers that do not report a version (publish `null`) cannot be
+   *    correlated, so their receipts are accepted as a best effort.
+   *  - When `minVersion` is undefined (e.g. unchanged content whose cached
+   *    diagnostics are already current, or a server that has not reported a
+   *    version yet) any receipt completes the wait.
+   *
+   * A receipt is emitted on every server response — including ones the hash
+   * dedup suppresses — so an unchanged re-lint resolves promptly instead of
+   * hanging. The overall timeout is a safety net for servers that never
+   * publish (unsupported file or a slow cold index).
+   */
+  public async waitForDiagnostics(
+    filePath: string,
+    minVersion?: number,
+  ): Promise<void> {
+    // A receipt is current when its document version is at least the version
+    // dispatched by the open/change preceding this wait. Both push servers
+    // (clangd, rust-analyzer) and our pull requests tag receipts with a
+    // version, so stale results from an earlier analysis are gated out. A
+    // truly version-less receipt (a server that reports no version at all)
+    // cannot be correlated and is accepted as a best effort rather than
+    // hanging to the timeout.
+    const isFresh = (version: number | undefined): boolean =>
+      minVersion === undefined ||
+      version === undefined ||
+      version >= minVersion;
+
+    // Fast path: the matching publish may already have arrived between the
+    // open/change dispatch and this call.
+    if (minVersion !== undefined) {
+      const last = this.lastDiagnosticsVersion.get(filePath);
+      if (last !== undefined && last >= minVersion) return;
+    }
+
     return new Promise((resolve) => {
       let debounceTimer: ReturnType<typeof setTimeout> | undefined;
 
       const cleanup = (timer: ReturnType<typeof setTimeout>) => {
         if (debounceTimer) clearTimeout(debounceTimer);
         clearTimeout(timer);
-        this.off('diagnostics', onDiagnostics);
+        this.off('diagnosticsReceived', onReceived);
       };
 
-      const onDiagnostics = (path: string) => {
+      const onReceived = (path: string, version?: number) => {
         if (path !== filePath) return;
+        // Ignore stale publishes from an earlier analysis.
+        if (!isFresh(version)) return;
 
-        // Debounce to allow follow-up diagnostics (syntax errors first, then semantic)
+        // Debounce to coalesce follow-up publishes (e.g. syntax diagnostics
+        // first, then semantic) into a single resolve.
         if (debounceTimer) clearTimeout(debounceTimer);
         debounceTimer = setTimeout(() => {
           cleanup(timeoutTimer);
@@ -713,14 +781,18 @@ export class LspClient extends EventEmitter {
         }, LspClient.DIAGNOSTICS_DEBOUNCE_MS);
       };
 
-      // Subscribe to diagnostics events
-      this.on('diagnostics', onDiagnostics);
+      // Subscribe to diagnostics receipts
+      this.on('diagnosticsReceived', onReceived);
 
-      // Overall timeout - resolve anyway to avoid hanging
+      // Safety net: a server that never publishes (unsupported file, or a slow
+      // cold index) must not hang the caller forever. Cargo-backed servers like
+      // rust-analyzer override the default with a larger window so a cold
+      // flycheck (several seconds) is not cut off into an empty result.
       const timeoutTimer = setTimeout(() => {
         cleanup(timeoutTimer);
         resolve();
-      }, LspClient.DIAGNOSTICS_TIMEOUT_MS);
+      }, this.serverInfo.diagnosticsTimeoutMs ??
+        LspClient.DIAGNOSTICS_TIMEOUT_MS);
     });
   }
 
@@ -1090,6 +1162,8 @@ export class LspClient extends EventEmitter {
     this.openDocuments.clear();
     this.diagnostics.clear();
     this.diagnosticsHash.clear();
+    this.lastDiagnosticsVersion.clear();
+    this.sentContentHash.clear();
 
     // Emit 'close' after all teardown work completes so observers
     // (LspService.on('close'), tests) see the client in its final

--- a/apps/browser/src/backend/services/toolbox/services/lsp/index.ts
+++ b/apps/browser/src/backend/services/toolbox/services/lsp/index.ts
@@ -101,20 +101,22 @@ export class LspService extends DisposableService {
       return;
     }
 
-    // Start waiting for diagnostics BEFORE opening (to not miss fast responses)
-    const waitPromises = waitForDiagnostics
-      ? clients.map((client) => client.waitForDiagnostics(absoluteFilePath))
-      : [];
-
-    // Open document in all clients
-    const openPromises = clients.map((client) =>
-      client.openDocument(absoluteFilePath),
+    // Open (or re-sync) the document in every client first, capturing the
+    // document version each server will report diagnostics against. Opening
+    // before waiting is safe: waitForDiagnostics has a fast path that catches a
+    // publish that arrived during the open, and it is version-gated so it only
+    // completes on diagnostics produced for the current content.
+    const versions = await Promise.all(
+      clients.map((client) => client.openDocument(absoluteFilePath)),
     );
-    await Promise.all(openPromises);
 
     // Wait for all diagnostics if requested
     if (waitForDiagnostics) {
-      await Promise.all(waitPromises);
+      await Promise.all(
+        clients.map((client, index) =>
+          client.waitForDiagnostics(absoluteFilePath, versions[index]),
+        ),
+      );
     }
   }
 

--- a/apps/browser/src/backend/services/toolbox/services/lsp/language-map.test.ts
+++ b/apps/browser/src/backend/services/toolbox/services/lsp/language-map.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getLanguageId,
+  CLANGD_EXTENSIONS,
+  RUST_EXTENSIONS,
+} from './language-map';
+
+describe('getLanguageId — C/C++/Rust', () => {
+  it('maps .rs to rust', () => {
+    expect(getLanguageId('src/main.rs')).toBe('rust');
+  });
+
+  it('maps C sources/headers to c', () => {
+    expect(getLanguageId('a/b.c')).toBe('c');
+    expect(getLanguageId('a/b.h')).toBe('c');
+  });
+
+  it('maps C++ sources/headers to cpp', () => {
+    expect(getLanguageId('a/b.cpp')).toBe('cpp');
+    expect(getLanguageId('a/b.cc')).toBe('cpp');
+    expect(getLanguageId('a/b.cxx')).toBe('cpp');
+    expect(getLanguageId('a/b.hpp')).toBe('cpp');
+    expect(getLanguageId('a/b.hh')).toBe('cpp');
+    expect(getLanguageId('a/b.hxx')).toBe('cpp');
+  });
+
+  it('still handles existing TS mappings', () => {
+    expect(getLanguageId('a/b.tsx')).toBe('typescriptreact');
+  });
+});
+
+describe('extension lists', () => {
+  it('CLANGD_EXTENSIONS contains the expected C/C++ extensions', () => {
+    for (const ext of ['.c', '.cc', '.cpp', '.cxx', '.h', '.hpp']) {
+      expect(CLANGD_EXTENSIONS).toContain(ext);
+    }
+  });
+
+  it('RUST_EXTENSIONS contains .rs', () => {
+    expect(RUST_EXTENSIONS).toEqual(['.rs']);
+  });
+});

--- a/apps/browser/src/backend/services/toolbox/services/lsp/language-map.ts
+++ b/apps/browser/src/backend/services/toolbox/services/lsp/language-map.ts
@@ -21,6 +21,20 @@ export function getLanguageId(filePath: string): string {
     case '.mts':
     case '.cts':
       return 'typescript';
+    case '.rs':
+      return 'rust';
+    case '.c':
+    case '.h':
+      return 'c';
+    case '.cc':
+    case '.cpp':
+    case '.cxx':
+    case '.c++':
+    case '.hpp':
+    case '.hh':
+    case '.hxx':
+    case '.h++':
+      return 'cpp';
     default:
       // Remove the dot: .ts → typescript, .json → json, etc.
       return ext ? ext.slice(1) : 'plaintext';
@@ -84,3 +98,27 @@ export const BIOME_EXTENSIONS = [
   '.json',
   '.jsonc',
 ];
+
+/**
+ * Extensions handled by clangd (C/C++).
+ *
+ * clangd re-derives the true language from compile flags / compile_commands;
+ * these IDs only route files to the server.
+ */
+export const CLANGD_EXTENSIONS = [
+  '.c',
+  '.cc',
+  '.cpp',
+  '.cxx',
+  '.c++',
+  '.h',
+  '.hh',
+  '.hpp',
+  '.hxx',
+  '.h++',
+];
+
+/**
+ * Extensions handled by rust-analyzer.
+ */
+export const RUST_EXTENSIONS = ['.rs'];

--- a/apps/browser/src/backend/services/toolbox/services/lsp/servers/clangd.test.ts
+++ b/apps/browser/src/backend/services/toolbox/services/lsp/servers/clangd.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import os from 'node:os';
+import path from 'node:path';
+import nodeFs from 'node:fs/promises';
+import { randomUUID } from 'node:crypto';
+import { clangdServer } from './clangd';
+
+let root: string;
+
+beforeEach(async () => {
+  root = path.join(os.tmpdir(), `clangd-activate-${randomUUID()}`);
+  await nodeFs.mkdir(root, { recursive: true });
+});
+
+afterEach(async () => {
+  await nodeFs.rm(root, { recursive: true, force: true });
+});
+
+async function touch(relPath: string): Promise<void> {
+  const full = path.join(root, relPath);
+  await nodeFs.mkdir(path.dirname(full), { recursive: true });
+  await nodeFs.writeFile(full, '');
+}
+
+describe('clangdServer.shouldActivate', () => {
+  // compile_flags.txt is the minimal clangd compilation database and a very
+  // common single-target setup; it must activate clangd. (Regression: it was
+  // initially missing from the marker list, so projects using only
+  // compile_flags.txt never started the server.)
+  it('activates on compile_flags.txt', async () => {
+    await touch('compile_flags.txt');
+    expect(await clangdServer.shouldActivate(root)).toBe(true);
+  });
+
+  it('activates on compile_commands.json', async () => {
+    await touch('compile_commands.json');
+    expect(await clangdServer.shouldActivate(root)).toBe(true);
+  });
+
+  it('activates on a nested compile_flags.txt', async () => {
+    await touch('src/module/compile_flags.txt');
+    expect(await clangdServer.shouldActivate(root)).toBe(true);
+  });
+
+  it('activates on CMakeLists.txt / Makefile casings', async () => {
+    await touch('CMakeLists.txt');
+    expect(await clangdServer.shouldActivate(root)).toBe(true);
+  });
+
+  it('does NOT activate on source-only projects (no build info)', async () => {
+    await touch('src/main.c');
+    await touch('include/greet.h');
+    expect(await clangdServer.shouldActivate(root)).toBe(false);
+  });
+});

--- a/apps/browser/src/backend/services/toolbox/services/lsp/servers/clangd.ts
+++ b/apps/browser/src/backend/services/toolbox/services/lsp/servers/clangd.ts
@@ -1,0 +1,66 @@
+import type { LspServerInfo, LspServerHandle } from '../types';
+import { CLANGD_EXTENSIONS } from '../language-map';
+import { hasFileInTree } from './utils/root-finder';
+import { findExecutableOnPath } from './utils/binary-finder';
+import { spawnStdioLspServer } from './utils/spawn-helpers';
+
+/**
+ * Markers that identify a C/C++ project clangd can meaningfully serve.
+ *
+ * Both clangd compilation databases are recognized: `compile_commands.json`
+ * (full, tool-generated) and `compile_flags.txt` (the minimal one-flag-per-line
+ * alternative clangd reads directly). Includes common Makefile casings
+ * (GNU/lowercase). Source-only projects are intentionally NOT activated:
+ * clangd without any build info gives poor results, and activating on bare
+ * `.c`/`.cpp` files was a rejected design option.
+ */
+const CLANGD_MARKERS = [
+  'compile_commands.json',
+  'compile_flags.txt',
+  '.clangd',
+  'CMakeLists.txt',
+  'Makefile',
+  'makefile',
+  'GNUmakefile',
+];
+
+/**
+ * clangd Language Server definition (C / C++).
+ *
+ * Relies on a user-installed `clangd` binary discovered on the resolved
+ * shell PATH. Skips gracefully (returns undefined) when the binary is
+ * absent. Activates when a recognizable C/C++ marker exists anywhere in a
+ * bounded slice of the project tree (covers `build/compile_commands.json`
+ * and nested CMake/Make setups), so we do not spawn clangd for unrelated
+ * repositories.
+ */
+export const clangdServer: LspServerInfo = {
+  id: 'clangd',
+  name: 'clangd',
+  extensions: CLANGD_EXTENSIONS,
+
+  async shouldActivate(projectRoot: string): Promise<boolean> {
+    return hasFileInTree(projectRoot, CLANGD_MARKERS);
+  },
+
+  async spawn(
+    projectRoot: string,
+    resolvedEnv?: Record<string, string> | null,
+  ): Promise<LspServerHandle | undefined> {
+    const env = resolvedEnv ?? globalThis.process.env;
+
+    const binary = await findExecutableOnPath('clangd', env);
+    if (!binary) {
+      console.warn(
+        '[clangd] Binary not found on PATH. C/C++ LSP support disabled. Install clangd (e.g. LLVM release) and ensure it is on PATH.',
+      );
+      return undefined;
+    }
+
+    // clangd communicates over stdio by default (no flag required).
+    return spawnStdioLspServer(binary, ['--background-index', '--clang-tidy'], {
+      cwd: projectRoot,
+      env,
+    });
+  },
+};

--- a/apps/browser/src/backend/services/toolbox/services/lsp/servers/index.ts
+++ b/apps/browser/src/backend/services/toolbox/services/lsp/servers/index.ts
@@ -2,6 +2,8 @@ import type { LspServerInfo } from '../types';
 import { typescriptServer } from './typescript';
 import { eslintServer } from './eslint';
 import { biomeServer } from './biome';
+import { clangdServer } from './clangd';
+import { rustAnalyzerServer } from './rust-analyzer';
 
 /**
  * Registry of all available LSP servers
@@ -18,6 +20,12 @@ export const servers: LspServerInfo[] = [
 
   // Biome (linting, formatting - alternative to ESLint/Prettier)
   biomeServer,
+
+  // clangd (C/C++ diagnostics, types, navigation) - native binary
+  clangdServer,
+
+  // rust-analyzer (Rust diagnostics, types, navigation) - native binary
+  rustAnalyzerServer,
 ];
 
 /**
@@ -45,3 +53,5 @@ export function getAllServerIds(): string[] {
 export { typescriptServer } from './typescript';
 export { eslintServer } from './eslint';
 export { biomeServer } from './biome';
+export { clangdServer } from './clangd';
+export { rustAnalyzerServer } from './rust-analyzer';

--- a/apps/browser/src/backend/services/toolbox/services/lsp/servers/rust-analyzer.test.ts
+++ b/apps/browser/src/backend/services/toolbox/services/lsp/servers/rust-analyzer.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { rustAnalyzerServer } from './rust-analyzer';
+
+describe('rustAnalyzerServer config', () => {
+  // rust-analyzer's diagnostics come from `cargo check` (flycheck), which can
+  // take several seconds on a cold target cache. The LspClient default
+  // diagnostics wait is 3000ms; relying on it would cut a cold flycheck off
+  // and surface an empty result. This guards against accidentally dropping the
+  // elevated per-server timeout. (Regression: cold Rust opens reported no
+  // diagnostics because the flycheck publish landed just after 3000ms.)
+  it('overrides the diagnostics wait with a generous flycheck window', () => {
+    expect(rustAnalyzerServer.diagnosticsTimeoutMs).toBeDefined();
+    expect(rustAnalyzerServer.diagnosticsTimeoutMs ?? 0).toBeGreaterThan(3000);
+  });
+});

--- a/apps/browser/src/backend/services/toolbox/services/lsp/servers/rust-analyzer.ts
+++ b/apps/browser/src/backend/services/toolbox/services/lsp/servers/rust-analyzer.ts
@@ -1,0 +1,103 @@
+import * as os from 'node:os';
+import * as path from 'node:path';
+import type { LspServerInfo, LspServerHandle } from '../types';
+import { RUST_EXTENSIONS } from '../language-map';
+import { hasFileInTree, fileExists } from './utils/root-finder';
+import {
+  findExecutableOnPath,
+  findInDirs,
+  runCommandForPath,
+} from './utils/binary-finder';
+import { spawnStdioLspServer } from './utils/spawn-helpers';
+
+/**
+ * rust-analyzer Language Server definition (Rust).
+ *
+ * Relies on a user-installed `rust-analyzer` binary. Resolution order:
+ *   1. PATH lookup.
+ *   2. `rustup which rust-analyzer` (respects the active toolchain).
+ *   3. The cargo bin directory (derived from the resolved env, not just the
+ *      Electron process home).
+ * Skips gracefully (returns undefined) when no binary can be found.
+ *
+ * Activates when a `Cargo.toml` exists anywhere in a bounded slice of the
+ * project tree, so monorepos with `crates/foo/Cargo.toml` but no top-level
+ * manifest still get Rust support.
+ */
+export const rustAnalyzerServer: LspServerInfo = {
+  id: 'rust-analyzer',
+  name: 'rust-analyzer',
+  extensions: RUST_EXTENSIONS,
+
+  // rust-analyzer's diagnostics come from `cargo check` (flycheck), which can
+  // take several seconds on a cold target cache. The default 3s cap would time
+  // out before the first publish and surface an empty result, so give it a
+  // generous safety-net window; the wait still resolves the instant the publish
+  // arrives.
+  diagnosticsTimeoutMs: 15_000,
+
+  async shouldActivate(projectRoot: string): Promise<boolean> {
+    return hasFileInTree(projectRoot, ['Cargo.toml']);
+  },
+
+  async spawn(
+    projectRoot: string,
+    resolvedEnv?: Record<string, string> | null,
+  ): Promise<LspServerHandle | undefined> {
+    const env = resolvedEnv ?? globalThis.process.env;
+
+    const binary = await resolveRustAnalyzer(env);
+    if (!binary) {
+      console.warn(
+        '[rust-analyzer] Binary not found. Rust LSP support disabled. Install it via `rustup component add rust-analyzer` and ensure it is on PATH.',
+      );
+      return undefined;
+    }
+
+    // rust-analyzer communicates over stdio by default (no flag required).
+    return spawnStdioLspServer(binary, [], { cwd: projectRoot, env });
+  },
+};
+
+/**
+ * Candidate cargo bin directories, honoring the resolved shell environment.
+ * Order: CARGO_HOME/bin, then ~/.cargo/bin for the resolved HOME/USERPROFILE,
+ * then the Electron process home as a last resort.
+ */
+function cargoBinDirs(
+  env: Record<string, string> | NodeJS.ProcessEnv,
+): string[] {
+  const dirs: string[] = [];
+  const cargoHome = env.CARGO_HOME;
+  if (cargoHome) dirs.push(path.join(cargoHome, 'bin'));
+
+  const home = env.HOME || env.USERPROFILE;
+  if (home) dirs.push(path.join(home, '.cargo', 'bin'));
+
+  dirs.push(path.join(os.homedir(), '.cargo', 'bin'));
+
+  // De-duplicate while preserving order.
+  return [...new Set(dirs)];
+}
+
+async function resolveRustAnalyzer(
+  env: Record<string, string> | NodeJS.ProcessEnv,
+): Promise<string | undefined> {
+  // 1. Direct PATH lookup.
+  const onPath = await findExecutableOnPath('rust-analyzer', env);
+  if (onPath) return onPath;
+
+  // 2. Ask rustup for the toolchain-managed binary.
+  const rustup = await findExecutableOnPath('rustup', env);
+  if (rustup) {
+    const viaRustup = await runCommandForPath(
+      rustup,
+      ['which', 'rust-analyzer'],
+      env,
+    );
+    if (viaRustup && (await fileExists(viaRustup))) return viaRustup;
+  }
+
+  // 3. Conventional cargo bin locations (resolved-env aware).
+  return findInDirs('rust-analyzer', cargoBinDirs(env), env);
+}

--- a/apps/browser/src/backend/services/toolbox/services/lsp/servers/utils/binary-finder.test.ts
+++ b/apps/browser/src/backend/services/toolbox/services/lsp/servers/utils/binary-finder.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import os from 'node:os';
+import path from 'node:path';
+import nodeFs from 'node:fs/promises';
+import { randomUUID } from 'node:crypto';
+import {
+  findExecutableOnPath,
+  findInDirs,
+  runCommandForPath,
+} from './binary-finder';
+
+const isWindows = process.platform === 'win32';
+
+let tmpDir: string;
+
+beforeEach(async () => {
+  tmpDir = path.join(os.tmpdir(), `binary-finder-${randomUUID()}`);
+  await nodeFs.mkdir(tmpDir, { recursive: true });
+});
+
+afterEach(async () => {
+  await nodeFs.rm(tmpDir, { recursive: true, force: true });
+});
+
+/** Create a fake executable file and return its bare name. */
+async function makeExecutable(name: string): Promise<string> {
+  const full = path.join(tmpDir, name);
+  await nodeFs.writeFile(full, '#!/bin/sh\necho hi\n');
+  if (!isWindows) await nodeFs.chmod(full, 0o755);
+  return full;
+}
+
+describe('findInDirs', () => {
+  it('finds an executable in a provided directory', async () => {
+    const name = isWindows ? 'mytool.exe' : 'mytool';
+    await makeExecutable(name);
+    const found = await findInDirs('mytool', [tmpDir]);
+    expect(found).toBe(path.join(tmpDir, name));
+  });
+
+  it('returns undefined when the binary is absent', async () => {
+    const found = await findInDirs('does-not-exist', [tmpDir]);
+    expect(found).toBeUndefined();
+  });
+
+  it('ignores empty directory entries', async () => {
+    const name = isWindows ? 'mytool.exe' : 'mytool';
+    await makeExecutable(name);
+    const found = await findInDirs('mytool', ['', tmpDir]);
+    expect(found).toBe(path.join(tmpDir, name));
+  });
+});
+
+describe('findExecutableOnPath', () => {
+  it('splits PATH on the platform delimiter and resolves a match', async () => {
+    const name = isWindows ? 'mytool.exe' : 'mytool';
+    await makeExecutable(name);
+    const otherDir = path.join(tmpDir, 'empty');
+    await nodeFs.mkdir(otherDir, { recursive: true });
+
+    const PATH = [otherDir, tmpDir].join(path.delimiter);
+    const found = await findExecutableOnPath('mytool', { PATH });
+    expect(found).toBe(path.join(tmpDir, name));
+  });
+
+  it('honors a lowercase Path key (Windows env block casing)', async () => {
+    const name = isWindows ? 'mytool.exe' : 'mytool';
+    await makeExecutable(name);
+    const found = await findExecutableOnPath('mytool', { Path: tmpDir });
+    expect(found).toBe(path.join(tmpDir, name));
+  });
+
+  it('returns undefined when PATH is empty', async () => {
+    const found = await findExecutableOnPath('mytool', { PATH: '' });
+    expect(found).toBeUndefined();
+  });
+});
+
+describe('runCommandForPath', () => {
+  it('returns the first non-empty stdout line on success', async () => {
+    const out = await runCommandForPath(process.execPath, [
+      '-e',
+      "process.stdout.write('\\n  /path/to/bin  \\nsecond')",
+    ]);
+    expect(out).toBe('/path/to/bin');
+  });
+
+  it('returns undefined on non-zero exit', async () => {
+    const out = await runCommandForPath(process.execPath, [
+      '-e',
+      'process.exit(1)',
+    ]);
+    expect(out).toBeUndefined();
+  });
+
+  it('returns undefined when the command cannot be spawned', async () => {
+    const out = await runCommandForPath('definitely-not-a-real-binary-xyz', [
+      '--version',
+    ]);
+    expect(out).toBeUndefined();
+  });
+
+  it('returns undefined on timeout', async () => {
+    const out = await runCommandForPath(
+      process.execPath,
+      ['-e', 'setTimeout(() => {}, 1000)'],
+      undefined,
+      10,
+    );
+    expect(out).toBeUndefined();
+  });
+});

--- a/apps/browser/src/backend/services/toolbox/services/lsp/servers/utils/binary-finder.ts
+++ b/apps/browser/src/backend/services/toolbox/services/lsp/servers/utils/binary-finder.ts
@@ -1,0 +1,189 @@
+import { spawn } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+/**
+ * Cross-platform native-executable discovery for LSP servers that are NOT
+ * distributed via npm (e.g. clangd, rust-analyzer).
+ *
+ * All functions are defensive: they never throw and resolve to `undefined`
+ * on any failure, so a missing binary degrades gracefully into a skipped
+ * LSP server rather than a crash.
+ */
+
+const isWindows = process.platform === 'win32';
+
+/**
+ * Extensions that can be launched *directly* by `spawn(..., { shell: false })`
+ * on Windows (PE images). `.cmd` / `.bat` are intentionally excluded: they are
+ * batch shims that require `cmd.exe` to run, so returning them here would
+ * succeed at lookup time but fail at process start. We honor PATHEXT but keep
+ * only the directly-spawnable entries.
+ */
+function windowsDirectExtensions(
+  env?: Record<string, string> | NodeJS.ProcessEnv,
+): string[] {
+  // Prefer the resolved shell env's PATHEXT (it is read alongside PATH); fall
+  // back to the process env. A desktop-launched Electron session can have a
+  // stale process.env while the resolved env carries the real PATHEXT.
+  const resolved = env ?? process.env;
+  const rawPathExt =
+    (resolved as Record<string, string | undefined>).PATHEXT ??
+    (resolved as Record<string, string | undefined>).Pathext ??
+    process.env.PATHEXT ??
+    '';
+  const fromEnv = rawPathExt
+    .split(';')
+    .map((e) => e.trim().toLowerCase())
+    .filter((e) => e === '.exe' || e === '.com');
+  return fromEnv.length > 0 ? fromEnv : ['.exe', '.com'];
+}
+
+/**
+ * Candidate file names to try for a given logical binary name.
+ *
+ * On Windows, `child_process.spawn` does not append executable extensions
+ * for absolute paths, so we probe the directly-spawnable ones explicitly.
+ */
+function executableCandidates(
+  binary: string,
+  env?: Record<string, string> | NodeJS.ProcessEnv,
+): string[] {
+  if (!isWindows) return [binary];
+  // If an extension is already present, trust it as-is.
+  if (path.extname(binary)) return [binary];
+  return [
+    ...windowsDirectExtensions(env).map((ext) => `${binary}${ext}`),
+    binary,
+  ];
+}
+
+/**
+ * Check that a resolved path is a regular file and (on non-Windows) is
+ * executable. The file-type check prevents a directory that happens to match
+ * the binary name from being returned as an executable.
+ */
+async function isUsableExecutable(candidate: string): Promise<boolean> {
+  let stat: fs.Stats;
+  try {
+    stat = await fs.promises.stat(candidate);
+  } catch {
+    return false;
+  }
+  if (!stat.isFile()) return false;
+  if (isWindows) return true;
+  try {
+    await fs.promises.access(candidate, fs.constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Resolve the first usable executable for `binary` across the given
+ * directories. Returns an absolute-ish path (joined from the dir) or
+ * `undefined` if none match.
+ */
+export async function findInDirs(
+  binary: string,
+  dirs: string[],
+  env?: Record<string, string> | NodeJS.ProcessEnv,
+): Promise<string | undefined> {
+  const candidates = executableCandidates(binary, env);
+  for (const dir of dirs) {
+    if (!dir) continue;
+    for (const candidate of candidates) {
+      const full = path.join(dir, candidate);
+      if (await isUsableExecutable(full)) return full;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Resolve `binary` by scanning the PATH entries of the provided environment.
+ *
+ * Splits on `path.delimiter` (`;` on Windows, `:` elsewhere) and, on
+ * Windows, also honors a lowercase `Path` key (Win32 env blocks vary in
+ * casing). Returns the first usable match or `undefined`.
+ */
+export async function findExecutableOnPath(
+  binary: string,
+  env?: Record<string, string> | NodeJS.ProcessEnv,
+): Promise<string | undefined> {
+  const resolvedEnv = env ?? process.env;
+  const rawPath =
+    resolvedEnv.PATH ??
+    (resolvedEnv as Record<string, string | undefined>).Path ??
+    (resolvedEnv as Record<string, string | undefined>).path ??
+    '';
+
+  const dirs = rawPath.split(path.delimiter).filter(Boolean);
+  return findInDirs(binary, dirs, resolvedEnv);
+}
+
+/**
+ * Spawn a command and return the trimmed first non-empty line of stdout.
+ *
+ * Used for toolchain proxies like `rustup which rust-analyzer`. Resolves
+ * `undefined` on spawn error, non-zero exit, timeout, or empty output.
+ */
+export async function runCommandForPath(
+  cmd: string,
+  args: string[],
+  env?: Record<string, string> | NodeJS.ProcessEnv,
+  timeoutMs = 3000,
+): Promise<string | undefined> {
+  return new Promise<string | undefined>((resolve) => {
+    let settled = false;
+    const done = (value: string | undefined) => {
+      if (settled) return;
+      settled = true;
+      resolve(value);
+    };
+
+    let child: ReturnType<typeof spawn>;
+    try {
+      child = spawn(cmd, args, {
+        stdio: ['ignore', 'pipe', 'pipe'],
+        env: env ?? process.env,
+      });
+    } catch {
+      done(undefined);
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      try {
+        child.kill();
+      } catch {
+        // ignore
+      }
+      done(undefined);
+    }, timeoutMs);
+
+    const chunks: Buffer[] = [];
+    child.stdout?.on('data', (c: Buffer) => chunks.push(c));
+    child.on('error', () => {
+      clearTimeout(timer);
+      done(undefined);
+    });
+    child.on('close', (code, signal) => {
+      clearTimeout(timer);
+      // Only a clean exit-0 counts as success. A non-zero code, or a
+      // signal-terminated process (code === null), must not yield a
+      // "valid path" from whatever partial stdout was captured.
+      if (signal !== null || code !== 0) {
+        done(undefined);
+        return;
+      }
+      const out = Buffer.concat(chunks).toString('utf-8');
+      const firstLine = out
+        .split(/\r?\n/)
+        .map((l) => l.trim())
+        .find((l) => l.length > 0);
+      done(firstLine);
+    });
+  });
+}

--- a/apps/browser/src/backend/services/toolbox/services/lsp/servers/utils/root-finder.test.ts
+++ b/apps/browser/src/backend/services/toolbox/services/lsp/servers/utils/root-finder.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import os from 'node:os';
+import path from 'node:path';
+import nodeFs from 'node:fs/promises';
+import { randomUUID } from 'node:crypto';
+import { hasFileInTree } from './root-finder';
+
+let root: string;
+
+beforeEach(async () => {
+  root = path.join(os.tmpdir(), `root-finder-${randomUUID()}`);
+  await nodeFs.mkdir(root, { recursive: true });
+});
+
+afterEach(async () => {
+  await nodeFs.rm(root, { recursive: true, force: true });
+});
+
+async function touch(relPath: string): Promise<void> {
+  const full = path.join(root, relPath);
+  await nodeFs.mkdir(path.dirname(full), { recursive: true });
+  await nodeFs.writeFile(full, '');
+}
+
+describe('hasFileInTree', () => {
+  it('finds a marker at the root', async () => {
+    await touch('Cargo.toml');
+    expect(await hasFileInTree(root, ['Cargo.toml'])).toBe(true);
+  });
+
+  it('finds a nested marker (monorepo crate without root manifest)', async () => {
+    await touch('crates/foo/Cargo.toml');
+    expect(await hasFileInTree(root, ['Cargo.toml'])).toBe(true);
+  });
+
+  it('finds compile_commands.json kept under build/', async () => {
+    await touch('build/compile_commands.json');
+    expect(await hasFileInTree(root, ['compile_commands.json'])).toBe(true);
+  });
+
+  it('finds a deeply nested marker at the default depth (packages/backend/crates/foo)', async () => {
+    await touch('packages/backend/crates/foo/Cargo.toml');
+    expect(await hasFileInTree(root, ['Cargo.toml'])).toBe(true);
+  });
+
+  it('returns false when no marker exists', async () => {
+    await touch('src/main.rs');
+    expect(await hasFileInTree(root, ['Cargo.toml'])).toBe(false);
+  });
+
+  it('skips heavy directories like target/', async () => {
+    await touch('target/Cargo.toml');
+    expect(await hasFileInTree(root, ['Cargo.toml'])).toBe(false);
+  });
+
+  it('respects maxDepth', async () => {
+    await touch('a/b/c/d/Cargo.toml');
+    expect(await hasFileInTree(root, ['Cargo.toml'], { maxDepth: 2 })).toBe(
+      false,
+    );
+    expect(await hasFileInTree(root, ['Cargo.toml'], { maxDepth: 5 })).toBe(
+      true,
+    );
+  });
+});

--- a/apps/browser/src/backend/services/toolbox/services/lsp/servers/utils/root-finder.ts
+++ b/apps/browser/src/backend/services/toolbox/services/lsp/servers/utils/root-finder.ts
@@ -62,3 +62,67 @@ export async function getPackagePath(
 
   return undefined;
 }
+
+const DEFAULT_TREE_SKIP_DIRS = [
+  'node_modules',
+  '.git',
+  'target',
+  'dist',
+  '.next',
+  'vendor',
+  '.venv',
+];
+
+/**
+ * Check whether any of `filenames` exists within the directory tree rooted at
+ * `root`, up to `maxDepth` levels deep (root is depth 0). Heavy/irrelevant
+ * directories are skipped to bound the cost.
+ *
+ * This supports project layouts that markers-at-root checks miss, e.g. a
+ * monorepo with `crates/foo/Cargo.toml` and no top-level manifest, a
+ * `compile_commands.json` kept under `build/`, or a deeper nesting like
+ * `packages/backend/crates/foo/Cargo.toml` (depth 4). The default depth of 5
+ * covers these without unbounded recursion; combined with the skip list it
+ * runs once per workspace at LSP-activation time (the result is cached
+ * upstream), so a bounded breadth-first scan is acceptable.
+ */
+export async function hasFileInTree(
+  root: string,
+  filenames: string[],
+  opts: { maxDepth?: number; skipDirs?: string[] } = {},
+): Promise<boolean> {
+  const maxDepth = opts.maxDepth ?? 5;
+  const skipDirs = new Set(opts.skipDirs ?? DEFAULT_TREE_SKIP_DIRS);
+  const wanted = new Set(filenames);
+
+  let frontier: Array<{ dir: string; depth: number }> = [
+    { dir: root, depth: 0 },
+  ];
+
+  while (frontier.length > 0) {
+    const next: Array<{ dir: string; depth: number }> = [];
+    for (const { dir, depth } of frontier) {
+      let entries: fs.Dirent[];
+      try {
+        entries = await fs.promises.readdir(dir, { withFileTypes: true });
+      } catch {
+        continue;
+      }
+      for (const entry of entries) {
+        if (entry.isFile() && wanted.has(entry.name)) return true;
+      }
+      if (depth < maxDepth) {
+        for (const entry of entries) {
+          // isDirectory() is false for symlinks, so we never follow them
+          // and cannot loop on cyclic links.
+          if (entry.isDirectory() && !skipDirs.has(entry.name)) {
+            next.push({ dir: path.join(dir, entry.name), depth: depth + 1 });
+          }
+        }
+      }
+    }
+    frontier = next;
+  }
+
+  return false;
+}

--- a/apps/browser/src/backend/services/toolbox/services/lsp/servers/utils/spawn-helpers.ts
+++ b/apps/browser/src/backend/services/toolbox/services/lsp/servers/utils/spawn-helpers.ts
@@ -1,0 +1,56 @@
+import { spawn } from 'node:child_process';
+import type { LspServerHandle } from '../../types';
+
+/**
+ * Spawn a stdio-based LSP server and resolve a handle once it survives a short
+ * handshake window.
+ *
+ * Shared by the native-binary servers (clangd, rust-analyzer) so the
+ * spawn/handshake behavior stays consistent. Resolves `undefined` when:
+ *   - the process fails to spawn (e.g. ENOENT), or
+ *   - the process exits/crashes within the handshake window.
+ *
+ * The latter prevents a server that dies immediately (bad binary, missing
+ * shared library, instant crash) from being reported as successfully started.
+ * A crash *after* the window is still handled downstream by the LSP client's
+ * initialize timeout.
+ */
+export function spawnStdioLspServer(
+  binary: string,
+  args: string[],
+  options: {
+    cwd: string;
+    env: Record<string, string> | NodeJS.ProcessEnv;
+    handshakeMs?: number;
+  },
+): Promise<LspServerHandle | undefined> {
+  const { cwd, env, handshakeMs = 150 } = options;
+
+  let child: ReturnType<typeof spawn>;
+  try {
+    child = spawn(binary, args, {
+      stdio: ['pipe', 'pipe', 'pipe'],
+      cwd,
+      env,
+    });
+  } catch {
+    return Promise.resolve(undefined);
+  }
+
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = (value: LspServerHandle | undefined) => {
+      if (settled) return;
+      settled = true;
+      resolve(value);
+    };
+
+    child.on('error', () => finish(undefined));
+    // Early exit within the handshake window means the server is unusable.
+    child.on('exit', () => finish(undefined));
+
+    setTimeout(() => {
+      finish({ process: child as LspServerHandle['process'] });
+    }, handshakeMs);
+  });
+}

--- a/apps/browser/src/backend/services/toolbox/services/lsp/types.ts
+++ b/apps/browser/src/backend/services/toolbox/services/lsp/types.ts
@@ -96,6 +96,17 @@ export interface LspServerInfo {
     projectRoot: string,
     resolvedEnv?: Record<string, string> | null,
   ) => Promise<LspServerHandle | undefined>;
+
+  /**
+   * Optional override for how long `waitForDiagnostics` waits for a fresh
+   * diagnostics publish before giving up (milliseconds). The wait still
+   * resolves early the moment a matching receipt arrives — this is only the
+   * safety-net cap. Servers backed by a slow external checker (e.g.
+   * rust-analyzer's `cargo check` flycheck, which can take several seconds on
+   * a cold cache) need a larger value than the default so a cold first open
+   * does not report an empty result. Defaults to 3000ms when unset.
+   */
+  diagnosticsTimeoutMs?: number;
 }
 
 /**


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds native LSP support for Rust and C/C++ with `rust-analyzer` and `clangd`. Improves diagnostics waits, binary discovery, and project activation for reliable startup.

- New Features
  - New servers: `rust-analyzer` and `clangd`; activation scans a bounded tree for `Cargo.toml`, `compile_commands.json`, `compile_flags.txt`, `.clangd`, `CMakeLists.txt`, and Makefile variants; `clangd` runs with `--background-index` and `--clang-tidy`.
  - Diagnostics: version-gated waits with 150ms debounce; receipts on every publish; fast-path for unchanged content; per-server timeout override (`rust-analyzer`: 15s).
  - Open/update flow: `openDocument`/`updateDocument` return the doc version; `LspService` opens first and waits using that version; pull-model servers schedule `textDocument/diagnostic`.
  - Binary spawn: robust lookup (`PATH`/`Path`/`path`, `PATHEXT` .exe/.com, `rustup which`, `CARGO_HOME/bin`, `~/.cargo/bin`) and a shared stdio spawn helper with an early-crash handshake; exports `CLANGD_EXTENSIONS` and `RUST_EXTENSIONS`.

- Bug Fixes
  - Workspace folder names use `getBaseName`; activation recognizes `compile_flags.txt` and nested markers.

<sup>Written for commit a5d8fd7e865392bd78962696915799794c2f9eb6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1230?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added C/C++ and Rust LSP server support and improved language detection for C, C++, Rust, and TypeScript React.
  * Enhanced native LSP server startup and executable discovery across platforms.

* **Bug Fixes / Improvements**
  * More reliable workspace display names derived from project roots.

* **Tests**
  * New tests for language mapping, binary discovery, repo root detection, and LSP spawn behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stagewise-io/stagewise/pull/1230?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->