### PR TITLE
feat(stagewise): add minimax m3

### DIFF
--- a/.agents/skills/add-llm-model/SKILL.md
+++ b/.agents/skills/add-llm-model/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: add-llm-model
+description: Use when adding a new LLM/model to stagewise model catalogs, provider routing, validation, docs, or showcase UI.
+---
+
+# Add LLM Model
+
+Use this workflow when adding or updating model support in stagewise.
+
+## Required Checks
+
+1. Inspect existing provider entries before editing.
+   - Read `apps/browser/src/shared/available-models.ts` around the provider.
+   - Keep still-supported sibling models. Do not replace old models with the new one unless explicitly requested.
+
+2. Wire the model through all relevant product surfaces.
+   - Model catalog: `apps/browser/src/shared/available-models.ts`.
+   - Provider routing: `apps/browser/src/backend/agents/model-provider.ts`.
+   - API-key validation: `apps/browser/src/backend/utils/validate-api-keys.ts`.
+   - Coding plans: `apps/browser/src/shared/coding-plans.ts`.
+   - Website showcase: `apps/website/src/app/(home)/_components/model-provider-showcase.tsx`.
+   - README files and localized README variants.
+
+3. Keep plan docs aligned with plan config.
+   - If `featuredModelIds` lists multiple models, README subscription tables must list the same featured lineup in readable display names.
+   - The later full model lists may include more models, but must not contradict the plan table.
+
+4. Preserve showcase truthfulness.
+   - If the homepage showcase is curated, make that intentional.
+   - Otherwise include still-supported sibling models so marketing does not understate provider support.
+
+5. Handle provider-native IDs everywhere requests can route.
+   - Internal model IDs may differ from native provider IDs.
+   - Apply native ID mapping in official provider mode.
+   - Apply the same default native ID mapping for built-in models routed through custom endpoints.
+   - Explicit `customEndpoint.modelIdMapping` must always override default mapping.
+
+6. Validate API keys with broadly accessible probes.
+   - Do not validate a provider exclusively against the newest or highest-tier model if older supported models remain available.
+   - Prefer a cheap broadly available model, or fallback probes that accept success from any supported entitlement.
+   - Keep validation errors compatible with existing `{ success: false; error: string }` callers.
+
+## Validation
+
+After changes:
+
+- Run targeted LSP/lint diagnostics on edited files.
+- Search for the new model ID and display name across code/docs.
+- Confirm request routing uses native provider IDs in official and built-in custom endpoint modes.
+- Confirm docs, coding-plan `featuredModelIds`, and showcase entries are intentionally aligned.

--- a/README.de.md
+++ b/README.de.md
@@ -41,7 +41,7 @@ Verbinde eines der folgenden Abos mit einem einzigen API-Schlüssel und erhalte 
 | GLM Coding Plan | [Z.ai](https://z.ai) | GLM-5.1, GLM-5V-Turbo | [API-Schlüssel holen](https://z.ai/manage-apikey/apikey-list) |
 | Kimi | [Moonshot AI](https://platform.moonshot.ai) | Kimi K2.6, Kimi K2.5 | [API-Schlüssel holen](https://platform.moonshot.ai/console/api-keys) |
 | Qwen Coding Plan | [Alibaba DashScope](https://dashscope.console.aliyun.com) | Qwen3-Coder-30B, Qwen3-32B | [API-Schlüssel holen](https://dashscope.console.aliyun.com/apiKey) |
-| MiniMax | [MiniMax](https://platform.minimax.io) | MiniMax M2.7 | [API-Schlüssel holen](https://platform.minimax.io/user-center/basic-information/interface-key) |
+| MiniMax | [MiniMax](https://platform.minimax.io) | MiniMax M3, MiniMax M2.7 | [API-Schlüssel holen](https://platform.minimax.io/user-center/basic-information/interface-key) |
 
 ### stagewise Account
 
@@ -62,7 +62,7 @@ Enthaltene Modelle:
 - **Alibaba**: Qwen 3-32B, Qwen 3-Coder 30B-A3B
 - **DeepSeek**: DeepSeek V4 Pro, DeepSeek V4 Flash
 - **Z.ai**: GLM 5.1, GLM 5V-Turbo
-- **MiniMax**: MiniMax M2.7, MiniMax M2
+- **MiniMax**: MiniMax M3, MiniMax M2.7, MiniMax M2
 
 ## Lizenz
 

--- a/README.es.md
+++ b/README.es.md
@@ -41,7 +41,7 @@ Conecta cualquiera de las siguientes suscripciones con una sola clave de API par
 | GLM Coding Plan | [Z.ai](https://z.ai) | GLM-5.1, GLM-5V-Turbo | [Obtener clave de API](https://z.ai/manage-apikey/apikey-list) |
 | Kimi | [Moonshot AI](https://platform.moonshot.ai) | Kimi K2.6, Kimi K2.5 | [Obtener clave de API](https://platform.moonshot.ai/console/api-keys) |
 | Qwen Coding Plan | [Alibaba DashScope](https://dashscope.console.aliyun.com) | Qwen3-Coder-30B, Qwen3-32B | [Obtener clave de API](https://dashscope.console.aliyun.com/apiKey) |
-| MiniMax | [MiniMax](https://platform.minimax.io) | MiniMax M2.7 | [Obtener clave de API](https://platform.minimax.io/user-center/basic-information/interface-key) |
+| MiniMax | [MiniMax](https://platform.minimax.io) | MiniMax M3, MiniMax M2.7 | [Obtener clave de API](https://platform.minimax.io/user-center/basic-information/interface-key) |
 
 ### Cuenta stagewise
 
@@ -62,7 +62,7 @@ Modelos incluidos:
 - **Alibaba**: Qwen 3-32B, Qwen 3-Coder 30B-A3B
 - **DeepSeek**: DeepSeek V4 Pro, DeepSeek V4 Flash
 - **Z.ai**: GLM 5.1, GLM 5V-Turbo
-- **MiniMax**: MiniMax M2.7, MiniMax M2
+- **MiniMax**: MiniMax M3, MiniMax M2.7, MiniMax M2
 
 ## Licencia
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -41,7 +41,7 @@
 | GLM Coding Plan | [Z.ai](https://z.ai) | GLM-5.1, GLM-5V-Turbo | [APIキーを取得](https://z.ai/manage-apikey/apikey-list) |
 | Kimi | [Moonshot AI](https://platform.moonshot.ai) | Kimi K2.6, Kimi K2.5 | [APIキーを取得](https://platform.moonshot.ai/console/api-keys) |
 | Qwen Coding Plan | [Alibaba DashScope](https://dashscope.console.aliyun.com) | Qwen3-Coder-30B, Qwen3-32B | [APIキーを取得](https://dashscope.console.aliyun.com/apiKey) |
-| MiniMax | [MiniMax](https://platform.minimax.io) | MiniMax M2.7 | [APIキーを取得](https://platform.minimax.io/user-center/basic-information/interface-key) |
+| MiniMax | [MiniMax](https://platform.minimax.io) | MiniMax M3, MiniMax M2.7 | [APIキーを取得](https://platform.minimax.io/user-center/basic-information/interface-key) |
 
 ### stagewise アカウント
 
@@ -62,7 +62,7 @@
 - **Alibaba**: Qwen 3-32B, Qwen 3-Coder 30B-A3B
 - **DeepSeek**: DeepSeek V4 Pro, DeepSeek V4 Flash
 - **Z.ai**: GLM 5.1, GLM 5V-Turbo
-- **MiniMax**: MiniMax M2.7, MiniMax M2
+- **MiniMax**: MiniMax M3, MiniMax M2.7, MiniMax M2
 
 ## ライセンス
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -41,7 +41,7 @@
 | GLM Coding Plan | [Z.ai](https://z.ai) | GLM-5.1, GLM-5V-Turbo | [API 키 받기](https://z.ai/manage-apikey/apikey-list) |
 | Kimi | [Moonshot AI](https://platform.moonshot.ai) | Kimi K2.6, Kimi K2.5 | [API 키 받기](https://platform.moonshot.ai/console/api-keys) |
 | Qwen Coding Plan | [Alibaba DashScope](https://dashscope.console.aliyun.com) | Qwen3-Coder-30B, Qwen3-32B | [API 키 받기](https://dashscope.console.aliyun.com/apiKey) |
-| MiniMax | [MiniMax](https://platform.minimax.io) | MiniMax M2.7 | [API 키 받기](https://platform.minimax.io/user-center/basic-information/interface-key) |
+| MiniMax | [MiniMax](https://platform.minimax.io) | MiniMax M3, MiniMax M2.7 | [API 키 받기](https://platform.minimax.io/user-center/basic-information/interface-key) |
 
 ### stagewise 계정
 
@@ -62,7 +62,7 @@
 - **Alibaba**: Qwen 3-32B, Qwen 3-Coder 30B-A3B
 - **DeepSeek**: DeepSeek V4 Pro, DeepSeek V4 Flash
 - **Z.ai**: GLM 5.1, GLM 5V-Turbo
-- **MiniMax**: MiniMax M2.7, MiniMax M2
+- **MiniMax**: MiniMax M3, MiniMax M2.7, MiniMax M2
 
 ## 라이선스
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Connect any of the following subscriptions with a single API key to unlock all m
 | GLM Coding Plan  | [Z.ai](https://z.ai) | GLM-5.1, GLM-5V-Turbo | [Get API key](https://z.ai/manage-apikey/apikey-list) |
 | Kimi             | [Moonshot AI](https://platform.moonshot.ai) | Kimi K2.6, Kimi K2.5 | [Get API key](https://platform.moonshot.ai/console/api-keys) |
 | Qwen Coding Plan | [Alibaba DashScope](https://dashscope.console.aliyun.com) | Qwen3-Coder-30B, Qwen3-32B | [Get API key](https://dashscope.console.aliyun.com/apiKey) |
-| MiniMax          | [MiniMax](https://platform.minimax.io) | MiniMax M2.7 | [Get API key](https://platform.minimax.io/user-center/basic-information/interface-key) |
+| MiniMax          | [MiniMax](https://platform.minimax.io) | MiniMax M3, MiniMax M2.7 | [Get API key](https://platform.minimax.io/user-center/basic-information/interface-key) |
 
 ### stagewise Account
 
@@ -62,7 +62,7 @@ Included models:
 - **Alibaba**: Qwen 3-32B, Qwen 3-Coder 30B-A3B
 - **DeepSeek**: DeepSeek V4 Pro, DeepSeek V4 Flash
 - **Z.ai**: GLM 5.1, GLM 5V-Turbo
-- **MiniMax**: MiniMax M2.7, MiniMax M2
+- **MiniMax**: MiniMax M3, MiniMax M2.7, MiniMax M2
 
 ## License
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -41,7 +41,7 @@
 | GLM 编程计划 | [Z.ai](https://z.ai) | GLM-5.1、GLM-5V-Turbo | [获取 API 密钥](https://z.ai/manage-apikey/apikey-list) |
 | Kimi | [Moonshot AI](https://platform.moonshot.ai) | Kimi K2.6、Kimi K2.5 | [获取 API 密钥](https://platform.moonshot.ai/console/api-keys) |
 | Qwen 编程计划 | [阿里云 DashScope](https://dashscope.console.aliyun.com) | Qwen3-Coder-30B、Qwen3-32B | [获取 API 密钥](https://dashscope.console.aliyun.com/apiKey) |
-| MiniMax | [MiniMax](https://platform.minimax.io) | MiniMax M2.7 | [获取 API 密钥](https://platform.minimax.io/user-center/basic-information/interface-key) |
+| MiniMax | [MiniMax](https://platform.minimax.io) | MiniMax M3, MiniMax M2.7 | [获取 API 密钥](https://platform.minimax.io/user-center/basic-information/interface-key) |
 
 ### stagewise 账户
 
@@ -62,7 +62,7 @@
 - **Alibaba**：Qwen 3-32B、Qwen 3-Coder 30B-A3B
 - **DeepSeek**：DeepSeek V4 Pro、DeepSeek V4 Flash
 - **Z.ai**：GLM 5.1、GLM 5V-Turbo
-- **MiniMax**：MiniMax M2.7、MiniMax M2
+- **MiniMax**：MiniMax M3、MiniMax M2.7、MiniMax M2
 
 ## 许可证
 

--- a/apps/browser/src/backend/agents/model-provider.ts
+++ b/apps/browser/src/backend/agents/model-provider.ts
@@ -38,6 +38,11 @@ function toNativeAnthropicModelId(modelId: string): string {
   return modelId.replace(/\./g, '-');
 }
 
+function toNativeMiniMaxModelId(modelId: string): string {
+  if (modelId === 'minimax-m3') return 'MiniMax-M3';
+  return modelId;
+}
+
 /**
  * Middleware that tells the SDK all HTTP(S) URLs are natively supported by the
  * stagewise gateway. Without this the SDK downloads every image/file URL and
@@ -400,9 +405,13 @@ export class ModelProviderService {
         'amazon-bedrock',
         'google-vertex',
       ]);
+      const defaultModelId =
+        officialProvider === 'minimax'
+          ? toNativeMiniMaxModelId(modelSettings.modelId)
+          : modelSettings.modelId;
       const remappedModelId =
         resolved.customEndpoint.modelIdMapping?.[modelSettings.modelId] ??
-        modelSettings.modelId;
+        defaultModelId;
       if (
         incompatibleSpecs.has(resolved.customEndpoint.apiSpec) &&
         remappedModelId === modelSettings.modelId
@@ -601,7 +610,7 @@ export class ModelProviderService {
         return {
           model: this.telemetryService.withTracing(
             // MiniMax's OpenAI-compatible endpoint speaks Chat Completions.
-            p.chat(modelId as any),
+            p.chat(toNativeMiniMaxModelId(modelId) as any),
             posthogConfig,
           ),
           headers,

--- a/apps/browser/src/backend/utils/validate-api-keys.ts
+++ b/apps/browser/src/backend/utils/validate-api-keys.ts
@@ -1,7 +1,7 @@
 import { createAnthropic } from '@ai-sdk/anthropic';
 import { createGoogleGenerativeAI } from '@ai-sdk/google';
 import { createOpenAI } from '@ai-sdk/openai';
-import { generateText } from 'ai';
+import { generateText, type ModelMessage } from 'ai';
 
 export type ApiKeyProvider =
   | 'anthropic'
@@ -25,12 +25,18 @@ export type ApiKeyValidationResults = Record<
 
 export type ApiKeysInput = Partial<Record<ApiKeyProvider, string>>;
 
+type ValidationModel = Parameters<typeof generateText>[0]['model'];
+
+const validationMessages: ModelMessage[] = [
+  {
+    role: 'user',
+    content: 'What is the capital of France? Respond with one word.',
+  },
+];
+
 const providerConfigs: Record<
   ApiKeyProvider,
-  (
-    apiKey: string,
-    baseURL?: string,
-  ) => Parameters<typeof generateText>[0]['model']
+  (apiKey: string, baseURL?: string) => ValidationModel
 > = {
   anthropic: (apiKey, baseURL) =>
     createAnthropic({ apiKey, baseURL })('claude-haiku-4-5'),
@@ -70,6 +76,39 @@ const providerConfigs: Record<
     }).chat('minimax-m2.7'),
 };
 
+async function validateModel(model: ValidationModel): Promise<void> {
+  await generateText({
+    model,
+    messages: validationMessages,
+  });
+}
+
+async function validateMiniMaxApiKey(
+  apiKey: string,
+  baseURL?: string,
+): Promise<ApiKeyValidationResult> {
+  const provider = createOpenAI({
+    apiKey,
+    baseURL: baseURL ?? 'https://api.minimax.io/v1',
+  });
+  const models = [provider.chat('minimax-m2.7'), provider.chat('MiniMax-M3')];
+  const errors: string[] = [];
+
+  for (const model of models) {
+    try {
+      await validateModel(model);
+      return { success: true };
+    } catch (err) {
+      errors.push(err instanceof Error ? err.message : String(err));
+    }
+  }
+
+  return {
+    success: false,
+    error: `Invalid minimax provider key: ${errors.join(' | ')}`,
+  };
+}
+
 /**
  * Validate API keys by making a lightweight test request to each provider.
  * Keys that are empty/undefined are skipped (result stays `null`).
@@ -98,26 +137,21 @@ export async function validateApiKeys(
     if (!apiKey) continue;
     const k = provider as ApiKeyProvider;
     if (!providerConfigs[k]) continue;
-    const model = providerConfigs[k](apiKey, baseUrl);
-
-    const p = generateText({
-      model,
-      messages: [
-        {
-          role: 'user',
-          content: 'What is the capital of France? Respond with one word.',
-        },
-      ],
-    })
-      .then(() => {
-        results[k] = { success: true };
-      })
-      .catch((err) => {
-        results[k] = {
-          success: false,
-          error: `Invalid ${k} provider key: ${err instanceof Error ? err.message : String(err)}`,
-        };
-      });
+    const p =
+      k === 'minimax'
+        ? validateMiniMaxApiKey(apiKey, baseUrl).then((result) => {
+            results[k] = result;
+          })
+        : validateModel(providerConfigs[k](apiKey, baseUrl))
+            .then(() => {
+              results[k] = { success: true };
+            })
+            .catch((err) => {
+              results[k] = {
+                success: false,
+                error: `Invalid ${k} provider key: ${err instanceof Error ? err.message : String(err)}`,
+              };
+            });
 
     promises.push(p);
   }

--- a/apps/browser/src/shared/available-models.ts
+++ b/apps/browser/src/shared/available-models.ts
@@ -107,6 +107,22 @@ const GEMINI35_INPUT_CONSTRAINTS: InputConstraints = {
   },
 };
 
+const MINIMAX_M3_INPUT_CONSTRAINTS: InputConstraints = {
+  image: {
+    mimeTypes: ['image/jpeg', 'image/png', 'image/gif', 'image/webp'],
+    maxBytes: 10_485_760, // 10 MB per image
+  },
+  video: {
+    mimeTypes: [
+      'video/mp4',
+      'video/quicktime',
+      'video/x-msvideo',
+      'video/x-matroska',
+    ],
+    maxBytes: 52_428_800, // 50 MB inline video input
+  },
+};
+
 export const availableModels = [
   // Anthropic Models
   {
@@ -1050,6 +1066,45 @@ export const availableModels = [
         ...GOOGLE_INPUT_CONSTRAINTS,
         file: undefined,
       },
+      toolCalling: true,
+    },
+  },
+  {
+    officialProvider: 'minimax',
+    modelId: 'minimax-m3',
+    modelDisplayName: 'MiniMax M3',
+    modelDescription:
+      'Frontier multimodal coding model with strong agentic reasoning, tool use, and long-context performance.',
+    modelContext: '1M context',
+    modelContextRaw: 1_000_000,
+    headers: {},
+    providerOptions: {
+      stagewise: {
+        reasoning: { enabled: true, effort: 'medium' },
+      },
+    },
+    thinkingEnabled: true,
+    pricing: {
+      inputPerMillion: 0.3,
+      outputPerMillion: 1.2,
+      relativeMultiplier: 0.25,
+    },
+    capabilities: {
+      inputModalities: {
+        text: true,
+        audio: false,
+        image: true,
+        video: true,
+        file: false,
+      },
+      outputModalities: {
+        text: true,
+        audio: false,
+        image: false,
+        video: false,
+        file: false,
+      },
+      inputConstraints: MINIMAX_M3_INPUT_CONSTRAINTS,
       toolCalling: true,
     },
   },

--- a/apps/browser/src/shared/coding-plans.ts
+++ b/apps/browser/src/shared/coding-plans.ts
@@ -78,7 +78,7 @@ export const CODING_PLANS: Record<CodingPlanId, CodingPlan> = {
     apiKeyUrl:
       'https://platform.minimax.io/user-center/basic-information/interface-key',
     helpText: 'Create one at platform.minimax.io → User Center → Interface key',
-    featuredModelIds: ['minimax-m2.7'],
+    featuredModelIds: ['minimax-m3', 'minimax-m2.7'],
   },
 };
 

--- a/apps/website/src/app/(home)/_components/model-provider-showcase.tsx
+++ b/apps/website/src/app/(home)/_components/model-provider-showcase.tsx
@@ -96,8 +96,9 @@ const PROVIDERS: ProviderInfo[] = [
     description:
       'Agentic models tuned for multi-step reasoning and coding tasks.',
     models: [
-      { name: 'MiniMax M2.7', tier: 'frontier' },
-      { name: 'MiniMax M2', tier: 'general' },
+      { name: 'MiniMax M3', tier: 'frontier' },
+      { name: 'MiniMax M2.7', tier: 'general' },
+      { name: 'MiniMax M2', tier: 'lightweight' },
     ],
   },
   {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add MiniMax M3 as a first-class model across the app, with native provider mapping, robust validation, and UI/docs updates. Users can select `minimax-m3` with reasoning, tool use, and long-context support.

- **New Features**
  - Added `minimax-m3` to available models: 1M context, reasoning enabled, tool use, text/image/video input, pricing $0.30/M input and $1.20/M output, input limits 10 MB/image and 50 MB/video.
  - Mapped `minimax-m3` to native API ID `MiniMax-M3` in provider routing, with default native ID mapping in official MiniMax mode.
  - API key validation now succeeds with either `minimax-m2.7` or `MiniMax-M3` to reduce false negatives.
  - MiniMax coding plan now features `minimax-m3` and `minimax-m2.7`.
  - Updated READMEs (EN/DE/ES/JA/KO/ZH) and homepage showcase to include MiniMax M3 and reflect tiers for M3/M2.7/M2.

<sup>Written for commit 48d63b6982082736a49c6917887c7fecc9ae41d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1255?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * MiniMax M3 added as a featured model and as an available model with text, image, and video input support.

* **Documentation**
  * README updates in multiple languages and website showcase updated to reflect MiniMax M3 and adjusted MiniMax lineup.

* **Chores**
  * Coding plan listings updated to include MiniMax M3; API-key validation improved to accept MiniMax M2.7 or M3 for validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->