### PR TITLE
Worktree settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,4 +46,5 @@ yarn-error.log*
 *storybook.log
 storybook-static
 
-.stagewise
+.stagewise/*
+!.stagewise/worktree-setup.sh

--- a/.stagewise/worktree-setup.sh
+++ b/.stagewise/worktree-setup.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+set -eu
+
+echo "[stagewise dummy setup] started"
+echo "cwd: $(pwd)"
+echo "source worktree: ${STAGEWISE_SOURCE_WORKTREE_PATH:-unset}"
+echo "target worktree: ${STAGEWISE_TARGET_WORKTREE_PATH:-unset}"
+echo "main worktree: ${STAGEWISE_MAIN_WORKTREE_PATH:-unset}"
+
+# Make the async setup state visible in the UI.
+sleep 8
+
+# Write under .stagewise/ so the generated file stays gitignored and does not
+# dirty the worktree (a dirty worktree would block managed-worktree removal).
+cat > .stagewise/dummy-setup-result.txt <<EOF
+Dummy worktree setup completed at $(date -u +%Y-%m-%dT%H:%M:%SZ)
+Source worktree: ${STAGEWISE_SOURCE_WORKTREE_PATH:-unset}
+Target worktree: ${STAGEWISE_TARGET_WORKTREE_PATH:-unset}
+Main worktree: ${STAGEWISE_MAIN_WORKTREE_PATH:-unset}
+EOF
+
+echo "[stagewise dummy setup] wrote .stagewise/dummy-setup-result.txt"
+echo "[stagewise dummy setup] finished"

--- a/apps/browser/src/backend/main.ts
+++ b/apps/browser/src/backend/main.ts
@@ -32,6 +32,7 @@ import type { AgentManagerStartupPolicy } from '@stagewise/agent-core';
 import { AgentTypes } from '@shared/karton-contracts/ui/agent';
 import { AutoUpdateService } from './services/auto-update';
 import { LocalPortsScannerService } from './services/local-ports-scanner';
+import { WorktreeSetupSettingsService } from './services/worktree-setup-settings';
 import { DevToolAPIService } from './services/dev-tool-api';
 import { OmniboxSuggestionsService } from './services/omnibox-suggestions';
 import { ensureRipgrepInstalled } from '@stagewise/agent-runtime-node';
@@ -249,7 +250,7 @@ export async function main({ launchOptions: { verbose } }: MainParameters) {
 
   // Push bundled plugin definitions to UI karton state
   discoverPlugins(getPluginsPath()).then((plugins) => {
-    uiKarton.setState((draft) => {
+    uiKarton.setState((draft: { plugins: typeof plugins }) => {
       draft.plugins = plugins;
     });
     if (verbose)
@@ -737,6 +738,18 @@ export async function main({ launchOptions: { verbose } }: MainParameters) {
     agentManagerService,
   );
 
+  const getWorkspaceLastUsedAtByPath = async (workspacePaths: string[]) =>
+    (await persistence.agentDb.getWorkspaceLastUsedAtByPath(workspacePaths)) ??
+    new Map();
+
+  const worktreeSetupSettingsService = WorktreeSetupSettingsService.create({
+    logger,
+    userExperienceService,
+    gitService,
+    getWorkspaceLastUsedAtByPath,
+    getMountedWorkspacePaths: () => toolboxService.getAllMountedPaths(),
+  });
+
   // Wire all uiKarton-to-pages state syncs (pending edits, mounts,
   // workspace-md generating, search engines, global config, auth)
   await wirePagesStateSync({
@@ -753,6 +766,7 @@ export async function main({ launchOptions: { verbose } }: MainParameters) {
     pagesService,
     diffHistoryService,
     windowLayoutService,
+
     logger,
   });
 
@@ -926,6 +940,22 @@ export async function main({ launchOptions: { verbose } }: MainParameters) {
     async (_cid: string, params: { days?: number }) => {
       return authService.getUsageHistory(params.days);
     },
+  );
+
+  // toolbox worktree setup settings procedures
+  uiKarton.registerServerProcedureHandler(
+    'toolbox.listWorktreeSetupRepositories',
+    async () => worktreeSetupSettingsService.listRepositories(),
+  );
+  uiKarton.registerServerProcedureHandler(
+    'toolbox.saveWorktreeSetupScript',
+    async (_cid: string, mainWorktreePath: string, content: string) =>
+      worktreeSetupSettingsService.saveScript(mainWorktreePath, content),
+  );
+  uiKarton.registerServerProcedureHandler(
+    'toolbox.deleteWorktreeSetupWorktree',
+    async (_cid: string, worktreePath: string) =>
+      worktreeSetupSettingsService.deleteManagedWorktree(worktreePath),
   );
 
   // credentials.set / credentials.delete / credentials.getConfiguredIds

--- a/apps/browser/src/backend/services/toolbox/services/mount-manager/git-path-actions.test.ts
+++ b/apps/browser/src/backend/services/toolbox/services/mount-manager/git-path-actions.test.ts
@@ -363,7 +363,15 @@ describe('MountManagerService path-based Git actions', () => {
     const linkedPath = await fs.mkdtemp(path.join(repoDir, 'linked-worktree-'));
     const mainPath = linkedPath.replace('linked-worktree', 'main-worktree');
     await fs.mkdir(mainPath, { recursive: true });
-    const { service, procedureHandlers, gitService } = createHarness({
+    const createdPath = path.join(mainPath, '..', 'created-worktree');
+    const scriptPath = path.join(
+      createdPath,
+      '.stagewise',
+      'worktree-setup.sh',
+    );
+    await fs.mkdir(path.dirname(scriptPath), { recursive: true });
+    await fs.writeFile(scriptPath, 'exit 0');
+    const { service, procedureHandlers, gitService, state } = createHarness({
       recentPaths: [linkedPath],
     });
     await initializeService(service);
@@ -379,6 +387,17 @@ describe('MountManagerService path-based Git actions', () => {
     expect(gitService.createWorktree).toHaveBeenCalledWith(mainPath, {
       worktreeName: 'feature-a',
       sourceBranch: 'main',
+    });
+
+    const mountHandler = procedureHandlers.get('toolbox.mountWorkspace');
+    await mountHandler?.('client1', 'agent1', createdPath);
+
+    await vi.waitFor(() => {
+      expect(state.workspaceGitSetup.runsByPath[createdPath]).toMatchObject({
+        workspacePath: createdPath,
+        sourceWorktreePath: linkedPath,
+        mainWorktreePath: mainPath,
+      });
     });
   });
 

--- a/apps/browser/src/backend/services/toolbox/services/mount-manager/index.ts
+++ b/apps/browser/src/backend/services/toolbox/services/mount-manager/index.ts
@@ -727,10 +727,8 @@ export class MountManagerService extends DisposableService {
     if (result.ok) {
       await this.setPendingWorktreeSetup(result.path, {
         workspacePath: result.path,
+        sourceWorktreePath: workspacePath,
         mainWorktreePath,
-        repositoryId: repositoryInfo.repositoryId,
-        sourceBranch: options.sourceBranch,
-        worktreeBranch: result.branchName,
       });
     }
     return result;

--- a/apps/browser/src/backend/services/toolbox/services/mount-manager/worktree-setup-runner.test.ts
+++ b/apps/browser/src/backend/services/toolbox/services/mount-manager/worktree-setup-runner.test.ts
@@ -50,10 +50,8 @@ function createKarton() {
 function metadata(mainWorktreePath: string, workspacePath: string) {
   return {
     workspacePath,
+    sourceWorktreePath: mainWorktreePath,
     mainWorktreePath,
-    repositoryId: path.join(mainWorktreePath, '.git'),
-    sourceBranch: 'main',
-    worktreeBranch: 'feature-a',
   };
 }
 
@@ -126,13 +124,14 @@ describe('WorktreeSetupRunner', () => {
     expect(state.workspaceGitSetup.runsByPath[workspacePath]).toBeUndefined();
   });
 
-  it('ignores setup scripts that exist only in the main worktree', async () => {
+  it('falls back to setup scripts that exist only in the main worktree', async () => {
     const mainWorktreePath = path.join(tempDir, 'main');
     const workspacePath = path.join(tempDir, 'worktree');
     await fs.mkdir(workspacePath, { recursive: true });
-    await writeSetupScript(mainWorktreePath);
+    const scriptPath = await writeSetupScript(mainWorktreePath);
+    const child = createProcess();
     const { state, uiKarton } = createKarton();
-    const spawnProcess = vi.fn();
+    const spawnProcess = vi.fn(() => child);
     const runner = createRunner({
       logger: { warn: vi.fn() } as unknown as Logger,
       telemetryService: {
@@ -145,8 +144,20 @@ describe('WorktreeSetupRunner', () => {
 
     await runner.start(metadata(mainWorktreePath, workspacePath));
 
-    expect(spawnProcess).not.toHaveBeenCalled();
-    expect(state.workspaceGitSetup.runsByPath[workspacePath]).toBeUndefined();
+    expect(spawnProcess).toHaveBeenCalledWith('/bin/sh', [scriptPath], {
+      cwd: workspacePath,
+      env: expect.not.objectContaining({
+        STAGEWISE_SETUP_SCRIPT: expect.any(String),
+      }),
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    expect(state.workspaceGitSetup.runsByPath[workspacePath]).toMatchObject({
+      scriptPath,
+      status: 'running',
+    });
+
+    child.emit('close', 0);
+    runner.teardown();
   });
 
   it('spawns the setup script with expected cwd and environment', async () => {
@@ -155,7 +166,21 @@ describe('WorktreeSetupRunner', () => {
     await fs.mkdir(workspacePath, { recursive: true });
     const scriptPath = await writeSetupScript(workspacePath);
     const child = createProcess();
-    const spawnProcess = vi.fn(() => child);
+    let capturedEnv: NodeJS.ProcessEnv | undefined;
+    const spawnProcess = vi.fn(
+      (
+        _command: string,
+        _args: string[],
+        options: {
+          cwd: string;
+          env: NodeJS.ProcessEnv;
+          stdio: ['ignore', 'pipe', 'pipe'];
+        },
+      ) => {
+        capturedEnv = options.env;
+        return child;
+      },
+    );
     const { state, uiKarton } = createKarton();
     const runner = createRunner({
       logger: { warn: vi.fn() } as unknown as Logger,
@@ -173,16 +198,23 @@ describe('WorktreeSetupRunner', () => {
       cwd: workspacePath,
       env: expect.objectContaining({
         PATH: '/custom/bin',
-        STAGEWISE_MAIN_WORKTREE: mainWorktreePath,
-        STAGEWISE_NEW_WORKTREE: workspacePath,
-        STAGEWISE_WORKTREE: workspacePath,
-        STAGEWISE_SOURCE_BRANCH: 'main',
-        STAGEWISE_WORKTREE_BRANCH: 'feature-a',
-        STAGEWISE_REPOSITORY_ID: path.join(mainWorktreePath, '.git'),
-        STAGEWISE_SETUP_SCRIPT: scriptPath,
+        STAGEWISE_SOURCE_WORKTREE_PATH: mainWorktreePath,
+        STAGEWISE_TARGET_WORKTREE_PATH: workspacePath,
+        STAGEWISE_MAIN_WORKTREE_PATH: mainWorktreePath,
       }),
       stdio: ['ignore', 'pipe', 'pipe'],
     });
+    expect(capturedEnv).toEqual(
+      expect.not.objectContaining({
+        STAGEWISE_MAIN_WORKTREE: expect.any(String),
+        STAGEWISE_NEW_WORKTREE: expect.any(String),
+        STAGEWISE_WORKTREE: expect.any(String),
+        STAGEWISE_SOURCE_BRANCH: expect.any(String),
+        STAGEWISE_WORKTREE_BRANCH: expect.any(String),
+        STAGEWISE_REPOSITORY_ID: expect.any(String),
+        STAGEWISE_SETUP_SCRIPT: expect.any(String),
+      }),
+    );
     expect(state.workspaceGitSetup.runsByPath[workspacePath]?.status).toBe(
       'running',
     );

--- a/apps/browser/src/backend/services/toolbox/services/mount-manager/worktree-setup-runner.ts
+++ b/apps/browser/src/backend/services/toolbox/services/mount-manager/worktree-setup-runner.ts
@@ -45,10 +45,8 @@ type SpawnFn = (
 
 export type WorktreeSetupMetadata = {
   workspacePath: string;
+  sourceWorktreePath: string;
   mainWorktreePath: string;
-  repositoryId: string;
-  sourceBranch: string;
-  worktreeBranch: string;
 };
 
 type WorktreeSetupRunnerDeps = {
@@ -108,11 +106,20 @@ export class WorktreeSetupRunner {
   public async start(metadata: WorktreeSetupMetadata): Promise<void> {
     if (this.activeRuns.has(metadata.workspacePath)) return;
 
-    const scriptPath = path.join(
+    const workspaceScriptPath = path.join(
       metadata.workspacePath,
       WORKTREE_SETUP_SCRIPT_RELATIVE_PATH,
     );
-    if (!(await this.pathExists(scriptPath))) return;
+    const mainWorktreeScriptPath = path.join(
+      metadata.mainWorktreePath,
+      WORKTREE_SETUP_SCRIPT_RELATIVE_PATH,
+    );
+    const scriptPath = (await this.pathExists(workspaceScriptPath))
+      ? workspaceScriptPath
+      : (await this.pathExists(mainWorktreeScriptPath))
+        ? mainWorktreeScriptPath
+        : null;
+    if (!scriptPath) return;
 
     const runId = randomUUID();
     const startedAt = Date.now();
@@ -120,10 +127,8 @@ export class WorktreeSetupRunner {
       draft.workspaceGitSetup.runsByPath[metadata.workspacePath] = {
         id: runId,
         workspacePath: metadata.workspacePath,
+        sourceWorktreePath: metadata.sourceWorktreePath,
         mainWorktreePath: metadata.mainWorktreePath,
-        repositoryId: metadata.repositoryId,
-        sourceBranch: metadata.sourceBranch,
-        worktreeBranch: metadata.worktreeBranch,
         scriptPath,
         status: 'running',
         startedAt,
@@ -222,13 +227,9 @@ export class WorktreeSetupRunner {
     const env: NodeJS.ProcessEnv = {
       ...process.env,
       ...(resolvedEnv ?? {}),
-      STAGEWISE_MAIN_WORKTREE: metadata.mainWorktreePath,
-      STAGEWISE_NEW_WORKTREE: metadata.workspacePath,
-      STAGEWISE_WORKTREE: metadata.workspacePath,
-      STAGEWISE_SOURCE_BRANCH: metadata.sourceBranch,
-      STAGEWISE_WORKTREE_BRANCH: metadata.worktreeBranch,
-      STAGEWISE_REPOSITORY_ID: metadata.repositoryId,
-      STAGEWISE_SETUP_SCRIPT: scriptPath,
+      STAGEWISE_SOURCE_WORKTREE_PATH: metadata.sourceWorktreePath,
+      STAGEWISE_TARGET_WORKTREE_PATH: metadata.workspacePath,
+      STAGEWISE_MAIN_WORKTREE_PATH: metadata.mainWorktreePath,
     };
 
     try {

--- a/apps/browser/src/backend/services/worktree-setup-settings.test.ts
+++ b/apps/browser/src/backend/services/worktree-setup-settings.test.ts
@@ -1,0 +1,470 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+let mockHomeDir = path.join(os.tmpdir(), 'worktree-setup-settings-home');
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: (name: string) =>
+      name === 'home' ? mockHomeDir : path.join(os.tmpdir(), `mock-${name}`),
+  },
+}));
+
+import { WorktreeSetupSettingsService } from './worktree-setup-settings';
+import { getWorktreesDir } from '@/utils/paths';
+import type { GitService } from '@/services/git';
+import type { Logger } from '@/services/logger';
+import type { UserExperienceService } from '@/services/experience';
+
+const logger = {
+  debug: vi.fn(),
+  warn: vi.fn(),
+} as unknown as Logger;
+
+let repoPath = path.join(os.tmpdir(), 'worktree-setup-settings-repo');
+let repoGitDir = path.join(repoPath, '.git');
+
+beforeEach(async () => {
+  mockHomeDir = await fs.mkdtemp(
+    path.join(os.tmpdir(), 'worktree-setup-settings-home-'),
+  );
+  repoPath = await fs.realpath(
+    await fs.mkdtemp(path.join(os.tmpdir(), 'worktree-setup-settings-repo-')),
+  );
+  repoGitDir = path.join(repoPath, '.git');
+});
+
+afterEach(async () => {
+  await fs.rm(mockHomeDir, { recursive: true, force: true });
+  await fs.rm(repoPath, { recursive: true, force: true });
+  vi.clearAllMocks();
+});
+
+function createService({
+  recentPaths = [repoPath],
+  managedPath,
+  dirty = false,
+}: {
+  recentPaths?: string[];
+  managedPath?: string;
+  dirty?: boolean;
+} = {}) {
+  const userExperienceService = {
+    getRecentlyOpenedWorkspaces: vi.fn(async () =>
+      recentPaths.map((workspacePath) => ({
+        path: workspacePath,
+        name: path.basename(workspacePath),
+        openedAt: 1,
+      })),
+    ),
+  } as unknown as UserExperienceService;
+
+  const gitService = {
+    getWorkspaceRepositoryInfo: vi.fn(async (workspacePath: string) => {
+      if (workspacePath === repoPath) {
+        return {
+          repositoryId: repoGitDir,
+          repoRoot: repoPath,
+          commonGitDir: repoGitDir,
+        };
+      }
+      return null;
+    }),
+    getWorkspaceMainWorktreePath: vi.fn(async (workspacePath: string) =>
+      workspacePath === repoPath ? repoPath : null,
+    ),
+    getMountedWorkspaceSummary: vi.fn(async (workspacePath: string) => {
+      if (workspacePath !== managedPath) return null;
+      return {
+        repositoryId: repoGitDir,
+        repoRoot: workspacePath,
+        worktreeId: workspacePath,
+        mainWorktreePath: repoPath,
+        commonGitDir: repoGitDir,
+        isWorktree: true,
+        branch: 'feature-a',
+        headSha: 'abc123',
+        status: {
+          dirty,
+          stagedCount: dirty ? 1 : 0,
+          unstagedCount: 0,
+          untrackedCount: 0,
+        },
+      };
+    }),
+    getWorktreeInfo: vi.fn(async (workspacePath: string) => ({
+      worktreeId: workspacePath,
+      path: workspacePath,
+      branch: 'feature-a',
+      headSha: 'abc123',
+      isDetached: false,
+      isMainWorktree: false,
+    })),
+    getWorktreeStatus: vi.fn(async () => ({
+      dirty,
+      stagedCount: dirty ? 1 : 0,
+      unstagedCount: 0,
+      untrackedCount: 0,
+    })),
+    removeWorktree: vi.fn(async () => ({ ok: true })),
+  } as unknown as GitService;
+
+  const service = WorktreeSetupSettingsService.create({
+    logger,
+    userExperienceService,
+    gitService,
+    getWorkspaceLastUsedAtByPath: async (workspacePaths) =>
+      new Map(workspacePaths.map((workspacePath) => [workspacePath, 123])),
+    getMountedWorkspacePaths: () => new Set(),
+  });
+
+  return { service, gitService };
+}
+
+async function createManagedWorktree(relativePath = 'repo-hash/feature-a') {
+  const worktreePath = path.join(getWorktreesDir(), relativePath);
+  await fs.mkdir(path.join(worktreePath, '.git'), { recursive: true });
+  return await fs.realpath(worktreePath);
+}
+
+describe('WorktreeSetupSettingsService', () => {
+  it('rejects setup script saves for unknown repositories', async () => {
+    const { service } = createService({ recentPaths: [] });
+
+    await expect(service.saveScript(repoPath, '#!/bin/sh')).resolves.toEqual({
+      ok: false,
+      message: 'Repository is no longer available.',
+    });
+  });
+
+  it('saves setup scripts only under the repository setup script path', async () => {
+    const { service } = createService();
+
+    const result = await service.saveScript(repoPath, '#!/bin/sh\necho ok\n');
+
+    expect(result.ok).toBe(true);
+    await expect(
+      fs.readFile(
+        path.join(repoPath, '.stagewise', 'worktree-setup.sh'),
+        'utf8',
+      ),
+    ).resolves.toBe('#!/bin/sh\necho ok\n');
+  });
+
+  it('returns the saved script state when refresh after save cannot find the repository', async () => {
+    let repositoryAvailable = true;
+    const userExperienceService = {
+      getRecentlyOpenedWorkspaces: vi.fn(async () => {
+        const workspaces = repositoryAvailable
+          ? [
+              {
+                path: repoPath,
+                name: path.basename(repoPath),
+                openedAt: 1,
+              },
+            ]
+          : [];
+        repositoryAvailable = false;
+        return workspaces;
+      }),
+    } as unknown as UserExperienceService;
+    const gitService = {
+      getWorkspaceRepositoryInfo: vi.fn(async (workspacePath: string) => {
+        if (workspacePath !== repoPath) return null;
+        return {
+          repositoryId: repoGitDir,
+          repoRoot: repoPath,
+          commonGitDir: repoGitDir,
+        };
+      }),
+      getWorkspaceMainWorktreePath: vi.fn(async (workspacePath: string) =>
+        workspacePath === repoPath ? repoPath : null,
+      ),
+      getMountedWorkspaceSummary: vi.fn(async () => null),
+      getWorktreeInfo: vi.fn(),
+      getWorktreeStatus: vi.fn(),
+      removeWorktree: vi.fn(async () => ({ ok: true })),
+    } as unknown as GitService;
+    const service = WorktreeSetupSettingsService.create({
+      logger,
+      userExperienceService,
+      gitService,
+      getWorkspaceLastUsedAtByPath: async () => new Map(),
+      getMountedWorkspacePaths: () => new Set(),
+    });
+    const content = '#!/bin/sh\necho saved\n';
+
+    const result = await service.saveScript(repoPath, content);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.repository).toMatchObject({
+        mainWorktreePath: repoPath,
+        scriptExists: true,
+        scriptContent: content,
+      });
+    }
+  });
+
+  it('sorts repositories by latest managed worktree usage', async () => {
+    const alphaRepo = await fs.realpath(
+      await fs.mkdtemp(path.join(os.tmpdir(), 'worktree-settings-alpha-')),
+    );
+    const bravoRepo = await fs.realpath(
+      await fs.mkdtemp(path.join(os.tmpdir(), 'worktree-settings-bravo-')),
+    );
+    const olderRepo = await fs.realpath(
+      await fs.mkdtemp(path.join(os.tmpdir(), 'worktree-settings-older-')),
+    );
+    const newerRepo = await fs.realpath(
+      await fs.mkdtemp(path.join(os.tmpdir(), 'worktree-settings-newer-')),
+    );
+    const olderWorktree = await createManagedWorktree('older/feature-a');
+    const newerWorktree = await createManagedWorktree('newer/feature-b');
+    const repos = [bravoRepo, olderRepo, newerRepo, alphaRepo];
+    const repoGitDirs = new Map(
+      repos.map((repo) => [repo, path.join(repo, '.git')]),
+    );
+    const worktreeRepoPaths = new Map([
+      [olderWorktree, olderRepo],
+      [newerWorktree, newerRepo],
+    ]);
+
+    try {
+      const userExperienceService = {
+        getRecentlyOpenedWorkspaces: vi.fn(async () =>
+          repos.map((workspacePath) => ({
+            path: workspacePath,
+            name: path.basename(workspacePath),
+            openedAt: 1,
+          })),
+        ),
+      } as unknown as UserExperienceService;
+
+      const gitService = {
+        getWorkspaceRepositoryInfo: vi.fn(async (workspacePath: string) => {
+          const commonGitDir = repoGitDirs.get(workspacePath);
+          if (!commonGitDir) return null;
+          return {
+            repositoryId: commonGitDir,
+            repoRoot: workspacePath,
+            commonGitDir,
+          };
+        }),
+        getWorkspaceMainWorktreePath: vi.fn(async (workspacePath: string) =>
+          repoGitDirs.has(workspacePath) ? workspacePath : null,
+        ),
+        getMountedWorkspaceSummary: vi.fn(async (workspacePath: string) => {
+          const mainWorktreePath = worktreeRepoPaths.get(workspacePath);
+          if (!mainWorktreePath) return null;
+          const commonGitDir = repoGitDirs.get(mainWorktreePath);
+          return {
+            repositoryId: commonGitDir,
+            repoRoot: workspacePath,
+            worktreeId: workspacePath,
+            mainWorktreePath,
+            commonGitDir,
+            isWorktree: true,
+            branch: 'feature-a',
+            headSha: 'abc123',
+            status: {
+              dirty: false,
+              stagedCount: 0,
+              unstagedCount: 0,
+              untrackedCount: 0,
+            },
+          };
+        }),
+        getWorktreeInfo: vi.fn(async (workspacePath: string) => ({
+          worktreeId: workspacePath,
+          path: workspacePath,
+          branch: 'feature-a',
+          headSha: 'abc123',
+          isDetached: false,
+          isMainWorktree: false,
+        })),
+        getWorktreeStatus: vi.fn(async () => ({
+          dirty: false,
+          stagedCount: 0,
+          unstagedCount: 0,
+          untrackedCount: 0,
+        })),
+        removeWorktree: vi.fn(async () => ({ ok: true })),
+      } as unknown as GitService;
+
+      const service = WorktreeSetupSettingsService.create({
+        logger,
+        userExperienceService,
+        gitService,
+        getWorkspaceLastUsedAtByPath: async () =>
+          new Map([
+            [olderWorktree, 100],
+            [newerWorktree, 200],
+          ]),
+        getMountedWorkspacePaths: () => new Set(),
+      });
+
+      const result = await service.listRepositories();
+
+      expect(result.repositories.map((repo) => repo.mainWorktreePath)).toEqual([
+        newerRepo,
+        olderRepo,
+        alphaRepo,
+        bravoRepo,
+      ]);
+    } finally {
+      await Promise.all(
+        repos.map((repo) => fs.rm(repo, { recursive: true, force: true })),
+      );
+    }
+  });
+
+  it('keeps listing repositories when one setup script is unreadable', async () => {
+    const readableRepo = await fs.realpath(
+      await fs.mkdtemp(path.join(os.tmpdir(), 'worktree-readable-')),
+    );
+    const unreadableRepo = await fs.realpath(
+      await fs.mkdtemp(path.join(os.tmpdir(), 'worktree-unreadable-')),
+    );
+    const repos = [readableRepo, unreadableRepo];
+    const repoGitDirs = new Map(
+      repos.map((repo) => [repo, path.join(repo, '.git')]),
+    );
+    const realReadFile = fs.readFile;
+    const readFileSpy = vi
+      .spyOn(fs, 'readFile')
+      .mockImplementation(
+        async (
+          filePath: Parameters<typeof fs.readFile>[0],
+          options?: Parameters<typeof fs.readFile>[1],
+        ) => {
+          if (
+            String(filePath) ===
+            path.join(unreadableRepo, '.stagewise', 'worktree-setup.sh')
+          ) {
+            throw Object.assign(new Error('permission denied'), {
+              code: 'EACCES',
+            });
+          }
+          return realReadFile(filePath, options);
+        },
+      );
+
+    try {
+      const userExperienceService = {
+        getRecentlyOpenedWorkspaces: vi.fn(async () =>
+          repos.map((workspacePath) => ({
+            path: workspacePath,
+            name: path.basename(workspacePath),
+            openedAt: 1,
+          })),
+        ),
+      } as unknown as UserExperienceService;
+      const gitService = {
+        getWorkspaceRepositoryInfo: vi.fn(async (workspacePath: string) => {
+          const commonGitDir = repoGitDirs.get(workspacePath);
+          if (!commonGitDir) return null;
+          return {
+            repositoryId: commonGitDir,
+            repoRoot: workspacePath,
+            commonGitDir,
+          };
+        }),
+        getWorkspaceMainWorktreePath: vi.fn(async (workspacePath: string) =>
+          repoGitDirs.has(workspacePath) ? workspacePath : null,
+        ),
+        getMountedWorkspaceSummary: vi.fn(async () => null),
+        getWorktreeInfo: vi.fn(),
+        getWorktreeStatus: vi.fn(),
+        removeWorktree: vi.fn(async () => ({ ok: true })),
+      } as unknown as GitService;
+      const service = WorktreeSetupSettingsService.create({
+        logger,
+        userExperienceService,
+        gitService,
+        getWorkspaceLastUsedAtByPath: async () => new Map(),
+        getMountedWorkspacePaths: () => new Set(),
+      });
+
+      const result = await service.listRepositories();
+
+      expect(result.repositories.map((repo) => repo.mainWorktreePath)).toEqual([
+        readableRepo,
+        unreadableRepo,
+      ]);
+      expect(
+        result.repositories.find(
+          (repo) => repo.mainWorktreePath === unreadableRepo,
+        )?.scriptExists,
+      ).toBe(false);
+    } finally {
+      readFileSpy.mockRestore();
+      await Promise.all(
+        repos.map((repo) => fs.rm(repo, { recursive: true, force: true })),
+      );
+    }
+  });
+
+  it('includes managed-only repositories and deletes their worktrees', async () => {
+    const managedPath = await createManagedWorktree();
+    const { service, gitService } = createService({
+      recentPaths: [],
+      managedPath,
+    });
+
+    const listResult = await service.listRepositories();
+
+    expect(listResult.repositories).toHaveLength(1);
+    expect(listResult.repositories[0]).toMatchObject({
+      mainWorktreePath: repoPath,
+      repositoryId: repoGitDir,
+    });
+    expect(listResult.repositories[0]?.managedWorktrees).toHaveLength(1);
+    expect(listResult.repositories[0]?.managedWorktrees[0]?.path).toBe(
+      managedPath,
+    );
+
+    const deleteResult = await service.deleteManagedWorktree(managedPath);
+
+    expect(deleteResult.ok).toBe(true);
+    expect(gitService.removeWorktree).toHaveBeenCalledWith(managedPath);
+  });
+
+  it('rejects deleting dirty managed worktrees', async () => {
+    const managedPath = await createManagedWorktree();
+    const { service, gitService } = createService({ managedPath, dirty: true });
+
+    await expect(service.deleteManagedWorktree(managedPath)).resolves.toEqual({
+      ok: false,
+      message: 'Worktree has uncommitted changes.',
+    });
+    expect(gitService.removeWorktree).not.toHaveBeenCalled();
+  });
+
+  it('rejects deleting paths outside the managed worktree directory', async () => {
+    const { service, gitService } = createService();
+
+    await expect(
+      service.deleteManagedWorktree('/tmp/outside'),
+    ).resolves.toEqual({
+      ok: false,
+      message: 'Worktree is not stagewise-managed.',
+    });
+    expect(gitService.removeWorktree).not.toHaveBeenCalled();
+  });
+
+  it('deletes clean managed worktrees and returns refreshed repository state', async () => {
+    const managedPath = await createManagedWorktree();
+    const { service, gitService } = createService({ managedPath });
+
+    const result = await service.deleteManagedWorktree(managedPath);
+
+    expect(result.ok).toBe(true);
+    expect(gitService.removeWorktree).toHaveBeenCalledWith(managedPath);
+    if (result.ok) {
+      expect(result.repository?.mainWorktreePath).toBe(repoPath);
+    }
+  });
+});

--- a/apps/browser/src/backend/services/worktree-setup-settings.ts
+++ b/apps/browser/src/backend/services/worktree-setup-settings.ts
@@ -1,0 +1,503 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import type { GitService } from '@/services/git';
+import type { Logger } from '@/services/logger';
+import type { UserExperienceService } from '@/services/experience';
+import { getWorktreesDir } from '@/utils/paths';
+import type {
+  DeleteWorktreeSetupWorktreeResult,
+  WorktreeSetupManagedWorktree,
+  WorktreeSetupRepositoriesResult,
+  WorktreeSetupRepositorySettings,
+  SaveWorktreeSetupScriptResult,
+} from '@shared/karton-contracts/ui';
+
+const SETUP_SCRIPT_RELATIVE_PATH = path.join('.stagewise', 'worktree-setup.sh');
+const MANAGED_WORKTREE_INSPECTION_CONCURRENCY = 4;
+
+type ManagedWorktreeInspection = WorktreeSetupManagedWorktree & {
+  repositoryId: string | null;
+  mainWorktreePath: string | null;
+  normalizedMainWorktreePath: string | null;
+};
+
+async function safeRealpath(targetPath: string): Promise<string | null> {
+  try {
+    return await fs.realpath(targetPath);
+  } catch {
+    return null;
+  }
+}
+
+function normalizePathForKey(value: string): string {
+  const resolved = path.resolve(value);
+  return process.platform === 'win32' ? resolved.toLowerCase() : resolved;
+}
+
+function getLatestRepositoryWorktreeUsage(
+  repository: WorktreeSetupRepositorySettings,
+): number {
+  return Math.max(
+    ...repository.managedWorktrees.map((worktree) => worktree.lastUsedAt ?? 0),
+    0,
+  );
+}
+
+async function mapWithConcurrency<T, R>(
+  items: T[],
+  concurrency: number,
+  mapper: (item: T) => Promise<R>,
+): Promise<R[]> {
+  const results: R[] = new Array(items.length);
+  let nextIndex = 0;
+  const workers = Array.from(
+    { length: Math.min(concurrency, items.length) },
+    async () => {
+      while (nextIndex < items.length) {
+        const index = nextIndex;
+        nextIndex += 1;
+        results[index] = await mapper(items[index]);
+      }
+    },
+  );
+  await Promise.all(workers);
+  return results;
+}
+
+export class WorktreeSetupSettingsService {
+  private listRepositoriesInFlight: Promise<WorktreeSetupRepositoriesResult> | null =
+    null;
+
+  private constructor(
+    private readonly logger: Logger,
+    private readonly userExperienceService: UserExperienceService,
+    private readonly gitService: GitService,
+    private getWorkspaceLastUsedAtByPath: (
+      workspacePaths: string[],
+    ) => Promise<Map<string, number>>,
+    private getMountedWorkspacePaths: () => Set<string>,
+  ) {}
+
+  public static create(deps: {
+    logger: Logger;
+    userExperienceService: UserExperienceService;
+    gitService: GitService;
+    getWorkspaceLastUsedAtByPath: (
+      workspacePaths: string[],
+    ) => Promise<Map<string, number>>;
+    getMountedWorkspacePaths: () => Set<string>;
+  }): WorktreeSetupSettingsService {
+    return new WorktreeSetupSettingsService(
+      deps.logger,
+      deps.userExperienceService,
+      deps.gitService,
+      deps.getWorkspaceLastUsedAtByPath,
+      deps.getMountedWorkspacePaths,
+    );
+  }
+
+  public async listRepositories(): Promise<WorktreeSetupRepositoriesResult> {
+    if (this.listRepositoriesInFlight) {
+      return this.listRepositoriesInFlight;
+    }
+
+    this.listRepositoriesInFlight = this.resolveRepositoryList();
+    try {
+      return await this.listRepositoriesInFlight;
+    } finally {
+      this.listRepositoriesInFlight = null;
+    }
+  }
+
+  private async resolveRepositoryList(): Promise<WorktreeSetupRepositoriesResult> {
+    const repositories = await this.resolveRepositories();
+    return { repositories };
+  }
+
+  public async saveScript(
+    mainWorktreePath: string,
+    content: string,
+  ): Promise<SaveWorktreeSetupScriptResult> {
+    const repository =
+      await this.findRepositoryByMainWorktreePath(mainWorktreePath);
+    if (!repository) {
+      return { ok: false, message: 'Repository is no longer available.' };
+    }
+
+    try {
+      await fs.mkdir(path.dirname(repository.scriptPath), { recursive: true });
+      await fs.writeFile(repository.scriptPath, content, 'utf8');
+      if (process.platform !== 'win32') {
+        await fs.chmod(repository.scriptPath, 0o755);
+      }
+      const refreshed = await this.findRepositoryByMainWorktreePath(
+        repository.mainWorktreePath,
+      );
+      return {
+        ok: true,
+        repository: refreshed ?? {
+          ...repository,
+          scriptExists: true,
+          scriptContent: content,
+        },
+      };
+    } catch (error) {
+      return {
+        ok: false,
+        message:
+          error instanceof Error
+            ? error.message
+            : 'Failed to save worktree setup script.',
+      };
+    }
+  }
+
+  public async deleteManagedWorktree(
+    worktreePath: string,
+  ): Promise<DeleteWorktreeSetupWorktreeResult> {
+    const resolvedWorktreePath =
+      await this.resolveManagedWorktreePath(worktreePath);
+    if (!resolvedWorktreePath) {
+      return { ok: false, message: 'Worktree is not stagewise-managed.' };
+    }
+
+    const repositories = await this.resolveRepositories();
+    const owningRepository = repositories.find((repository) =>
+      repository.managedWorktrees.some(
+        (worktree) =>
+          normalizePathForKey(worktree.path) ===
+          normalizePathForKey(resolvedWorktreePath),
+      ),
+    );
+    if (!owningRepository) {
+      return { ok: false, message: 'Worktree repository is not known.' };
+    }
+
+    const worktree = owningRepository.managedWorktrees.find(
+      (item) =>
+        normalizePathForKey(item.path) ===
+        normalizePathForKey(resolvedWorktreePath),
+    );
+    if (!worktree?.removable) {
+      return {
+        ok: false,
+        message: worktree?.disabledReason ?? 'Worktree is not safe to delete.',
+      };
+    }
+
+    const result = await this.gitService.removeWorktree(resolvedWorktreePath);
+    if (!result.ok) return { ok: false, message: result.message };
+
+    const refreshed = await this.findRepositoryByMainWorktreePath(
+      owningRepository.mainWorktreePath,
+    );
+    return { ok: true, repository: refreshed };
+  }
+
+  private async findRepositoryByMainWorktreePath(
+    mainWorktreePath: string,
+  ): Promise<WorktreeSetupRepositorySettings | null> {
+    const requestedPath =
+      (await safeRealpath(mainWorktreePath)) ?? path.resolve(mainWorktreePath);
+    const repositories = await this.resolveRepositories();
+    return (
+      repositories.find(
+        (repository) =>
+          normalizePathForKey(repository.mainWorktreePath) ===
+          normalizePathForKey(requestedPath),
+      ) ?? null
+    );
+  }
+
+  private async resolveRepositories(): Promise<
+    WorktreeSetupRepositorySettings[]
+  > {
+    const recentWorkspaces =
+      await this.userExperienceService.getRecentlyOpenedWorkspaces();
+
+    const repositoriesByKey = new Map<
+      string,
+      {
+        repositoryId: string | null;
+        mainWorktreePath: string;
+        openedAt: number;
+      }
+    >();
+
+    await Promise.all(
+      recentWorkspaces.map(async (workspace) => {
+        try {
+          const [repositoryInfo, mainWorktreePath] = await Promise.all([
+            this.gitService.getWorkspaceRepositoryInfo(workspace.path),
+            this.gitService.getWorkspaceMainWorktreePath(workspace.path),
+          ]);
+          if (!repositoryInfo || !mainWorktreePath) return;
+
+          const resolvedMainWorktreePath =
+            (await safeRealpath(mainWorktreePath)) ??
+            path.resolve(mainWorktreePath);
+          const key =
+            repositoryInfo.repositoryId ??
+            normalizePathForKey(resolvedMainWorktreePath);
+          const existing = repositoriesByKey.get(key);
+          if (existing && existing.openedAt >= workspace.openedAt) return;
+
+          repositoriesByKey.set(key, {
+            repositoryId: repositoryInfo.repositoryId,
+            mainWorktreePath: resolvedMainWorktreePath,
+            openedAt: workspace.openedAt,
+          });
+        } catch (error) {
+          this.logger.debug(
+            `[WorktreeSetupSettings] Failed to resolve recent repository ${workspace.path}: ${error instanceof Error ? error.message : String(error)}`,
+          );
+        }
+      }),
+    );
+
+    const managedWorktrees = await this.inspectManagedWorktrees();
+    for (const worktree of managedWorktrees) {
+      if (!worktree.mainWorktreePath) continue;
+      const key =
+        worktree.repositoryId ?? normalizePathForKey(worktree.mainWorktreePath);
+      const existing = repositoriesByKey.get(key);
+      if (existing && existing.openedAt >= 0) continue;
+
+      repositoriesByKey.set(key, {
+        repositoryId: worktree.repositoryId,
+        mainWorktreePath: worktree.mainWorktreePath,
+        openedAt: 0,
+      });
+    }
+
+    const repositories = await Promise.all(
+      [...repositoriesByKey.values()].map((repository) =>
+        this.buildRepositorySettings(
+          repository.mainWorktreePath,
+          repository.repositoryId,
+          managedWorktrees,
+        ),
+      ),
+    );
+
+    const sortedRepositories = repositories.sort((a, b) => {
+      const latestA = getLatestRepositoryWorktreeUsage(a);
+      const latestB = getLatestRepositoryWorktreeUsage(b);
+      if (latestA !== latestB) return latestB - latestA;
+      return a.name.localeCompare(b.name);
+    });
+
+    return sortedRepositories;
+  }
+
+  private async buildRepositorySettings(
+    mainWorktreePath: string,
+    repositoryId: string | null,
+    managedWorktrees: ManagedWorktreeInspection[],
+  ): Promise<WorktreeSetupRepositorySettings> {
+    const scriptPath = path.join(mainWorktreePath, SETUP_SCRIPT_RELATIVE_PATH);
+    const scriptContent = await this.readScriptContent(scriptPath);
+    return {
+      id: repositoryId ?? normalizePathForKey(mainWorktreePath),
+      name: path.basename(mainWorktreePath),
+      mainWorktreePath,
+      repositoryId,
+      scriptPath,
+      scriptExists: scriptContent !== null,
+      scriptContent: scriptContent ?? '',
+      managedWorktrees: this.filterManagedWorktreesForRepository(
+        mainWorktreePath,
+        repositoryId,
+        managedWorktrees,
+      ),
+    };
+  }
+
+  private async readScriptContent(scriptPath: string): Promise<string | null> {
+    try {
+      return await fs.readFile(scriptPath, 'utf8');
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code === 'ENOENT') return null;
+      this.logger.debug(
+        `[WorktreeSetupSettings] Failed to read setup script ${scriptPath}: ${error instanceof Error ? error.message : String(error)}`,
+      );
+      return null;
+    }
+  }
+
+  private filterManagedWorktreesForRepository(
+    mainWorktreePath: string,
+    repositoryId: string | null,
+    managedWorktrees: ManagedWorktreeInspection[],
+  ): WorktreeSetupManagedWorktree[] {
+    const normalizedMainWorktreePath = normalizePathForKey(mainWorktreePath);
+    return managedWorktrees
+      .filter((worktree) => {
+        if (repositoryId) return worktree.repositoryId === repositoryId;
+        return (
+          worktree.normalizedMainWorktreePath === normalizedMainWorktreePath
+        );
+      })
+      .map(
+        ({
+          repositoryId: _repositoryId,
+          mainWorktreePath: _mainWorktreePath,
+          normalizedMainWorktreePath: _normalizedMainWorktreePath,
+          ...worktree
+        }) => worktree,
+      )
+      .sort((a, b) => (b.lastUsedAt ?? 0) - (a.lastUsedAt ?? 0));
+  }
+
+  private async inspectManagedWorktrees(): Promise<
+    ManagedWorktreeInspection[]
+  > {
+    const managedPaths = await this.listManagedWorktreePaths();
+
+    const lastUsedByPath =
+      await this.getWorkspaceLastUsedAtByPath(managedPaths);
+    const mountedPaths = await this.getNormalizedMountedPaths();
+
+    const worktrees = await mapWithConcurrency(
+      managedPaths,
+      MANAGED_WORKTREE_INSPECTION_CONCURRENCY,
+      async (managedPath): Promise<ManagedWorktreeInspection | null> => {
+        try {
+          const summary =
+            await this.gitService.getMountedWorkspaceSummary(managedPath);
+          if (!summary?.isWorktree) return null;
+          const summaryMainWorktreePath = summary.mainWorktreePath
+            ? ((await safeRealpath(summary.mainWorktreePath)) ??
+              path.resolve(summary.mainWorktreePath))
+            : null;
+          const normalizedMainWorktreePath = summaryMainWorktreePath
+            ? normalizePathForKey(summaryMainWorktreePath)
+            : null;
+
+          const worktreeInfo =
+            await this.gitService.getWorktreeInfo(managedPath);
+          const status = await this.gitService.getWorktreeStatus(managedPath);
+          const clean = status?.dirty === false;
+          const normalizedManagedPath = normalizePathForKey(managedPath);
+          const current = worktreeInfo?.isMainWorktree === true;
+          let disabledReason: string | null = null;
+          if (current) {
+            disabledReason = 'Main worktree cannot be deleted.';
+          } else if (mountedPaths.has(normalizedManagedPath)) {
+            disabledReason = 'Worktree is currently mounted.';
+          } else if (!worktreeInfo?.branch || worktreeInfo.isDetached) {
+            disabledReason = 'Detached worktrees cannot be deleted.';
+          } else if (!clean) {
+            disabledReason = 'Worktree has uncommitted changes.';
+          }
+
+          return {
+            path: managedPath,
+            name: path.basename(managedPath),
+            branch: worktreeInfo?.branch ?? summary.branch,
+            headSha: worktreeInfo?.headSha ?? summary.headSha,
+            lastUsedAt: lastUsedByPath.get(managedPath) ?? null,
+            clean,
+            current,
+            removable: disabledReason === null,
+            disabledReason,
+            repositoryId: summary.repositoryId ?? null,
+            mainWorktreePath: summaryMainWorktreePath,
+            normalizedMainWorktreePath,
+          } satisfies ManagedWorktreeInspection;
+        } catch (error) {
+          this.logger.debug(
+            `[WorktreeSetupSettings] Failed to inspect managed worktree ${managedPath}: ${error instanceof Error ? error.message : String(error)}`,
+          );
+          return null;
+        }
+      },
+    );
+
+    const inspectedWorktrees = worktrees.filter(
+      (worktree): worktree is ManagedWorktreeInspection => Boolean(worktree),
+    );
+
+    return inspectedWorktrees;
+  }
+
+  private async listManagedWorktreePaths(): Promise<string[]> {
+    const worktreesDir = getWorktreesDir();
+    let repoEntries: string[];
+    try {
+      repoEntries = await fs.readdir(worktreesDir);
+    } catch {
+      return [];
+    }
+
+    const paths: string[] = [];
+    const visitDirectory = async (directoryPath: string): Promise<void> => {
+      try {
+        const stat = await fs.lstat(directoryPath);
+        if (!stat.isDirectory() || stat.isSymbolicLink()) return;
+
+        await fs.lstat(path.join(directoryPath, '.git'));
+        const resolvedPath =
+          await this.resolveManagedWorktreePath(directoryPath);
+        if (resolvedPath) paths.push(resolvedPath);
+        return;
+      } catch {
+        // No .git entry at this level, or the directory is not readable.
+      }
+
+      let directoryEntries: string[];
+      try {
+        directoryEntries = await fs.readdir(directoryPath);
+      } catch {
+        return;
+      }
+
+      await Promise.all(
+        directoryEntries
+          .filter((entry) => entry !== '.git')
+          .map((entry) => visitDirectory(path.join(directoryPath, entry))),
+      );
+    };
+
+    await Promise.all(
+      repoEntries.map((repoEntry) =>
+        visitDirectory(path.join(worktreesDir, repoEntry)),
+      ),
+    );
+
+    return paths;
+  }
+
+  private async resolveManagedWorktreePath(
+    workspacePath: string,
+  ): Promise<string | null> {
+    const [worktreesDir, resolvedPath] = await Promise.all([
+      safeRealpath(getWorktreesDir()),
+      safeRealpath(workspacePath),
+    ]);
+    if (!worktreesDir || !resolvedPath) return null;
+    const relativeToWorktrees = path.relative(worktreesDir, resolvedPath);
+    if (
+      relativeToWorktrees.length === 0 ||
+      relativeToWorktrees.startsWith('..') ||
+      path.isAbsolute(relativeToWorktrees)
+    ) {
+      return null;
+    }
+    return resolvedPath;
+  }
+
+  private async getNormalizedMountedPaths(): Promise<Set<string>> {
+    const mountedPaths = this.getMountedWorkspacePaths();
+    const normalized = new Set<string>();
+    await Promise.all(
+      [...mountedPaths].map(async (mountedPath) => {
+        const resolvedPath =
+          (await safeRealpath(mountedPath)) ?? path.resolve(mountedPath);
+        normalized.add(normalizePathForKey(resolvedPath));
+      }),
+    );
+    return normalized;
+  }
+}

--- a/apps/browser/src/shared/karton-contracts/ui/index.ts
+++ b/apps/browser/src/shared/karton-contracts/ui/index.ts
@@ -155,10 +155,8 @@ export type WorkspaceGitSetupStatus = 'running' | 'succeeded' | 'failed';
 export type WorkspaceGitSetupRun = {
   id: string;
   workspacePath: string;
+  sourceWorktreePath: string;
   mainWorktreePath: string;
-  repositoryId: string;
-  sourceBranch: string;
-  worktreeBranch: string;
   scriptPath: string;
   status: WorkspaceGitSetupStatus;
   startedAt: number;
@@ -172,6 +170,41 @@ export type WorkspaceGitSetupRun = {
 export type WorkspaceGitSetupState = {
   runsByPath: Record<string, WorkspaceGitSetupRun>;
 };
+
+export type WorktreeSetupManagedWorktree = {
+  path: string;
+  name: string;
+  branch: string | null;
+  headSha: string | null;
+  lastUsedAt: number | null;
+  clean: boolean;
+  current: boolean;
+  removable: boolean;
+  disabledReason: string | null;
+};
+
+export type WorktreeSetupRepositorySettings = {
+  id: string;
+  name: string;
+  mainWorktreePath: string;
+  repositoryId: string | null;
+  scriptPath: string;
+  scriptExists: boolean;
+  scriptContent: string;
+  managedWorktrees: WorktreeSetupManagedWorktree[];
+};
+
+export type WorktreeSetupRepositoriesResult = {
+  repositories: WorktreeSetupRepositorySettings[];
+};
+
+export type SaveWorktreeSetupScriptResult =
+  | { ok: true; repository: WorktreeSetupRepositorySettings }
+  | { ok: false; message: string };
+
+export type DeleteWorktreeSetupWorktreeResult =
+  | { ok: true; repository: WorktreeSetupRepositorySettings | null }
+  | { ok: false; message: string };
 
 export type WorkspaceGitFailureReason =
   | 'not-git-repo'
@@ -1089,6 +1122,14 @@ export type KartonContract = {
         path: string,
         options?: WorkspaceGitWorktreeDeleteOptions,
       ) => Promise<WorkspaceGitWorktreeDeleteResult>;
+      listWorktreeSetupRepositories: () => Promise<WorktreeSetupRepositoriesResult>;
+      saveWorktreeSetupScript: (
+        mainWorktreePath: string,
+        content: string,
+      ) => Promise<SaveWorktreeSetupScriptResult>;
+      deleteWorktreeSetupWorktree: (
+        worktreePath: string,
+      ) => Promise<DeleteWorktreeSetupWorktreeResult>;
       listWorkspaceGitBranches: (
         agentInstanceId: string,
         mountPrefix: string,

--- a/apps/browser/src/shared/settings-route.ts
+++ b/apps/browser/src/shared/settings-route.ts
@@ -3,6 +3,7 @@ export type SettingsSection =
   | 'custom-providers'
   | 'agent-general'
   | 'skills-context'
+  | 'worktree-setup'
   | 'plugins'
   | 'browsing'
   | 'history'
@@ -20,6 +21,7 @@ export const SETTINGS_SECTION_LABELS: Record<SettingsSection, string> = {
   'custom-providers': 'Custom Providers',
   'agent-general': 'General',
   'skills-context': 'Skills & Context files',
+  'worktree-setup': 'Worktrees',
   plugins: 'Plugins',
   browsing: 'General',
   history: 'History',

--- a/apps/browser/src/ui/screens/settings/content.tsx
+++ b/apps/browser/src/ui/screens/settings/content.tsx
@@ -11,6 +11,7 @@ import { ClearDataSection } from './sections/clear-data-section';
 import { AccountSection } from './sections/account-section';
 import { AboutSection } from './sections/about-section';
 import { HistorySection } from './sections/history-section';
+import { WorktreeSetupSection } from './sections/agent-settings.worktree-setup';
 
 export function SettingsContent() {
   const settingsRoute = useKartonState((s) => s.appScreen.settingsRoute);
@@ -25,6 +26,8 @@ export function SettingsContent() {
       return <GeneralSettingsSection />;
     case 'skills-context':
       return <SkillsContextSection />;
+    case 'worktree-setup':
+      return <WorktreeSetupSection />;
     case 'plugins':
       return <PluginsSection />;
     case 'browsing':

--- a/apps/browser/src/ui/screens/settings/sections/agent-settings.worktree-setup.tsx
+++ b/apps/browser/src/ui/screens/settings/sections/agent-settings.worktree-setup.tsx
@@ -1,0 +1,712 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { CheckIcon, CopyIcon } from 'lucide-react';
+import { Button, buttonVariants } from '@stagewise/stage-ui/components/button';
+import { Input } from '@stagewise/stage-ui/components/input';
+import { OverlayScrollbar } from '@stagewise/stage-ui/components/overlay-scrollbar';
+import {
+  Popover,
+  PopoverClose,
+  PopoverContent,
+  PopoverDescription,
+  PopoverFooter,
+  PopoverTitle,
+  PopoverTrigger,
+} from '@stagewise/stage-ui/components/popover';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@stagewise/stage-ui/components/tooltip';
+import { toast } from '@stagewise/stage-ui/components/toaster';
+import { useKartonProcedure } from '@ui/hooks/use-karton';
+import { cn } from '@ui/utils';
+import { useScrollFadeMask } from '@ui/hooks/use-scroll-fade-mask';
+import type {
+  KartonContract,
+  WorktreeSetupManagedWorktree,
+  WorktreeSetupRepositorySettings,
+} from '@shared/karton-contracts/ui';
+import {
+  IconBranchOutOutline18,
+  IconCircleQuestionOutline18,
+  IconTrashOutline18,
+} from 'nucleo-ui-outline-18';
+import { FileIcon } from '@ui/components/file-icon';
+import { FileContextMenu } from '@ui/components/file-context-menu';
+
+const SETUP_SCRIPT_TEMPLATE = `#!/bin/sh
+set -e
+
+# Runs after stagewise creates and mounts a new Git worktree.
+# CWD is the new worktree.
+
+# Example:
+# pnpm install
+`;
+
+function getInitialScriptDraft(
+  repository: WorktreeSetupRepositorySettings,
+): string {
+  return repository.scriptExists
+    ? repository.scriptContent
+    : SETUP_SCRIPT_TEMPLATE;
+}
+
+function formatRelativeTime(timestamp: number | null): string {
+  if (timestamp === null) return 'Never used';
+  const diffMs = Date.now() - timestamp;
+  const diffMinutes = Math.max(1, Math.floor(diffMs / 60_000));
+  if (diffMinutes < 60) return `${diffMinutes}m ago`;
+  const diffHours = Math.floor(diffMinutes / 60);
+  if (diffHours < 24) return `${diffHours}h ago`;
+  const diffDays = Math.floor(diffHours / 24);
+  return `${diffDays}d ago`;
+}
+
+export function WorktreeSetupSection() {
+  const listRepositories = useKartonProcedure(
+    (p: KartonContract['serverProcedures']) =>
+      p.toolbox.listWorktreeSetupRepositories,
+  );
+  const saveScript = useKartonProcedure(
+    (p: KartonContract['serverProcedures']) =>
+      p.toolbox.saveWorktreeSetupScript,
+  );
+  const deleteWorktree = useKartonProcedure(
+    (p: KartonContract['serverProcedures']) =>
+      p.toolbox.deleteWorktreeSetupWorktree,
+  );
+  const listRepositoriesRef = useRef(listRepositories);
+  listRepositoriesRef.current = listRepositories;
+  const refreshInFlightRef = useRef<Promise<void> | null>(null);
+  const mountedRef = useRef(true);
+
+  const [repositories, setRepositories] = useState<
+    WorktreeSetupRepositorySettings[]
+  >([]);
+  const [selectedRepositoryId, setSelectedRepositoryId] = useState<
+    string | null
+  >(null);
+  const [scriptDraft, setScriptDraft] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [deletingPath, setDeletingPath] = useState<string | null>(null);
+  const previousSelectedRepositoryIdRef = useRef<string | null>(null);
+
+  const selectedRepository = useMemo(
+    () =>
+      repositories.find(
+        (repository) => repository.id === selectedRepositoryId,
+      ) ??
+      repositories[0] ??
+      null,
+    [repositories, selectedRepositoryId],
+  );
+
+  const dirty =
+    selectedRepository !== null &&
+    scriptDraft !== getInitialScriptDraft(selectedRepository);
+
+  const refreshRepositories = useCallback(async () => {
+    if (refreshInFlightRef.current) {
+      return refreshInFlightRef.current;
+    }
+
+    const refreshPromise = (async () => {
+      if (mountedRef.current) setLoading(true);
+      try {
+        const result = await listRepositoriesRef.current();
+
+        if (!mountedRef.current) return;
+        setRepositories(result.repositories);
+        setSelectedRepositoryId((current) => {
+          if (
+            current &&
+            result.repositories.some(
+              (repo: WorktreeSetupRepositorySettings) => repo.id === current,
+            )
+          ) {
+            return current;
+          }
+          return result.repositories[0]?.id ?? null;
+        });
+      } finally {
+        refreshInFlightRef.current = null;
+        if (mountedRef.current) setLoading(false);
+      }
+    })();
+
+    refreshInFlightRef.current = refreshPromise;
+    return refreshPromise;
+  }, []);
+
+  useEffect(() => {
+    void refreshRepositories();
+  }, [refreshRepositories]);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    const selectedRepositoryId = selectedRepository?.id ?? null;
+    if (previousSelectedRepositoryIdRef.current === selectedRepositoryId) {
+      return;
+    }
+
+    previousSelectedRepositoryIdRef.current = selectedRepositoryId;
+    setScriptDraft(
+      selectedRepository ? getInitialScriptDraft(selectedRepository) : '',
+    );
+  }, [selectedRepository]);
+
+  const updateRepository = useCallback(
+    (repository: WorktreeSetupRepositorySettings) => {
+      setRepositories((current) => {
+        const index = current.findIndex((item) => item.id === repository.id);
+        if (index === -1) return current;
+        const next = [...current];
+        next[index] = repository;
+        return next;
+      });
+      setSelectedRepositoryId(repository.id);
+    },
+    [],
+  );
+
+  const handleSave = useCallback(async () => {
+    if (!selectedRepository) return;
+    setSaving(true);
+    try {
+      const result = await saveScript(
+        selectedRepository.mainWorktreePath,
+        scriptDraft,
+      );
+      if (result.ok) {
+        updateRepository(result.repository);
+        toast({
+          id: `worktree-setup-save-${Date.now()}`,
+          title: 'Worktree setup script saved',
+          message: 'Your setup script was updated.',
+          type: 'info',
+          actions: [],
+        });
+      } else {
+        toast({
+          id: `worktree-setup-save-error-${Date.now()}`,
+          title: 'Failed to save setup script',
+          message: result.message,
+          type: 'error',
+          actions: [],
+        });
+      }
+    } finally {
+      setSaving(false);
+    }
+  }, [saveScript, scriptDraft, selectedRepository, updateRepository]);
+
+  const handleReset = useCallback(() => {
+    if (!selectedRepository) return;
+    setScriptDraft(getInitialScriptDraft(selectedRepository));
+  }, [selectedRepository]);
+
+  const handleConfirmDelete = useCallback(
+    async (worktree: WorktreeSetupManagedWorktree) => {
+      setDeletingPath(worktree.path);
+      try {
+        const result = await deleteWorktree(worktree.path);
+        if (result.ok) {
+          if (result.repository) updateRepository(result.repository);
+          else await refreshRepositories();
+          toast({
+            id: `worktree-delete-${Date.now()}`,
+            title: 'Worktree deleted',
+            message: 'The local worktree checkout was removed.',
+            type: 'info',
+            actions: [],
+          });
+          return true;
+        }
+
+        toast({
+          id: `worktree-delete-error-${Date.now()}`,
+          title: 'Failed to delete worktree',
+          message: result.message,
+          type: 'error',
+          actions: [],
+        });
+        return false;
+      } finally {
+        setDeletingPath(null);
+      }
+    },
+    [deleteWorktree, refreshRepositories, updateRepository],
+  );
+
+  return (
+    <div className="h-full w-full">
+      {/* Content */}
+      <OverlayScrollbar className="h-full" contentClassName="px-6 pt-24 pb-24">
+        <div className="mx-auto max-w-3xl space-y-8">
+          {/* Header */}
+          <div>
+            <h1 className="font-semibold text-foreground text-xl">Worktrees</h1>
+            <p className="text-muted-foreground text-sm">
+              Configure scripts and clean stagewise-managed Git worktrees.
+            </p>
+          </div>
+
+          <RepositoryList
+            repositories={repositories}
+            selectedRepositoryId={selectedRepository?.id ?? null}
+            onSelect={setSelectedRepositoryId}
+          />
+
+          <section className="min-w-0">
+            {selectedRepository ? (
+              <RepositoryDetails
+                repository={selectedRepository}
+                scriptDraft={scriptDraft}
+                dirty={dirty}
+                saving={saving}
+                deletingPath={deletingPath}
+                onScriptDraftChange={setScriptDraft}
+                onReset={handleReset}
+                onSave={handleSave}
+                onConfirmDelete={handleConfirmDelete}
+              />
+            ) : (
+              <div className="flex min-h-80 items-center justify-center rounded-lg border border-derived-subtle">
+                <p className="text-muted-foreground text-sm">
+                  {loading
+                    ? 'Loading repositories...'
+                    : 'No known Git repositories yet. Connect a Git workspace once to configure worktree setup here.'}
+                </p>
+              </div>
+            )}
+          </section>
+        </div>
+      </OverlayScrollbar>
+    </div>
+  );
+}
+
+function RepositoryList({
+  repositories,
+  selectedRepositoryId,
+  onSelect,
+}: {
+  repositories: WorktreeSetupRepositorySettings[];
+  selectedRepositoryId: string | null;
+  onSelect: (id: string) => void;
+}) {
+  const [viewport, setViewport] = useState<HTMLElement | null>(null);
+  const viewportRef = useRef<HTMLElement | null>(null);
+  viewportRef.current = viewport;
+  const { maskStyle } = useScrollFadeMask(viewportRef, {
+    axis: 'horizontal',
+    fadeDistance: 24,
+  });
+
+  return (
+    <OverlayScrollbar
+      className="scrollbar-subtle mask-alpha max-w-full"
+      style={maskStyle}
+      options={{ overflow: { x: 'scroll', y: 'hidden' } }}
+      onViewportRef={setViewport}
+      contentClassName="flex gap-2"
+    >
+      <nav className="flex gap-2">
+        {repositories.map((repository) => {
+          const selected = selectedRepositoryId === repository.id;
+          const worktreeCount = repository.managedWorktrees.length;
+          return (
+            <button
+              key={repository.id}
+              type="button"
+              onClick={() => onSelect(repository.id)}
+              className={cn(
+                buttonVariants({
+                  variant: 'ghost',
+                }),
+                'h-auto shrink-0 flex-col items-start px-3 py-2 text-left first:pl-0',
+                selected && 'font-medium text-foreground',
+              )}
+            >
+              <span className="block truncate text-sm">{repository.name}</span>
+              <span
+                className={cn(
+                  'block truncate text-xs',
+                  selected
+                    ? 'text-muted-foreground group-hover/button:text-foreground group-focus-visible/button:text-foreground'
+                    : 'text-subtle-foreground group-hover/button:text-muted-foreground group-focus-visible/button:text-muted-foreground',
+                )}
+              >
+                {worktreeCount} {worktreeCount === 1 ? 'worktree' : 'worktrees'}{' '}
+                used
+              </span>
+            </button>
+          );
+        })}
+      </nav>
+    </OverlayScrollbar>
+  );
+}
+
+function RepositoryDetails({
+  repository,
+  scriptDraft,
+  dirty,
+  saving,
+  deletingPath,
+  onScriptDraftChange,
+  onReset,
+  onSave,
+  onConfirmDelete,
+}: {
+  repository: WorktreeSetupRepositorySettings;
+  scriptDraft: string;
+  dirty: boolean;
+  saving: boolean;
+  deletingPath: string | null;
+  onScriptDraftChange: (value: string) => void;
+  onReset: () => void;
+  onSave: () => void;
+  onConfirmDelete: (worktree: WorktreeSetupManagedWorktree) => Promise<boolean>;
+}) {
+  return (
+    <div className="space-y-8">
+      <section className="space-y-3">
+        <div>
+          <div className="flex items-center gap-2">
+            <h3 className="font-medium text-foreground text-sm">Script</h3>
+            <SetupVariablesPopover />
+          </div>
+          <div className="flex items-center justify-between">
+            <p className="text-muted-foreground text-xs">
+              Runs for new worktrees when the checked-out branch contains this
+              file.
+            </p>
+            <FileContextMenu
+              relativePath={repository.scriptPath}
+              resolvePath={(p) => p}
+            >
+              <Tooltip>
+                <TooltipTrigger>
+                  <button
+                    type="button"
+                    className={cn(
+                      buttonVariants({ variant: 'ghost', size: 'xs' }),
+                      'h-auto px-1 py-0.5',
+                    )}
+                  >
+                    <FileIcon
+                      filePath={repository.scriptPath}
+                      className="size-4 shrink-0"
+                    />
+                    <span>worktree-setup.sh</span>
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent>{repository.scriptPath}</TooltipContent>
+              </Tooltip>
+            </FileContextMenu>
+          </div>
+        </div>
+        <textarea
+          value={scriptDraft}
+          onChange={(event) => onScriptDraftChange(event.target.value)}
+          spellCheck={false}
+          className="scrollbar-subtle min-h-72 w-full resize-y rounded-lg border border-derived bg-surface-1 p-3 font-mono text-foreground text-xs outline-none ring-0 transition-colors placeholder:text-subtle-foreground focus:border-derived-strong"
+        />
+        <div className="flex justify-end gap-2">
+          <Button variant="ghost" size="sm" onClick={onReset} disabled={!dirty}>
+            Reset
+          </Button>
+          <Button
+            size="sm"
+            onClick={() => void onSave()}
+            disabled={!dirty || saving}
+          >
+            {saving ? 'Saving...' : 'Save'}
+          </Button>
+        </div>
+      </section>
+
+      <ManagedWorktreeList
+        worktrees={repository.managedWorktrees}
+        deletingPath={deletingPath}
+        onConfirmDelete={onConfirmDelete}
+      />
+    </div>
+  );
+}
+
+function SetupVariablesPopover() {
+  return (
+    <Popover>
+      <PopoverTrigger>
+        <button
+          type="button"
+          className="group/button relative box-border flex h-5 cursor-pointer flex-row items-center justify-center gap-1 rounded-md bg-transparent px-1.5 py-1 font-normal text-subtle-foreground text-xs outline-none transition-colors hover:text-muted-foreground focus-visible:text-muted-foreground focus-visible:ring-2 focus-visible:ring-primary-solid/40 active:text-muted-foreground"
+          aria-label="Show setup script environment variables"
+        >
+          <span>Available variables</span>
+          <IconCircleQuestionOutline18 className="size-3.5" />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent side="top" align="start" className="w-80 gap-4 p-3">
+        <PopoverTitle>Setup script environment variables</PopoverTitle>
+        <PopoverDescription>
+          These path variables are available when the worktree setup script
+          runs.
+        </PopoverDescription>
+        <PopoverClose />
+        <div className="space-y-3">
+          <SetupVariableItem
+            label="Source worktree path"
+            value="STAGEWISE_SOURCE_WORKTREE_PATH"
+          />
+          <SetupVariableItem
+            label="Target worktree path"
+            value="STAGEWISE_TARGET_WORKTREE_PATH"
+          />
+          <SetupVariableItem
+            label="Main worktree path"
+            value="STAGEWISE_MAIN_WORKTREE_PATH"
+          />
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+function SetupVariableItem({ label, value }: { label: string; value: string }) {
+  const [hasCopied, setHasCopied] = useState(false);
+  const resetTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const handleCopy = useCallback(() => {
+    void navigator.clipboard?.writeText(value);
+    setHasCopied(true);
+    if (resetTimeoutRef.current) clearTimeout(resetTimeoutRef.current);
+    resetTimeoutRef.current = setTimeout(() => setHasCopied(false), 2000);
+  }, [value]);
+
+  useEffect(() => {
+    return () => {
+      if (resetTimeoutRef.current) clearTimeout(resetTimeoutRef.current);
+    };
+  }, []);
+
+  return (
+    <div className="space-y-1.5">
+      <p className="text-muted-foreground text-xs">{label}</p>
+      <button
+        type="button"
+        onClick={handleCopy}
+        className="group/variable flex w-full cursor-pointer items-center gap-2 rounded-md border border-derived-subtle bg-surface-1 px-2 py-1.5 text-left font-mono text-foreground text-xs outline-none transition-colors hover:bg-hover-derived focus-visible:ring-2 focus-visible:ring-primary-solid/40"
+        aria-label={`Copy ${value}`}
+      >
+        <code className="min-w-0 flex-1 truncate">{value}</code>
+        {hasCopied ? (
+          <CheckIcon className="size-3 shrink-0 text-foreground" />
+        ) : (
+          <CopyIcon className="size-3 shrink-0 text-muted-foreground opacity-0 transition-opacity group-hover/variable:opacity-100 group-focus-visible/variable:opacity-100" />
+        )}
+      </button>
+    </div>
+  );
+}
+
+function ManagedWorktreeList({
+  worktrees,
+  deletingPath,
+  onConfirmDelete,
+}: {
+  worktrees: WorktreeSetupManagedWorktree[];
+  deletingPath: string | null;
+  onConfirmDelete: (worktree: WorktreeSetupManagedWorktree) => Promise<boolean>;
+}) {
+  const [searchQuery, setSearchQuery] = useState('');
+  const [viewport, setViewport] = useState<HTMLElement | null>(null);
+  const viewportRef = useRef<HTMLElement | null>(null);
+  viewportRef.current = viewport;
+  const { maskStyle } = useScrollFadeMask(viewportRef, {
+    axis: 'vertical',
+    fadeDistance: 24,
+  });
+
+  const filteredWorktrees = useMemo(() => {
+    const query = searchQuery.trim().toLowerCase();
+    if (!query) return worktrees;
+
+    return worktrees.filter((worktree) =>
+      [
+        worktree.name,
+        worktree.path,
+        worktree.branch ?? '',
+        worktree.headSha ?? '',
+      ].some((value) => value.toLowerCase().includes(query)),
+    );
+  }, [searchQuery, worktrees]);
+
+  const noResults =
+    searchQuery.trim().length > 0 && filteredWorktrees.length === 0;
+
+  return (
+    <section className="space-y-3">
+      <div>
+        <h3 className="font-medium text-foreground text-sm">
+          Managed worktrees
+        </h3>
+        <p className="text-muted-foreground text-xs">
+          Stagewise-controlled worktree instances for this repository.
+        </p>
+      </div>
+
+      {worktrees.length > 0 ? (
+        <Input
+          placeholder="Filter worktrees..."
+          value={searchQuery}
+          onValueChange={setSearchQuery}
+          size="sm"
+          className="flex-1"
+          style={{ maxWidth: 'none' }}
+        />
+      ) : null}
+
+      {worktrees.length === 0 ? (
+        <div className="rounded-lg border border-derived-subtle p-4">
+          <p className="text-center text-muted-foreground text-sm">
+            No stagewise-managed worktrees for this repository.
+          </p>
+        </div>
+      ) : (
+        <OverlayScrollbar
+          className="mask-alpha max-h-80"
+          style={maskStyle}
+          onViewportRef={setViewport}
+          contentClassName="space-y-2"
+        >
+          {filteredWorktrees.map((worktree) => (
+            <WorktreeRow
+              key={worktree.path}
+              worktree={worktree}
+              deleting={deletingPath === worktree.path}
+              onConfirmDelete={onConfirmDelete}
+            />
+          ))}
+
+          {noResults ? (
+            <div className="rounded-lg border border-derived-subtle p-4">
+              <p className="text-center text-muted-foreground text-sm">
+                No worktrees match your filter.
+              </p>
+            </div>
+          ) : null}
+        </OverlayScrollbar>
+      )}
+    </section>
+  );
+}
+
+function WorktreeRow({
+  worktree,
+  deleting,
+  onConfirmDelete,
+}: {
+  worktree: WorktreeSetupManagedWorktree;
+  deleting: boolean;
+  onConfirmDelete: (worktree: WorktreeSetupManagedWorktree) => Promise<boolean>;
+}) {
+  const [deletePopoverOpen, setDeletePopoverOpen] = useState(false);
+  const timeAgo = formatRelativeTime(worktree.lastUsedAt);
+
+  const deleteButtonClassName =
+    'absolute right-3 flex size-5 cursor-pointer items-center justify-center text-muted-foreground opacity-0 outline-none transition-opacity hover:text-foreground focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-primary-solid/40 disabled:cursor-not-allowed disabled:opacity-0 group-focus-within/worktree:opacity-100 group-hover/worktree:opacity-100 disabled:group-hover/worktree:opacity-40';
+
+  const deleteButton = (
+    <button
+      type="button"
+      disabled={!worktree.removable || deleting}
+      aria-label={`Delete ${worktree.name}`}
+      className={deleteButtonClassName}
+    >
+      <IconTrashOutline18 className="size-3.5" />
+    </button>
+  );
+
+  return (
+    <div className="group/worktree relative flex items-center gap-3 rounded-lg border border-derived bg-surface-1 p-3 pr-10">
+      <IconBranchOutOutline18 className="size-4 shrink-0 text-muted-foreground" />
+      <div className="min-w-0 flex-1">
+        <h4 className="flex min-w-0 items-center gap-1.5 font-medium text-sm">
+          <span className="truncate text-foreground">{worktree.name}</span>
+          <span className="shrink-0 text-subtle-foreground text-xs">
+            {timeAgo}
+          </span>
+        </h4>
+        <p className="truncate text-muted-foreground text-xs">
+          {worktree.path}
+        </p>
+      </div>
+      {worktree.removable ? (
+        <Popover open={deletePopoverOpen} onOpenChange={setDeletePopoverOpen}>
+          <PopoverTrigger>{deleteButton}</PopoverTrigger>
+          <PopoverContent side="top" align="end" className="w-72">
+            <PopoverTitle>Delete worktree?</PopoverTitle>
+            <PopoverDescription>
+              This removes the local worktree checkout. It does not delete the
+              branch.
+            </PopoverDescription>
+            <PopoverClose />
+            <PopoverFooter>
+              <Button
+                variant="primary"
+                size="xs"
+                disabled={deleting}
+                onClick={async () => {
+                  const deleted = await onConfirmDelete(worktree);
+                  if (deleted) setDeletePopoverOpen(false);
+                }}
+                autoFocus
+              >
+                {deleting ? 'Deleting...' : 'Delete worktree'}
+              </Button>
+              <Button
+                variant="ghost"
+                size="xs"
+                disabled={deleting}
+                onClick={() => setDeletePopoverOpen(false)}
+              >
+                Cancel
+              </Button>
+            </PopoverFooter>
+          </PopoverContent>
+        </Popover>
+      ) : (
+        <Tooltip>
+          <TooltipTrigger>
+            <button
+              type="button"
+              className={cn(
+                deleteButtonClassName,
+                'cursor-not-allowed group-hover/worktree:opacity-40',
+              )}
+              aria-disabled="true"
+              aria-label={`Cannot delete ${worktree.name}`}
+              onClick={(event) => event.preventDefault()}
+            >
+              <IconTrashOutline18 className="size-3.5" />
+            </button>
+          </TooltipTrigger>
+          {worktree.disabledReason ? (
+            <TooltipContent>{worktree.disabledReason}</TooltipContent>
+          ) : null}
+        </Tooltip>
+      )}
+    </div>
+  );
+}

--- a/apps/browser/src/ui/screens/settings/settings-route.tsx
+++ b/apps/browser/src/ui/screens/settings/settings-route.tsx
@@ -4,6 +4,7 @@ import {
   SettingsIcon,
   FileTextIcon,
   PuzzleIcon,
+  GitBranchIcon,
   GlobeIcon,
   Trash2Icon,
   ClockIcon,
@@ -43,6 +44,10 @@ export const SETTINGS_NAV_GROUPS: SettingsNavGroup[] = [
       {
         section: 'skills-context',
         icon: <FileTextIcon className="size-4 shrink-0" />,
+      },
+      {
+        section: 'worktree-setup',
+        icon: <GitBranchIcon className="size-4 shrink-0" />,
       },
       {
         section: 'plugins',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Worktrees" (Agent) settings section with repository picker, searchable managed-worktree list, per-repo setup script editor (Save/Reset), copyable env vars, and delete controls with confirmation/tooltips.
  * New backend/UI procedures to list repositories, save per-repo setup scripts, and delete managed worktrees; worktree setup runs now pass source/target/main worktree paths to scripts.

* **Tests**
  * New and updated tests covering repository listing, script saving, worktree deletion, and setup-run behavior.

* **Chores**
  * Ignored stagewise directory contents while allowing per-repo setup script to be tracked; added example setup script used by tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Worktrees settings section to configure per-repo setup scripts and manage stagewise-managed Git worktrees. Scripts now use simpler path-based env vars and fall back to the main worktree’s script when the target has none.

- **New Features**
  - Settings > Worktrees tab to manage repos and stagewise-managed worktrees; repos and worktrees sorted by recent usage.
  - Edit a per-repo setup script at `.stagewise/worktree-setup.sh`; UI shows copyable env vars; Save/Reset; runner runs the target worktree using the main worktree’s script when the target lacks one.
  - View/filter managed worktrees; shows branch, SHA, and “last used”; delete with confirmation and validations (blocks main, mounted, dirty, or detached).
  - Backend `WorktreeSetupSettingsService` and procedures: `toolbox.listWorktreeSetupRepositories`, `toolbox.saveWorktreeSetupScript`, `toolbox.deleteWorktreeSetupWorktree`; includes managed-dir scanning, last-used lookup, handling unreadable scripts and managed-only repos; tests.

- **Refactors**
  - Worktree setup env vars simplified to `STAGEWISE_SOURCE_WORKTREE_PATH`, `STAGEWISE_TARGET_WORKTREE_PATH`, and `STAGEWISE_MAIN_WORKTREE_PATH`.
  - Setup run metadata trimmed to source and main worktree paths; minor UI polish and ARIA/fade-out fixes.

<sup>Written for commit ce5164db692b4a045c12e6ba80eb7d8ad475fc56. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1245?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

