### PR TITLE
fix(stagewise): fix rust lsp server

### DIFF
--- a/apps/browser/src/backend/services/toolbox/services/lsp/client.ts
+++ b/apps/browser/src/backend/services/toolbox/services/lsp/client.ts
@@ -140,6 +140,19 @@ export class LspClient extends EventEmitter {
     this.emit('diagnosticsReceived', filePath, version);
   }
 
+  /**
+   * Whether this client should use the pull-diagnostics model
+   * (`textDocument/diagnostic`). True only when the server advertises
+   * `diagnosticProvider` AND is not flagged push-only. Push-native servers
+   * such as rust-analyzer and clangd advertise pull support but deliver their
+   * authoritative diagnostics via push, so their pull endpoint must not be
+   * used (see `LspServerInfo.pushDiagnosticsOnly`).
+   */
+  private usesPullDiagnostics(): boolean {
+    if (this.serverInfo.pushDiagnosticsOnly) return false;
+    return !!(this.capabilities as Record<string, unknown>)?.diagnosticProvider;
+  }
+
   private readonly resolvedEnv: Record<string, string> | null;
 
   private constructor(
@@ -370,11 +383,7 @@ export class LspClient extends EventEmitter {
    * Called when server sends workspace/diagnostic/refresh notification.
    */
   private refreshAllDiagnostics(): void {
-    if (
-      !this.connection ||
-      this.disposed ||
-      !(this.capabilities as Record<string, unknown>)?.diagnosticProvider
-    ) {
+    if (!this.connection || this.disposed || !this.usesPullDiagnostics()) {
       return;
     }
 
@@ -508,7 +517,7 @@ export class LspClient extends EventEmitter {
     filePath: string,
     delays: number[],
   ): void {
-    if (!(this.capabilities as Record<string, unknown>)?.diagnosticProvider) {
+    if (!this.usesPullDiagnostics()) {
       return;
     }
     for (const delay of delays) {
@@ -614,8 +623,7 @@ export class LspClient extends EventEmitter {
       const params: DidOpenTextDocumentParams = { textDocument };
       await conn.sendNotification(DidOpenTextDocumentNotification.type, params);
 
-      const isPullServer = !!(this.capabilities as Record<string, unknown>)
-        ?.diagnosticProvider;
+      const isPullServer = this.usesPullDiagnostics();
 
       // Pull-model servers (e.g. ESLint with run: "onType") validate in
       // response to changes, not bare opens, so nudge them with a no-op change

--- a/apps/browser/src/backend/services/toolbox/services/lsp/servers/clangd.ts
+++ b/apps/browser/src/backend/services/toolbox/services/lsp/servers/clangd.ts
@@ -39,6 +39,11 @@ export const clangdServer: LspServerInfo = {
   name: 'clangd',
   extensions: CLANGD_EXTENSIONS,
 
+  // clangd publishes diagnostics via push on didOpen/didChange. It is
+  // push-native, so never route it through the pull path (which advances the
+  // document to a no-op second version and can resolve the wait early).
+  pushDiagnosticsOnly: true,
+
   async shouldActivate(projectRoot: string): Promise<boolean> {
     return hasFileInTree(projectRoot, CLANGD_MARKERS);
   },

--- a/apps/browser/src/backend/services/toolbox/services/lsp/servers/rust-analyzer.ts
+++ b/apps/browser/src/backend/services/toolbox/services/lsp/servers/rust-analyzer.ts
@@ -36,6 +36,13 @@ export const rustAnalyzerServer: LspServerInfo = {
   // arrives.
   diagnosticsTimeoutMs: 15_000,
 
+  // rust-analyzer advertises pull diagnostics (`diagnosticProvider`) but its
+  // pull endpoint only returns syntax diagnostics and always omits the
+  // `cargo check` (flycheck) results, which arrive exclusively via push. Using
+  // the pull path would resolve the diagnostics wait with an empty report
+  // before the real push lands, so force the push-only model.
+  pushDiagnosticsOnly: true,
+
   async shouldActivate(projectRoot: string): Promise<boolean> {
     return hasFileInTree(projectRoot, ['Cargo.toml']);
   },

--- a/apps/browser/src/backend/services/toolbox/services/lsp/types.ts
+++ b/apps/browser/src/backend/services/toolbox/services/lsp/types.ts
@@ -107,6 +107,25 @@ export interface LspServerInfo {
    * does not report an empty result. Defaults to 3000ms when unset.
    */
   diagnosticsTimeoutMs?: number;
+
+  /**
+   * Force the client to treat this server as push-only for diagnostics,
+   * ignoring any advertised `diagnosticProvider` (pull) capability.
+   *
+   * Some native servers advertise pull support but deliver their authoritative
+   * diagnostics exclusively via push (`textDocument/publishDiagnostics`).
+   * rust-analyzer is the canonical example: its pull endpoint
+   * (`textDocument/diagnostic`) only returns syntax/proc-macro diagnostics and
+   * always omits the `cargo check` (flycheck) results, which arrive solely via
+   * push after a delay. Querying the pull endpoint therefore returns an empty
+   * report that resolves `waitForDiagnostics` prematurely — before the real
+   * push lands — surfacing an empty result. clangd is likewise push-native.
+   *
+   * When true, the client skips the pull path entirely and does not advance the
+   * document to a no-op second version, so the wait resolves on the genuine
+   * push (or the safety-net timeout) instead of an empty pull.
+   */
+  pushDiagnosticsOnly?: boolean;
 }
 
 /**

--- a/apps/browser/src/backend/services/toolbox/tools/file-modification/get-linting-diagnostics.ts
+++ b/apps/browser/src/backend/services/toolbox/tools/file-modification/get-linting-diagnostics.ts
@@ -25,7 +25,16 @@ type LintingDiagnosticsResult = {
   summary: DiagnosticsSummary;
 };
 
-const TOOL_TIMEOUT_MS = 15_000;
+// Outer safety-net cap for the whole request (touch + wait + collect across all
+// files). This MUST stay strictly greater than the largest per-server
+// `diagnosticsTimeoutMs` (currently rust-analyzer at 15_000ms) plus headroom for
+// the diagnostics debounce and result collection. If it merely equals the inner
+// wait, a valid publish landing right at the boundary is resolved by the inner
+// wait only after the debounce window — just as this outer race fires — and the
+// caller would receive the empty timeout fallback instead of the real results.
+// The 5s margin keeps the inner wait the binding constraint for slow (cold
+// flycheck) servers while reserving room to actually return their diagnostics.
+const TOOL_TIMEOUT_MS = 20_000;
 
 export const getLintingDiagnosticsToolExecute = async (
   mountedLspServices: MountedLspServices,
@@ -75,8 +84,10 @@ async function doGetLintingDiagnostics(
   mountedLspServices: MountedLspServices,
   paths: string[],
 ) {
-  // Touch all files in parallel so LSP servers open and analyze them,
-  // then wait for diagnostics to arrive (3s timeout per file).
+  // Touch all files in parallel so LSP servers open and analyze them, then wait
+  // for diagnostics to arrive. Each wait is bounded by the server's own
+  // `diagnosticsTimeoutMs` safety net (default 3s; rust-analyzer 15s for cold
+  // cargo-check flycheck), always below the outer TOOL_TIMEOUT_MS above.
   await Promise.all(
     paths.map(async (mountedPath) => {
       try {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missing or empty diagnostics from Rust and C/C++ by treating `rust-analyzer` and `clangd` as push-only and only using pull when appropriate. This prevents early empty results and waits for real diagnostics to arrive.

- **Bug Fixes**
  - Added `pushDiagnosticsOnly` to `LspServerInfo`; enabled for `rust-analyzer` and `clangd`.
  - LSP client now routes diagnostics via `usesPullDiagnostics()`; skips pull when push-only.
  - Increased tool-level timeout to 20s to avoid racing the 15s rust-analyzer wait, ensuring push diagnostics return instead of the empty fallback.

<sup>Written for commit d0dcc5cc3f92503544f5ff86a213799606845ddb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1237?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Respect servers that deliver diagnostics via push-only to avoid premature/empty diagnostic results for clangd and Rust Analyzer.
  * Prevent early completion of diagnostics waiting logic so real pushed diagnostics appear reliably.

* **Chores**
  * Increased overall diagnostics timeout to reduce spurious “timed out” fallbacks, improving linting reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stagewise-io/stagewise/pull/1237?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->