### PR TITLE
fix(browser): add Cache-Control: no-store to attachment protocol handler

### DIFF
--- a/apps/browser/src/backend/services/window-layout/ui-controller.ts
+++ b/apps/browser/src/backend/services/window-layout/ui-controller.ts
@@ -309,7 +309,10 @@ export class UIController extends EventEmitter<UIControllerEventMap> {
 
         return new Response(fileResponse.body, {
           status: 200,
-          headers: { 'Content-Type': mediaType },
+          headers: {
+            'Content-Type': mediaType,
+            'Cache-Control': 'no-store',
+          },
         });
       } catch (err) {
         this.logger.error('[UIController] attachment protocol error', {


### PR DESCRIPTION
## Problem

When an agent captures multiple screenshots reusing the same filename, the chat UI always shows the first (oldest) screenshot — even after the file is overwritten with a new image.

Root cause: the `attachment://` custom protocol handler in `registerAttachmentProtocol()` returns responses with only a `Content-Type` header. Without a `Cache-Control` header, Chromium applies its default caching heuristics and serves the cached response for the same URL, ignoring the updated file on disk.

Fixes #1149

## Solution

Add `Cache-Control: no-store` to every successful `attachment://` response. This prevents Chromium from storing the response in its cache, so each request reads the current file from disk.

## Testing

1. Start the app and open an agent session.
2. Ask the agent to take a screenshot and note the result shown in the chat.
3. Ask the agent to take another screenshot with the same filename (e.g. instruct it to save to the same path).
4. **Before:** the chat shows the old screenshot (browser cache hit).  
   **After:** the chat shows the latest screenshot on each request.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Cache-Control: no-store to all `attachment://` protocol responses to disable Chromium caching and prevent stale images in chat. Ensures the latest file is shown even when a screenshot reuses the same filename (fixes #1149).

<sup>Written for commit 926b986f9277b121e007c287803f05fa19885cc7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1246?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Modified attachment response headers to prevent caching, ensuring attachments are always retrieved fresh.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->