### PR TITLE
feat(stagewise): improve sidebar workspace grouping

### DIFF
--- a/apps/browser/src/backend/services/agent-manager/agent-manager.ts
+++ b/apps/browser/src/backend/services/agent-manager/agent-manager.ts
@@ -4,6 +4,7 @@ import type {
 } from '@/agents/shared/base-agent';
 import {
   type AgentHistoryEntry,
+  type AgentHistoryWorkspaceEntry,
   AgentTypes,
 } from '@shared/karton-contracts/ui/agent';
 import { DisposableService } from '../disposable';
@@ -232,6 +233,7 @@ export class AgentManagerService extends DisposableService {
         modelId?: ModelId,
         toolApprovalMode?: ToolApprovalMode,
         workspacePaths?: string[],
+        preserveWorkspacePaths?: boolean,
       ) => {
         const normalizedToolApprovalMode =
           toolApprovalMode === 'alwaysAllow' ? 'smart' : toolApprovalMode;
@@ -255,7 +257,9 @@ export class AgentManagerService extends DisposableService {
         if (workspacePaths) {
           try {
             for (const wp of workspacePaths) {
-              const mountPath = await this.getNewAgentWorkspaceMountPath(wp);
+              const mountPath = preserveWorkspacePaths
+                ? wp
+                : await this.getNewAgentWorkspaceMountPath(wp);
               await this.toolbox.handleMountWorkspace(
                 agent.instanceId,
                 mountPath,
@@ -1409,6 +1413,46 @@ export class AgentManagerService extends DisposableService {
     });
   }
 
+  private async enrichHistoryEntryWorkspaces(
+    entries: AgentHistoryEntry[],
+  ): Promise<AgentHistoryEntry[]> {
+    const gitSummaryByPath = new Map<
+      string,
+      Promise<AgentHistoryWorkspaceEntry['git']>
+    >();
+
+    const getGitSummary = (workspacePath: string) => {
+      let promise = gitSummaryByPath.get(workspacePath);
+      if (!promise) {
+        promise = this.gitService
+          .getMountedWorkspaceSummary(workspacePath)
+          .catch((error) => {
+            this.logger.warn(
+              `[AgentManager] Failed to resolve Git summary for history workspace ${workspacePath}`,
+              { error },
+            );
+            return null;
+          });
+        gitSummaryByPath.set(workspacePath, promise);
+      }
+      return promise;
+    };
+
+    return await Promise.all(
+      entries.map(async (entry) => ({
+        ...entry,
+        mountedWorkspaces: entry.mountedWorkspaces
+          ? await Promise.all(
+              entry.mountedWorkspaces.map(async (workspace) => ({
+                ...workspace,
+                git: await getGitSummary(workspace.path),
+              })),
+            )
+          : entry.mountedWorkspaces,
+      })),
+    );
+  }
+
   /**
    * Responds with a list of agent history entries. Includes all existing agents (including currently active ones) and is sorted by agents (newest first).
    *
@@ -1430,7 +1474,7 @@ export class AgentManagerService extends DisposableService {
       return [];
     }
 
-    return await db.getAgentHistoryEntries(
+    const entries = await db.getAgentHistoryEntries(
       limit,
       offset,
       [],
@@ -1438,6 +1482,8 @@ export class AgentManagerService extends DisposableService {
         ? `%${searchString.trim()}%`
         : undefined,
     );
+
+    return await this.enrichHistoryEntryWorkspaces(entries);
   }
 
   private async getAgentHistoryEntriesByIds(
@@ -1445,6 +1491,7 @@ export class AgentManagerService extends DisposableService {
   ): Promise<AgentHistoryEntry[]> {
     const db = await this.ensureDBReady();
     if (!db) return [];
-    return await db.getAgentHistoryEntriesByIds(ids);
+    const entries = await db.getAgentHistoryEntriesByIds(ids);
+    return await this.enrichHistoryEntryWorkspaces(entries);
   }
 }

--- a/apps/browser/src/backend/services/agent-manager/agent-manager.ts
+++ b/apps/browser/src/backend/services/agent-manager/agent-manager.ts
@@ -940,6 +940,17 @@ export class AgentManagerService extends DisposableService {
 
     if (agent.mountedWorkspaces && Array.isArray(agent.mountedWorkspaces)) {
       for (const ws of agent.mountedWorkspaces) {
+        // Skip workspaces whose directory no longer exists on disk (e.g. a
+        // worktree that was deleted between sessions). The agent and its
+        // history are kept — it simply restores with that mount dropped
+        // and falls into the "No workspace" group rather than re-creating
+        // a runtime / watcher / LSP for a path that's gone.
+        if (!existsSync(ws.path)) {
+          this.logger.debug(
+            `[AgentManager] Skipping re-mount of missing workspace ${ws.path} for agent ${instanceId}`,
+          );
+          continue;
+        }
         try {
           await this.toolbox.handleMountWorkspace(
             createdAgent.instanceId,
@@ -1443,10 +1454,17 @@ export class AgentManagerService extends DisposableService {
         ...entry,
         mountedWorkspaces: entry.mountedWorkspaces
           ? await Promise.all(
-              entry.mountedWorkspaces.map(async (workspace) => ({
-                ...workspace,
-                git: await getGitSummary(workspace.path),
-              })),
+              entry.mountedWorkspaces
+                // Drop persisted mounts whose directory no longer exists on
+                // disk (e.g. a deleted worktree). Otherwise the agent would
+                // keep showing under a workspace/worktree group that points
+                // at a path that's gone. Mirrors the re-mount skip in
+                // resumeAgent so list and runtime stay consistent.
+                .filter((workspace) => existsSync(workspace.path))
+                .map(async (workspace) => ({
+                  ...workspace,
+                  git: await getGitSummary(workspace.path),
+                })),
             )
           : entry.mountedWorkspaces,
       })),

--- a/apps/browser/src/backend/services/agent-manager/persistence/db.ts
+++ b/apps/browser/src/backend/services/agent-manager/persistence/db.ts
@@ -21,6 +21,7 @@ import type { Logger } from '@/services/logger';
 import {
   AgentTypes,
   type AgentHistoryEntry,
+  type AgentHistoryWorkspaceEntry,
   type AgentMessage,
 } from '@shared/karton-contracts/ui/agent';
 import type { ToolApprovalMode } from '@shared/karton-contracts/ui/shared-types';
@@ -178,6 +179,7 @@ export class AgentPersistenceDB {
         lastMessageAt: schema.agentInstances.lastMessageAt,
         messageCount: sql<number>`(SELECT COUNT(*) FROM agentMessages WHERE agent_instance_id = ${schema.agentInstances.id})`,
         parentAgentInstanceId: schema.agentInstances.parentAgentInstanceId,
+        mountedWorkspaces: schema.agentInstances.mountedWorkspaces,
       })
       .from(schema.agentInstances)
       // Order by lastMessageAt so the sidebar's time-bucket grouping
@@ -203,7 +205,12 @@ export class AgentPersistenceDB {
 
     this._logger.debug(`[AgentPersistenceDB] Fetched agent history entries`);
 
-    return results;
+    return results.map((entry) => ({
+      ...entry,
+      mountedWorkspaces: entry.mountedWorkspaces as
+        | AgentHistoryWorkspaceEntry[]
+        | null,
+    }));
   }
 
   /**
@@ -230,6 +237,7 @@ export class AgentPersistenceDB {
         lastMessageAt: schema.agentInstances.lastMessageAt,
         messageCount: sql<number>`(SELECT COUNT(*) FROM agentMessages WHERE agent_instance_id = ${schema.agentInstances.id})`,
         parentAgentInstanceId: schema.agentInstances.parentAgentInstanceId,
+        mountedWorkspaces: schema.agentInstances.mountedWorkspaces,
       })
       .from(schema.agentInstances)
       .where(
@@ -244,7 +252,16 @@ export class AgentPersistenceDB {
       `[AgentPersistenceDB] Fetched agent history entries by ids`,
     );
 
-    const resultById = new Map(results.map((entry) => [entry.id, entry]));
+    const normalizedResults: AgentHistoryEntry[] = results.map((entry) => ({
+      ...entry,
+      mountedWorkspaces: entry.mountedWorkspaces as
+        | AgentHistoryWorkspaceEntry[]
+        | null,
+    }));
+
+    const resultById = new Map(
+      normalizedResults.map((entry) => [entry.id, entry]),
+    );
     return ids
       .map((id) => resultById.get(id))
       .filter((entry): entry is AgentHistoryEntry => entry !== undefined);

--- a/apps/browser/src/backend/services/git/index.test.ts
+++ b/apps/browser/src/backend/services/git/index.test.ts
@@ -121,6 +121,62 @@ describe('GitService', () => {
     ).resolves.toBeNull();
   });
 
+  it('returns normalized web URL for HTTPS Git remotes', async () => {
+    const { service } = await createGitService({
+      'remote -v':
+        'origin\thttps://github.com/stagewise-io/stagewise.git (fetch)\n' +
+        'origin\thttps://github.com/stagewise-io/stagewise.git (push)\n',
+    });
+
+    await expect(service.getRepositoryRemoteUrl('/repo')).resolves.toBe(
+      'https://github.com/stagewise-io/stagewise',
+    );
+  });
+
+  it('returns normalized web URL for SSH Git remotes', async () => {
+    const { service } = await createGitService({
+      'remote -v':
+        'origin\tgit@gitlab.com:stagewise-io/stagewise.git (fetch)\n' +
+        'origin\tgit@gitlab.com:stagewise-io/stagewise.git (push)\n',
+    });
+
+    await expect(service.getRepositoryRemoteUrl('/repo')).resolves.toBe(
+      'https://gitlab.com/stagewise-io/stagewise',
+    );
+  });
+
+  it('returns normalized web URL for ssh protocol Git remotes', async () => {
+    const { service } = await createGitService({
+      'remote -v':
+        'origin\tssh://git@bitbucket.org/stagewise-io/stagewise.git (fetch)\n' +
+        'origin\tssh://git@bitbucket.org/stagewise-io/stagewise.git (push)\n',
+    });
+
+    await expect(service.getRepositoryRemoteUrl('/repo')).resolves.toBe(
+      'https://bitbucket.org/stagewise-io/stagewise',
+    );
+  });
+
+  it('prefers the origin remote web URL', async () => {
+    const { service } = await createGitService({
+      'remote -v':
+        'upstream\thttps://github.com/stagewise-io/upstream.git (fetch)\n' +
+        'origin\thttps://github.com/stagewise-io/stagewise.git (fetch)\n',
+    });
+
+    await expect(service.getRepositoryRemoteUrl('/repo')).resolves.toBe(
+      'https://github.com/stagewise-io/stagewise',
+    );
+  });
+
+  it('returns null when no parseable Git remote exists', async () => {
+    const { service } = await createGitService({
+      'remote -v': 'origin\tfile:///tmp/repo.git (fetch)\n',
+    });
+
+    await expect(service.getRepositoryRemoteUrl('/repo')).resolves.toBeNull();
+  });
+
   it('returns branch summary for a normal repo', async () => {
     const { service } = await createGitService(baseReadResponses);
 

--- a/apps/browser/src/backend/services/git/index.ts
+++ b/apps/browser/src/backend/services/git/index.ts
@@ -16,6 +16,7 @@ import type {
   GitMutationResult,
   GitMergedTargetResult,
   GitRepositoryInfo,
+  GitRepositoryRemoteInfo,
   GitServiceDeps,
   GitStatusSummary,
   GitStrictCommandResult,
@@ -38,6 +39,7 @@ export type {
   GitMutationResult,
   GitMergedTargetResult,
   GitRepositoryInfo,
+  GitRepositoryRemoteInfo,
   GitServiceDeps,
   GitStatusSummary,
   GitStrictCommandResult,
@@ -54,6 +56,72 @@ const MUTATION_GIT_TIMEOUT_MS = 30_000;
 function normalizeGitPath(value: string): string {
   const resolved = path.resolve(value);
   return process.platform === 'win32' ? resolved.toLowerCase() : resolved;
+}
+
+function stripGitSuffix(value: string): string {
+  return value.replace(/\.git\/?$/, '').replace(/\/$/, '');
+}
+
+function normalizeRemotePathname(pathname: string): string {
+  const withoutSuffix = stripGitSuffix(pathname);
+  return withoutSuffix.startsWith('/') ? withoutSuffix : `/${withoutSuffix}`;
+}
+
+function remoteUrlToWebUrl(remoteUrl: string): string | null {
+  const trimmed = remoteUrl.trim();
+  if (!trimmed) return null;
+
+  if (/^https?:\/\//i.test(trimmed)) {
+    try {
+      const parsed = new URL(trimmed);
+      parsed.username = '';
+      parsed.password = '';
+      parsed.pathname = normalizeRemotePathname(parsed.pathname);
+      parsed.search = '';
+      parsed.hash = '';
+      return parsed.toString();
+    } catch {
+      return null;
+    }
+  }
+
+  if (/^(ssh|git):\/\//i.test(trimmed)) {
+    try {
+      const parsed = new URL(trimmed);
+      if (!parsed.hostname || !parsed.pathname) return null;
+      return `https://${parsed.hostname}${normalizeRemotePathname(
+        parsed.pathname,
+      )}`;
+    } catch {
+      return null;
+    }
+  }
+
+  const scpLikeMatch = trimmed.match(/^(?:[^@\s]+@)?([^:\s]+):(.+)$/);
+  if (scpLikeMatch) {
+    const [, host, repoPath] = scpLikeMatch;
+    if (!host || !repoPath || repoPath.startsWith('/')) return null;
+    return `https://${host}${normalizeRemotePathname(repoPath)}`;
+  }
+
+  return null;
+}
+
+function parseRemoteList(output: string): GitRepositoryRemoteInfo | null {
+  const remotes = output
+    .split('\n')
+    .map((line) => line.trim().match(/^(\S+)\s+(\S+)\s+\(fetch\)$/))
+    .filter((match): match is RegExpMatchArray => Boolean(match))
+    .map((match) => ({
+      remoteName: match[1]!,
+      url: match[2]!,
+    }));
+
+  return (
+    remotes.find((remote) => remote.remoteName === 'origin') ??
+    remotes[0] ??
+    null
+  );
 }
 
 const defaultRunGitCommand: GitCommandRunner = async (cwd, args, env) => {
@@ -183,6 +251,16 @@ export class GitService extends DisposableService {
 
     const worktrees = await this.listWorktrees(workspacePath);
     return worktrees.find((worktree) => worktree.isMainWorktree)?.path ?? null;
+  }
+
+  public async getRepositoryRemoteUrl(
+    workspacePath: string,
+  ): Promise<string | null> {
+    const remotesOutput = await this.runGit(workspacePath, ['remote', '-v']);
+    if (!remotesOutput) return null;
+
+    const remote = parseRemoteList(remotesOutput);
+    return remote ? remoteUrlToWebUrl(remote.url) : null;
   }
 
   public async getRepositoryInfo(
@@ -410,12 +488,14 @@ export class GitService extends DisposableService {
 
   public async removeWorktree(
     workspacePath: string,
+    options: { force?: boolean } = {},
   ): Promise<GitWorktreeRemoveResult> {
     const repositoryInfo = await this.getRepositoryInfo(workspacePath);
     const cwd = repositoryInfo?.repoRoot ?? workspacePath;
     const result = await this.runGitStrict(cwd, [
       'worktree',
       'remove',
+      ...(options.force ? ['--force'] : []),
       workspacePath,
     ]);
     if (result.exitCode === 0) return { ok: true };

--- a/apps/browser/src/backend/services/git/types.ts
+++ b/apps/browser/src/backend/services/git/types.ts
@@ -37,6 +37,11 @@ export type GitRepositoryInfo = {
   commonGitDir: string;
 };
 
+export type GitRepositoryRemoteInfo = {
+  remoteName: string;
+  url: string;
+};
+
 export type GitWorktreeInfo = {
   worktreeId: string;
   path: string;

--- a/apps/browser/src/backend/services/toolbox/services/mount-manager/git-path-actions.test.ts
+++ b/apps/browser/src/backend/services/toolbox/services/mount-manager/git-path-actions.test.ts
@@ -179,6 +179,30 @@ function setWorkspacePathForMount(
   workspacePathsPerMount.set(mountPrefix, workspacePath);
 }
 
+function setAgentMount(
+  service: MountManagerService,
+  agentId: string,
+  mountPrefix: string,
+) {
+  const agentMounts = Reflect.get(service, 'agentMounts') as Map<
+    string,
+    Map<string, string[]>
+  >;
+  const mounts = agentMounts.get(agentId) ?? new Map<string, string[]>();
+  mounts.set(mountPrefix, ['read']);
+  agentMounts.set(agentId, mounts);
+}
+
+function detachWorkspacePathFromAgents(
+  service: MountManagerService,
+  workspacePath: string,
+): Promise<string[]> {
+  const fn = Reflect.get(service, 'detachWorkspacePathFromAgents') as (
+    p: string,
+  ) => Promise<string[]>;
+  return fn.call(service, workspacePath);
+}
+
 describe('MountManagerService path-based Git actions', () => {
   it('accepts a recent workspace path', async () => {
     const recentPath = await fs.mkdtemp(path.join(os.tmpdir(), 'recent-repo-'));
@@ -488,5 +512,86 @@ describe('MountManagerService path-based Git actions', () => {
         (mount) => mount.path === createdPath,
       ),
     ).toBe(true);
+  });
+
+  it('detaches a deleted worktree path from agent mounts', async () => {
+    const worktreePath = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'deleted-worktree-'),
+    );
+    const { service, state } = createHarness();
+    await initializeService(service);
+
+    state.toolbox.agent1.workspace.mounts.push({
+      prefix: 'w1234',
+      path: worktreePath,
+      git: null,
+      skills: [],
+      workspaceMdContent: null,
+      agentsMdContent: null,
+    });
+    setWorkspacePathForMount(service, 'w1234', worktreePath);
+    setAgentMount(service, 'agent1', 'w1234');
+
+    const affected = await detachWorkspacePathFromAgents(service, worktreePath);
+
+    expect(affected).toEqual(['agent1']);
+    expect(state.toolbox.agent1.workspace.mounts).toHaveLength(0);
+
+    const agentMounts = Reflect.get(service, 'agentMounts') as Map<
+      string,
+      Map<string, string[]>
+    >;
+    expect(agentMounts.get('agent1')?.has('w1234')).toBe(false);
+
+    const workspacePathsPerMount = Reflect.get(
+      service,
+      'workspacePathsPerMount',
+    ) as Map<string, string>;
+    expect(workspacePathsPerMount.has('w1234')).toBe(false);
+  });
+
+  it('leaves unrelated agent mounts untouched when detaching', async () => {
+    const deletedPath = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'deleted-worktree-'),
+    );
+    const keptPath = await fs.mkdtemp(path.join(os.tmpdir(), 'kept-worktree-'));
+    const { service, state } = createHarness();
+    await initializeService(service);
+
+    state.toolbox.agent1.workspace.mounts.push(
+      {
+        prefix: 'wdead',
+        path: deletedPath,
+        git: null,
+        skills: [],
+        workspaceMdContent: null,
+        agentsMdContent: null,
+      },
+      {
+        prefix: 'wkeep',
+        path: keptPath,
+        git: null,
+        skills: [],
+        workspaceMdContent: null,
+        agentsMdContent: null,
+      },
+    );
+    setWorkspacePathForMount(service, 'wdead', deletedPath);
+    setWorkspacePathForMount(service, 'wkeep', keptPath);
+    setAgentMount(service, 'agent1', 'wdead');
+    setAgentMount(service, 'agent1', 'wkeep');
+
+    await detachWorkspacePathFromAgents(service, deletedPath);
+
+    expect(
+      state.toolbox.agent1.workspace.mounts.map((mount) => mount.prefix),
+    ).toEqual(['wkeep']);
+
+    const agentMounts = Reflect.get(service, 'agentMounts') as Map<
+      string,
+      Map<string, string[]>
+    >;
+    expect(agentMounts.get('agent1')?.has('wkeep')).toBe(true);
+    expect(agentMounts.get('agent1')?.has('wdead')).toBe(false);
   });
 });

--- a/apps/browser/src/backend/services/toolbox/services/mount-manager/git-worktree-watcher.test.ts
+++ b/apps/browser/src/backend/services/toolbox/services/mount-manager/git-worktree-watcher.test.ts
@@ -1,0 +1,388 @@
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// --- chokidar mock -----------------------------------------------------------
+// A controllable fake watcher so we can deterministically drive `addDir` /
+// `unlinkDir` events without touching the real filesystem (real chokidar
+// events are inherently flaky in unit tests — see the diff-history suite which
+// skips them for the same reason).
+const { watchInstances, resetWatchInstances } = vi.hoisted(() => {
+  const instances: unknown[] = [];
+  return {
+    watchInstances: instances,
+    resetWatchInstances: () => {
+      instances.length = 0;
+    },
+  };
+});
+
+vi.mock('chokidar', () => ({
+  default: {
+    watch: (p: string, o: Record<string, unknown>) => {
+      // Constructed lazily so the hoisted class is in scope.
+      const watcher = {
+        watchPath: p,
+        options: o,
+        handlers: new Map<string, ((...a: unknown[]) => void)[]>(),
+        closed: false,
+        closeCount: 0,
+        on(event: string, cb: (...a: unknown[]) => void) {
+          const list = this.handlers.get(event) ?? [];
+          list.push(cb);
+          this.handlers.set(event, list);
+          return this;
+        },
+        trigger(event: string, ...args: unknown[]) {
+          // Mirror chokidar: a concrete fs event fires both its named
+          // listeners and the `all` listener (with the event name prepended).
+          for (const cb of this.handlers.get(event) ?? []) cb(...args);
+          if (event !== 'all' && event !== 'error') {
+            for (const cb of this.handlers.get('all') ?? []) cb(event, ...args);
+          }
+        },
+        close() {
+          this.closed = true;
+          this.closeCount += 1;
+          return Promise.resolve();
+        },
+      };
+      watchInstances.push(watcher as never);
+      return watcher;
+    },
+  },
+}));
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: (name: string) =>
+      name === 'home'
+        ? path.join(os.tmpdir(), 'mm-watcher-home')
+        : path.join(os.tmpdir(), `mock-${name}`),
+  },
+}));
+
+import { MountManagerService, shouldIgnoreForGitWorktreeWatch } from '.';
+import type { FilePickerService } from '@/services/file-picker';
+import type { GitService } from '@/services/git';
+import type { KartonService } from '@/services/karton';
+import type { Logger } from '@/services/logger';
+import type { TelemetryService } from '@/services/telemetry';
+import type { UserExperienceService } from '@/services/experience';
+
+type FakeWatcherInstance = {
+  watchPath: string;
+  options: Record<string, unknown>;
+  closed: boolean;
+  closeCount: number;
+  trigger: (event: string, ...args: unknown[]) => void;
+};
+
+const services: MountManagerService[] = [];
+
+function createHarness() {
+  const state = {
+    toolbox: {},
+    gitWorktreeRevisions: {} as Record<string, number>,
+    agents: { instances: {} },
+    workspaceGitSetup: { runsByPath: {} },
+  };
+
+  const uiKarton = {
+    state,
+    setState: vi.fn((recipe: (draft: typeof state) => void) => recipe(state)),
+    registerServerProcedureHandler: vi.fn(),
+    removeServerProcedureHandler: vi.fn(),
+  } as unknown as KartonService;
+
+  const gitService = {} as unknown as GitService;
+  const userExperienceService = {
+    saveRecentlyOpenedWorkspace: vi.fn(),
+    getRecentlyOpenedWorkspaces: vi.fn(async () => []),
+  } as unknown as UserExperienceService;
+  const preferencesService = {
+    get: vi.fn(() => ({
+      agent: { workspaceGitCleanup: { dismissedCandidates: {} } },
+    })),
+  };
+
+  const service = new MountManagerService(
+    {
+      debug: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      isDebugEnabled: false,
+    } as unknown as Logger,
+    {} as FilePickerService,
+    userExperienceService,
+    uiKarton,
+    {
+      capture: vi.fn(),
+      captureException: vi.fn(),
+    } as unknown as TelemetryService,
+    gitService,
+    preferencesService as never,
+  );
+
+  services.push(service);
+  return { service, state };
+}
+
+function ensureWatcher(
+  service: MountManagerService,
+  wsPath: string,
+  commonGitDir: string,
+): void {
+  const fn = Reflect.get(service, 'ensureGitWorktreeWatcher') as (
+    p: string,
+    g: string,
+  ) => void;
+  fn.call(service, wsPath, commonGitDir);
+}
+
+function releaseWatcher(service: MountManagerService, wsPath: string): void {
+  const fn = Reflect.get(service, 'releaseGitWorktreeWatcher') as (
+    p: string,
+  ) => void;
+  fn.call(service, wsPath);
+}
+
+function watchersForRepo(
+  service: MountManagerService,
+): Map<string, { refs: Set<string> }> {
+  return Reflect.get(service, 'gitWorktreeWatchersPerRepo') as Map<
+    string,
+    { refs: Set<string> }
+  >;
+}
+
+beforeEach(() => {
+  resetWatchInstances();
+  vi.useFakeTimers();
+});
+
+afterEach(async () => {
+  vi.runOnlyPendingTimers();
+  vi.useRealTimers();
+  await Promise.all(services.splice(0).map((s) => s.teardown()));
+});
+
+describe('shouldIgnoreForGitWorktreeWatch', () => {
+  const gitDir = '/repo/.git';
+
+  it('never ignores the common git dir root (so worktrees/ creation is seen)', () => {
+    expect(shouldIgnoreForGitWorktreeWatch(gitDir, gitDir)).toBe(false);
+  });
+
+  it('watches the worktrees directory and its direct children', () => {
+    expect(shouldIgnoreForGitWorktreeWatch(gitDir, `${gitDir}/worktrees`)).toBe(
+      false,
+    );
+    expect(
+      shouldIgnoreForGitWorktreeWatch(gitDir, `${gitDir}/worktrees/feature-x`),
+    ).toBe(false);
+  });
+
+  it('ignores the heavy/noisy parts of the git dir', () => {
+    for (const noisy of [
+      'objects',
+      'objects/pack/pack-abc.pack',
+      'refs',
+      'refs/heads/main',
+      'logs',
+      'logs/HEAD',
+      'index',
+      'config',
+      'packed-refs',
+      'ORIG_HEAD',
+      'COMMIT_EDITMSG',
+      'HEAD.lock',
+    ]) {
+      expect(
+        shouldIgnoreForGitWorktreeWatch(gitDir, `${gitDir}/${noisy}`),
+        `expected ${noisy} to be ignored`,
+      ).toBe(true);
+    }
+  });
+
+  it('watches HEAD files (root + per-worktree) for branch-switch detection', () => {
+    // Main worktree's checked-out ref.
+    expect(shouldIgnoreForGitWorktreeWatch(gitDir, `${gitDir}/HEAD`)).toBe(
+      false,
+    );
+    // Linked worktree's checked-out ref.
+    expect(
+      shouldIgnoreForGitWorktreeWatch(
+        gitDir,
+        `${gitDir}/worktrees/feature-x/HEAD`,
+      ),
+    ).toBe(false);
+  });
+
+  it('ignores per-worktree churn but keeps that worktree\u2019s HEAD', () => {
+    for (const ignored of [
+      'worktrees/feature-x/index',
+      'worktrees/feature-x/commondir',
+      'worktrees/feature-x/gitdir',
+      'worktrees/feature-x/ORIG_HEAD',
+      'worktrees/feature-x/logs/HEAD',
+    ]) {
+      expect(
+        shouldIgnoreForGitWorktreeWatch(gitDir, `${gitDir}/${ignored}`),
+        `expected ${ignored} to be ignored`,
+      ).toBe(true);
+    }
+    expect(
+      shouldIgnoreForGitWorktreeWatch(
+        gitDir,
+        `${gitDir}/worktrees/feature-x/HEAD`,
+      ),
+    ).toBe(false);
+  });
+
+  it('ignores paths resolving outside the git dir', () => {
+    expect(shouldIgnoreForGitWorktreeWatch(gitDir, '/repo/other')).toBe(true);
+    expect(shouldIgnoreForGitWorktreeWatch(gitDir, '/elsewhere')).toBe(true);
+  });
+
+  it('works cross-platform with windows-style separators', () => {
+    const winGitDir = 'C:\\repo\\.git';
+    const winPath = {
+      sep: '\\',
+      relative: (from: string, to: string) =>
+        to.startsWith(`${from}\\`) ? to.slice(from.length + 1) : '..',
+    };
+    expect(
+      shouldIgnoreForGitWorktreeWatch(
+        winGitDir,
+        'C:\\repo\\.git\\worktrees\\feat',
+        winPath,
+      ),
+    ).toBe(false);
+    expect(
+      shouldIgnoreForGitWorktreeWatch(
+        winGitDir,
+        'C:\\repo\\.git\\objects\\ab',
+        winPath,
+      ),
+    ).toBe(true);
+    // Per-worktree HEAD allow-list also holds with windows separators.
+    expect(
+      shouldIgnoreForGitWorktreeWatch(
+        winGitDir,
+        'C:\\repo\\.git\\worktrees\\feat\\HEAD',
+        winPath,
+      ),
+    ).toBe(false);
+  });
+});
+
+describe('git worktree watcher lifecycle', () => {
+  it('starts a single shallow, event-driven watcher per repository', () => {
+    const { service } = createHarness();
+    ensureWatcher(service, '/repo/wt-a', '/repo/.git');
+
+    expect(watchInstances).toHaveLength(1);
+    const w = watchInstances[0] as unknown as FakeWatcherInstance;
+    expect(w.watchPath).toBe('/repo/.git');
+    // depth: 2 reaches `worktrees/<name>/HEAD` for branch-switch detection,
+    // but the `ignored` predicate keeps it off the noisy parts of the repo.
+    expect(w.options.depth).toBe(2);
+    expect(w.options.ignoreInitial).toBe(true);
+    expect(w.options.usePolling).toBeUndefined();
+    expect(w.options.awaitWriteFinish).toBeUndefined();
+  });
+
+  it('shares one watcher across multiple mounts of the same repo', () => {
+    const { service } = createHarness();
+    ensureWatcher(service, '/repo/wt-a', '/repo/.git');
+    ensureWatcher(service, '/repo/wt-b', '/repo/.git');
+
+    expect(watchInstances).toHaveLength(1);
+    const entry = watchersForRepo(service).get('/repo/.git');
+    expect(entry?.refs.size).toBe(2);
+  });
+
+  it('only closes the watcher once every referencing mount is released', () => {
+    const { service } = createHarness();
+    ensureWatcher(service, '/repo/wt-a', '/repo/.git');
+    ensureWatcher(service, '/repo/wt-b', '/repo/.git');
+    const w = watchInstances[0] as unknown as FakeWatcherInstance;
+
+    releaseWatcher(service, '/repo/wt-a');
+    expect(w.closed).toBe(false);
+    expect(watchersForRepo(service).has('/repo/.git')).toBe(true);
+
+    releaseWatcher(service, '/repo/wt-b');
+    expect(w.closed).toBe(true);
+    expect(watchersForRepo(service).has('/repo/.git')).toBe(false);
+  });
+
+  it('bumps the per-repository revision (debounced) when a worktree dir is added', () => {
+    const { service, state } = createHarness();
+    ensureWatcher(service, '/repo/wt-a', '/repo/.git');
+    const w = watchInstances[0] as unknown as FakeWatcherInstance;
+
+    w.trigger('addDir', '/repo/.git/worktrees/feature-x');
+    // Debounced — nothing yet.
+    expect(state.gitWorktreeRevisions['/repo/.git']).toBeUndefined();
+
+    vi.advanceTimersByTime(400);
+    expect(state.gitWorktreeRevisions['/repo/.git']).toBe(1);
+  });
+
+  it('bumps on a HEAD change (branch switch in a linked worktree)', () => {
+    const { service, state } = createHarness();
+    ensureWatcher(service, '/repo/wt-a', '/repo/.git');
+    const w = watchInstances[0] as unknown as FakeWatcherInstance;
+
+    // `git switch` rewrites the worktree's HEAD file — chokidar emits `change`.
+    w.trigger('change', '/repo/.git/worktrees/feature-x/HEAD');
+    vi.advanceTimersByTime(400);
+    expect(state.gitWorktreeRevisions['/repo/.git']).toBe(1);
+  });
+
+  it('bumps on the main worktree HEAD changing', () => {
+    const { service, state } = createHarness();
+    ensureWatcher(service, '/repo/wt-a', '/repo/.git');
+    const w = watchInstances[0] as unknown as FakeWatcherInstance;
+
+    w.trigger('change', '/repo/.git/HEAD');
+    vi.advanceTimersByTime(400);
+    expect(state.gitWorktreeRevisions['/repo/.git']).toBe(1);
+  });
+
+  it('coalesces a burst of events into a single revision bump', () => {
+    const { service, state } = createHarness();
+    ensureWatcher(service, '/repo/wt-a', '/repo/.git');
+    const w = watchInstances[0] as unknown as FakeWatcherInstance;
+
+    // `git worktree add` produces several rapid fs events.
+    w.trigger('addDir', '/repo/.git/worktrees');
+    w.trigger('addDir', '/repo/.git/worktrees/feature-x');
+    vi.advanceTimersByTime(100);
+    w.trigger('addDir', '/repo/.git/worktrees/feature-x');
+    vi.advanceTimersByTime(400);
+
+    expect(state.gitWorktreeRevisions['/repo/.git']).toBe(1);
+  });
+
+  it('bumps again on a later removal, and tracks repos independently', () => {
+    const { service, state } = createHarness();
+    ensureWatcher(service, '/repo-a/wt', '/repo-a/.git');
+    ensureWatcher(service, '/repo-b/wt', '/repo-b/.git');
+    const [wa, wb] = watchInstances as unknown as FakeWatcherInstance[];
+
+    wa.trigger('addDir', '/repo-a/.git/worktrees/x');
+    vi.advanceTimersByTime(400);
+    wa.trigger('unlinkDir', '/repo-a/.git/worktrees/x');
+    vi.advanceTimersByTime(400);
+
+    expect(state.gitWorktreeRevisions['/repo-a/.git']).toBe(2);
+    expect(state.gitWorktreeRevisions['/repo-b/.git']).toBeUndefined();
+
+    wb.trigger('unlinkDir', '/repo-b/.git/worktrees/y');
+    vi.advanceTimersByTime(400);
+    expect(state.gitWorktreeRevisions['/repo-b/.git']).toBe(1);
+  });
+});

--- a/apps/browser/src/backend/services/toolbox/services/mount-manager/index.ts
+++ b/apps/browser/src/backend/services/toolbox/services/mount-manager/index.ts
@@ -18,6 +18,9 @@ import type {
   WorkspaceGitCleanupCandidate,
   WorkspaceGitCleanupResult,
   WorkspaceGitCleanupState,
+  WorkspaceGitWorktreeDeleteOptions,
+  WorkspaceGitWorktreeDeleteResult,
+  WorkspaceGitWorktreeDeletionInfo,
   MountEntry,
   WorkspaceGitCreateBranchOptions,
   WorkspaceGitCreateWorktreeOptions,
@@ -252,6 +255,13 @@ export class MountManagerService extends DisposableService {
     );
 
     this.uiKarton.registerServerProcedureHandler(
+      'toolbox.getGitRepositoryRemoteUrlByPath',
+      async (_callingClientId: string, workspacePath: string) => {
+        return this.getGitRepositoryRemoteUrlByPath(workspacePath);
+      },
+    );
+
+    this.uiKarton.registerServerProcedureHandler(
       'toolbox.switchGitBranchByPath',
       async (
         _callingClientId: string,
@@ -406,6 +416,24 @@ export class MountManagerService extends DisposableService {
     );
 
     this.uiKarton.registerServerProcedureHandler(
+      'toolbox.getGitWorktreeDeletionInfo',
+      async (_callingClientId: string, workspacePath: string) => {
+        return this.getGitWorktreeDeletionInfo(workspacePath);
+      },
+    );
+
+    this.uiKarton.registerServerProcedureHandler(
+      'toolbox.deleteGitWorktreeByPath',
+      async (
+        _callingClientId: string,
+        workspacePath: string,
+        options?: WorkspaceGitWorktreeDeleteOptions,
+      ) => {
+        return this.deleteGitWorktreeByPath(workspacePath, options);
+      },
+    );
+
+    this.uiKarton.registerServerProcedureHandler(
       'toolbox.searchMentionFiles',
       async (
         _callingClientId: string,
@@ -508,6 +536,13 @@ export class MountManagerService extends DisposableService {
   private async listGitWorktreesByPath(workspacePath: string) {
     if (!(await this.isTrustedGitPath(workspacePath))) return null;
     return this.gitService.listWorkspaceWorktrees(workspacePath);
+  }
+
+  private async getGitRepositoryRemoteUrlByPath(
+    workspacePath: string,
+  ): Promise<string | null> {
+    if (!(await this.isTrustedGitPath(workspacePath))) return null;
+    return this.gitService.getRepositoryRemoteUrl(workspacePath);
   }
 
   private async switchGitBranchByPath(
@@ -848,6 +883,80 @@ export class MountManagerService extends DisposableService {
         draft.workspaceGitCleanup.cleaning = false;
       });
     }
+  }
+
+  private async getGitWorktreeDeletionInfo(
+    workspacePath: string,
+  ): Promise<WorkspaceGitWorktreeDeletionInfo | null> {
+    if (!(await this.isTrustedGitPath(workspacePath))) return null;
+
+    const resolvedWorkspacePath = await safeRealpath(workspacePath);
+    if (!resolvedWorkspacePath) return null;
+
+    const summary = await this.gitService.getMountedWorkspaceSummary(
+      resolvedWorkspacePath,
+    );
+    if (!summary?.isWorktree) return null;
+
+    const worktrees = await this.gitService.listWorktrees(
+      resolvedWorkspacePath,
+    );
+    let currentWorktree = null;
+    for (const worktree of worktrees) {
+      const resolvedWorktreePath =
+        (await safeRealpath(worktree.path)) ?? path.resolve(worktree.path);
+      if (resolvedWorktreePath === resolvedWorkspacePath) {
+        currentWorktree = worktree;
+        break;
+      }
+    }
+    if (!currentWorktree) return null;
+
+    const status = await this.gitService.getWorktreeStatus(
+      resolvedWorkspacePath,
+    );
+
+    return {
+      path: resolvedWorkspacePath,
+      branch: currentWorktree.branch,
+      isMainWorktree: currentWorktree.isMainWorktree,
+      status,
+      hasUncommittedChanges: status?.dirty ?? true,
+    };
+  }
+
+  private async deleteGitWorktreeByPath(
+    workspacePath: string,
+    options: WorkspaceGitWorktreeDeleteOptions = {},
+  ): Promise<WorkspaceGitWorktreeDeleteResult> {
+    const info = await this.getGitWorktreeDeletionInfo(workspacePath);
+    if (!info) {
+      return { ok: false, message: 'Worktree is no longer available.' };
+    }
+    if (info.isMainWorktree) {
+      return { ok: false, message: 'Cannot delete the root worktree.' };
+    }
+    if (info.hasUncommittedChanges && !options.force) {
+      return {
+        ok: false,
+        message: 'Worktree has uncommitted changes. Confirm force deletion.',
+      };
+    }
+
+    const result = await this.gitService.removeWorktree(info.path, {
+      force: options.force,
+    });
+    if (!result.ok) return result;
+
+    this.uiKarton.setState((draft: KartonStateDraft) => {
+      draft.workspaceGitCleanup.candidates =
+        draft.workspaceGitCleanup.candidates.filter(
+          (candidate: WorkspaceGitCleanupCandidate) =>
+            candidate.path !== info.path,
+        );
+    });
+
+    return { ok: true, path: info.path, branch: info.branch };
   }
 
   private async cleanWorkspaceGitWorktrees(
@@ -1472,6 +1581,9 @@ export class MountManagerService extends DisposableService {
     this.uiKarton.removeServerProcedureHandler('toolbox.listGitBranchesByPath');
     this.uiKarton.removeServerProcedureHandler(
       'toolbox.listGitWorktreesByPath',
+    );
+    this.uiKarton.removeServerProcedureHandler(
+      'toolbox.getGitRepositoryRemoteUrlByPath',
     );
     this.uiKarton.removeServerProcedureHandler('toolbox.switchGitBranchByPath');
     this.uiKarton.removeServerProcedureHandler('toolbox.createGitBranchByPath');

--- a/apps/browser/src/backend/services/toolbox/services/mount-manager/index.ts
+++ b/apps/browser/src/backend/services/toolbox/services/mount-manager/index.ts
@@ -948,6 +948,12 @@ export class MountManagerService extends DisposableService {
     });
     if (!result.ok) return result;
 
+    // The worktree directory no longer exists on disk. Detach it from
+    // every agent that still mounts it so the sidebar stops showing the
+    // dead path and follow-up actions (open path, create agent) can't
+    // target a workspace that's gone. Agents themselves are preserved.
+    await this.detachWorkspacePathFromAgents(info.path);
+
     this.uiKarton.setState((draft: KartonStateDraft) => {
       draft.workspaceGitCleanup.candidates =
         draft.workspaceGitCleanup.candidates.filter(
@@ -957,6 +963,61 @@ export class MountManagerService extends DisposableService {
     });
 
     return { ok: true, path: info.path, branch: info.branch };
+  }
+
+  /**
+   * Removes every active mount that points at `workspacePath` from all
+   * agents — both the internal runtime maps (so watcher / LSP / runtime
+   * resources are released via `releaseMountIfUnused`) and the Karton UI
+   * state (so the sidebar stops grouping agents under the now-deleted
+   * path). Agents themselves are intentionally preserved; an agent left
+   * with no remaining mounts simply moves to the "No workspace" group.
+   *
+   * Paths are compared after `realpath` resolution because mount paths
+   * may differ from `workspacePath` by symlink or trailing separators.
+   * Returns the distinct agent instance ids that lost a mount.
+   */
+  private async detachWorkspacePathFromAgents(
+    workspacePath: string,
+  ): Promise<string[]> {
+    const resolvedTarget =
+      (await safeRealpath(workspacePath)) ?? path.resolve(workspacePath);
+
+    const affected: Array<{ agentId: string; prefix: string }> = [];
+    for (const [agentId, mounts] of this.agentMounts) {
+      for (const prefix of mounts.keys()) {
+        const mountedPath = this.workspacePathsPerMount.get(prefix);
+        if (!mountedPath) continue;
+        const resolvedMounted =
+          (await safeRealpath(mountedPath)) ?? path.resolve(mountedPath);
+        if (resolvedMounted === resolvedTarget) {
+          affected.push({ agentId, prefix });
+        }
+      }
+    }
+
+    if (affected.length === 0) return [];
+
+    for (const { agentId, prefix } of affected) {
+      this.agentMounts.get(agentId)?.delete(prefix);
+      this.releaseMountIfUnused(prefix);
+    }
+
+    this.uiKarton.setState((draft: KartonStateDraft) => {
+      for (const { agentId, prefix } of affected) {
+        const toolbox = draft.toolbox[agentId];
+        if (!toolbox) continue;
+        toolbox.workspace.mounts = toolbox.workspace.mounts.filter(
+          (mount: MountEntry) => mount.prefix !== prefix,
+        );
+      }
+    });
+
+    const affectedAgentIds = [...new Set(affected.map((a) => a.agentId))];
+    for (const agentId of affectedAgentIds) {
+      this.onMountsChanged?.(agentId);
+    }
+    return affectedAgentIds;
   }
 
   private async cleanWorkspaceGitWorktrees(

--- a/apps/browser/src/backend/services/toolbox/services/mount-manager/index.ts
+++ b/apps/browser/src/backend/services/toolbox/services/mount-manager/index.ts
@@ -47,6 +47,7 @@ import {
 
 type KartonStateDraft = {
   workspaceGitCleanup: WorkspaceGitCleanupState;
+  gitWorktreeRevisions: Record<string, number>;
   toolbox: Record<
     string,
     {
@@ -83,6 +84,66 @@ function mountPrefixForPath(workspacePath: string): MountPrefix {
     .digest('hex')
     .slice(0, 4);
   return `w${hash}`;
+}
+
+/**
+ * chokidar `ignored` predicate for the git worktree watcher.
+ *
+ * The watcher is rooted at a repository's common git dir and must only ever
+ * keep watch handles on a tiny allow-list — returning `true` (ignore) for
+ * everything else keeps chokidar (which places one non-recursive `fs.watch`
+ * per traversed directory) off the large/noisy parts of the git dir
+ * (`objects/`, `refs/`, `logs/`, root `index`/`config`, per-worktree `index`,
+ * etc.), so heavy git activity does not generate useless filesystem reads.
+ *
+ * Allowed (watched), so the sidebar can react to worktree topology *and*
+ * branch changes made outside the app:
+ * - the common git dir root itself (so `worktrees/` creation is seen even
+ *   before it exists);
+ * - `HEAD` at the root (the main worktree's checked-out ref — changes on
+ *   `git switch`/detach, not on commits since `HEAD` is a symref);
+ * - the `worktrees/` directory and each `worktrees/<name>/` directory
+ *   (add/remove is the topology signal; we must descend to reach HEAD);
+ * - `worktrees/<name>/HEAD` (a linked worktree's checked-out ref).
+ *
+ * Everything deeper (e.g. `worktrees/<name>/logs/HEAD` reflog, `index`) is
+ * ignored. Combined with `depth: 2`, the deepest watched path is
+ * `worktrees/<name>/HEAD`.
+ *
+ * Exported for unit testing; pure and platform-aware via the injectable
+ * `sep`/`relative` (defaults to the host `path`).
+ */
+export function shouldIgnoreForGitWorktreeWatch(
+  commonGitDir: string,
+  filePath: string,
+  pathLike: { sep: string; relative: (from: string, to: string) => string } = {
+    sep: path.sep,
+    relative: path.relative,
+  },
+): boolean {
+  // Always watch the root itself so worktrees/ creation is detected even when
+  // it does not exist yet.
+  if (filePath === commonGitDir) return false;
+  const rel = pathLike.relative(commonGitDir, filePath);
+  // The dir itself ('') is watched; anything resolving outside (`..`) is not.
+  if (rel === '') return false;
+  if (rel === '..' || rel.startsWith(`..${pathLike.sep}`)) return true;
+  const segments = rel.split(pathLike.sep);
+
+  if (segments[0] !== 'worktrees') {
+    // Root-level entries: allow only the main worktree's HEAD; ignore
+    // objects/, refs/, logs/, config, index, ORIG_HEAD, packed-refs, etc.
+    return !(segments.length === 1 && segments[0] === 'HEAD');
+  }
+
+  // Under `worktrees/`:
+  // - depth 1 (`worktrees`) and depth 2 (`worktrees/<name>`) dirs: watch so
+  //   topology changes fire and we can descend to reach HEAD.
+  // - depth 3: allow only `worktrees/<name>/HEAD`; ignore index/commondir/etc.
+  // - depth 4+ (e.g. logs/HEAD reflog): ignore.
+  if (segments.length <= 2) return false;
+  if (segments.length === 3) return segments[2] !== 'HEAD';
+  return true;
 }
 
 export type MountedClientRuntimes = Map<MountPrefix, ClientRuntimeNode>;
@@ -134,6 +195,24 @@ export class MountManagerService extends DisposableService {
     WorkspacePath,
     ReturnType<typeof setTimeout>
   > = new Map();
+
+  /**
+   * Watchers on each repository's common git dir that detect worktrees
+   * created/removed externally (e.g. `git worktree add/remove` in a terminal).
+   * Keyed by common git dir (== repositoryId). Multiple mounted worktrees of
+   * the same repo share one watcher, ref-counted by workspace path so it is
+   * only torn down once every mount referencing the repo is gone.
+   */
+  private gitWorktreeWatchersPerRepo: Map<
+    string,
+    { watcher: FSWatcher; refs: Set<WorkspacePath> }
+  > = new Map();
+  private gitWorktreeWatcherDebounceTimers: Map<
+    string,
+    ReturnType<typeof setTimeout>
+  > = new Map();
+  /** Maps a mounted workspace path to the common git dir it references. */
+  private commonGitDirPerPath: Map<WorkspacePath, string> = new Map();
 
   public constructor(
     logger: Logger,
@@ -706,6 +785,9 @@ export class MountManagerService extends DisposableService {
     const git = await this.gitService.getMountedWorkspaceSummary(
       resolvedWorkspacePath,
     );
+    if (git?.commonGitDir) {
+      this.ensureGitWorktreeWatcher(resolvedWorkspacePath, git.commonGitDir);
+    }
 
     this.uiKarton.setState((draft: KartonStateDraft) => {
       draft.toolbox[agentInstanceId].workspace.mounts.push({
@@ -1505,6 +1587,117 @@ export class MountManagerService extends DisposableService {
         path: wsPath,
       });
     }
+    this.releaseGitWorktreeWatcher(wsPath);
+  }
+
+  /**
+   * Ensures a watcher exists for the repository's worktree metadata so that
+   * worktrees added/removed outside the app are reflected in the sidebar.
+   *
+   * Git stores one directory per linked worktree under
+   * `<commonGitDir>/worktrees/<name>`; `git worktree add/remove/prune` create
+   * and delete these directories. Watching the common git dir (shared by every
+   * worktree of the repo) means a single watcher detects changes regardless of
+   * which worktree happens to be mounted. On a relevant change we bump a
+   * per-repository revision in UI state; the sidebar invalidates its cached
+   * worktree list when that revision changes.
+   */
+  private ensureGitWorktreeWatcher(
+    wsPath: WorkspacePath,
+    commonGitDir: string,
+  ): void {
+    this.commonGitDirPerPath.set(wsPath, commonGitDir);
+
+    const existing = this.gitWorktreeWatchersPerRepo.get(commonGitDir);
+    if (existing) {
+      existing.refs.add(wsPath);
+      return;
+    }
+
+    const scheduleBump = () => {
+      const pending = this.gitWorktreeWatcherDebounceTimers.get(commonGitDir);
+      if (pending) clearTimeout(pending);
+      this.gitWorktreeWatcherDebounceTimers.set(
+        commonGitDir,
+        setTimeout(() => {
+          this.gitWorktreeWatcherDebounceTimers.delete(commonGitDir);
+          this.bumpGitWorktreeRevision(commonGitDir);
+        }, 400),
+      );
+    };
+
+    const watcher = chokidar.watch(commonGitDir, {
+      persistent: true,
+      ignoreInitial: true,
+      // chokidar counts depth from the watched root: root = 0, `worktrees/` = 1,
+      // `worktrees/<name>` = 2, `worktrees/<name>/HEAD` = 3. `depth` is the
+      // deepest level chokidar *descends into* (places an fs.watch on). depth: 2
+      // descends into each `worktrees/<name>` so its `HEAD` (depth 3) is
+      // watched for branch switches, while never descending deeper (no watch on
+      // per-worktree `index`/`logs/` churn). The `ignored` predicate further
+      // prunes everything except the HEAD allow-list, so only `HEAD` writes and
+      // worktree dir add/remove ever reach us — even though depth: 2 reads each
+      // worktree dir once on setup.
+      depth: 2,
+      // No awaitWriteFinish: it polls file writes to detect stability, but we
+      // react to discrete events (dir add/remove, HEAD change), so polling here
+      // would be pure overhead. Stay fully event-driven (no usePolling) for
+      // low CPU on all platforms; chokidar v4 uses native fs.watch per dir.
+      ignored: (filePath: string) =>
+        shouldIgnoreForGitWorktreeWatch(commonGitDir, filePath),
+    });
+
+    // The `ignored` predicate restricts watched paths to the worktree topology
+    // (`worktrees/<name>` dirs) and the checked-out refs (`HEAD` files), so any
+    // event from this watcher is relevant: dir add/remove = worktree created or
+    // destroyed; HEAD add/change/unlink = a branch switch / detach (incl. the
+    // atomic `HEAD.lock` → `HEAD` rename git uses). Bump on all of them.
+    watcher.on('all', scheduleBump).on('error', (error) => {
+      this.logger.debug('[MountManager] Git worktree watcher error', {
+        error,
+        commonGitDir,
+      });
+    });
+
+    this.gitWorktreeWatchersPerRepo.set(commonGitDir, {
+      watcher,
+      refs: new Set([wsPath]),
+    });
+    this.logger.debug('[MountManager] Started git worktree watcher', {
+      commonGitDir,
+    });
+  }
+
+  private releaseGitWorktreeWatcher(wsPath: WorkspacePath): void {
+    const commonGitDir = this.commonGitDirPerPath.get(wsPath);
+    if (!commonGitDir) return;
+    this.commonGitDirPerPath.delete(wsPath);
+
+    const entry = this.gitWorktreeWatchersPerRepo.get(commonGitDir);
+    if (!entry) return;
+    entry.refs.delete(wsPath);
+    if (entry.refs.size > 0) return;
+
+    const timer = this.gitWorktreeWatcherDebounceTimers.get(commonGitDir);
+    if (timer) {
+      clearTimeout(timer);
+      this.gitWorktreeWatcherDebounceTimers.delete(commonGitDir);
+    }
+    void entry.watcher.close();
+    this.gitWorktreeWatchersPerRepo.delete(commonGitDir);
+    this.logger.debug('[MountManager] Stopped git worktree watcher', {
+      commonGitDir,
+    });
+  }
+
+  private bumpGitWorktreeRevision(repositoryId: string): void {
+    this.uiKarton.setState((draft: KartonStateDraft) => {
+      draft.gitWorktreeRevisions[repositoryId] =
+        (draft.gitWorktreeRevisions[repositoryId] ?? 0) + 1;
+    });
+    this.logger.debug('[MountManager] Detected external worktree change', {
+      repositoryId,
+    });
   }
 
   /** Re-reads skills and MD files from disk, then pushes updated data to UI state. */
@@ -1525,6 +1718,9 @@ export class MountManagerService extends DisposableService {
       }));
 
       const git = await this.gitService.getMountedWorkspaceSummary(wsPath);
+      if (git?.commonGitDir) {
+        this.ensureGitWorktreeWatcher(wsPath, git.commonGitDir);
+      }
 
       this.uiKarton.setState((draft: KartonStateDraft) => {
         for (const agentId in draft.toolbox) {
@@ -1619,6 +1815,16 @@ export class MountManagerService extends DisposableService {
 
     for (const wsPath of this.watchersPerPath.keys())
       this.stopWorkspaceWatcher(wsPath);
+
+    // Defensive: close any git worktree watchers not already released via
+    // stopWorkspaceWatcher above.
+    for (const timer of this.gitWorktreeWatcherDebounceTimers.values())
+      clearTimeout(timer);
+    this.gitWorktreeWatcherDebounceTimers.clear();
+    for (const { watcher } of this.gitWorktreeWatchersPerRepo.values())
+      void watcher.close();
+    this.gitWorktreeWatchersPerRepo.clear();
+    this.commonGitDirPerPath.clear();
 
     // Await every LSP teardown so the overall shutdown chain (main
     // process -> toolbox -> mount-manager -> lsp -> client) is fully

--- a/apps/browser/src/shared/karton-contracts/ui/agent/index.ts
+++ b/apps/browser/src/shared/karton-contracts/ui/agent/index.ts
@@ -83,6 +83,12 @@ export type ToolboxState = {
   // Later on, tool calls that involve interaction with the user should also be placed here!!!
 };
 
+export type AgentHistoryWorkspaceEntry = {
+  path: string;
+  permissions: MountPermission[];
+  git: MountedWorkspaceGitSummary | null;
+};
+
 export type AgentHistoryEntry = {
   id: string; // agent instance ID
   title: string; // agent title
@@ -90,6 +96,7 @@ export type AgentHistoryEntry = {
   lastMessageAt: Date; // last message timestamp
   messageCount: number; // number of messages in the agent's history
   parentAgentInstanceId: string | null; // parent agent instance ID
+  mountedWorkspaces?: AgentHistoryWorkspaceEntry[] | null;
 };
 
 /**

--- a/apps/browser/src/shared/karton-contracts/ui/index.ts
+++ b/apps/browser/src/shared/karton-contracts/ui/index.ts
@@ -130,6 +130,22 @@ export type WorkspaceGitCleanupResult = {
   failed: Array<{ path: string; message: string }>;
 };
 
+export type WorkspaceGitWorktreeDeletionInfo = {
+  path: string;
+  branch: string | null;
+  isMainWorktree: boolean;
+  status: MountedWorkspaceGitStatusSummary | null;
+  hasUncommittedChanges: boolean;
+};
+
+export type WorkspaceGitWorktreeDeleteResult =
+  | { ok: true; path: string; branch: string | null }
+  | { ok: false; message: string };
+
+export type WorkspaceGitWorktreeDeleteOptions = {
+  force?: boolean;
+};
+
 export type WorkspaceGitCleanupState = {
   checkedAt: number | null;
   dismissed: boolean;
@@ -929,6 +945,7 @@ export type KartonContract = {
         modelId?: ModelId,
         toolApprovalMode?: ToolApprovalMode,
         workspacePaths?: string[],
+        preserveWorkspacePaths?: boolean,
       ) => Promise<string>;
       resume: (agentId: string) => Promise<void>;
       archive: (agentId: string) => Promise<void>;
@@ -1036,6 +1053,9 @@ export type KartonContract = {
       listGitWorktreesByPath: (
         workspacePath: string,
       ) => Promise<WorkspaceGitWorktreesResult | null>;
+      getGitRepositoryRemoteUrlByPath: (
+        workspacePath: string,
+      ) => Promise<string | null>;
       switchGitBranchByPath: (
         workspacePath: string,
         branchName: string,
@@ -1052,6 +1072,13 @@ export type KartonContract = {
       cleanWorkspaceGitWorktrees: (
         paths: string[],
       ) => Promise<WorkspaceGitCleanupResult>;
+      getGitWorktreeDeletionInfo: (
+        path: string,
+      ) => Promise<WorkspaceGitWorktreeDeletionInfo | null>;
+      deleteGitWorktreeByPath: (
+        path: string,
+        options?: WorkspaceGitWorktreeDeleteOptions,
+      ) => Promise<WorkspaceGitWorktreeDeleteResult>;
       listWorkspaceGitBranches: (
         agentInstanceId: string,
         mountPrefix: string,

--- a/apps/browser/src/shared/karton-contracts/ui/index.ts
+++ b/apps/browser/src/shared/karton-contracts/ui/index.ts
@@ -732,6 +732,15 @@ export type AppState = {
   };
   workspaceGitCleanup: WorkspaceGitCleanupState;
   workspaceGitSetup: WorkspaceGitSetupState;
+  /**
+   * Monotonic per-repository revision counters, bumped whenever the backend
+   * detects an external git worktree add/remove (e.g. `git worktree add` or
+   * `git worktree remove` run from a terminal outside the app). Keyed by
+   * repositoryId, which equals the repository's common git dir. The sidebar
+   * watches these to invalidate its cached worktree lists so the UI stays in
+   * sync with the filesystem.
+   */
+  gitWorktreeRevisions: Record<string, number>;
   toolbox: {
     [agentInstanceId: string]: {
       workspace: {
@@ -1622,6 +1631,7 @@ export const defaultState: KartonContract['state'] = {
   workspaceGitSetup: {
     runsByPath: {},
   },
+  gitWorktreeRevisions: {},
   toolbox: {},
   userAccount: {
     status: 'unauthenticated',

--- a/apps/browser/src/shared/karton-contracts/ui/index.ts
+++ b/apps/browser/src/shared/karton-contracts/ui/index.ts
@@ -144,6 +144,13 @@ export type WorkspaceGitWorktreeDeleteResult =
 
 export type WorkspaceGitWorktreeDeleteOptions = {
   force?: boolean;
+  /**
+   * When true, callers are responsible for deleting the agents that live
+   * in this worktree before invoking deletion. The mount manager always
+   * detaches the deleted path from surviving agents regardless of this
+   * flag; it exists so the UI can record intent / telemetry.
+   */
+  deleteAgents?: boolean;
 };
 
 export type WorkspaceGitCleanupState = {

--- a/apps/browser/src/shared/karton-contracts/ui/shared-types.test.ts
+++ b/apps/browser/src/shared/karton-contracts/ui/shared-types.test.ts
@@ -8,6 +8,9 @@ describe('userPreferencesSchema sidebar defaults', () => {
     expect(parsed.sidebar).toEqual({
       showActiveAgents: true,
       pinnedAgentIds: [],
+      agentListGroupingMode: 'age',
+      workspaceGroupOrder: [],
+      collapsedWorkspaceGroupKeys: [],
     });
   });
 
@@ -19,6 +22,9 @@ describe('userPreferencesSchema sidebar defaults', () => {
     expect(parsed.sidebar).toEqual({
       showActiveAgents: false,
       pinnedAgentIds: [],
+      agentListGroupingMode: 'age',
+      workspaceGroupOrder: [],
+      collapsedWorkspaceGroupKeys: [],
     });
   });
 
@@ -30,17 +36,43 @@ describe('userPreferencesSchema sidebar defaults', () => {
     expect(parsed.sidebar).toEqual({
       showActiveAgents: true,
       pinnedAgentIds: ['agent-b', 'agent-a'],
+      agentListGroupingMode: 'age',
+      workspaceGroupOrder: [],
+      collapsedWorkspaceGroupKeys: [],
+    });
+  });
+
+  it('defaults invalid grouping mode values', () => {
+    const parsed = userPreferencesSchema.parse({
+      sidebar: { agentListGroupingMode: 'invalid' },
+    });
+
+    expect(parsed.sidebar).toEqual({
+      showActiveAgents: true,
+      pinnedAgentIds: [],
+      agentListGroupingMode: 'age',
+      workspaceGroupOrder: [],
+      collapsedWorkspaceGroupKeys: [],
     });
   });
 
   it('preserves complete sidebar preferences', () => {
     const parsed = userPreferencesSchema.parse({
-      sidebar: { showActiveAgents: false, pinnedAgentIds: ['agent-a'] },
+      sidebar: {
+        showActiveAgents: false,
+        pinnedAgentIds: ['agent-a'],
+        agentListGroupingMode: 'workspace',
+        workspaceGroupOrder: ['repo:b', 'repo:a'],
+        collapsedWorkspaceGroupKeys: ['repo:a', 'repo:a:root'],
+      },
     });
 
     expect(parsed.sidebar).toEqual({
       showActiveAgents: false,
       pinnedAgentIds: ['agent-a'],
+      agentListGroupingMode: 'workspace',
+      workspaceGroupOrder: ['repo:b', 'repo:a'],
+      collapsedWorkspaceGroupKeys: ['repo:a', 'repo:a:root'],
     });
   });
 });

--- a/apps/browser/src/shared/karton-contracts/ui/shared-types.ts
+++ b/apps/browser/src/shared/karton-contracts/ui/shared-types.ts
@@ -492,9 +492,15 @@ export const DEFAULT_TOOL_APPROVAL_MODE: ToolApprovalMode = 'alwaysAsk';
 export const updateChannelSchema = z.enum(['alpha', 'beta']);
 export type UpdateChannel = z.infer<typeof updateChannelSchema>;
 
+const agentListGroupingModeSchema = z.enum(['age', 'workspace']);
+export type AgentListGroupingMode = z.infer<typeof agentListGroupingModeSchema>;
+
 const defaultSidebarPreferences = {
   showActiveAgents: true,
   pinnedAgentIds: [],
+  agentListGroupingMode: 'age' as AgentListGroupingMode,
+  workspaceGroupOrder: [],
+  collapsedWorkspaceGroupKeys: [],
 };
 
 const sidebarPreferencesSchema = z
@@ -503,6 +509,12 @@ const sidebarPreferencesSchema = z
     showActiveAgents: z.boolean().default(true),
     /** Ordered agent IDs pinned to the top of the sidebar */
     pinnedAgentIds: z.array(z.string()).default([]),
+    /** How the unpinned agent list is grouped in the sidebar */
+    agentListGroupingMode: agentListGroupingModeSchema.default('age'),
+    /** Ordered workspace group keys in the sidebar workspace grouping mode */
+    workspaceGroupOrder: z.array(z.string()).default([]),
+    /** Collapsed workspace/worktree group keys in the sidebar workspace grouping mode */
+    collapsedWorkspaceGroupKeys: z.array(z.string()).default([]),
   })
   .default(defaultSidebarPreferences)
   .catch(defaultSidebarPreferences);

--- a/apps/browser/src/ui/screens/main/_components/delete-confirm-popover.tsx
+++ b/apps/browser/src/ui/screens/main/_components/delete-confirm-popover.tsx
@@ -11,6 +11,7 @@ import { Button } from '@stagewise/stage-ui/components/button';
 import { useEffect, useMemo, useRef } from 'react';
 import { useKartonState } from '@ui/hooks/use-karton';
 import { useFloatingIsolation } from './use-floating-isolation';
+import type { ReactNode } from 'react';
 
 /**
  * Top viewport padding reserved for the macOS traffic-light controls when
@@ -39,12 +40,24 @@ export function DeleteConfirmPopover({
   onConfirm,
   isolated = false,
   anchorPoint,
+  title = 'Delete agent?',
+  description = 'This will permanently delete this agent and its chat history.',
+  confirmLabel = 'Delete',
+  confirmVariant = 'primary',
+  confirmDisabled = false,
+  children,
 }: {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   onConfirm: () => void;
   isolated?: boolean;
   anchorPoint?: { x: number; y: number };
+  title?: ReactNode;
+  description?: ReactNode;
+  confirmLabel?: ReactNode;
+  confirmVariant?: 'primary' | 'destructive';
+  confirmDisabled?: boolean;
+  children?: ReactNode;
 }) {
   // On macOS with a hidden titlebar, keep the popover clear of the
   // traffic-light overlay that sits at the top of the window.
@@ -108,14 +121,19 @@ export function DeleteConfirmPopover({
         collisionPadding={collisionPadding}
       >
         <div ref={shieldRef} className="contents">
-          <PopoverTitle>Delete agent?</PopoverTitle>
-          <PopoverDescription>
-            This will permanently delete this agent and its chat history.
-          </PopoverDescription>
+          <PopoverTitle>{title}</PopoverTitle>
+          <PopoverDescription>{description}</PopoverDescription>
+          {children}
           <PopoverClose />
           <PopoverFooter>
-            <Button variant="primary" size="xs" onClick={onConfirm} autoFocus>
-              Delete
+            <Button
+              variant={confirmVariant}
+              size="xs"
+              disabled={confirmDisabled}
+              onClick={onConfirm}
+              autoFocus
+            >
+              {confirmLabel}
             </Button>
             <Button
               variant="ghost"

--- a/apps/browser/src/ui/screens/main/_lib/agent-list-model.test.ts
+++ b/apps/browser/src/ui/screens/main/_lib/agent-list-model.test.ts
@@ -128,4 +128,65 @@ describe('agent list workspace model', () => {
     ]);
     expect(groups[0]?.severity).toBe('warning');
   });
+
+  it('overlays the freshly fetched worktree branch onto agent-derived groups', () => {
+    // The agent mount captured `branch: 'feature'` at mount time. After an
+    // external `git switch`, the HEAD watcher bumps the repo revision and the
+    // worktree list is refetched with the new branch. The list must win so the
+    // sidebar label tracks branch changes made outside the app.
+    const groups = buildWorkspaceAgentGroups({
+      entries: [
+        agent('feature', {
+          mountedWorkspaces: [
+            {
+              path: '/worktrees/feature',
+              git: {
+                repositoryId: '/repo/.git',
+                worktreeId: '/worktrees/feature',
+                repoRoot: '/worktrees/feature',
+                mainWorktreePath: '/repo',
+                commonGitDir: '/repo/.git',
+                isWorktree: true,
+                branch: 'feature',
+                headSha: 'def',
+                status: {
+                  dirty: false,
+                  stagedCount: 0,
+                  unstagedCount: 0,
+                  untrackedCount: 0,
+                },
+              },
+            },
+          ],
+        }),
+      ],
+      pinnedIds: new Set(),
+      worktreeLists: new Map([
+        [
+          '/repo/.git',
+          {
+            currentPath: '/worktrees/feature',
+            worktrees: [
+              {
+                worktreeId: '/worktrees/feature',
+                path: '/worktrees/feature',
+                branch: 'feature-renamed',
+                headSha: 'def',
+                isDetached: false,
+                isMainWorktree: false,
+                current: true,
+              },
+            ],
+          },
+        ],
+      ]),
+      groupOrder: { repoKeys: [], worktreeKeysByRepo: {} },
+    });
+
+    const worktree = groups[0]?.worktrees[0];
+    expect(worktree?.branch).toBe('feature-renamed');
+    expect(worktree?.label).toBe('feature (feature-renamed)');
+    // The agent stays attached to the (now relabeled) group.
+    expect(worktree?.agents.map((row) => row.agent.id)).toEqual(['feature']);
+  });
 });

--- a/apps/browser/src/ui/screens/main/_lib/agent-list-model.test.ts
+++ b/apps/browser/src/ui/screens/main/_lib/agent-list-model.test.ts
@@ -123,7 +123,7 @@ describe('agent list workspace model', () => {
     });
 
     expect(groups[0]?.worktrees.map((group) => group.label)).toEqual([
-      'Root',
+      'Root (main)',
       'feature',
     ]);
     expect(groups[0]?.severity).toBe('warning');

--- a/apps/browser/src/ui/screens/main/_lib/agent-list-model.test.ts
+++ b/apps/browser/src/ui/screens/main/_lib/agent-list-model.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildWorkspaceAgentGroups,
+  getAgentStateSeverity,
+  type MergedAgentEntry,
+} from './agent-list-model';
+
+function agent(
+  id: string,
+  overrides: Partial<MergedAgentEntry> = {},
+): MergedAgentEntry {
+  return {
+    id,
+    title: id,
+    isWorking: false,
+    isWaitingForUser: false,
+    activityText: '',
+    activityIsUserInput: false,
+    hasError: false,
+    lastMessageAt: 0,
+    createdAt: 0,
+    messageCount: 0,
+    unread: false,
+    mountedWorkspaces: [],
+    isLive: true,
+    ...overrides,
+  };
+}
+
+describe('agent list workspace model', () => {
+  it('orders state severity by error, waiting, unread, working', () => {
+    expect(getAgentStateSeverity(agent('error', { hasError: true }))).toBe(
+      'error',
+    );
+    expect(
+      getAgentStateSeverity(agent('waiting', { isWaitingForUser: true })),
+    ).toBe('warning');
+    expect(getAgentStateSeverity(agent('unread', { unread: true }))).toBe(
+      'success',
+    );
+    expect(getAgentStateSeverity(agent('working', { isWorking: true }))).toBe(
+      'info',
+    );
+  });
+
+  it('duplicates multi-workspace agents into each workspace group', () => {
+    const groups = buildWorkspaceAgentGroups({
+      entries: [
+        agent('agent-a', {
+          mountedWorkspaces: [
+            { path: '/repo-a', git: null },
+            { path: '/repo-b', git: null },
+          ],
+        }),
+      ],
+      pinnedIds: new Set(),
+      worktreeLists: new Map(),
+      groupOrder: { repoKeys: [], worktreeKeysByRepo: {} },
+    });
+
+    expect(groups).toHaveLength(2);
+    expect(groups.map((group) => group.directAgents[0]?.agent.id)).toEqual([
+      'agent-a',
+      'agent-a',
+    ]);
+  });
+
+  it('keeps root worktree first and aggregates highest severity', () => {
+    const groups = buildWorkspaceAgentGroups({
+      entries: [
+        agent('root', {
+          unread: true,
+          mountedWorkspaces: [
+            {
+              path: '/repo',
+              git: {
+                repositoryId: '/repo/.git',
+                worktreeId: '/repo',
+                repoRoot: '/repo',
+                mainWorktreePath: '/repo',
+                commonGitDir: '/repo/.git',
+                isWorktree: false,
+                branch: 'main',
+                headSha: 'abc',
+                status: {
+                  dirty: false,
+                  stagedCount: 0,
+                  unstagedCount: 0,
+                  untrackedCount: 0,
+                },
+              },
+            },
+          ],
+        }),
+        agent('feature', {
+          isWaitingForUser: true,
+          mountedWorkspaces: [
+            {
+              path: '/worktrees/feature',
+              git: {
+                repositoryId: '/repo/.git',
+                worktreeId: '/worktrees/feature',
+                repoRoot: '/worktrees/feature',
+                mainWorktreePath: '/repo',
+                commonGitDir: '/repo/.git',
+                isWorktree: true,
+                branch: 'feature',
+                headSha: 'def',
+                status: {
+                  dirty: false,
+                  stagedCount: 0,
+                  unstagedCount: 0,
+                  untrackedCount: 0,
+                },
+              },
+            },
+          ],
+        }),
+      ],
+      pinnedIds: new Set(),
+      worktreeLists: new Map(),
+      groupOrder: { repoKeys: [], worktreeKeysByRepo: {} },
+    });
+
+    expect(groups[0]?.worktrees.map((group) => group.label)).toEqual([
+      'Root',
+      'feature',
+    ]);
+    expect(groups[0]?.severity).toBe('warning');
+  });
+});

--- a/apps/browser/src/ui/screens/main/_lib/agent-list-model.ts
+++ b/apps/browser/src/ui/screens/main/_lib/agent-list-model.ts
@@ -156,6 +156,11 @@ export function mergeAgentEntries({
       return {
         ...a,
         title: a.title || h?.title || a.title,
+        // Live toolbox mounts win once present. While an agent is still
+        // (re)mounting its toolbox entry briefly reports zero mounts, so fall
+        // back to the persisted history mounts to avoid flicker. The history
+        // list is filtered to existing paths (and refetched after worktree
+        // deletions), so this fallback never resurrects a deleted workspace.
         mountedWorkspaces:
           a.mountedWorkspaces.length > 0
             ? a.mountedWorkspaces

--- a/apps/browser/src/ui/screens/main/_lib/agent-list-model.ts
+++ b/apps/browser/src/ui/screens/main/_lib/agent-list-model.ts
@@ -374,7 +374,19 @@ export function buildWorkspaceAgentGroups({
         const key = item.isMainWorktree
           ? 'root'
           : `worktree:${item.worktreeId}`;
-        if (repo.worktrees.some((group) => group.key === key)) return;
+        const existing = repo.worktrees.find((group) => group.key === key);
+        if (existing) {
+          // Worktree groups created from agent mounts carry the branch that was
+          // captured in Karton state at mount time, which goes stale when the
+          // branch is switched outside the app. The worktree list is refetched
+          // whenever the HEAD watcher bumps the repo revision, so it is the
+          // authoritative source for the *current* branch — overlay it onto the
+          // existing group so the label tracks external `git switch`es.
+          existing.branch = item.branch;
+          existing.label = formatWorktreeLabel(item);
+          existing.isRoot = item.isMainWorktree;
+          return;
+        }
         repo.worktrees.push({
           key,
           label: formatWorktreeLabel(item),

--- a/apps/browser/src/ui/screens/main/_lib/agent-list-model.ts
+++ b/apps/browser/src/ui/screens/main/_lib/agent-list-model.ts
@@ -1,4 +1,18 @@
-import type { AgentHistoryEntry } from '@shared/karton-contracts/ui/agent';
+import type {
+  AgentHistoryEntry,
+  AgentHistoryWorkspaceEntry,
+} from '@shared/karton-contracts/ui/agent';
+import type {
+  MountEntry,
+  WorkspaceGitWorktreeInfo,
+  WorkspaceGitWorktreesResult,
+} from '@shared/karton-contracts/ui';
+import { getBaseName, normalizePath } from '@shared/path-utils';
+
+export type AgentWorkspaceEntry = Pick<MountEntry, 'path' | 'git'> & {
+  permissions?: AgentHistoryWorkspaceEntry['permissions'];
+  prefix?: string;
+};
 
 export type ActiveAgentCardData = {
   id: string;
@@ -12,12 +26,46 @@ export type ActiveAgentCardData = {
   createdAt: number;
   messageCount: number;
   unread: boolean;
+  mountedWorkspaces: AgentWorkspaceEntry[];
 };
 
 /** Unified entry for the merged active + history list. */
 export type MergedAgentEntry = ActiveAgentCardData & {
   /** True when this agent is currently loaded in-memory (active instance). */
   isLive: boolean;
+};
+
+export type AgentStateSeverity = 'error' | 'warning' | 'success' | 'info';
+
+export type WorkspaceAgentRow = {
+  agent: MergedAgentEntry;
+  workspace: AgentWorkspaceEntry;
+};
+
+export type WorkspaceWorktreeGroup = {
+  key: string;
+  label: string;
+  path: string;
+  branch: string | null;
+  isRoot: boolean;
+  severity: AgentStateSeverity | null;
+  agents: WorkspaceAgentRow[];
+};
+
+export type WorkspaceRepoGroup = {
+  key: string;
+  label: string;
+  path: string;
+  git: AgentWorkspaceEntry['git'];
+  isGit: boolean;
+  severity: AgentStateSeverity | null;
+  directAgents: WorkspaceAgentRow[];
+  worktrees: WorkspaceWorktreeGroup[];
+};
+
+export type WorkspaceGroupOrder = {
+  repoKeys: string[];
+  worktreeKeysByRepo: Record<string, string[]>;
 };
 
 export function activeAgentCardsEqual(
@@ -39,9 +87,26 @@ export function activeAgentCardsEqual(
       ai.lastMessageAt !== bi.lastMessageAt ||
       ai.createdAt !== bi.createdAt ||
       ai.messageCount !== bi.messageCount ||
-      ai.unread !== bi.unread
+      ai.unread !== bi.unread ||
+      ai.mountedWorkspaces.length !== bi.mountedWorkspaces.length
     )
       return false;
+
+    for (let j = 0; j < ai.mountedWorkspaces.length; j++) {
+      const aw = ai.mountedWorkspaces[j]!;
+      const bw = bi.mountedWorkspaces[j]!;
+      if (
+        aw.path !== bw.path ||
+        aw.prefix !== bw.prefix ||
+        aw.git?.repositoryId !== bw.git?.repositoryId ||
+        aw.git?.worktreeId !== bw.git?.worktreeId ||
+        aw.git?.branch !== bw.git?.branch ||
+        aw.git?.headSha !== bw.git?.headSha ||
+        aw.git?.isWorktree !== bw.git?.isWorktree ||
+        aw.git?.mainWorktreePath !== bw.git?.mainWorktreePath
+      )
+        return false;
+    }
   }
   return true;
 }
@@ -74,6 +139,7 @@ export function mergeAgentEntries({
       lastMessageAt: new Date(e.lastMessageAt).getTime(),
       createdAt: new Date(e.createdAt).getTime(),
       messageCount: e.messageCount,
+      mountedWorkspaces: e.mountedWorkspaces ?? [],
       isLive: false,
     }));
 
@@ -90,6 +156,10 @@ export function mergeAgentEntries({
       return {
         ...a,
         title: a.title || h?.title || a.title,
+        mountedWorkspaces:
+          a.mountedWorkspaces.length > 0
+            ? a.mountedWorkspaces
+            : (h?.mountedWorkspaces ?? []),
         isLive: true,
         lastMessageAt:
           a.lastMessageAt > 0
@@ -116,4 +186,227 @@ export function sortAgentEntriesNewestFirst(
 
 export function getOrderedAgentIds(entries: MergedAgentEntry[]): string[] {
   return entries.map((agent) => agent.id);
+}
+
+export function getAgentStateSeverity(
+  agent: MergedAgentEntry,
+): AgentStateSeverity | null {
+  if (agent.hasError) return 'error';
+  if (agent.isWaitingForUser) return 'warning';
+  if (agent.unread) return 'success';
+  if (agent.isWorking) return 'info';
+  return null;
+}
+
+export function maxSeverity(
+  values: ReadonlyArray<AgentStateSeverity | null>,
+): AgentStateSeverity | null {
+  let best: AgentStateSeverity | null = null;
+  const priority: Record<AgentStateSeverity, number> = {
+    error: 4,
+    warning: 3,
+    success: 2,
+    info: 1,
+  };
+  values.forEach((value) => {
+    if (!value) return;
+    if (!best || priority[value] > priority[best]) best = value;
+  });
+  return best;
+}
+
+export function getSeverityDotClass(
+  severity: AgentStateSeverity | null,
+): string | null {
+  switch (severity) {
+    case 'error':
+      return 'bg-error-solid';
+    case 'warning':
+      return 'bg-warning-solid';
+    case 'success':
+      return 'bg-success-solid';
+    case 'info':
+      return 'bg-primary-solid';
+    default:
+      return null;
+  }
+}
+
+export function getWorkspaceGroupKey(workspace: AgentWorkspaceEntry): string {
+  return workspace.git
+    ? `git:${workspace.git.repositoryId}`
+    : `dir:${normalizePath(workspace.path)}`;
+}
+
+export function getWorktreeGroupKey(workspace: AgentWorkspaceEntry): string {
+  if (!workspace.git) return `dir:${normalizePath(workspace.path)}`;
+  if (!workspace.git.isWorktree) return 'root';
+  return `worktree:${workspace.git.worktreeId}`;
+}
+
+export function formatWorktreeLabel(
+  worktree:
+    | Pick<
+        WorkspaceGitWorktreeInfo,
+        'path' | 'branch' | 'headSha' | 'isMainWorktree'
+      >
+    | {
+        path: string;
+        branch: string | null;
+        headSha?: string | null;
+        isMainWorktree?: boolean;
+      },
+): string {
+  const pathName = worktree.isMainWorktree
+    ? 'Root'
+    : getBaseName(worktree.path) || worktree.path;
+  const ref = worktree.branch ?? worktree.headSha?.slice(0, 7) ?? null;
+  if (!ref || ref === pathName) return pathName;
+  return `${pathName} (${ref})`;
+}
+
+function getRepoLabel(workspace: AgentWorkspaceEntry): string {
+  if (!workspace.git) return getBaseName(workspace.path) || workspace.path;
+  const pathName = workspace.git.mainWorktreePath ?? workspace.git.repoRoot;
+  return getBaseName(pathName) || pathName;
+}
+
+function getRepoPath(workspace: AgentWorkspaceEntry): string {
+  return (
+    workspace.git?.mainWorktreePath ?? workspace.git?.repoRoot ?? workspace.path
+  );
+}
+
+function isStagewiseOwnedWorktreePath(worktreePath: string): boolean {
+  return normalizePath(worktreePath).includes('/.stagewise/worktrees/');
+}
+
+function orderByStableKeys<T extends { key: string }>(
+  values: T[],
+  orderedKeys: string[] | undefined,
+): T[] {
+  if (!orderedKeys || orderedKeys.length === 0) return values;
+  const byKey = new Map(values.map((value) => [value.key, value]));
+  const used = new Set<string>();
+  const ordered: T[] = [];
+  orderedKeys.forEach((key) => {
+    const value = byKey.get(key);
+    if (!value) return;
+    ordered.push(value);
+    used.add(key);
+  });
+  values.forEach((value) => {
+    if (!used.has(value.key)) ordered.push(value);
+  });
+  return ordered;
+}
+
+export function buildWorkspaceAgentGroups({
+  entries,
+  worktreeLists,
+  groupOrder,
+}: {
+  entries: MergedAgentEntry[];
+  pinnedIds: ReadonlySet<string>;
+  worktreeLists: ReadonlyMap<string, WorkspaceGitWorktreesResult | null>;
+  groupOrder: WorkspaceGroupOrder;
+}): WorkspaceRepoGroup[] {
+  const repoGroups = new Map<string, WorkspaceRepoGroup>();
+
+  for (const agent of entries) {
+    for (const workspace of agent.mountedWorkspaces) {
+      const repoKey = getWorkspaceGroupKey(workspace);
+      let repo = repoGroups.get(repoKey);
+      if (!repo) {
+        repo = {
+          key: repoKey,
+          label: getRepoLabel(workspace),
+          path: getRepoPath(workspace),
+          git: workspace.git,
+          isGit: workspace.git !== null,
+          severity: null,
+          directAgents: [],
+          worktrees: [],
+        };
+        repoGroups.set(repoKey, repo);
+      }
+
+      const row = { agent, workspace };
+      if (!workspace.git) {
+        repo.directAgents.push(row);
+        continue;
+      }
+
+      const worktreeKey = getWorktreeGroupKey(workspace);
+      let worktree = repo.worktrees.find((group) => group.key === worktreeKey);
+      if (!worktree) {
+        worktree = {
+          key: worktreeKey,
+          label: formatWorktreeLabel({
+            path: workspace.path,
+            branch: workspace.git.branch,
+            headSha: workspace.git.headSha,
+            isMainWorktree: !workspace.git.isWorktree,
+          }),
+          path: workspace.path,
+          branch: workspace.git.branch,
+          isRoot: !workspace.git.isWorktree,
+          severity: null,
+          agents: [],
+        };
+        repo.worktrees.push(worktree);
+      }
+      worktree.agents.push(row);
+    }
+  }
+
+  Array.from(repoGroups.values()).forEach((repo) => {
+    const worktreeList = repo.git
+      ? worktreeLists.get(repo.git.repositoryId)
+      : undefined;
+    if (worktreeList) {
+      worktreeList.worktrees.forEach((item) => {
+        const key = item.isMainWorktree
+          ? 'root'
+          : `worktree:${item.worktreeId}`;
+        if (repo.worktrees.some((group) => group.key === key)) return;
+        repo.worktrees.push({
+          key,
+          label: formatWorktreeLabel(item),
+          path: item.path,
+          branch: item.branch,
+          isRoot: item.isMainWorktree,
+          severity: null,
+          agents: [],
+        });
+      });
+    }
+
+    repo.worktrees = orderByStableKeys<WorkspaceWorktreeGroup>(
+      repo.worktrees,
+      groupOrder.worktreeKeysByRepo[repo.key],
+    ).sort((a, b) => {
+      if (a.isRoot !== b.isRoot) return Number(b.isRoot) - Number(a.isRoot);
+      const aStagewise = isStagewiseOwnedWorktreePath(a.path);
+      const bStagewise = isStagewiseOwnedWorktreePath(b.path);
+      return Number(bStagewise) - Number(aStagewise);
+    });
+
+    repo.worktrees.forEach((worktree) => {
+      worktree.severity = maxSeverity(
+        worktree.agents.map((row) => getAgentStateSeverity(row.agent)),
+      );
+    });
+
+    repo.severity = maxSeverity(
+      repo.directAgents
+        .map((row) => getAgentStateSeverity(row.agent))
+        .concat(repo.worktrees.map((worktree) => worktree.severity)),
+    );
+  });
+
+  return orderByStableKeys(
+    Array.from(repoGroups.values()),
+    groupOrder.repoKeys,
+  );
 }

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/panel-footer.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/panel-footer.tsx
@@ -35,6 +35,7 @@ import {
 } from './chat-input';
 import {
   WorkspaceSelect,
+  applyMountedWorkspaceActionDefault,
   createDefaultWorkspaceActionConfig,
   executeWorkspaceGitAction,
   type WorkspaceActionConfig,
@@ -1542,8 +1543,7 @@ export const ChatPanelFooter = memo(function ChatPanelFooter() {
         const gitRef = formatWorkspaceGitRef(mount.git);
         const sourceBranchItems = getBranchSelectItems(gitRef);
         const worktreeItems = getWorktreeSelectItems();
-        next.set(
-          mount.prefix,
+        const baseConfig = applyMountedWorkspaceActionDefault(
           applyWorkspaceGitActionPreferences(
             createDefaultWorkspaceActionConfig(
               sourceBranchItems,
@@ -1554,7 +1554,9 @@ export const ChatPanelFooter = memo(function ChatPanelFooter() {
             workspaceGitActionPreferences.general,
             workspaceGitActionPreferences.repositories[mount.git.repositoryId],
           ),
+          mount,
         );
+        next.set(mount.prefix, baseConfig);
         changed = true;
       }
 

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/workspace-select.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/workspace-select.tsx
@@ -1248,6 +1248,27 @@ export type WorkspaceActionPayload =
       targetBranch: string;
     };
 
+export function applyMountedWorkspaceActionDefault(
+  config: WorkspaceActionConfig,
+  mount: MountEntry,
+): WorkspaceActionConfig {
+  if (!mount.git) return config;
+
+  if (mount.git.isWorktree) {
+    return {
+      ...config,
+      selectedAction: 'switch-worktree',
+      switchWorktreeTarget: mount.path,
+    };
+  }
+
+  return {
+    ...config,
+    selectedAction: 'create-worktree',
+    ...(mount.git.branch ? { createWorktreeFrom: mount.git.branch } : {}),
+  };
+}
+
 export function toWorkspaceActionPayload(
   config: WorkspaceActionConfig,
 ): WorkspaceActionPayload {
@@ -1821,18 +1842,21 @@ const WorkspaceActionSelect = memo(function WorkspaceActionSelect({
 
   const [open, setOpen] = useState(false);
   const [localConfig, setLocalConfig] = useState(() =>
-    applyWorkspaceGitActionPreferences(
-      createDefaultWorkspaceActionConfig(
+    applyMountedWorkspaceActionDefault(
+      applyWorkspaceGitActionPreferences(
+        createDefaultWorkspaceActionConfig(
+          sourceBranchItems,
+          worktreeItems,
+          checkoutBranchItems,
+          defaultBranch,
+          checkoutDefaultBranch,
+        ),
         sourceBranchItems,
         worktreeItems,
-        checkoutBranchItems,
-        defaultBranch,
-        checkoutDefaultBranch,
+        generalWorkspaceGitActionPreference,
+        repositoryWorkspaceGitActionPreference,
       ),
-      sourceBranchItems,
-      worktreeItems,
-      generalWorkspaceGitActionPreference,
-      repositoryWorkspaceGitActionPreference,
+      mount,
     ),
   );
   const config = controlledConfig ?? localConfig;
@@ -1860,18 +1884,21 @@ const WorkspaceActionSelect = memo(function WorkspaceActionSelect({
   useEffect(() => {
     if (!gitDataLoaded) return;
 
-    const defaults = applyWorkspaceGitActionPreferences(
-      createDefaultWorkspaceActionConfig(
+    const defaults = applyMountedWorkspaceActionDefault(
+      applyWorkspaceGitActionPreferences(
+        createDefaultWorkspaceActionConfig(
+          sourceBranchItems,
+          worktreeItems,
+          checkoutBranchItems,
+          defaultBranch,
+          checkoutDefaultBranch,
+        ),
         sourceBranchItems,
         worktreeItems,
-        checkoutBranchItems,
-        defaultBranch,
-        checkoutDefaultBranch,
+        generalWorkspaceGitActionPreference,
+        repositoryWorkspaceGitActionPreference,
       ),
-      sourceBranchItems,
-      worktreeItems,
-      generalWorkspaceGitActionPreference,
-      repositoryWorkspaceGitActionPreference,
+      mount,
     );
     const previousCurrentBranchDefault = getCurrentBranchValue(null, gitRef);
     const previousDefaultBranchDefault = getDefaultBranchValue(null, gitRef);

--- a/apps/browser/src/ui/screens/main/command-center/sources/use-agent-command-items.ts
+++ b/apps/browser/src/ui/screens/main/command-center/sources/use-agent-command-items.ts
@@ -182,6 +182,7 @@ export function useAgentCommandItems(
                 ? new Date(history[0].metadata.createdAt).getTime()
                 : 0,
               messageCount: history.length,
+              mountedWorkspaces: s.toolbox[id]?.workspace?.mounts ?? [],
             };
           }),
       activeAgentCardsEqual,

--- a/apps/browser/src/ui/screens/main/sidebar/agents-list/_components/agent-card.tsx
+++ b/apps/browser/src/ui/screens/main/sidebar/agents-list/_components/agent-card.tsx
@@ -63,7 +63,7 @@ export function AgentCardSkeleton() {
     <div
       className={cn(
         buttonVariants({ variant: 'ghost', size: 'sm' }),
-        'justify-start pl-1.5 text-muted-foreground hover:bg-base-500/10',
+        'justify-start pr-3.5 pl-2 text-muted-foreground hover:bg-base-500/10',
       )}
     >
       <div className="h-4 w-2/5 animate-pulse rounded bg-surface-3" />
@@ -148,7 +148,7 @@ export const AgentCard = memo(
         }}
         className={cn(
           buttonVariants({ variant: 'ghost', size: 'sm' }),
-          'group/card relative justify-start pl-1.5 text-start text-muted-foreground hover:bg-foreground/8',
+          'group/card relative justify-start gap-1 pr-3.5 pl-2 text-start text-muted-foreground hover:bg-foreground/8',
           isPreviewActive && !isActive && 'bg-foreground/8 text-foreground',
           isActive && 'bg-foreground/5 text-foreground',
         )}

--- a/apps/browser/src/ui/screens/main/sidebar/agents-list/index.tsx
+++ b/apps/browser/src/ui/screens/main/sidebar/agents-list/index.tsx
@@ -729,6 +729,12 @@ export function AgentsList() {
       (s) => s.preferences.sidebar.collapsedWorkspaceGroupKeys,
     ),
   );
+  // Per-repository revision counters bumped by the backend when a worktree is
+  // added/removed externally (e.g. `git worktree add/remove` in a terminal).
+  // Folded into the worktree-fetch signature below so the cached list refreshes.
+  const gitWorktreeRevisions = useKartonState(
+    useComparingSelector((s) => s.gitWorktreeRevisions),
+  );
 
   const [, emptyAgentIdRef] = useEmptyAgentId();
 
@@ -983,6 +989,13 @@ export function AgentsList() {
         console.error('Failed to delete worktree:', result.message);
         return;
       }
+      // Invalidate the cached git worktree lists so the fetch effect reloads
+      // them. The agent-mount signature only changes for worktrees that had
+      // agents; deleting an empty worktree leaves the signature untouched, so
+      // without an explicit reset the removed worktree would linger in the
+      // sidebar until the component remounts.
+      worktreeRefreshKeyByRepoRef.current.clear();
+      setWorktreeListsByRepo(new Map());
       if (deleteAgents && agentIds.length > 0) {
         await Promise.allSettled(agentIds.map((id) => deleteAgent(id)));
       }
@@ -1558,6 +1571,11 @@ export function AgentsList() {
     ReadonlyMap<string, string | null>
   >(new Map());
   const loadingWorktreeReposRef = useRef<Set<string>>(new Set());
+  // Per-repo signature of the worktrees its agents currently mount. Lets the
+  // worktree-list fetch effect detect when worktrees were created/removed
+  // while the sidebar stayed mounted, so the cached git list can be refreshed
+  // instead of staying frozen for the component's lifetime.
+  const worktreeRefreshKeyByRepoRef = useRef<Map<string, string>>(new Map());
   const loadingRemoteRepositoryReposRef = useRef<Set<string>>(new Set());
   const workspaceGroupOrderRef = useRef<WorkspaceGroupOrder>({
     repoKeys: workspaceGroupOrder,
@@ -1665,17 +1683,52 @@ export function AgentsList() {
   useEffect(() => {
     if (agentListGroupingMode !== 'workspace') return;
 
+    // Collect the worktree ids each repo's agents currently mount. When this
+    // set changes (a worktree was created and mounted, or an agent's mount was
+    // detached after a worktree deletion) the cached git worktree list is
+    // stale and must be refetched. Derived purely from agent mounts so it does
+    // not depend on — and therefore can't loop with — the cache itself.
+    const agentWorktreeIdsByRepo = new Map<string, Set<string>>();
+    for (const agent of filteredWorkspaceAgents) {
+      for (const ws of agent.mountedWorkspaces) {
+        if (!ws.git) continue;
+        let set = agentWorktreeIdsByRepo.get(ws.git.repositoryId);
+        if (!set) {
+          set = new Set<string>();
+          agentWorktreeIdsByRepo.set(ws.git.repositoryId, set);
+        }
+        set.add(ws.git.worktreeId);
+      }
+    }
+
     for (const group of workspaceGroups) {
       if (!group.git) continue;
-      if (worktreeListsByRepo.has(group.git.repositoryId)) continue;
-      if (loadingWorktreeReposRef.current.has(group.git.repositoryId)) continue;
+      const repoId = group.git.repositoryId;
+      if (loadingWorktreeReposRef.current.has(repoId)) continue;
 
-      loadingWorktreeReposRef.current.add(group.git.repositoryId);
+      // Combine the agent-mount worktree set with the backend's external-change
+      // revision. The revision catches worktrees added/removed outside the app
+      // (terminal git commands) that leave the agent-mount set unchanged.
+      const externalRevision = gitWorktreeRevisions[repoId] ?? 0;
+      const signature = `${externalRevision}::${Array.from(
+        agentWorktreeIdsByRepo.get(repoId) ?? [],
+      )
+        .sort()
+        .join('|')}`;
+      const hasCache = worktreeListsByRepo.has(repoId);
+      const signatureChanged =
+        worktreeRefreshKeyByRepoRef.current.get(repoId) !== signature;
+
+      // Already have a fresh list and nothing changed — skip.
+      if (hasCache && !signatureChanged) continue;
+
+      worktreeRefreshKeyByRepoRef.current.set(repoId, signature);
+      loadingWorktreeReposRef.current.add(repoId);
       listGitWorktreesByPath(group.path)
         .then((result) => {
           setWorktreeListsByRepo((current) => {
             const next = new Map(current);
-            next.set(group.git!.repositoryId, result);
+            next.set(repoId, result);
             return next;
           });
         })
@@ -1683,16 +1736,18 @@ export function AgentsList() {
           console.error('Failed to fetch workspace worktrees:', err);
           setWorktreeListsByRepo((current) => {
             const next = new Map(current);
-            next.set(group.git!.repositoryId, null);
+            next.set(repoId, null);
             return next;
           });
         })
         .finally(() => {
-          loadingWorktreeReposRef.current.delete(group.git!.repositoryId);
+          loadingWorktreeReposRef.current.delete(repoId);
         });
     }
   }, [
     agentListGroupingMode,
+    filteredWorkspaceAgents,
+    gitWorktreeRevisions,
     listGitWorktreesByPath,
     workspaceGroups,
     worktreeListsByRepo,

--- a/apps/browser/src/ui/screens/main/sidebar/agents-list/index.tsx
+++ b/apps/browser/src/ui/screens/main/sidebar/agents-list/index.tsx
@@ -6,6 +6,7 @@ import {
   useState,
   type CSSProperties,
   type PointerEvent as ReactPointerEvent,
+  type ReactNode,
 } from 'react';
 import { enablePatches, type Patch } from 'immer';
 import {
@@ -45,9 +46,16 @@ import { AgentTypes } from '@shared/karton-contracts/ui/agent';
 import type { AgentHistoryEntry } from '@shared/karton-contracts/ui/agent';
 import {
   activeAgentCardsEqual,
+  buildWorkspaceAgentGroups,
+  getAgentStateSeverity,
+  getSeverityDotClass,
+  maxSeverity,
   mergeAgentEntries,
   type ActiveAgentCardData,
   type MergedAgentEntry,
+  type WorkspaceGroupOrder,
+  type WorkspaceRepoGroup,
+  type WorkspaceWorktreeGroup,
 } from '../../_lib/agent-list-model';
 import {
   AGENT_TITLE_RENAMED_EVENT,
@@ -59,16 +67,45 @@ import {
   dispatchAgentDeleted,
   isAgentDeletedEvent,
 } from '../../_lib/agent-deleted-event';
-import { EMPTY_MOUNTS } from '@shared/karton-contracts/ui';
-import type { ToolApprovalMode } from '@shared/karton-contracts/ui/shared-types';
+import {
+  EMPTY_MOUNTS,
+  type WorkspaceGitWorktreeDeletionInfo,
+  type WorkspaceGitWorktreesResult,
+} from '@shared/karton-contracts/ui';
+import type {
+  AgentListGroupingMode,
+  ToolApprovalMode,
+} from '@shared/karton-contracts/ui/shared-types';
 import { Button } from '@stagewise/stage-ui/components/button';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@stagewise/stage-ui/components/tooltip';
+import {
+  Menu,
+  MenuContent,
+  MenuItem,
+  MenuTrigger,
+} from '@stagewise/stage-ui/components/menu';
 import {
   OverlayScrollbar,
   type OverlayScrollbarRef,
 } from '@stagewise/stage-ui/components/overlay-scrollbar';
 import {
-  IconPenPlusOutline18,
+  IconBranchOutOutline18,
+  IconCheckOutline18,
+  IconChevronDownOutline18,
+  IconCodeBranchOutline18,
+  IconCodeCommitOutline18,
+  IconFolderCloudOutline18,
+  IconFolderOpenOutline18,
+  IconFolderOutline18,
   IconMagnifierOutline18,
+  IconPenPlusOutline18,
+  IconSquareDashedOutline18,
+  IconTrashOutline18,
+  IconTriangleWarningOutline18,
 } from 'nucleo-ui-outline-18';
 import { extractTipTapText, firstWords } from '@ui/utils/text-utils';
 import { cn } from '@ui/utils';
@@ -86,6 +123,8 @@ import { DeleteConfirmPopover } from '../../_components/delete-confirm-popover';
 import { usePendingRemovals } from '@ui/hooks/use-pending-agent-removals';
 import { useScrollFadeMask } from '@ui/hooks/use-scroll-fade-mask';
 import { useCommandCenter } from '../../command-center';
+import { IDE_SELECTION_ITEMS } from '@shared/ide-url';
+import { getBaseName } from '@shared/path-utils';
 
 enablePatches();
 
@@ -182,6 +221,30 @@ function deriveActivityText(
 const DEFAULT_VISIBLE = 10;
 const SHOW_MORE_INCREMENT = 20;
 const INITIAL_HISTORY_FETCH = DEFAULT_VISIBLE + SHOW_MORE_INCREMENT; // 30
+const DEFAULT_VISIBLE_WORKTREES_PER_REPO = 6;
+const SHOW_MORE_WORKTREES_INCREMENT = 10;
+const NO_WORKSPACE_GROUP_KEY = '__no-workspace__';
+
+function getRemoteRepositoryOpenLabel(url: string | null | undefined): string {
+  if (!url) return 'Open remote repository';
+
+  try {
+    const host = new URL(url).hostname.toLowerCase();
+    if (host === 'github.com' || host.endsWith('.github.com')) {
+      return 'Open in GitHub';
+    }
+    if (host === 'gitlab.com' || host.endsWith('.gitlab.com')) {
+      return 'Open in GitLab';
+    }
+    if (host === 'bitbucket.org' || host.endsWith('.bitbucket.org')) {
+      return 'Open in Bitbucket';
+    }
+  } catch {
+    return 'Open remote repository';
+  }
+
+  return 'Open remote repository';
+}
 
 // ============================================================================
 // Time grouping
@@ -238,7 +301,7 @@ function insertGroupHeaders(agents: MergedAgentEntry[]): GroupedItem[] {
 }
 
 // ============================================================================
-// Sortable pinned rows
+// Sortable rows
 // ============================================================================
 
 function isPinnedDragBlockedTarget(target: EventTarget | null): boolean {
@@ -270,6 +333,46 @@ class PinnedPointerSensor extends PointerSensor {
       },
     },
   ];
+}
+
+function SortableWorkspaceGroup({
+  repo,
+  children,
+}: {
+  repo: WorkspaceRepoGroup;
+  children: ReactNode;
+}) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({
+    id: repo.key,
+  });
+
+  const style: CSSProperties = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0 : 1,
+  };
+
+  return (
+    <div
+      ref={setNodeRef}
+      className={cn(
+        'flex flex-col gap-px',
+        isDragging && '[&_*]:!cursor-grabbing',
+      )}
+      style={style}
+      {...attributes}
+      {...listeners}
+    >
+      {children}
+    </div>
+  );
 }
 
 function SortablePinnedAgentCard({
@@ -342,6 +445,237 @@ function SortablePinnedAgentCard({
   );
 }
 
+function AggregateStatusDot({
+  className,
+  dotClassName,
+}: {
+  className?: string;
+  dotClassName: string | null;
+}) {
+  if (!dotClassName) return null;
+  return (
+    <div
+      className={cn(
+        'relative flex size-3 shrink-0 items-center justify-center dark:brightness-125',
+        className,
+      )}
+    >
+      <div className={cn('relative size-1.5 shrink-0', dotClassName)}>
+        <div className={cn('size-full rounded-full', dotClassName)} />
+        <div
+          className={cn(
+            'absolute inset-0 size-full animate-ping rounded-full',
+            dotClassName,
+          )}
+        />
+      </div>
+    </div>
+  );
+}
+
+function WorkspaceGroupHeader({
+  label,
+  depth,
+  collapsed,
+  dotClassName,
+  hasContent,
+  collapsible = hasContent,
+  idleIcon: IdleIcon,
+  onToggle,
+  onOpenInFileManager,
+  onOpenRemoteRepository,
+  openRemoteRepositoryLabel,
+  openInFileManagerIcon: OpenInFileManagerIcon = IconFolderOpenOutline18,
+  onDeleteWorktree,
+  onCreateAgent,
+  hideActions = false,
+}: {
+  label: string;
+  depth: 0 | 1;
+  collapsed: boolean;
+  dotClassName: string | null;
+  hasContent: boolean;
+  collapsible?: boolean;
+  idleIcon: typeof IconFolderOutline18 | null;
+  onToggle: () => void;
+  onOpenInFileManager?: () => void;
+  onOpenRemoteRepository?: () => void;
+  openRemoteRepositoryLabel?: string;
+  openInFileManagerIcon?: typeof IconFolderOutline18;
+  onDeleteWorktree?: (anchorPoint: { x: number; y: number }) => void;
+  onCreateAgent?: () => void;
+  hideActions?: boolean;
+}) {
+  const openInFileManagerLabel = `Open in ${IDE_SELECTION_ITEMS.other}`;
+  const remoteRepositoryLabel =
+    openRemoteRepositoryLabel ?? 'Open remote repository';
+
+  return (
+    <div
+      className={cn(
+        'group/workspace-header flex shrink-0 items-center gap-1 py-1 pr-1 text-muted-foreground text-xs',
+        depth === 0 ? 'pt-5 pl-1 font-medium' : 'pt-2 pl-2.5 font-medium',
+      )}
+    >
+      <button
+        type="button"
+        className={cn(
+          'flex min-w-0 flex-1 items-center gap-1.5 rounded-sm text-left',
+          collapsible && 'hover:text-foreground',
+        )}
+        disabled={!collapsible}
+        onClick={collapsible ? onToggle : undefined}
+      >
+        {(IdleIcon || collapsible) && (
+          <span className="relative size-3 shrink-0">
+            {IdleIcon && (
+              <IdleIcon
+                className={cn(
+                  'absolute inset-0 size-3 transition-opacity duration-150 ease-out',
+                  collapsible && 'group-hover/workspace-header:opacity-0',
+                )}
+              />
+            )}
+            {collapsible && (
+              <IconChevronDownOutline18
+                className={cn(
+                  'absolute inset-0 size-3 opacity-0 transition-[opacity,transform] duration-300 ease-out group-hover/workspace-header:opacity-100',
+                  collapsed && '-rotate-90',
+                )}
+              />
+            )}
+          </span>
+        )}
+        <AggregateStatusDot
+          dotClassName={collapsible && collapsed ? dotClassName : null}
+        />
+        <span className="truncate">{label}</span>
+      </button>
+      {!hideActions && onOpenRemoteRepository && (
+        <Tooltip>
+          <TooltipTrigger>
+            <Button
+              variant="ghost"
+              size="icon-2xs"
+              aria-label={remoteRepositoryLabel}
+              className="size-5 shrink-0 opacity-0 transition-opacity group-hover/workspace-header:opacity-100"
+              onClick={(event) => {
+                event.stopPropagation();
+                onOpenRemoteRepository();
+              }}
+            >
+              <IconFolderCloudOutline18 className="size-3.5" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>{remoteRepositoryLabel}</TooltipContent>
+        </Tooltip>
+      )}
+      {!hideActions && onOpenInFileManager && (
+        <Tooltip>
+          <TooltipTrigger>
+            <Button
+              variant="ghost"
+              size="icon-2xs"
+              aria-label={openInFileManagerLabel}
+              className="size-5 shrink-0 opacity-0 transition-opacity group-hover/workspace-header:opacity-100"
+              onClick={(event) => {
+                event.stopPropagation();
+                onOpenInFileManager();
+              }}
+            >
+              <OpenInFileManagerIcon className="size-3.5" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>{openInFileManagerLabel}</TooltipContent>
+        </Tooltip>
+      )}
+      {!hideActions && onDeleteWorktree && (
+        <Tooltip>
+          <TooltipTrigger>
+            <Button
+              variant="ghost"
+              size="icon-2xs"
+              aria-label="Delete worktree"
+              className="size-5 shrink-0 opacity-0 transition-opacity group-hover/workspace-header:opacity-100"
+              onClick={(event) => {
+                event.stopPropagation();
+                const rect = event.currentTarget.getBoundingClientRect();
+                onDeleteWorktree({
+                  x: rect.left + rect.width / 2,
+                  y: rect.top + rect.height / 2,
+                });
+              }}
+            >
+              <IconTrashOutline18 className="size-3.5" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>Delete worktree</TooltipContent>
+        </Tooltip>
+      )}
+      {!hideActions && onCreateAgent && (
+        <Button
+          variant="ghost"
+          size="icon-2xs"
+          aria-label={`New agent for ${label}`}
+          className="size-5 shrink-0 opacity-0 transition-opacity group-hover/workspace-header:opacity-100"
+          onClick={(event) => {
+            event.stopPropagation();
+            onCreateAgent();
+          }}
+        >
+          <IconPenPlusOutline18 className="size-3.5" />
+        </Button>
+      )}
+    </div>
+  );
+}
+
+function AgentListGroupingToggle({
+  mode,
+  onModeChange,
+}: {
+  mode: AgentListGroupingMode;
+  onModeChange: (mode: AgentListGroupingMode) => void;
+}) {
+  const label = mode === 'workspace' ? 'Group by Workspace' : 'Group by Age';
+  const options = [
+    { value: 'age', label: 'Age' },
+    { value: 'workspace', label: 'Workspace' },
+  ] as const;
+
+  return (
+    <Menu>
+      <MenuTrigger>
+        <button
+          type="button"
+          className="flex h-5 shrink-0 items-center gap-1 rounded-md px-1 text-muted-foreground text-xs transition-colors hover:bg-foreground/8 hover:text-foreground"
+          aria-label="Change agent grouping mode"
+        >
+          <span>{label}</span>
+          <IconChevronDownOutline18 className="size-3 shrink-0" />
+        </button>
+      </MenuTrigger>
+      <MenuContent side="bottom" align="end" sideOffset={2} size="xs">
+        {options.map((option) => (
+          <MenuItem
+            key={option.value}
+            size="xs"
+            onClick={() => onModeChange(option.value)}
+          >
+            <IconCheckOutline18
+              className={cn(
+                'size-3 shrink-0',
+                mode !== option.value && 'opacity-0',
+              )}
+            />
+            {option.label}
+          </MenuItem>
+        ))}
+      </MenuContent>
+    </Menu>
+  );
+}
+
 // ============================================================================
 // AgentsList
 // ============================================================================
@@ -363,12 +697,36 @@ export function AgentsList() {
   const getAgentHistoryEntriesByIds = useKartonProcedure(
     (p) => p.agents.getAgentHistoryEntriesByIds,
   );
+  const listGitWorktreesByPath = useKartonProcedure(
+    (p) => p.toolbox.listGitWorktreesByPath,
+  );
+  const getGitRepositoryRemoteUrlByPath = useKartonProcedure(
+    (p) => p.toolbox.getGitRepositoryRemoteUrlByPath,
+  );
+  const getGitWorktreeDeletionInfo = useKartonProcedure(
+    (p) => p.toolbox.getGitWorktreeDeletionInfo,
+  );
+  const deleteGitWorktreeByPath = useKartonProcedure(
+    (p) => p.toolbox.deleteGitWorktreeByPath,
+  );
   const getAgentHistoryEntriesByIdsRef = useRef(getAgentHistoryEntriesByIds);
   getAgentHistoryEntriesByIdsRef.current = getAgentHistoryEntriesByIds;
   const updatePreferences = useKartonProcedure((p) => p.preferences.update);
+  const openExternalUrl = useKartonProcedure((p) => p.openExternalUrl);
   const { open: openCommandCenter } = useCommandCenter();
   const pinnedAgentIds = useKartonState(
     useComparingSelector((s) => s.preferences.sidebar.pinnedAgentIds),
+  );
+  const agentListGroupingMode = useKartonState(
+    (s) => s.preferences.sidebar.agentListGroupingMode,
+  );
+  const workspaceGroupOrder = useKartonState(
+    useComparingSelector((s) => s.preferences.sidebar.workspaceGroupOrder),
+  );
+  const collapsedWorkspaceGroupKeys = useKartonState(
+    useComparingSelector(
+      (s) => s.preferences.sidebar.collapsedWorkspaceGroupKeys,
+    ),
   );
 
   const [, emptyAgentIdRef] = useEmptyAgentId();
@@ -467,6 +825,7 @@ export function AgentsList() {
                 ? new Date(agent.state.history[0].metadata.createdAt).getTime()
                 : 0,
               messageCount: history.length,
+              mountedWorkspaces: s.toolbox[id]?.workspace?.mounts ?? [],
             };
           }),
       activeAgentCardsEqual,
@@ -522,6 +881,121 @@ export function AgentsList() {
       void setLastOpenAgentId(id);
     });
   }, [agents.length, createAgent, emptyAgentIdRef, setOpenAgent, track]);
+
+  const pendingScrollToCreatedAgentRef = useRef<string | null>(null);
+
+  const handleOpenWorkspaceInFileManager = useCallback(
+    (workspacePath: string) => {
+      window.open(
+        `stagewise://reveal-file/${encodeURIComponent(workspacePath)}`,
+        '_blank',
+      );
+    },
+    [],
+  );
+
+  const handleOpenRemoteRepository = useCallback(
+    (workspacePath: string) => {
+      void getGitRepositoryRemoteUrlByPath(workspacePath)
+        .then((url) => {
+          if (url) void openExternalUrl(url);
+        })
+        .catch((err) => {
+          console.error('Failed to open remote repository:', err);
+        });
+    },
+    [getGitRepositoryRemoteUrlByPath, openExternalUrl],
+  );
+
+  const [worktreeDelete, setWorktreeDelete] = useState<{
+    path: string;
+    label: string;
+    info: WorkspaceGitWorktreeDeletionInfo | null;
+    loading: boolean;
+    error: string | null;
+    anchorPoint: { x: number; y: number };
+  } | null>(null);
+
+  const handleDeleteWorktree = useCallback(
+    (
+      worktreePath: string,
+      label: string,
+      anchorPoint: { x: number; y: number },
+    ) => {
+      setWorktreeDelete({
+        path: worktreePath,
+        label,
+        info: null,
+        loading: true,
+        error: null,
+        anchorPoint,
+      });
+      void getGitWorktreeDeletionInfo(worktreePath)
+        .then((info) => {
+          setWorktreeDelete((current) =>
+            current?.path === worktreePath
+              ? { ...current, info, loading: false }
+              : current,
+          );
+        })
+        .catch((err) => {
+          setWorktreeDelete((current) =>
+            current?.path === worktreePath
+              ? {
+                  ...current,
+                  loading: false,
+                  error:
+                    err instanceof Error
+                      ? err.message
+                      : 'Failed to inspect worktree.',
+                }
+              : current,
+          );
+        });
+    },
+    [getGitWorktreeDeletionInfo],
+  );
+
+  const handleWorktreeDeleteConfirm = useCallback(() => {
+    const target = worktreeDelete;
+    if (!target?.info || target.info.isMainWorktree) return;
+
+    setWorktreeDelete(null);
+    void deleteGitWorktreeByPath(target.info.path, {
+      force: target.info.hasUncommittedChanges,
+    }).then((result) => {
+      if (!result.ok) {
+        console.error('Failed to delete worktree:', result.message);
+      }
+    });
+  }, [deleteGitWorktreeByPath, worktreeDelete]);
+
+  const handleCreateAgentForWorkspace = useCallback(
+    (workspacePath: string) => {
+      void track('chat-new-agent-clicked', {
+        source: 'sidebar-workspace-group',
+      });
+      agentCountAtCreateRef.current = agents.length;
+      setPendingCreate(true);
+      window.dispatchEvent(new Event('sidebar-chat-panel-opened'));
+      const currentModelId = openAgentModelIdRef.current ?? undefined;
+      const currentToolApprovalMode =
+        openAgentToolApprovalModeRef.current ?? undefined;
+      void createAgent(
+        undefined,
+        currentModelId,
+        currentToolApprovalMode,
+        [workspacePath],
+        true,
+      ).then((id) => {
+        pendingScrollToCreatedAgentRef.current = id;
+        setOpenAgent(id);
+        setPendingCreate(false);
+        void setLastOpenAgentId(id);
+      });
+    },
+    [agents.length, createAgent, setLastOpenAgentId, setOpenAgent, track],
+  );
 
   // Cmd/Ctrl+N: create (or focus an existing empty) agent from the keyboard.
   // Mirrors the click handler on the "new agent" button.
@@ -841,6 +1315,40 @@ export function AgentsList() {
     };
   }, [historyPinnedAgentIdsKey]);
 
+  const handleGroupingModeChange = useCallback(
+    (mode: AgentListGroupingMode) => {
+      if (mode === agentListGroupingMode) return;
+      const patches: Patch[] = [
+        {
+          op: 'replace',
+          path: ['sidebar', 'agentListGroupingMode'],
+          value: mode,
+        },
+      ];
+      void updatePreferences(patches).catch((err) => {
+        console.error('Failed to update sidebar grouping mode:', err);
+      });
+    },
+    [agentListGroupingMode, updatePreferences],
+  );
+
+  const handleReorderWorkspaceGroups = useCallback(
+    (repoKeys: string[]) => {
+      if (stringArraysEqual(repoKeys, workspaceGroupOrder)) return;
+      const patches: Patch[] = [
+        {
+          op: 'replace',
+          path: ['sidebar', 'workspaceGroupOrder'],
+          value: repoKeys,
+        },
+      ];
+      void updatePreferences(patches).catch((err) => {
+        console.error('Failed to update sidebar workspace order:', err);
+      });
+    },
+    [updatePreferences, workspaceGroupOrder],
+  );
+
   // =========================================================================
   // Search
   // =========================================================================
@@ -899,6 +1407,15 @@ export function AgentsList() {
   ]);
 
   const dndSensors = useSensors(
+    useSensor(PinnedPointerSensor, {
+      activationConstraint: { distance: 6 },
+    }),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    }),
+  );
+
+  const workspaceDndSensors = useSensors(
     useSensor(PinnedPointerSensor, {
       activationConstraint: { distance: 6 },
     }),
@@ -991,6 +1508,270 @@ export function AgentsList() {
 
   const hasMoreToShow = effectiveVisible < filteredUnpinnedAgents.length;
 
+  const collapsedWorkspaceGroups = useMemo(
+    () => new Set(collapsedWorkspaceGroupKeys),
+    [collapsedWorkspaceGroupKeys],
+  );
+  const [visibleWorktreeCountsByRepo, setVisibleWorktreeCountsByRepo] =
+    useState<Record<string, number>>({});
+  const [worktreeListsByRepo, setWorktreeListsByRepo] = useState<
+    ReadonlyMap<string, WorkspaceGitWorktreesResult | null>
+  >(new Map());
+  const [remoteRepositoryUrlsByRepo, setRemoteRepositoryUrlsByRepo] = useState<
+    ReadonlyMap<string, string | null>
+  >(new Map());
+  const loadingWorktreeReposRef = useRef<Set<string>>(new Set());
+  const loadingRemoteRepositoryReposRef = useRef<Set<string>>(new Set());
+  const workspaceGroupOrderRef = useRef<WorkspaceGroupOrder>({
+    repoKeys: workspaceGroupOrder,
+    worktreeKeysByRepo: {},
+  });
+  const prevWorkspaceGroupKeysRef = useRef<Set<string>>(new Set());
+
+  const filteredWorkspaceAgents = useMemo(() => {
+    const q = searchQuery.trim().toLowerCase();
+    return allAgents.filter(
+      (agent) => !q || agent.title.toLowerCase().includes(q),
+    );
+  }, [allAgents, searchQuery]);
+
+  const visibleNoWorkspaceAgents = useMemo(
+    () =>
+      filteredWorkspaceAgents.filter(
+        (agent) => agent.mountedWorkspaces.length === 0,
+      ),
+    [filteredWorkspaceAgents],
+  );
+
+  const workspaceGroups = useMemo(() => {
+    const nextGroups = buildWorkspaceAgentGroups({
+      entries: filteredWorkspaceAgents,
+      pinnedIds: pinnedAgentIdSet,
+      worktreeLists: worktreeListsByRepo,
+      groupOrder: workspaceGroupOrderRef.current,
+    });
+    const order = workspaceGroupOrderRef.current;
+    order.repoKeys = workspaceGroupOrder;
+    const nextKeys = new Set(nextGroups.map((group) => group.key));
+    const newRepoKeys: string[] = [];
+
+    for (const group of nextGroups) {
+      if (!order.repoKeys.includes(group.key)) {
+        newRepoKeys.push(group.key);
+      }
+      const worktreeOrder = order.worktreeKeysByRepo[group.key] ?? [];
+      for (const worktree of group.worktrees) {
+        if (!worktreeOrder.includes(worktree.key)) {
+          if (worktree.isRoot) worktreeOrder.unshift(worktree.key);
+          else worktreeOrder.push(worktree.key);
+        }
+      }
+      order.worktreeKeysByRepo[group.key] = Array.from(new Set(worktreeOrder));
+    }
+
+    order.repoKeys = [
+      ...newRepoKeys,
+      ...order.repoKeys.filter((key) => nextKeys.has(key)),
+    ];
+    prevWorkspaceGroupKeysRef.current = nextKeys;
+
+    return buildWorkspaceAgentGroups({
+      entries: filteredWorkspaceAgents,
+      pinnedIds: pinnedAgentIdSet,
+      worktreeLists: worktreeListsByRepo,
+      groupOrder: order,
+    });
+  }, [
+    filteredWorkspaceAgents,
+    pinnedAgentIdSet,
+    workspaceGroupOrder,
+    worktreeListsByRepo,
+  ]);
+
+  const [activeWorkspaceDragKey, setActiveWorkspaceDragKey] = useState<
+    string | null
+  >(null);
+
+  const activeWorkspaceDragRepo = useMemo(
+    () =>
+      activeWorkspaceDragKey
+        ? (workspaceGroups.find(
+            (repo) => repo.key === activeWorkspaceDragKey,
+          ) ?? null)
+        : null,
+    [activeWorkspaceDragKey, workspaceGroups],
+  );
+
+  const handleWorkspaceDragStart = useCallback(({ active }: DragStartEvent) => {
+    setActiveWorkspaceDragKey(String(active.id));
+  }, []);
+
+  const handleWorkspaceDragEnd = useCallback(
+    ({ active, over }: DragEndEvent) => {
+      setActiveWorkspaceDragKey(null);
+      if (!over || active.id === over.id) return;
+
+      const repoKeys = workspaceGroups.map((repo) => repo.key);
+      const oldIndex = repoKeys.indexOf(String(active.id));
+      const newIndex = repoKeys.indexOf(String(over.id));
+      if (oldIndex === -1 || newIndex === -1) return;
+
+      handleReorderWorkspaceGroups(arrayMove(repoKeys, oldIndex, newIndex));
+    },
+    [handleReorderWorkspaceGroups, workspaceGroups],
+  );
+
+  const handleWorkspaceDragCancel = useCallback(() => {
+    setActiveWorkspaceDragKey(null);
+  }, []);
+
+  useEffect(() => {
+    if (agentListGroupingMode !== 'workspace') return;
+
+    for (const group of workspaceGroups) {
+      if (!group.git) continue;
+      if (worktreeListsByRepo.has(group.git.repositoryId)) continue;
+      if (loadingWorktreeReposRef.current.has(group.git.repositoryId)) continue;
+
+      loadingWorktreeReposRef.current.add(group.git.repositoryId);
+      listGitWorktreesByPath(group.path)
+        .then((result) => {
+          setWorktreeListsByRepo((current) => {
+            const next = new Map(current);
+            next.set(group.git!.repositoryId, result);
+            return next;
+          });
+        })
+        .catch((err) => {
+          console.error('Failed to fetch workspace worktrees:', err);
+          setWorktreeListsByRepo((current) => {
+            const next = new Map(current);
+            next.set(group.git!.repositoryId, null);
+            return next;
+          });
+        })
+        .finally(() => {
+          loadingWorktreeReposRef.current.delete(group.git!.repositoryId);
+        });
+    }
+  }, [
+    agentListGroupingMode,
+    listGitWorktreesByPath,
+    workspaceGroups,
+    worktreeListsByRepo,
+  ]);
+
+  useEffect(() => {
+    if (agentListGroupingMode !== 'workspace') return;
+
+    for (const group of workspaceGroups) {
+      if (!group.git) continue;
+      if (remoteRepositoryUrlsByRepo.has(group.git.repositoryId)) continue;
+      if (loadingRemoteRepositoryReposRef.current.has(group.git.repositoryId)) {
+        continue;
+      }
+
+      loadingRemoteRepositoryReposRef.current.add(group.git.repositoryId);
+      getGitRepositoryRemoteUrlByPath(group.path)
+        .then((url) => {
+          setRemoteRepositoryUrlsByRepo((current) => {
+            const next = new Map(current);
+            next.set(group.git!.repositoryId, url);
+            return next;
+          });
+        })
+        .catch((err) => {
+          console.error('Failed to fetch remote repository URL:', err);
+          setRemoteRepositoryUrlsByRepo((current) => {
+            const next = new Map(current);
+            next.set(group.git!.repositoryId, null);
+            return next;
+          });
+        })
+        .finally(() => {
+          loadingRemoteRepositoryReposRef.current.delete(
+            group.git!.repositoryId,
+          );
+        });
+    }
+  }, [
+    agentListGroupingMode,
+    getGitRepositoryRemoteUrlByPath,
+    remoteRepositoryUrlsByRepo,
+    workspaceGroups,
+  ]);
+
+  const findWorkspaceGroupKeysForAgent = useCallback(
+    (agentId: string): string[] => {
+      if (visibleNoWorkspaceAgents.some((agent) => agent.id === agentId)) {
+        return [NO_WORKSPACE_GROUP_KEY];
+      }
+
+      for (const repo of workspaceGroups) {
+        if (repo.directAgents.some((row) => row.agent.id === agentId)) {
+          return [repo.key];
+        }
+
+        const worktree = repo.worktrees.find((group) =>
+          group.agents.some((row) => row.agent.id === agentId),
+        );
+        if (worktree) return [repo.key, `${repo.key}:${worktree.key}`];
+      }
+
+      return [];
+    },
+    [visibleNoWorkspaceAgents, workspaceGroups],
+  );
+
+  const updateCollapsedWorkspaceGroupKeys = useCallback(
+    (keys: string[]) => {
+      const nextKeys = keys.filter(
+        (key, index, values) => values.indexOf(key) === index,
+      );
+      if (stringArraysEqual(nextKeys, collapsedWorkspaceGroupKeys)) return;
+
+      const patches: Patch[] = [
+        {
+          op: 'replace',
+          path: ['sidebar', 'collapsedWorkspaceGroupKeys'],
+          value: nextKeys,
+        },
+      ];
+      void updatePreferences(patches).catch((err) => {
+        console.error('Failed to update collapsed workspace groups:', err);
+      });
+    },
+    [collapsedWorkspaceGroupKeys, updatePreferences],
+  );
+
+  const toggleWorkspaceGroupCollapsed = useCallback(
+    (key: string) => {
+      const next = new Set(collapsedWorkspaceGroups);
+      if (next.has(key)) {
+        next.delete(key);
+        setVisibleWorktreeCountsByRepo((counts) => {
+          if (counts[key] === undefined) return counts;
+          const nextCounts = { ...counts };
+          delete nextCounts[key];
+          return nextCounts;
+        });
+      } else {
+        next.add(key);
+      }
+      updateCollapsedWorkspaceGroupKeys(Array.from(next));
+    },
+    [collapsedWorkspaceGroups, updateCollapsedWorkspaceGroupKeys],
+  );
+
+  const handleShowMoreWorktrees = useCallback((repoKey: string) => {
+    setVisibleWorktreeCountsByRepo((current) => ({
+      ...current,
+      [repoKey]:
+        (current[repoKey] ?? DEFAULT_VISIBLE_WORKTREES_PER_REPO) +
+        SHOW_MORE_WORKTREES_INCREMENT,
+    }));
+  }, []);
+
   const handleShowMore = useCallback(() => {
     setVisibleCount((c) => {
       const next = c + SHOW_MORE_INCREMENT;
@@ -1051,10 +1832,57 @@ export function AgentsList() {
     }
   }, []);
 
-  // Scroll to the active card when the user switches agents.
+  // Expand containing groups and scroll when the shown agent instance changes.
+  const lastRevealedOpenAgentRef = useRef<string | null>(null);
   useEffect(() => {
-    if (openAgent) scrollCardIntoView(openAgent);
-  }, [openAgent, scrollCardIntoView]);
+    if (!openAgent) {
+      lastRevealedOpenAgentRef.current = null;
+      return;
+    }
+    if (lastRevealedOpenAgentRef.current === openAgent) return;
+
+    const unpinnedIndex = filteredUnpinnedAgents.findIndex(
+      (agent) => agent.id === openAgent,
+    );
+    if (unpinnedIndex >= effectiveVisible) {
+      setVisibleCount(unpinnedIndex + 1);
+      return;
+    }
+
+    const keysToExpand =
+      agentListGroupingMode === 'workspace'
+        ? findWorkspaceGroupKeysForAgent(openAgent)
+        : [];
+    if (keysToExpand.length > 0) {
+      const next = new Set(collapsedWorkspaceGroups);
+      let changed = false;
+      for (const key of keysToExpand) {
+        if (next.delete(key)) changed = true;
+      }
+      if (changed) updateCollapsedWorkspaceGroupKeys(Array.from(next));
+    }
+
+    lastRevealedOpenAgentRef.current = openAgent;
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => scrollCardIntoView(openAgent));
+    });
+  }, [
+    agentListGroupingMode,
+    effectiveVisible,
+    collapsedWorkspaceGroups,
+    filteredUnpinnedAgents,
+    findWorkspaceGroupKeysForAgent,
+    openAgent,
+    scrollCardIntoView,
+    updateCollapsedWorkspaceGroupKeys,
+  ]);
+
+  useEffect(() => {
+    const agentId = pendingScrollToCreatedAgentRef.current;
+    if (!agentId) return;
+    pendingScrollToCreatedAgentRef.current = null;
+    requestAnimationFrame(() => scrollCardIntoView(agentId));
+  }, [workspaceGroups, scrollCardIntoView]);
 
   // During Ctrl+Tab cycling, keep the preview-highlighted card visible without
   // committing the chat-panel switch.
@@ -1114,6 +1942,256 @@ export function AgentsList() {
     setCtxDelete(null);
     if (id && !isAgentWorking(id)) handleDelete(id);
   }, [ctxDelete, handleDelete, isAgentWorking]);
+
+  const renderAgentCard = useCallback(
+    (agent: MergedAgentEntry, key: string) => {
+      const isOpen = agent.id === openAgent;
+      const isPreviewOpen = agent.id === previewAgentId;
+      const hasUnseen = !isOpen && agent.unread;
+
+      return (
+        <AgentCardWithPreview
+          key={key}
+          id={agent.id}
+          title={agent.title}
+          isActive={isOpen}
+          isPreviewActive={isPreviewOpen}
+          isWorking={agent.isWorking}
+          isWaitingForUser={agent.isWaitingForUser}
+          hasError={agent.hasError}
+          hasUnseen={hasUnseen}
+          activityText={agent.activityText}
+          activityIsUserInput={agent.activityIsUserInput}
+          lastMessageAt={agent.lastMessageAt}
+          contextMenuState={ctxMenuState}
+          onClick={handleClick}
+          onRename={handleRename}
+          isPinned={false}
+          onTogglePinned={handleTogglePinned}
+          cache={previewCacheRef.current}
+          isLiveAgent={agent.isLive}
+        />
+      );
+    },
+    [
+      ctxMenuState,
+      handleClick,
+      handleRename,
+      handleTogglePinned,
+      openAgent,
+      previewAgentId,
+    ],
+  );
+
+  const renderNoWorkspaceSection = useCallback(() => {
+    if (visibleNoWorkspaceAgents.length === 0) return null;
+
+    const collapsed = collapsedWorkspaceGroups.has(NO_WORKSPACE_GROUP_KEY);
+    const containsOpenAgent = visibleNoWorkspaceAgents.some(
+      (agent) => agent.id === openAgent,
+    );
+    const severity = maxSeverity(
+      visibleNoWorkspaceAgents.map((agent) => getAgentStateSeverity(agent)),
+    );
+
+    return (
+      <div className="contents">
+        <WorkspaceGroupHeader
+          label="No workspace"
+          depth={0}
+          collapsed={collapsed}
+          dotClassName={getSeverityDotClass(severity)}
+          hasContent={visibleNoWorkspaceAgents.length > 0}
+          collapsible={!containsOpenAgent}
+          idleIcon={IconSquareDashedOutline18}
+          onToggle={() => toggleWorkspaceGroupCollapsed(NO_WORKSPACE_GROUP_KEY)}
+          onOpenInFileManager={() => undefined}
+          hideActions
+        />
+        {!collapsed &&
+          visibleNoWorkspaceAgents.map((agent) =>
+            renderAgentCard(agent, `no-workspace:${agent.id}`),
+          )}
+      </div>
+    );
+  }, [
+    collapsedWorkspaceGroups,
+    openAgent,
+    renderAgentCard,
+    toggleWorkspaceGroupCollapsed,
+    visibleNoWorkspaceAgents,
+  ]);
+
+  const renderWorktreeGroup = useCallback(
+    (repo: WorkspaceRepoGroup, worktree: WorkspaceWorktreeGroup) => {
+      const key = `${repo.key}:${worktree.key}`;
+      const collapsed = collapsedWorkspaceGroups.has(key);
+      const containsOpenAgent = worktree.agents.some(
+        (row) => row.agent.id === openAgent,
+      );
+
+      return (
+        <div key={key} className="contents">
+          <WorkspaceGroupHeader
+            label={worktree.label}
+            depth={1}
+            collapsed={collapsed}
+            dotClassName={getSeverityDotClass(worktree.severity)}
+            hasContent={worktree.agents.length > 0}
+            collapsible={worktree.agents.length > 0 && !containsOpenAgent}
+            idleIcon={
+              worktree.isRoot ? IconCodeCommitOutline18 : IconBranchOutOutline18
+            }
+            onToggle={() => toggleWorkspaceGroupCollapsed(key)}
+            onOpenInFileManager={() =>
+              handleOpenWorkspaceInFileManager(worktree.path)
+            }
+            openInFileManagerIcon={
+              worktree.isRoot ? IconFolderOutline18 : undefined
+            }
+            onDeleteWorktree={
+              worktree.isRoot
+                ? undefined
+                : (anchorPoint) =>
+                    handleDeleteWorktree(
+                      worktree.path,
+                      worktree.label,
+                      anchorPoint,
+                    )
+            }
+            onCreateAgent={() => handleCreateAgentForWorkspace(worktree.path)}
+          />
+          {!collapsed &&
+            worktree.agents.map((row, index) =>
+              renderAgentCard(
+                row.agent,
+                `${repo.key}:${worktree.key}:${row.agent.id}:${index}`,
+              ),
+            )}
+        </div>
+      );
+    },
+    [
+      collapsedWorkspaceGroups,
+      handleCreateAgentForWorkspace,
+      handleDeleteWorktree,
+      handleOpenWorkspaceInFileManager,
+      openAgent,
+      renderAgentCard,
+      toggleWorkspaceGroupCollapsed,
+    ],
+  );
+
+  const renderWorkspaceGroup = useCallback(
+    (repo: WorkspaceRepoGroup, sortable = false) => {
+      const collapsed = collapsedWorkspaceGroups.has(repo.key);
+      const hasContent =
+        repo.directAgents.length > 0 ||
+        repo.worktrees.some((worktree) => worktree.agents.length > 0);
+      const containsOpenAgent =
+        repo.directAgents.some((row) => row.agent.id === openAgent) ||
+        repo.worktrees.some((worktree) =>
+          worktree.agents.some((row) => row.agent.id === openAgent),
+        );
+      const content = (
+        <>
+          <WorkspaceGroupHeader
+            label={repo.label}
+            depth={0}
+            collapsed={collapsed}
+            dotClassName={getSeverityDotClass(repo.severity)}
+            hasContent={hasContent}
+            collapsible={!containsOpenAgent}
+            idleIcon={
+              repo.isGit ? IconCodeBranchOutline18 : IconFolderOutline18
+            }
+            onToggle={() => toggleWorkspaceGroupCollapsed(repo.key)}
+            onOpenInFileManager={() =>
+              handleOpenWorkspaceInFileManager(repo.path)
+            }
+            onOpenRemoteRepository={
+              repo.isGit
+                ? () => handleOpenRemoteRepository(repo.path)
+                : undefined
+            }
+            openRemoteRepositoryLabel={
+              repo.git
+                ? getRemoteRepositoryOpenLabel(
+                    remoteRepositoryUrlsByRepo.get(repo.git.repositoryId),
+                  )
+                : undefined
+            }
+            openInFileManagerIcon={IconFolderOutline18}
+            onCreateAgent={() => handleCreateAgentForWorkspace(repo.path)}
+          />
+          {!collapsed &&
+            repo.directAgents.map((row, index) =>
+              renderAgentCard(
+                row.agent,
+                `${repo.key}:${row.agent.id}:${index}`,
+              ),
+            )}
+          {!collapsed &&
+            (() => {
+              const visibleWorktreeCount =
+                visibleWorktreeCountsByRepo[repo.key] ??
+                DEFAULT_VISIBLE_WORKTREES_PER_REPO;
+              const visibleWorktrees = repo.worktrees.filter(
+                (worktree, index) =>
+                  index < visibleWorktreeCount || worktree.agents.length > 0,
+              );
+              const hiddenWorktreeCount =
+                repo.worktrees.length - visibleWorktrees.length;
+
+              return (
+                <>
+                  {visibleWorktrees.map((worktree) =>
+                    renderWorktreeGroup(repo, worktree),
+                  )}
+                  {hiddenWorktreeCount > 0 && (
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="mt-1 ml-1 h-6 w-[calc(100%-0.25rem)] justify-start px-1.5 text-muted-foreground text-xs hover:bg-foreground/8"
+                      onClick={() => handleShowMoreWorktrees(repo.key)}
+                    >
+                      Show more worktrees...
+                    </Button>
+                  )}
+                </>
+              );
+            })()}
+        </>
+      );
+
+      if (!sortable) {
+        return (
+          <div key={repo.key} className="contents">
+            {content}
+          </div>
+        );
+      }
+
+      return (
+        <SortableWorkspaceGroup key={repo.key} repo={repo}>
+          {content}
+        </SortableWorkspaceGroup>
+      );
+    },
+    [
+      collapsedWorkspaceGroups,
+      handleCreateAgentForWorkspace,
+      handleOpenRemoteRepository,
+      handleOpenWorkspaceInFileManager,
+      handleShowMoreWorktrees,
+      openAgent,
+      renderAgentCard,
+      remoteRepositoryUrlsByRepo,
+      renderWorktreeGroup,
+      toggleWorkspaceGroupCollapsed,
+      visibleWorktreeCountsByRepo,
+    ],
+  );
 
   // =========================================================================
   // Render
@@ -1178,120 +2256,131 @@ export function AgentsList() {
         style={maskStyle}
         onViewportRef={setScrollViewport}
       >
+        <div className="flex shrink-0 items-center pt-0 pr-0 pb-1 pl-1.5">
+          <div className="min-w-0 flex-1 truncate font-medium text-muted-foreground text-xs">
+            {filteredPinnedAgents.length > 0 ? 'Pinned' : 'Agents'}
+          </div>
+          <AgentListGroupingToggle
+            mode={agentListGroupingMode}
+            onModeChange={handleGroupingModeChange}
+          />
+        </div>
+
         {filteredPinnedAgents.length > 0 && (
+          <DndContext
+            sensors={dndSensors}
+            collisionDetection={closestCenter}
+            modifiers={[
+              restrictToVerticalAxis,
+              restrictToFirstScrollableAncestor,
+            ]}
+            onDragStart={handlePinnedDragStart}
+            onDragEnd={handlePinnedDragEnd}
+            onDragCancel={handlePinnedDragCancel}
+          >
+            <SortableContext
+              items={filteredPinnedAgents.map((agent) => agent.id)}
+              strategy={verticalListSortingStrategy}
+            >
+              {filteredPinnedAgents.map((agent) => {
+                const isOpen = agent.id === openAgent;
+                const isPreviewOpen = agent.id === previewAgentId;
+                const hasUnseen = !isOpen && agent.unread;
+
+                return (
+                  <SortablePinnedAgentCard
+                    key={agent.id}
+                    agent={agent}
+                    isOpen={isOpen}
+                    isPreviewOpen={isPreviewOpen}
+                    hasUnseen={hasUnseen}
+                    contextMenuState={ctxMenuState}
+                    onClick={handleClick}
+                    onRename={handleRename}
+                    onTogglePinned={handleTogglePinned}
+                    cache={previewCacheRef.current}
+                  />
+                );
+              })}
+            </SortableContext>
+            <DragOverlay dropAnimation={null}>
+              {activePinnedDragAgent ? (
+                <div className="[&_*]:!cursor-grabbing shadow-elevation-1">
+                  <AgentCard
+                    id={activePinnedDragAgent.id}
+                    title={activePinnedDragAgent.title}
+                    isActive={activePinnedDragAgent.id === openAgent}
+                    isWorking={activePinnedDragAgent.isWorking}
+                    isWaitingForUser={activePinnedDragAgent.isWaitingForUser}
+                    hasError={activePinnedDragAgent.hasError}
+                    hasUnseen={
+                      activePinnedDragAgent.id !== openAgent &&
+                      activePinnedDragAgent.unread
+                    }
+                    activityText={activePinnedDragAgent.activityText}
+                    activityIsUserInput={
+                      activePinnedDragAgent.activityIsUserInput
+                    }
+                    lastMessageAt={activePinnedDragAgent.lastMessageAt}
+                    contextMenuState={ctxMenuState}
+                    onClick={handleClick}
+                    onRename={handleRename}
+                    isPinned
+                    onTogglePinned={handleTogglePinned}
+                  />
+                </div>
+              ) : null}
+            </DragOverlay>
+          </DndContext>
+        )}
+
+        {agentListGroupingMode === 'workspace' ? (
           <>
-            <div className="shrink-0 px-1.5 pt-0 pb-1 font-semibold text-subtle-foreground text-xs">
-              Pinned
-            </div>
+            {renderNoWorkspaceSection()}
             <DndContext
-              sensors={dndSensors}
+              sensors={workspaceDndSensors}
               collisionDetection={closestCenter}
               modifiers={[
                 restrictToVerticalAxis,
                 restrictToFirstScrollableAncestor,
               ]}
-              onDragStart={handlePinnedDragStart}
-              onDragEnd={handlePinnedDragEnd}
-              onDragCancel={handlePinnedDragCancel}
+              onDragStart={handleWorkspaceDragStart}
+              onDragEnd={handleWorkspaceDragEnd}
+              onDragCancel={handleWorkspaceDragCancel}
             >
               <SortableContext
-                items={filteredPinnedAgents.map((agent) => agent.id)}
+                items={workspaceGroups.map((repo) => repo.key)}
                 strategy={verticalListSortingStrategy}
               >
-                {filteredPinnedAgents.map((agent) => {
-                  const isOpen = agent.id === openAgent;
-                  const isPreviewOpen = agent.id === previewAgentId;
-                  const hasUnseen = !isOpen && agent.unread;
-
-                  return (
-                    <SortablePinnedAgentCard
-                      key={agent.id}
-                      agent={agent}
-                      isOpen={isOpen}
-                      isPreviewOpen={isPreviewOpen}
-                      hasUnseen={hasUnseen}
-                      contextMenuState={ctxMenuState}
-                      onClick={handleClick}
-                      onRename={handleRename}
-                      onTogglePinned={handleTogglePinned}
-                      cache={previewCacheRef.current}
-                    />
-                  );
-                })}
+                {workspaceGroups.map((repo) =>
+                  renderWorkspaceGroup(repo, true),
+                )}
               </SortableContext>
               <DragOverlay dropAnimation={null}>
-                {activePinnedDragAgent ? (
-                  <div className="[&_*]:!cursor-grabbing shadow-elevation-1">
-                    <AgentCard
-                      id={activePinnedDragAgent.id}
-                      title={activePinnedDragAgent.title}
-                      isActive={activePinnedDragAgent.id === openAgent}
-                      isWorking={activePinnedDragAgent.isWorking}
-                      isWaitingForUser={activePinnedDragAgent.isWaitingForUser}
-                      hasError={activePinnedDragAgent.hasError}
-                      hasUnseen={
-                        activePinnedDragAgent.id !== openAgent &&
-                        activePinnedDragAgent.unread
-                      }
-                      activityText={activePinnedDragAgent.activityText}
-                      activityIsUserInput={
-                        activePinnedDragAgent.activityIsUserInput
-                      }
-                      lastMessageAt={activePinnedDragAgent.lastMessageAt}
-                      contextMenuState={ctxMenuState}
-                      onClick={handleClick}
-                      onRename={handleRename}
-                      isPinned
-                      onTogglePinned={handleTogglePinned}
-                    />
+                {activeWorkspaceDragRepo ? (
+                  <div className="[&_*]:!cursor-grabbing rounded-lg bg-foreground/5">
+                    {renderWorkspaceGroup(activeWorkspaceDragRepo)}
                   </div>
                 ) : null}
               </DragOverlay>
             </DndContext>
           </>
+        ) : (
+          groupedItems.map((item) => {
+            if (item.type === 'header') {
+              return (
+                <div
+                  key={`h-${item.label}`}
+                  className="shrink-0 px-1.5 pt-3 pb-1 font-medium text-muted-foreground text-xs"
+                >
+                  {item.label}
+                </div>
+              );
+            }
+
+            return renderAgentCard(item.agent, item.agent.id);
+          })
         )}
-
-        {groupedItems.map((item) => {
-          if (item.type === 'header') {
-            return (
-              <div
-                key={`h-${item.label}`}
-                className="shrink-0 px-1.5 pt-3 pb-1 font-semibold text-subtle-foreground text-xs"
-              >
-                {item.label}
-              </div>
-            );
-          }
-
-          const agent = item.agent;
-          const isOpen = agent.id === openAgent;
-          const isPreviewOpen = agent.id === previewAgentId;
-          const hasUnseen = !isOpen && agent.unread;
-
-          return (
-            <AgentCardWithPreview
-              key={agent.id}
-              id={agent.id}
-              title={agent.title}
-              isActive={isOpen}
-              isPreviewActive={isPreviewOpen}
-              isWorking={agent.isWorking}
-              isWaitingForUser={agent.isWaitingForUser}
-              hasError={agent.hasError}
-              hasUnseen={hasUnseen}
-              activityText={agent.activityText}
-              activityIsUserInput={agent.activityIsUserInput}
-              lastMessageAt={agent.lastMessageAt}
-              contextMenuState={ctxMenuState}
-              onClick={handleClick}
-              onRename={handleRename}
-              isPinned={false}
-              onTogglePinned={handleTogglePinned}
-              cache={previewCacheRef.current}
-              isLiveAgent={agent.isLive}
-            />
-          );
-        })}
         {showCreateSkeleton && <AgentCardSkeleton />}
 
         {/* "Show more" button */}
@@ -1299,7 +2388,7 @@ export function AgentsList() {
           <Button
             variant="ghost"
             size="sm"
-            className="mt-1 w-full justify-start pl-1.5 text-sm text-subtle-foreground hover:bg-foreground/8"
+            className="mt-1 w-full justify-start pl-1.5 text-muted-foreground text-sm hover:bg-foreground/8"
             onClick={handleShowMore}
           >
             Show more...
@@ -1321,6 +2410,74 @@ export function AgentsList() {
         }}
         onConfirm={handleCtxDeleteConfirm}
       />
+      <DeleteConfirmPopover
+        open={worktreeDelete !== null}
+        isolated
+        anchorPoint={worktreeDelete?.anchorPoint}
+        title="Delete worktree?"
+        description={
+          worktreeDelete?.loading
+            ? 'Checking worktree status…'
+            : worktreeDelete?.info?.hasUncommittedChanges
+              ? 'This worktree has uncommitted changes. Deleting it will permanently discard those changes.'
+              : 'This will permanently delete this worktree from disk.'
+        }
+        confirmLabel={
+          worktreeDelete?.info?.hasUncommittedChanges
+            ? 'Delete anyway'
+            : 'Delete'
+        }
+        confirmVariant={
+          worktreeDelete?.info?.hasUncommittedChanges
+            ? 'destructive'
+            : 'primary'
+        }
+        confirmDisabled={
+          worktreeDelete?.loading ||
+          !worktreeDelete?.info ||
+          worktreeDelete.info.isMainWorktree
+        }
+        onOpenChange={(open) => {
+          if (!open) setWorktreeDelete(null);
+        }}
+        onConfirm={handleWorktreeDeleteConfirm}
+      >
+        <div className="mt-1 flex flex-col gap-1">
+          {worktreeDelete?.info?.hasUncommittedChanges && (
+            <div className="flex items-start gap-1.5 rounded-md bg-warning-background p-2 text-warning-foreground text-xs leading-snug ring-1 ring-warning-solid/30">
+              <IconTriangleWarningOutline18 className="mt-0.5 size-3.5 shrink-0" />
+              <span>
+                Uncommitted files in this worktree will be lost. This action
+                cannot be undone.
+              </span>
+            </div>
+          )}
+          {worktreeDelete?.error && (
+            <div className="text-error-foreground text-xs">
+              {worktreeDelete.error}
+            </div>
+          )}
+          {worktreeDelete && (
+            <div
+              className="flex flex-col gap-0.5 text-subtle-foreground text-xs"
+              title={worktreeDelete.info?.path ?? worktreeDelete.path}
+            >
+              <div className="min-w-0 truncate">
+                <span className="text-muted-foreground">Worktree: </span>
+                {getBaseName(
+                  worktreeDelete.info?.path ?? worktreeDelete.path,
+                ) || worktreeDelete.label}
+              </div>
+              <div className="min-w-0 truncate">
+                <span className="text-muted-foreground">
+                  Branch (will be kept):{' '}
+                </span>
+                {worktreeDelete.info?.branch ?? 'Detached'}
+              </div>
+            </div>
+          )}
+        </div>
+      </DeleteConfirmPopover>
     </div>
   );
 }

--- a/apps/browser/src/ui/screens/main/sidebar/agents-list/index.tsx
+++ b/apps/browser/src/ui/screens/main/sidebar/agents-list/index.tsx
@@ -972,16 +972,19 @@ export function AgentsList() {
 
     setWorktreeDelete(null);
     void (async () => {
-      // Optionally delete the agents that live in this worktree before
-      // removing it. Default keeps agents — the backend detaches the
-      // dead mount from any survivors automatically.
-      if (deleteAgents && agentIds.length > 0) {
-        await Promise.allSettled(agentIds.map((id) => deleteAgent(id)));
-      }
+      // Remove the worktree FIRST. Deleting agents is destructive and
+      // irreversible, so we only do it once git confirms the worktree is
+      // actually gone. If we deleted agents first and the worktree removal
+      // then failed (lock, fs error, race), we'd have permanently destroyed
+      // chat histories while the worktree still sat on disk. By default we
+      // keep agents — the backend detaches the dead mount from survivors.
       const result = await deleteGitWorktreeByPath(worktreePath, { force });
       if (!result.ok) {
         console.error('Failed to delete worktree:', result.message);
         return;
+      }
+      if (deleteAgents && agentIds.length > 0) {
+        await Promise.allSettled(agentIds.map((id) => deleteAgent(id)));
       }
       // Refetch history so surviving agents drop the now-deleted worktree from
       // their persisted mounts (getAgentsHistoryList filters missing paths).

--- a/apps/browser/src/ui/screens/main/sidebar/agents-list/index.tsx
+++ b/apps/browser/src/ui/screens/main/sidebar/agents-list/index.tsx
@@ -77,6 +77,7 @@ import type {
   ToolApprovalMode,
 } from '@shared/karton-contracts/ui/shared-types';
 import { Button } from '@stagewise/stage-ui/components/button';
+import { Checkbox } from '@stagewise/stage-ui/components/checkbox';
 import {
   Tooltip,
   TooltipContent,
@@ -914,6 +915,8 @@ export function AgentsList() {
     loading: boolean;
     error: string | null;
     anchorPoint: { x: number; y: number };
+    agentIds: string[];
+    deleteAgents: boolean;
   } | null>(null);
 
   const handleDeleteWorktree = useCallback(
@@ -921,6 +924,7 @@ export function AgentsList() {
       worktreePath: string,
       label: string,
       anchorPoint: { x: number; y: number },
+      agentIds: string[],
     ) => {
       setWorktreeDelete({
         path: worktreePath,
@@ -929,6 +933,8 @@ export function AgentsList() {
         loading: true,
         error: null,
         anchorPoint,
+        agentIds,
+        deleteAgents: false,
       });
       void getGitWorktreeDeletionInfo(worktreePath)
         .then((info) => {
@@ -960,15 +966,43 @@ export function AgentsList() {
     const target = worktreeDelete;
     if (!target?.info || target.info.isMainWorktree) return;
 
+    const { agentIds, deleteAgents } = target;
+    const worktreePath = target.info.path;
+    const force = target.info.hasUncommittedChanges;
+
     setWorktreeDelete(null);
-    void deleteGitWorktreeByPath(target.info.path, {
-      force: target.info.hasUncommittedChanges,
-    }).then((result) => {
+    void (async () => {
+      // Optionally delete the agents that live in this worktree before
+      // removing it. Default keeps agents — the backend detaches the
+      // dead mount from any survivors automatically.
+      if (deleteAgents && agentIds.length > 0) {
+        await Promise.allSettled(agentIds.map((id) => deleteAgent(id)));
+      }
+      const result = await deleteGitWorktreeByPath(worktreePath, { force });
       if (!result.ok) {
         console.error('Failed to delete worktree:', result.message);
+        return;
       }
-    });
-  }, [deleteGitWorktreeByPath, worktreeDelete]);
+      // Refetch history so surviving agents drop the now-deleted worktree from
+      // their persisted mounts (getAgentsHistoryList filters missing paths).
+      // Without this the stale mount lingers in the history fallback and the
+      // agent keeps showing under the deleted worktree group.
+      try {
+        const entries = await getAgentsHistoryList(0, fetchLimitRef.current);
+        setHistoryList(entries);
+      } catch (err) {
+        console.error(
+          'Failed to refetch agent history after worktree deletion:',
+          err,
+        );
+      }
+    })();
+  }, [
+    deleteAgent,
+    deleteGitWorktreeByPath,
+    getAgentsHistoryList,
+    worktreeDelete,
+  ]);
 
   const handleCreateAgentForWorkspace = useCallback(
     (workspacePath: string) => {
@@ -1986,10 +2020,15 @@ export function AgentsList() {
   const renderNoWorkspaceSection = useCallback(() => {
     if (visibleNoWorkspaceAgents.length === 0) return null;
 
-    const collapsed = collapsedWorkspaceGroups.has(NO_WORKSPACE_GROUP_KEY);
     const containsOpenAgent = visibleNoWorkspaceAgents.some(
       (agent) => agent.id === openAgent,
     );
+    // Force the section open whenever it holds the active agent — otherwise
+    // an agent that moves here (e.g. after its worktree is deleted) stays
+    // hidden behind a persisted-collapsed, non-collapsible header.
+    const collapsed =
+      collapsedWorkspaceGroups.has(NO_WORKSPACE_GROUP_KEY) &&
+      !containsOpenAgent;
     const severity = maxSeverity(
       visibleNoWorkspaceAgents.map((agent) => getAgentStateSeverity(agent)),
     );
@@ -2025,10 +2064,12 @@ export function AgentsList() {
   const renderWorktreeGroup = useCallback(
     (repo: WorkspaceRepoGroup, worktree: WorkspaceWorktreeGroup) => {
       const key = `${repo.key}:${worktree.key}`;
-      const collapsed = collapsedWorkspaceGroups.has(key);
       const containsOpenAgent = worktree.agents.some(
         (row) => row.agent.id === openAgent,
       );
+      // Force open when it holds the active agent so a non-collapsible
+      // header can never hide the currently open agent.
+      const collapsed = collapsedWorkspaceGroups.has(key) && !containsOpenAgent;
 
       return (
         <div key={key} className="contents">
@@ -2057,6 +2098,15 @@ export function AgentsList() {
                       worktree.path,
                       worktree.label,
                       anchorPoint,
+                      // Only agents that live *exclusively* in this worktree
+                      // are candidates for deletion. Agents also connected to
+                      // other workspaces must be preserved — the backend just
+                      // detaches the dead mount from them.
+                      worktree.agents
+                        .filter(
+                          (row) => row.agent.mountedWorkspaces.length <= 1,
+                        )
+                        .map((row) => row.agent.id),
                     )
             }
             onCreateAgent={() => handleCreateAgentForWorkspace(worktree.path)}
@@ -2084,7 +2134,6 @@ export function AgentsList() {
 
   const renderWorkspaceGroup = useCallback(
     (repo: WorkspaceRepoGroup, sortable = false) => {
-      const collapsed = collapsedWorkspaceGroups.has(repo.key);
       const hasContent =
         repo.directAgents.length > 0 ||
         repo.worktrees.some((worktree) => worktree.agents.length > 0);
@@ -2093,6 +2142,10 @@ export function AgentsList() {
         repo.worktrees.some((worktree) =>
           worktree.agents.some((row) => row.agent.id === openAgent),
         );
+      // Force open when it holds the active agent so a non-collapsible
+      // header can never hide the currently open agent.
+      const collapsed =
+        collapsedWorkspaceGroups.has(repo.key) && !containsOpenAgent;
       const content = (
         <>
           <WorkspaceGroupHeader
@@ -2475,6 +2528,33 @@ export function AgentsList() {
                 {worktreeDelete.info?.branch ?? 'Detached'}
               </div>
             </div>
+          )}
+          {worktreeDelete && worktreeDelete.agentIds.length > 0 && (
+            <button
+              type="button"
+              className="mt-1 flex w-full cursor-pointer items-center gap-2 text-left text-foreground text-xs"
+              onClick={() =>
+                setWorktreeDelete((current) =>
+                  current
+                    ? { ...current, deleteAgents: !current.deleteAgents }
+                    : current,
+                )
+              }
+            >
+              <Checkbox
+                size="xs"
+                tabIndex={-1}
+                className="pointer-events-none"
+                checked={worktreeDelete.deleteAgents}
+              />
+              <span>
+                Also delete{' '}
+                {worktreeDelete.agentIds.length === 1
+                  ? 'the 1 agent'
+                  : `all ${worktreeDelete.agentIds.length} agents`}{' '}
+                in this worktree
+              </span>
+            </button>
           )}
         </div>
       </DeleteConfirmPopover>

--- a/apps/browser/src/ui/screens/main/sidebar/agents-list/index.tsx
+++ b/apps/browser/src/ui/screens/main/sidebar/agents-list/index.tsx
@@ -1903,14 +1903,20 @@ export function AgentsList() {
     fadeDistance: 16,
   });
 
-  /** Scroll a card into the safe (non-masked) area of the scroll container. */
-  const scrollCardIntoView = useCallback((agentId: string) => {
+  /**
+   * Scroll a card into the safe (non-masked) area of the scroll container.
+   * The same agent can be rendered in multiple groups; `querySelector` returns
+   * the first instance in DOM (top-to-bottom) order, so we always reveal the
+   * topmost one. Returns `true` once a matching card exists in the DOM (whether
+   * or not a scroll was needed), `false` if it has not mounted yet.
+   */
+  const scrollCardIntoView = useCallback((agentId: string): boolean => {
     const container = scrollRef.current?.getViewport();
-    if (!container) return;
+    if (!container) return false;
     const card = container.querySelector<HTMLElement>(
       `[data-agent-id="${agentId}"]`,
     );
-    if (!card) return;
+    if (!card) return false;
 
     const fadeZone = 8;
     const cRect = container.getBoundingClientRect();
@@ -1922,6 +1928,7 @@ export function AgentsList() {
     ) {
       card.scrollIntoView({ block: 'center', behavior: 'smooth' });
     }
+    return true;
   }, []);
 
   // Expand containing groups and scroll when the shown agent instance changes.
@@ -1954,10 +1961,24 @@ export function AgentsList() {
       if (changed) updateCollapsedWorkspaceGroupKeys(Array.from(next));
     }
 
-    lastRevealedOpenAgentRef.current = openAgent;
-    requestAnimationFrame(() => {
-      requestAnimationFrame(() => scrollCardIntoView(openAgent));
+    // The card may mount a frame or two after groups expand and history data
+    // settles. Retry across a few frames and only mark the agent as revealed
+    // once its (first) card instance is actually in the DOM, so a missed early
+    // frame doesn't leave us permanently un-scrolled.
+    let cancelled = false;
+    let attempts = 0;
+    let raf = requestAnimationFrame(function tryReveal() {
+      if (cancelled) return;
+      if (scrollCardIntoView(openAgent)) {
+        lastRevealedOpenAgentRef.current = openAgent;
+        return;
+      }
+      if (attempts++ < 12) raf = requestAnimationFrame(tryReveal);
     });
+    return () => {
+      cancelled = true;
+      cancelAnimationFrame(raf);
+    };
   }, [
     agentListGroupingMode,
     effectiveVisible,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reworked the sidebar to group agents by workspace/worktrees with reorderable, collapsible groups that live‑update with Git changes. Added safer worktree deletion, normalized remote URLs, and richer agent history to power the UI.

- **New Features**
  - Workspace grouping: repos/worktrees with drag-to-reorder, collapse/expand, and “show more”; Age mode still available.
  - Live Git sync: watches worktree topology and HEAD; branch labels and groups update on external switches.
  - Status/UX: severity dots, search-aware groups, auto-expand active agent; multi-workspace agents appear in each group.
  - Quick actions: open repo in IDE, open remote (GitHub/GitLab/Bitbucket), create an agent for a workspace.
  - Worktree management: list and delete non-root worktrees with dirty-changes warning and optional force; action defaults pick “switch worktree” for worktree mounts, “create worktree” otherwise.
  - Agent history/API: entries include `mountedWorkspaces` with Git summary; `createAgent` supports `workspacePaths` with `preserveWorkspacePaths`; RPCs `toolbox.getGitRepositoryRemoteUrlByPath`, `toolbox.getGitWorktreeDeletionInfo`, `toolbox.deleteGitWorktreeByPath`.

- **Bug Fixes**
  - After deleting a worktree, surviving agents move to “No workspace”; closed agents drop stale mounts whose paths no longer exist.
  - Safer deletion flow: remove the Git worktree first, then delete agents; “Also delete agents” only removes agents that live exclusively in the deleted worktree, others are detached.
  - Sidebar now reliably scrolls to the active agent’s first card.

<sup>Written for commit 372e58dea37b320a7ab51b73d8a491d6d0699a2e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1234?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workspace-based grouping for agents with collapsible repo/worktree sections, drag-to-reorder, and per-repo pagination.
  * UI actions to view remote repository URLs and inspect/delete Git worktrees (with force/delete options).
  * Repository-URL resolution for workspaces (open remote in browser).

* **Improvements**
  * Agent history entries include Git summary metadata for mounted workspaces.
  * Workspace action defaults adapt to per-mount Git state (worktree vs non-worktree).
  * Git worktree change watching keeps repo revision state up to date.

* **Bug Fixes**
  * Agents no longer remount workspaces whose directories are missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->