### PR TITLE
fix(stagewise): prevent duplicate tab ids from crashing the UI

### DIFF
--- a/apps/browser/src/backend/main.ts
+++ b/apps/browser/src/backend/main.ts
@@ -2,7 +2,7 @@
  * This file stores the main setup for the CLI.
  */
 
-import { app, dialog } from 'electron';
+import { app, clipboard, dialog } from 'electron';
 import { AuthService } from './services/auth';
 import { AgentManagerService } from './services/agent-manager';
 import { UserExperienceService } from './services/experience';
@@ -583,6 +583,16 @@ export async function main({ launchOptions: { verbose } }: MainParameters) {
         });
       });
       return { success: removed };
+    },
+  );
+
+  // browser.copyText - write text to the system clipboard from the main
+  // process. The UI renderer's navigator.clipboard rejects when focus is
+  // inside a web-content view, so clipboard writes are routed through here.
+  uiKarton.registerServerProcedureHandler(
+    'browser.copyText',
+    async (_cid: string, text: string) => {
+      clipboard.writeText(text);
     },
   );
 

--- a/apps/browser/src/backend/services/terminal/index.ts
+++ b/apps/browser/src/backend/services/terminal/index.ts
@@ -586,11 +586,34 @@ export class TerminalService extends DisposableService {
         createdAt,
         lastFocusedAt: createdAt,
       };
+
+      // A tab id must live in exactly ONE order array. This is the only tab
+      // mutation that does not route through WindowLayoutService.addToTabOrder
+      // (which does a full cleanup-then-add), so we enforce the invariant
+      // here too: defensively strip any pre-existing entry of this id from
+      // every order array before inserting. Without this, a stale or
+      // interleaved entry would leave the id in two arrays at once, which
+      // makes the tab bar render two <Tabs.Tab> with the same `value` and
+      // triggers an infinite Base UI highlight-effect loop (React #185 ->
+      // whole-UI crash). For a brand-new id every filter is a no-op.
+      draft.contentTabs.globalOrder = draft.contentTabs.globalOrder.filter(
+        (id) => id !== terminalId,
+      );
+      for (const agentId of Object.keys(draft.contentTabs.agentOrders)) {
+        const filtered = draft.contentTabs.agentOrders[agentId]!.filter(
+          (id) => id !== terminalId,
+        );
+        if (filtered.length === 0) {
+          delete draft.contentTabs.agentOrders[agentId];
+        } else {
+          draft.contentTabs.agentOrders[agentId] = filtered;
+        }
+      }
+
       if (tabAgentInstanceId) {
         draft.contentTabs.agentOrders[tabAgentInstanceId] ??= [];
-        const order = draft.contentTabs.agentOrders[tabAgentInstanceId];
-        if (!order.includes(terminalId)) order.push(terminalId);
-      } else if (!draft.contentTabs.globalOrder.includes(terminalId)) {
+        draft.contentTabs.agentOrders[tabAgentInstanceId]!.push(terminalId);
+      } else {
         draft.contentTabs.globalOrder.push(terminalId);
       }
     });

--- a/apps/browser/src/shared/karton-contracts/ui/index.ts
+++ b/apps/browser/src/shared/karton-contracts/ui/index.ts
@@ -1446,6 +1446,14 @@ export type KartonContract = {
         cwd?: string,
         agentInstanceId?: string | null,
       ) => Promise<string | null>;
+      /**
+       * Copy text to the system clipboard.
+       *
+       * Routed through the main process because the UI renderer's
+       * `navigator.clipboard` rejects when focus lives inside a web-content
+       * view (a separate WebContentsView), which silently dropped writes.
+       */
+      copyText: (text: string) => Promise<void>;
       /** Write keystroke data to a terminal's PTY. */
       terminalInput: (terminalId: string, data: string) => Promise<void>;
       /** Resize a terminal's PTY dimensions. */

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/workspace-select.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/workspace-select.tsx
@@ -1017,6 +1017,9 @@ function WorkspacePreviewCardContent({
   const createTerminal = useKartonProcedure(
     (p: KartonProcedures) => p.browser.createTerminal,
   );
+  const copyText = useKartonProcedure(
+    (p: KartonProcedures) => p.browser.copyText,
+  );
   const { collapsed: contentCollapsed, setCollapsed: setContentCollapsed } =
     useContentCollapsed();
   const setupTitle = setupRun
@@ -1031,9 +1034,12 @@ function WorkspacePreviewCardContent({
     (event: React.MouseEvent) => {
       event.stopPropagation();
       event.preventDefault();
-      void navigator.clipboard?.writeText(mount.path);
+      // Route through the main process: the renderer's `navigator.clipboard`
+      // rejects when focus is inside a web-content view, which silently
+      // dropped the copy here.
+      void copyText(mount.path);
     },
-    [mount.path],
+    [mount.path, copyText],
   );
 
   const handleOpenTerminal = useCallback(

--- a/apps/browser/src/ui/screens/main/content/index.tsx
+++ b/apps/browser/src/ui/screens/main/content/index.tsx
@@ -360,12 +360,27 @@ export function MainSection({
   // ---------------------------------------------------------------------------
 
   const tabIdsSelector = useComparingSelector<KartonContract, string[]>(
-    (s) => [
-      ...s.contentTabs.globalOrder,
-      ...Object.keys(s.contentTabs.agentOrders)
-        .sort()
-        .flatMap((agentId) => s.contentTabs.agentOrders[agentId] ?? []),
-    ],
+    (s) => {
+      // De-duplicate ids across the global + per-agent order arrays.
+      // A tab id must NEVER appear twice in the rendered tab list: two
+      // <Tabs.Tab> with the same `value` both match the active value and
+      // their Base UI highlight effects ping-pong setHighlightedTabIndex
+      // forever (React error #185 → whole-UI crash). The backend can
+      // transiently hold an id in two arrays, so we mirror the dedupe
+      // already done in WindowLayoutService.getAllOrderedTabIds().
+      const seen = new Set<string>();
+      const ids: string[] = [];
+      const push = (id: string) => {
+        if (seen.has(id)) return;
+        seen.add(id);
+        ids.push(id);
+      };
+      for (const id of s.contentTabs.globalOrder) push(id);
+      for (const agentId of Object.keys(s.contentTabs.agentOrders).sort()) {
+        for (const id of s.contentTabs.agentOrders[agentId] ?? []) push(id);
+      }
+      return ids;
+    },
     (a, b) => a.length === b.length && a.every((id, i) => id === b[i]),
   );
   const serverTabIds = useKartonState(tabIdsSelector);
@@ -393,10 +408,20 @@ export function MainSection({
 
   // Visible tab IDs filtered to current agent (global + this agent's tabs)
   const visibleTabIds = useMemo(() => {
+    // Final dedupe guard at the render boundary: even if the optimistic
+    // order ever contains a duplicate id (e.g. from a reorder edge case),
+    // never emit it twice. Rendering duplicate <Tabs.Tab value> crashes
+    // the whole UI via an infinite Base UI highlight-effect loop (#185).
+    const seen = new Set<string>();
     return optimisticTabIds.filter((id) => {
+      if (seen.has(id)) return false;
       const tab = tabs[id];
       if (!tab) return false;
-      return tab.agentInstanceId === null || tab.agentInstanceId === openAgent;
+      if (tab.agentInstanceId !== null && tab.agentInstanceId !== openAgent) {
+        return false;
+      }
+      seen.add(id);
+      return true;
     });
   }, [optimisticTabIds, tabs, openAgent]);
 


### PR DESCRIPTION
A tab id present in two content-tab order arrays rendered two <Tabs.Tab> with the same value, making Base UI's highlight effect ping-pong setHighlightedTabIndex forever (React #185 -> whole-UI crash, only cleared by a full restart).

- terminal: route creation through a cross-array dedupe so an id lives in one order array
- content: dedupe ids in tabIdsSelector and visibleTabIds so the tab bar never renders duplicate Tabs.Tab values

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents duplicate tab IDs from crashing the UI and fixes the workspace copy‑path button by routing clipboard writes through the main process.

- **Bug Fixes**
  - Tabs: ensure each tab ID lives in one order list; de‑duplicate in `tabIdsSelector` and `visibleTabIds` so the tab bar never renders a duplicate and avoids the highlight loop crash.
  - Clipboard: add `browser.copyText` (main uses Electron `clipboard.writeText`) and switch the workspace copy‑path action to it instead of `navigator.clipboard`, which fails inside web‑content views.

<sup>Written for commit b9c382a1de6e708ffab2f2260af82deef0ff2163. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1243?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced clipboard support for improved copy functionality across the application.

* **Bug Fixes**
  * Resolved duplicate tab items appearing in the main interface.
  * Fixed tab ordering issues in terminal workspace management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->