### PR TITLE
fix(browser): collapse pending edits by default

### DIFF
--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/footer-status-card/file-diff-section.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/footer-status-card/file-diff-section.tsx
@@ -293,8 +293,8 @@ export function FileDiffSection(
   return {
     // Change key when transitioning from pending to summary - forces remount with new defaultOpen
     key: hasPendingDiffs ? 'file-diff-pending' : 'file-diff-summary',
-    // Expand when there are pending diffs to review, collapse for summary view
-    defaultOpen: hasPendingDiffs,
+    // Keep both pending diffs and summary collapsed by default.
+    defaultOpen: false,
     trigger: (isOpen: boolean) => (
       <div className="flex w-full flex-row items-center justify-between gap-2 pl-1.5 text-muted-foreground text-xs hover:text-foreground has-[button:hover]:text-muted-foreground">
         <ChevronDownIcon
@@ -312,7 +312,7 @@ export function FileDiffSection(
           </span>
         )}
 
-        {pendingDiffs?.length > 0 ? (
+        {pendingDiffs?.length > 0 && isOpen ? (
           <div className="ml-auto flex flex-row items-center justify-start gap-1">
             <Button
               variant="ghost"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Collapse the file diff section by default in the agent chat footer so pending edits no longer auto-expand. Both pending diffs and the summary start closed, and Accept/Reject controls render only when the section is open to reduce noise and layout shifts.

<sup>Written for commit 51d554bebf4848ea88c1c8e71f839c887bd05b96. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1231?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * File diff section now consistently starts collapsed, even when there are pending changes, improving layout predictability and reducing visual noise.
  * Accept/Reject controls are shown only when there are pending diffs and the section is open, preventing action buttons from appearing while the view is closed and reducing confusion.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stagewise-io/stagewise/pull/1231?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->