### PR TITLE
Osc fix

### DIFF
--- a/apps/browser/src/backend/services/toolbox/services/shell/osc-parser.test.ts
+++ b/apps/browser/src/backend/services/toolbox/services/shell/osc-parser.test.ts
@@ -209,6 +209,31 @@ describe('OscParser — OSC 133 mode', () => {
       '/Users/test/very/long/path/inside/workspace',
     );
   });
+
+  it('emits interleaved output before commandStart/commandDone within a single chunk', () => {
+    const order: string[] = [];
+    let done: CommandDoneEvent | undefined;
+    parser.on('output', () => order.push('output'));
+    parser.on('commandStart', () => order.push('commandStart'));
+    parser.on('commandDone', (e) => {
+      order.push('commandDone');
+      done = e;
+    });
+
+    // Echo, command start, output, and done marker all arrive in ONE PTY
+    // chunk. This is the chunk-boundary race the render-decoupling fix
+    // addresses: the parser must emit the pre-133;C echo as `output` BEFORE
+    // `commandStart`, and the command body as `output` BEFORE `commandDone`,
+    // so the session manager's renderToTerminal positions the cursor
+    // correctly before serializeFrom(markLine) runs in the resolution
+    // handlers. If output were emitted after the resolution events (or the
+    // whole chunk rendered up-front), the captured mark line would be blank.
+    parser.write(`pwd\n${osc('C')}/home/user\n${osc('D', '0')}`);
+
+    expect(order).toEqual(['output', 'commandStart', 'output', 'commandDone']);
+    expect(done?.output).toBe('/home/user\n');
+    expect(done?.exitCode).toBe(0);
+  });
 });
 
 // ─── OSC 7 cwd parsing ───────────────────────────────────────────

--- a/apps/browser/src/backend/services/toolbox/services/shell/osc-parser.test.ts
+++ b/apps/browser/src/backend/services/toolbox/services/shell/osc-parser.test.ts
@@ -494,6 +494,15 @@ describe('wrapWithSentinel', () => {
     expect(wrapped.endsWith('\r')).toBe(true);
   });
 
+  it('does not embed a literal newline in the printf format string', () => {
+    // A literal LF inside the single-quoted printf format breaks the line
+    // mid-quote over the PTY and triggers PS2 continuation prompts (quote>).
+    // The newline must be an escaped \n that printf expands at runtime.
+    const wrapped = wrapWithSentinel('nl1', 'pwd');
+    expect(wrapped).not.toContain('\n');
+    expect(wrapped).toContain('%d__\\n');
+  });
+
   it('escapes single quotes in command', () => {
     const wrapped = wrapWithSentinel('id1', "echo 'quoted'");
     expect(wrapped).toContain("\\'");

--- a/apps/browser/src/backend/services/toolbox/services/shell/osc-parser.ts
+++ b/apps/browser/src/backend/services/toolbox/services/shell/osc-parser.ts
@@ -189,12 +189,19 @@ export class OscParser extends (EventEmitter as new () => OscParserEmitter) {
     }
 
     if (this.mode === 'sentinel') {
-      // Emit OSC-stripped output so command output is accumulated by
-      // appendToCommandOutput even without OSC 133 framing. Stripping here
-      // keeps the `output` event contract uniform with OSC mode (always
-      // OSC-stripped), so stray OSC bytes a program prints in sentinel mode
-      // never pollute the rendered grid or captured output. processSentinel
-      // still receives the RAW bytes below so sentinel detection is unaffected.
+      // Strip the shell-integration markers (OSC 133/7) before emitting so the
+      // `output` event has the same shape in both modes — in OSC mode
+      // handleTextOutput() strips exactly those markers too. Only 133/7 are
+      // removed here: they are integration metadata the parser consumes.
+      // Other OSCs (title, hyperlink, color) are intentionally left intact so
+      // the headless xterm grid renders the same state as the real terminal.
+      // This is NOT the sanitization boundary for surfaced output: the text
+      // the agent sees is sanitized independently — stripAnsi() removes ALL
+      // OSC for the on-disk log, recentOutput, and the raw-pattern fallback,
+      // and grid serialization only reflects sequences xterm already consumed.
+      // So no raw OSC reaches captured output regardless of what is stripped
+      // here. processSentinel still receives the RAW bytes below so sentinel
+      // detection is unaffected.
       this.emit('output', stripOscSequences(processable));
       this.processSentinel(processable);
     }
@@ -404,6 +411,16 @@ export function stripOsc133(text: string): string {
   return stripOscSequences(text);
 }
 
+/**
+ * Remove the shell-integration OSC markers (OSC 133 command/prompt markers and
+ * OSC 7 cwd reports) from text.
+ *
+ * This intentionally does NOT strip other OSC sequences (title, hyperlink,
+ * color, clipboard): those are valid terminal output that the headless xterm
+ * grid renders faithfully. Surfaced text is sanitized separately — stripAnsi()
+ * in the session manager removes ALL OSC for the log/recentOutput/raw-pattern
+ * paths, and grid serialization only re-emits sequences xterm has consumed.
+ */
 function stripOscSequences(text: string): string {
   return text.replace(OSC_STRIP_RE, '');
 }

--- a/apps/browser/src/backend/services/toolbox/services/shell/osc-parser.ts
+++ b/apps/browser/src/backend/services/toolbox/services/shell/osc-parser.ts
@@ -444,7 +444,10 @@ export function wrapWithSentinel(
     return `try { ${command} } catch { }; Write-Host "__STAGE_DONE_${id}_$($LASTEXITCODE ?? 0)__"\r`;
   }
   // POSIX shells (bash, zsh, sh)
-  return `eval ${shellEscape(command)}; printf '__STAGE_DONE_${id}_%d__\n' $?\r`;
+  // NOTE: the newline must be an escaped \n (two chars) so printf expands it
+  // at runtime. A literal LF here would break the single-quoted format string
+  // mid-line and trigger PS2 continuation prompts (e.g. `quote>`) over the PTY.
+  return `eval ${shellEscape(command)}; printf '__STAGE_DONE_${id}_%d__\\n' $?\r`;
 }
 
 /**

--- a/apps/browser/src/backend/services/toolbox/services/shell/osc-parser.ts
+++ b/apps/browser/src/backend/services/toolbox/services/shell/osc-parser.ts
@@ -189,9 +189,13 @@ export class OscParser extends (EventEmitter as new () => OscParserEmitter) {
     }
 
     if (this.mode === 'sentinel') {
-      // Emit raw output so command output is accumulated
-      // by appendToCommandOutput even without OSC 133 framing.
-      this.emit('output', processable);
+      // Emit OSC-stripped output so command output is accumulated by
+      // appendToCommandOutput even without OSC 133 framing. Stripping here
+      // keeps the `output` event contract uniform with OSC mode (always
+      // OSC-stripped), so stray OSC bytes a program prints in sentinel mode
+      // never pollute the rendered grid or captured output. processSentinel
+      // still receives the RAW bytes below so sentinel detection is unaffected.
+      this.emit('output', stripOscSequences(processable));
       this.processSentinel(processable);
     }
 

--- a/apps/browser/src/backend/services/toolbox/services/shell/sanitize-env.test.ts
+++ b/apps/browser/src/backend/services/toolbox/services/shell/sanitize-env.test.ts
@@ -68,6 +68,17 @@ describe('sanitizeEnv', () => {
     expect(env.SOME_NORMAL_VAR).toBe('hello');
   });
 
+  it('strips the inherited shell-integration guard so each PTY can re-source', () => {
+    // If this leaks into the spawn env, the integration script's first-line
+    // guard short-circuits before registering OSC 133 hooks and every session
+    // falls back to sentinel mode.
+    process.env.__STAGEWISE_SHELL_INTEGRATION = '1';
+
+    const env = sanitizeEnv();
+
+    expect(env.__STAGEWISE_SHELL_INTEGRATION).toBeUndefined();
+  });
+
   describe('windows locale overrides', () => {
     let originalPlatform: NodeJS.Platform;
 

--- a/apps/browser/src/backend/services/toolbox/services/shell/sanitize-env.ts
+++ b/apps/browser/src/backend/services/toolbox/services/shell/sanitize-env.ts
@@ -114,6 +114,15 @@ export function sanitizeEnv(
 
     if (key.startsWith('ELECTRON_') || key.startsWith('ELECTRON ')) continue;
 
+    // Never inherit the shell-integration guard. The integration scripts set
+    // this to prevent double-sourcing within a single shell, but if it leaks
+    // into the spawn env (e.g. the app was launched from a terminal that had
+    // integration active), the script's first-line guard short-circuits before
+    // registering OSC 133 hooks. The parser then never detects integration and
+    // every session falls back to sentinel mode. Each fresh PTY must start with
+    // a clean slate so its own sourcing can register the hooks.
+    if (key === '__STAGEWISE_SHELL_INTEGRATION') continue;
+
     if (!isWhitelisted(key) && isSensitive(key)) continue;
 
     env[key] = value;

--- a/apps/browser/src/backend/services/toolbox/services/shell/session-logger.ts
+++ b/apps/browser/src/backend/services/toolbox/services/shell/session-logger.ts
@@ -137,15 +137,19 @@ export class SessionLogger {
   }
 
   /**
-   * Append raw (unstripped) PTY bytes to the in-memory circular buffer.
-   * Oldest chunks are evicted when the total exceeds MAX_RAW_BUFFER_BYTES.
+   * Store raw (unstripped) PTY bytes in the in-memory circular buffer for
+   * future xterm replay. Oldest chunks are evicted when the total exceeds
+   * MAX_RAW_BUFFER_BYTES.
+   *
+   * NOTE: This intentionally does NOT render to the headless terminal.
+   * Rendering is driven incrementally by the OscParser's `output` events
+   * via `renderToTerminal`, so the cursor position is accurate at each
+   * structural marker (e.g. OSC 133;C). Rendering the whole chunk here
+   * up-front would advance the cursor past the command output before the
+   * parser fires `commandStart`, corrupting the captured mark line when a
+   * fast command's echo + output + done markers arrive in one PTY chunk.
    */
-  appendRaw(data: Buffer): void {
-    // MUST use writeSync so the terminal buffer is immediately up-to-date
-    // when the OscParser fires synchronous resolution events that read it
-    // via serializeFrom(). The async write() queues data internally and
-    // the buffer would still be stale at resolution time.
-    (this._terminal as any)._core.writeSync(data);
+  storeRawChunk(data: Buffer): void {
     this._rawChunks.push(data);
     this._rawBytes += data.byteLength;
     // Evict oldest chunks until we are within the cap.
@@ -156,6 +160,20 @@ export class SessionLogger {
       this._rawBytes -= this._rawChunks[0]!.byteLength;
       this._rawChunks.shift();
     }
+  }
+
+  /**
+   * Render a segment of (OSC-133/7-stripped) PTY text into the headless
+   * terminal emulator. Called incrementally from the parser's `output`
+   * event so the buffer is current — and the cursor correctly positioned —
+   * before the parser fires synchronous resolution events (commandStart,
+   * commandDone, sentinelDone) that read the buffer via serializeFrom().
+   *
+   * MUST use writeSync (not the async write()) so the buffer is updated
+   * synchronously within the same parser tick.
+   */
+  renderToTerminal(data: string): void {
+    (this._terminal as any)._core.writeSync(data);
   }
 
   /**

--- a/apps/browser/src/backend/services/toolbox/services/shell/session-manager.test.ts
+++ b/apps/browser/src/backend/services/toolbox/services/shell/session-manager.test.ts
@@ -303,7 +303,13 @@ async function waitForCwd(
   }
 }
 
-describeIfShell('SessionManager (integration)', () => {
+// Real-PTY integration tests depend on live shell-process timing: OSC 133
+// completion ordering, lsof-based cwd-trust validation, and (on Windows)
+// ConPTY exit-event ordering. Under heavy CI load these can jitter enough that
+// a command resolves via the idle/timeout path with an unstable terminal-buffer
+// read, surfacing as a rare empty-output flake. `retry` absorbs that jitter
+// without masking real regressions — a genuine bug fails all attempts.
+describeIfShell('SessionManager (integration)', { retry: 2 }, () => {
   const env = sanitizeEnv();
   const cwd = fs.realpathSync(os.tmpdir());
   let sm: SessionManager;

--- a/apps/browser/src/backend/services/toolbox/services/shell/session-manager.test.ts
+++ b/apps/browser/src/backend/services/toolbox/services/shell/session-manager.test.ts
@@ -9,6 +9,8 @@ import {
   getCommandIdleMs,
   getCommandTimeoutMs,
   injectBoundaryToken,
+  BASH_INTEGRATION,
+  ZSH_INTEGRATION,
 } from './session-manager';
 import { detectShell } from './detect-shell';
 import { sanitizeEnv } from './sanitize-env';
@@ -825,5 +827,29 @@ describeIfShell('SessionManager (integration)', () => {
     expect(sm.getSessionsForAgent('agent-x')).toHaveLength(2);
     expect(sm.getSessionsForAgent('agent-y')).toHaveLength(1);
     expect(sm.getSessionsForAgent('agent-z')).toHaveLength(0);
+  });
+});
+
+// ─── Shell integration scripts ───────────────────────────────────
+
+describe('shell integration scripts', () => {
+  it('zsh encoder uses zsh-safe substring syntax and a non-special variable', () => {
+    // Regression guard: zsh misparses bash-style `${path:i:1}` as a `:i`
+    // history modifier, and `path` is a reserved special variable in zsh
+    // (tied to the $PATH array). The encoder must use `${p:$i:1}` on a
+    // plain local var `p`.
+    expect(ZSH_INTEGRATION).toContain('local p="$1"');
+    expect(ZSH_INTEGRATION).toContain('${p:$i:1}');
+    expect(ZSH_INTEGRATION).not.toContain('local path=');
+    expect(ZSH_INTEGRATION).not.toMatch(/\$\{path:i:1\}/);
+  });
+
+  it('integration guard is set but not exported (no leak into child shells)', () => {
+    // Exporting the guard leaks it into every PTY child, tripping the
+    // first-line guard before OSC 133 hooks register -> sentinel fallback.
+    for (const script of [BASH_INTEGRATION, ZSH_INTEGRATION]) {
+      expect(script).toContain('__STAGEWISE_SHELL_INTEGRATION=1');
+      expect(script).not.toContain('export __STAGEWISE_SHELL_INTEGRATION');
+    }
   });
 });

--- a/apps/browser/src/backend/services/toolbox/services/shell/session-manager.ts
+++ b/apps/browser/src/backend/services/toolbox/services/shell/session-manager.ts
@@ -464,16 +464,15 @@ export class SessionManager {
     this.onSessionStateChange?.(agentInstanceId);
 
     // Wire PTY data → parser
-    // IMPORTANT: appendRaw feeds the headless terminal which must be current
-    // before the parser fires synchronous resolution events (commandDone,
-    // sentinelDone) that read the buffer via collectOutput.
+    // Terminal rendering is NOT done here. We only store raw bytes (for
+    // replay) and append to the on-disk log. The headless xterm is rendered
+    // incrementally from the parser's `output` event (see below) so the
+    // cursor is correctly positioned at each OSC marker. Rendering the whole
+    // chunk up-front advanced the cursor past the command output before
+    // `commandStart` fired, corrupting the captured mark line whenever a fast
+    // command's echo + output + done markers arrived in a single PTY chunk.
     ptyProcess.onData((data: string) => {
-      // FIX: always feed the headless xterm emulator + logger so markLine
-      // and serializeFrom stay accurate even during session startup.
-      // UI streaming is handled via the parser's `output` event below,
-      // which fires only for text between OSC 133;C and 133;D (i.e. real
-      // command output — no prompt redraws, no command echo).
-      session.logger?.appendRaw(Buffer.from(data, 'utf-8'));
+      session.logger?.storeRawChunk(Buffer.from(data, 'utf-8'));
       session.logger?.append(stripAnsi(data));
       parser.write(data);
     });
@@ -556,6 +555,14 @@ export class SessionManager {
     });
 
     parser.on('output', (data) => {
+      // Render incrementally FIRST so the headless terminal's cursor reflects
+      // exactly the bytes up to the current parser position. This keeps the
+      // command mark (captured at OSC 133;C in the commandStart handler) and
+      // serializeFrom() accurate even when a fast command's echo, output, and
+      // 133;D done marker all arrive in a single PTY chunk. It must run before
+      // appendToCommandOutput, whose pattern matching reads the buffer.
+      session.logger?.renderToTerminal(data);
+
       // Stream to UI only when inside a real command's output region.
       // In OSC mode, this is between 133;C and 133;D. In sentinel mode,
       // all output is user-command output (prompt/echo aren't framed
@@ -1086,8 +1093,9 @@ export class SessionManager {
 
         if (logger) {
           // Buffer-based matching: test against visible terminal state.
-          // The buffer is already up-to-date (writeSync in appendRaw
-          // runs before the parser emits the output event that calls us).
+          // The buffer is already up-to-date: renderToTerminal runs at the
+          // top of the parser's `output` handler, before this code (also
+          // invoked from that handler via appendToCommandOutput).
           //
           // Skip the first serialized line because it typically contains
           // the prompt and the echoed command itself — matching against

--- a/apps/browser/src/backend/services/toolbox/services/shell/session-manager.ts
+++ b/apps/browser/src/backend/services/toolbox/services/shell/session-manager.ts
@@ -141,9 +141,12 @@ export function applyHeadTailCap(lines: string[]): string {
 // These are sourced inside the PTY to enable OSC 133 markers.
 // Inlined to avoid build-pipeline / path-resolution complexity.
 
-const BASH_INTEGRATION = `
+export const BASH_INTEGRATION = `
 if [ -n "$__STAGEWISE_SHELL_INTEGRATION" ]; then return 0 2>/dev/null || true; fi
-export __STAGEWISE_SHELL_INTEGRATION=1
+# Plain (non-exported) guard: prevents re-sourcing within THIS shell only.
+# Exporting it would leak into child shells, tripping their own guard before
+# they register OSC 133 hooks and forcing them into sentinel mode.
+__STAGEWISE_SHELL_INTEGRATION=1
 { unset HISTFILE; } 2>/dev/null
 HISTSIZE=0 2>/dev/null
 HISTFILESIZE=0 2>/dev/null
@@ -192,9 +195,12 @@ __stagewise_emit_cwd
 printf '\\033]133;A\\007'
 `.trim();
 
-const ZSH_INTEGRATION = `
+export const ZSH_INTEGRATION = `
 if [[ -n "$__STAGEWISE_SHELL_INTEGRATION" ]]; then return 0 2>/dev/null || true; fi
-export __STAGEWISE_SHELL_INTEGRATION=1
+# Plain (non-exported) guard: prevents re-sourcing within THIS shell only.
+# Exporting it would leak into child shells, tripping their own guard before
+# they register OSC 133 hooks and forcing them into sentinel mode.
+__STAGEWISE_SHELL_INTEGRATION=1
 { unset HISTFILE; } 2>/dev/null
 HISTSIZE=0 2>/dev/null
 SAVEHIST=0 2>/dev/null

--- a/apps/browser/src/backend/services/toolbox/services/shell/session-manager.ts
+++ b/apps/browser/src/backend/services/toolbox/services/shell/session-manager.ts
@@ -203,12 +203,12 @@ PROMPT_EOL_MARK=''
 __stagewise_command_executed=0
 __stagewise_boundary_token="__STAGEWISE_BOUNDARY_TOKEN__"
 __stagewise_file_uri_path() {
-  local path="$1"
+  local p="$1"
   local encoded=''
   local i ch hex
   local LC_ALL=C
-  for (( i = 0; i < \${#path}; i++ )); do
-    ch="\${path:i:1}"
+  for (( i = 0; i < \${#p}; i++ )); do
+    ch="\${p:$i:1}"
     case "$ch" in
       [A-Za-z0-9._~/-]) encoded+="$ch" ;;
       *) hex=$(printf '%%%02X' "'$ch"); encoded+="$hex" ;;

--- a/packages/agent-core/src/services/mount-manager/mount-registry.test.ts
+++ b/packages/agent-core/src/services/mount-manager/mount-registry.test.ts
@@ -354,8 +354,9 @@ describe('MountManager watcher refresh (integration)', () => {
     await new Promise((r) => setTimeout(r, 200));
     writeFileSync(wsMdPath, 'second', 'utf-8');
 
-    // 400 ms debounce + 150 ms awaitWriteFinish stability + slack.
-    const deadline = Date.now() + 4000;
+    // 400 ms debounce + 150 ms awaitWriteFinish stability + slack. chokidar
+    // on Windows CI can lag well beyond the POSIX case, so allow generous slack.
+    const deadline = Date.now() + 8000;
     while (Date.now() < deadline) {
       const latest = store.writes[store.writes.length - 1]!;
       if (latest.mounts[0]?.workspaceMdContent === 'second') break;
@@ -367,5 +368,5 @@ describe('MountManager watcher refresh (integration)', () => {
     expect(store.writes.length).toBeGreaterThan(writesAfterMount);
 
     await manager.teardownWatchers();
-  }, 10_000);
+  }, 15_000);
 });

--- a/packages/agent-core/src/services/processed-image-cache/processed-image-cache.test.ts
+++ b/packages/agent-core/src/services/processed-image-cache/processed-image-cache.test.ts
@@ -342,7 +342,7 @@ describe('ProcessedImageCacheService – LRU eviction', () => {
     expect(evicted).toBeNull();
 
     svc.teardown();
-  }, 20_000);
+  }, 60_000);
 
   it('does NOT evict a recently-used entry even if it was inserted first', async () => {
     const svc = await ProcessedImageCacheService.createWithUrl(
@@ -385,7 +385,7 @@ describe('ProcessedImageCacheService – LRU eviction', () => {
     expect(stillThere).not.toBeNull();
 
     svc.teardown();
-  }, 20_000);
+  }, 60_000);
 });
 
 describe('ProcessedImageCacheService – integration with processImageForModel', () => {

--- a/packages/agent-core/src/services/toolbox/universal-tools.test.ts
+++ b/packages/agent-core/src/services/toolbox/universal-tools.test.ts
@@ -225,7 +225,7 @@ describe('universal toolbox', () => {
     // Capped at 50 by the universal-tools layer; we only care that the
     // walk completed without throwing and returned a non-zero match.
     expect(result.result.totalMatches).toBeGreaterThanOrEqual(50);
-  });
+  }, 30_000);
 
   it('plumbs include_gitignored through to runtime-node', async () => {
     // A user-authored .gitignore that hides `secrets/`. Default glob


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes an OSC 133 rendering race that could drop fast command output when echo, markers, and output arrive in one PTY chunk. Hardens shell integration and sentinel mode to preserve terminal fidelity, remove PS2 prompt noise, and stabilize CI, including zsh-safe OSC 7 encoding.

- **Bug Fixes**
  - Render incrementally from parser `output`; add `renderToTerminal`; store raw bytes via `storeRawChunk` for replay only.
  - Ensure single-chunk ordering: emit `output` before `commandStart`/`commandDone`.
  - In sentinel mode, emit `OSC 133/7`-stripped output; other OSC is preserved for terminal fidelity; surfaced text is sanitized separately.
  - Use `\\n` in sentinel `printf` to avoid PS2 continuation prompts.
  - Prevent leaking `__STAGEWISE_SHELL_INTEGRATION` into child PTYs: guard is not exported and is stripped in `sanitizeEnv`.
  - Zsh OSC 7 encoder uses `${p:$i:1}` with a non-special local `p`.
  - Stabilize tests: add retry to real-PTY shell integration suite and raise timeouts for slow CI paths.

<sup>Written for commit b7cc0b05381bfbc3af63c91cc4b53f7a90aacabf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1254?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed terminal output rendering to properly handle OSC sequences in shell integration mode
  * Improved isolation of shell integration state between sessions to prevent cross-session interference
  * Enhanced accuracy of command output capture during execution

<!-- end of auto-generated comment: release notes by coderabbit.ai -->