### PR TITLE
fix(stagewise): fix patch-behaviour in karton x agent-core bridge

### DIFF
--- a/apps/browser/src/backend/services/agent-core-bridge/index.test.ts
+++ b/apps/browser/src/backend/services/agent-core-bridge/index.test.ts
@@ -1188,6 +1188,76 @@ describe('AgentCoreBridge (Phase 6 agent instances mirror)', () => {
     expect(getKartonState().agents?.instances.a1).toBe(envelopeAfterSeed);
   });
 
+  it('forwards granular patches: per-chunk-style mutation preserves Karton structural sharing on untouched history slots', () => {
+    const { store, getKartonState } = createAgentInstancesMirrorHarness();
+
+    // Seed with three history messages so we can assert that the two
+    // unmodified slots keep their references through the mirror.
+    const msg0 = {
+      id: 'm0',
+      role: 'user',
+      parts: [{ type: 'text', text: 'one' }],
+    };
+    const msg1 = {
+      id: 'm1',
+      role: 'assistant',
+      parts: [{ type: 'text', text: 'partial' }],
+    };
+    const msg2 = {
+      id: 'm2',
+      role: 'user',
+      parts: [{ type: 'text', text: 'three' }],
+    };
+    const seeded = makeEnvelope(
+      {},
+      {
+        history: [msg0, msg1, msg2] as unknown as AgentState['history'],
+      },
+    );
+    store.update((draft) => {
+      const systemDraft = draft as AgentSystemState;
+      systemDraft.agents.instances.a1 =
+        seeded as unknown as (typeof systemDraft.agents.instances)[string];
+    });
+
+    const kartonBefore = getKartonState().agents?.instances.a1?.state as
+      | AgentState
+      | undefined;
+    expect(kartonBefore).toBeDefined();
+    const before0 = kartonBefore!.history[0];
+    const before2 = kartonBefore!.history[2];
+
+    // Per-chunk streaming pattern: mutate exactly one part on one
+    // message. With patch forwarding this should produce a single
+    // narrow patch (path ends in `history,1,parts,0,text`), leaving
+    // every other history slot referentially equal in Karton.
+    store.update((draft) => {
+      const systemDraft = draft as AgentSystemState;
+      const entry = systemDraft.agents.instances.a1!;
+      const inner = entry.state as unknown as AgentState;
+      (inner.history[1] as unknown as { parts: { text: string }[] })
+        .parts[0]!.text = 'updated';
+    });
+
+    const kartonAfter = getKartonState().agents?.instances.a1?.state as
+      | AgentState
+      | undefined;
+    expect(kartonAfter).toBeDefined();
+
+    // Mutation landed.
+    expect(
+      (kartonAfter!.history[1] as unknown as { parts: { text: string }[] })
+        .parts[0]!.text,
+    ).toBe('updated');
+
+    // Structural sharing: untouched history slots keep their original
+    // reference. This is the property that whole-envelope replacement
+    // would violate and is the reason the patch-forwarding refactor
+    // exists.
+    expect(kartonAfter!.history[0]).toBe(before0);
+    expect(kartonAfter!.history[2]).toBe(before2);
+  });
+
   it('co-emits with a toolbox mirror write in the same karton.setState call', () => {
     const { store, setState, getKartonState } =
       createAgentInstancesMirrorHarness();

--- a/apps/browser/src/backend/services/agent-core-bridge/index.ts
+++ b/apps/browser/src/backend/services/agent-core-bridge/index.ts
@@ -4,9 +4,16 @@ import type {
   CommandName,
   CommandRegistry,
 } from '@stagewise/agent-core';
+import { applyPatches, enablePatches, type Patch } from 'immer';
 import type { KartonService } from '../karton';
 import { MIGRATED_PROCEDURES } from './contract-map';
 import { BridgeDriftError, serializeHandlerError } from './errors';
+
+// Immer's patches plugin must be enabled before any `applyPatches` call.
+// `agent-store.ts` also calls this on load — both are idempotent. Calling
+// it from the bridge module too keeps this file self-contained and removes
+// the implicit "AgentStore module must have loaded first" coupling.
+enablePatches();
 
 /**
  * Construction options for `AgentCoreBridge`.
@@ -32,9 +39,6 @@ type PendingFileDiffsValue = ToolboxEntry['pendingFileDiffs'];
 type EditSummaryValue = ToolboxEntry['editSummary'];
 type MountsValue = ToolboxEntry['workspace']['mounts'];
 
-type AgentsMap = AgentSystemState['agents']['instances'];
-type AgentEnvelope = AgentsMap[string];
-
 /**
  * Host-side adapter that routes Karton procedures through the
  * `CommandRegistry` in `@stagewise/agent-core` and mirrors AgentStore
@@ -53,11 +57,16 @@ type AgentEnvelope = AgentsMap[string];
  *      into Karton. Non-migrated Karton toolbox fields are never touched
  *      by the mirror.
  *
- * Phase 6 extends the mirror with whole-envelope projection of
+ * Phase 6 extends the mirror with projection of
  * `agents.instances[agentId]`. The store is canonical; Karton is
- * downstream. Dedup is reference-identity on the envelope — writers
- * always allocate a fresh envelope per mutation via Immer, so identity
- * equality is both correct and O(1).
+ * downstream. Projection is patch-forwarding: every `store.update()`
+ * yields the Immer patches that describe the mutation, and the
+ * bridge re-applies only the `agents.*` patches inside a single
+ * `karton.setState` call. Because `AgentSystemState.agents` is a
+ * path-equivalent subset of Karton `AppState.agents`, the patches
+ * apply verbatim with no re-rooting. Per-chunk streaming updates
+ * therefore broadcast `O(changed-path)` payloads instead of the
+ * full envelope, restoring origin/main's per-tick payload size.
  */
 export class AgentCoreBridge {
   private readonly karton: KartonService;
@@ -105,13 +114,46 @@ export class AgentCoreBridge {
 
     // Phase 1d mirror: store is canonical for `activeApp` and
     // `pendingAppMessage`; Karton is a per-field projection.
+    //
+    // Phase 6 + perf: `agents.instances` is forwarded as granular
+    // Immer patches (one patch per mutated path), so per-chunk
+    // streaming updates broadcast O(part_size) payloads instead of
+    // the full envelope.
     this.lastMirrored = this.store.get();
-    this.unsubscribeStore = this.store.subscribe((next) => {
-      this.mirrorToKarton(this.lastMirrored, next);
+    this.seedAgentInstancesIfAny();
+    this.unsubscribeStore = this.store.subscribe((next, _prev, patches) => {
+      this.mirrorToKarton(this.lastMirrored, next, patches);
       this.lastMirrored = next;
     });
 
     this.attached = true;
+  }
+
+  /**
+   * Defensive one-time seed: if the store already has agent instances
+   * at attach time, project them into Karton with a single
+   * `karton.setState`. Patch forwarding only kicks in on subsequent
+   * `store.update()` calls, so without this seed any pre-attach
+   * upsert would never reach Karton.
+   *
+   * In production and tests the store is empty at attach (the runtime
+   * order is `createAgentCoreSeam` → bridge construction → attach →
+   * `AgentManagerService` starts inserting agents), so this is a
+   * no-op in the happy path.
+   */
+  private seedAgentInstancesIfAny(): void {
+    const instances = this.store.get().agents.instances;
+    const ids = Object.keys(instances);
+    if (ids.length === 0) return;
+    this.karton.setState((draft) => {
+      const kInstances = draft.agents.instances as unknown as Record<
+        string,
+        unknown
+      >;
+      for (const id of ids) {
+        kInstances[id] = instances[id];
+      }
+    });
   }
 
   private registerProcedure(name: CommandName): void {
@@ -137,33 +179,43 @@ export class AgentCoreBridge {
   }
 
   /**
-   * Per-field mirror from AgentStore → Karton. Only fields for which the
-   * store is canonical (`activeApp`, `pendingAppMessage`, `pendingFileDiffs`,
-   * `editSummary`, `workspace.mounts`) are written. Unchanged fields skip
-   * `karton.setState` entirely so mirror traffic stays proportional to
-   * real state changes.
+   * Two-pronged mirror from AgentStore → Karton. Both prongs share a
+   * single `karton.setState` so each store emission produces at most
+   * one Karton broadcast, and emissions with no mirrorable change
+   * skip `karton.setState` entirely so mirror traffic stays
+   * proportional to real state changes.
    *
-   * Diff strategy:
+   * Toolbox (per-field diff): only fields for which the store is
+   * canonical (`activeApp`, `pendingAppMessage`, `pendingFileDiffs`,
+   * `editSummary`, `workspace.mounts`) are written.
    *   - `activeApp` / `pendingAppMessage`: shallow structural compare
    *     (fields that matter for the UI).
-   *   - `pendingFileDiffs` / `editSummary` / `workspace.mounts`: reference
-   *     identity. Writers (`DiffHistoryService.updateDiffKartonState`,
+   *   - `pendingFileDiffs` / `editSummary` / `workspace.mounts`:
+   *     reference identity. Writers (`DiffHistoryService.updateDiffKartonState`,
    *     `MountManagerService.rebuildMountsFor`) produce fresh array
    *     references only when content changes, so identity-based dedup is
    *     both correct and O(1).
-   *   - `agents.instances[id]`: reference identity on the whole
-   *     envelope. The core `state-mutations` utilities (and any host
-   *     setters built on `updateAgentInstanceState`) always allocate
-   *     a fresh envelope per mutation via Immer, so a preserved
-   *     reference
-   *     means "no change." Deletions (`id` in prev but not next) project
-   *     as Karton `delete`.
+   *
+   * `agents.instances` (patch forwarding): the Immer patches generated
+   * by `store.update()` are filtered to the `agents.*` subtree and
+   * re-applied to the Karton draft. `AgentSystemState.agents` mirrors
+   * `AppState.agents` path-for-path, so patches transfer verbatim —
+   * including granular paths like
+   * `['agents','instances',id,'state','history',i,'parts',j]` — and
+   * the Karton broadcast payload matches origin/main's per-chunk
+   * size instead of the whole envelope. Deletions arrive as `remove`
+   * patches and project as Karton `delete` automatically.
    */
   private mirrorToKarton(
     prev: AgentSystemState | null,
     next: AgentSystemState,
+    patches: Patch[],
   ): void {
-    const agentInstanceChanges = this.computeAgentInstanceChanges(prev, next);
+    // Granular projection for `agents.instances` — forward the exact
+    // Immer patches the store produced. `AgentSystemState.agents` is
+    // a path-equivalent subset of Karton `AppState.agents`, so the
+    // patches apply verbatim with no re-rooting.
+    const agentPatches = patches.filter((p) => p.path[0] === 'agents');
 
     const agentIds = new Set<string>();
     if (prev) for (const id of Object.keys(prev.toolbox)) agentIds.add(id);
@@ -241,28 +293,31 @@ export class AgentCoreBridge {
       changes.push(entry);
     }
 
-    if (changes.length === 0 && agentInstanceChanges === null) return;
+    if (changes.length === 0 && agentPatches.length === 0) return;
 
     this.karton.setState((draft) => {
-      if (agentInstanceChanges) {
+      if (agentPatches.length > 0) {
         // The store's envelope uses core types (`UniversalTools`,
         // `RequiredModelCapabilities = Record<string, boolean|undefined>`).
         // Karton's `AppState.agents.instances[id]` specializes to
         // `UIAgentTools` + a structured `ModelSettings['capabilities']`.
         // Runtime shape is identical because writers always build the
         // envelope from the host-narrowed source of truth before
-        // calling `controller.upsertInstance`. Cross the variance
-        // boundary through `unknown` at this single dedicated site.
-        const instances = draft.agents.instances as unknown as Record<
-          string,
-          unknown
-        >;
-        for (const id of agentInstanceChanges.deleted) {
-          delete instances[id];
-        }
-        for (const [id, envelope] of agentInstanceChanges.upserts) {
-          instances[id] = envelope;
-        }
+        // calling `upsertAgentInstance`. Cross the variance boundary
+        // through `unknown` at this single dedicated site.
+        //
+        // Structural drift between `AgentSystemState.agents` and
+        // `AppState.agents` is caught at typecheck by
+        // `apps/browser/src/shared/karton-contracts/ui/agent-core-parity.ts`
+        // (`_AgentsSliceParity`) — adding/renaming a field on either side
+        // without the other will fail compilation, so the cast here and
+        // the patch paths are safe.
+        //
+        // `applyPatches` mutates the draft in place — the surrounding
+        // `produce` records the same path-level patches against
+        // Karton's state, so the broadcast payload matches origin/main
+        // (one patch per mutated path, NOT the whole envelope).
+        applyPatches(draft as unknown as AgentSystemState, agentPatches);
       }
       for (const change of changes) {
         let kartonEntry = draft.toolbox[change.agentId];
@@ -303,43 +358,6 @@ export class AgentCoreBridge {
         }
       }
     });
-  }
-
-  /**
-   * Computes the diff of the `agents.instances` map between two store
-   * snapshots. Returns `null` when nothing changed so the caller can
-   * skip the `karton.setState` round-trip entirely.
-   *
-   * The `state-mutations` utilities always allocate a fresh
-   * envelope per mutation via Immer, so identity equality on the
-   * envelope is both correct and O(1).
-   */
-  private computeAgentInstanceChanges(
-    prev: AgentSystemState | null,
-    next: AgentSystemState,
-  ): {
-    upserts: Array<[string, AgentEnvelope]>;
-    deleted: string[];
-  } | null {
-    const prevMap = prev?.agents.instances ?? {};
-    const nextMap = next.agents.instances;
-
-    const upserts: Array<[string, AgentEnvelope]> = [];
-    for (const [id, envelope] of Object.entries(nextMap)) {
-      if (prevMap[id] !== envelope) {
-        upserts.push([id, envelope]);
-      }
-    }
-
-    const deleted: string[] = [];
-    for (const id of Object.keys(prevMap)) {
-      if (!(id in nextMap)) {
-        deleted.push(id);
-      }
-    }
-
-    if (upserts.length === 0 && deleted.length === 0) return null;
-    return { upserts, deleted };
   }
 
   /**

--- a/packages/agent-core/src/store/agent-store.test.ts
+++ b/packages/agent-core/src/store/agent-store.test.ts
@@ -64,6 +64,35 @@ describe('AgentStore', () => {
     expect(listener).not.toHaveBeenCalled();
   });
 
+  it('passes Immer patches describing the mutation to subscribers', () => {
+    const store = new AgentStore(makeInitialState());
+    const listener = vi.fn();
+    store.subscribe(listener);
+
+    store.update((draft) => {
+      draft.agents.instances['agent-1']!.state.title = 'patched';
+    });
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    const [, , patches] = listener.mock.calls[0]!;
+    expect(Array.isArray(patches)).toBe(true);
+    expect(patches.length).toBeGreaterThan(0);
+
+    // Patches describe the exact mutation path so downstream
+    // projections (notably the Karton bridge) can forward granular
+    // changes instead of replacing whole subtrees.
+    const titlePatch = (patches as { path: (string | number)[] }[]).find(
+      (p) =>
+        p.path.length === 5 &&
+        p.path[0] === 'agents' &&
+        p.path[1] === 'instances' &&
+        p.path[2] === 'agent-1' &&
+        p.path[3] === 'state' &&
+        p.path[4] === 'title',
+    );
+    expect(titlePatch).toBeDefined();
+  });
+
   it('exposes multiple slice mutations atomically to subscribers', () => {
     const store = new AgentStore(makeInitialState());
     const seen: Array<AgentSystemState> = [];

--- a/packages/agent-core/src/store/agent-store.ts
+++ b/packages/agent-core/src/store/agent-store.ts
@@ -1,14 +1,31 @@
-import { type Draft, produce } from 'immer';
+import {
+  type Draft,
+  type Patch,
+  enablePatches,
+  produceWithPatches,
+} from 'immer';
 import type { UITools } from 'ai';
 import type { UniversalTools } from '../types/tools';
 import type { AgentSystemState } from './state';
 
+// `produceWithPatches` requires Immer's patch machinery. Idempotent — safe to
+// call at module load.
+enablePatches();
+
 /**
  * Synchronous subscriber invoked on every committed state mutation.
  *
- * Subscribers receive the post-recipe `state` and the `previous` state that
- * was in effect just before the mutation. Per D18, subscribers never observe
- * intermediate Immer drafts — only the settled post-recipe state.
+ * Subscribers receive the post-recipe `state`, the `previous` state that
+ * was in effect just before the mutation, and the Immer patches that
+ * describe the change. Per D18, subscribers never observe intermediate
+ * Immer drafts — only the settled post-recipe state.
+ *
+ * `patches` enables downstream projections (notably the Karton bridge)
+ * to forward granular per-path changes instead of replacing whole
+ * subtrees, which is what restores per-chunk streaming payloads to
+ * pre-refactor size. Subscribers that don't need patches can declare
+ * fewer parameters — TypeScript's parameter bivariance accepts the
+ * shorter signature and the runtime ignores the extra argument.
  */
 export type StateListener<
   TTools extends UITools = UniversalTools,
@@ -17,6 +34,7 @@ export type StateListener<
 > = (
   state: AgentSystemState<TTools, TQuestionField, TQuestionAnswer>,
   previous: AgentSystemState<TTools, TQuestionField, TQuestionAnswer>,
+  patches: Patch[],
 ) => void;
 
 /**
@@ -104,7 +122,7 @@ export class AgentStore<
     this.isUpdating = true;
     try {
       const previous = this.state;
-      const next = produce(previous, recipe);
+      const [next, patches] = produceWithPatches(previous, recipe);
       this.state = next;
 
       if (next === previous) {
@@ -113,7 +131,7 @@ export class AgentStore<
 
       // Plain subscribers: synchronous, errors propagate.
       for (const listener of this.subscribers) {
-        listener(next, previous);
+        listener(next, previous, patches);
       }
 
       // Side-effect subscribers: synchronous dispatch, promise tracked.


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes patch behavior in the Karton ↔ `@stagewise/agent-core` bridge by forwarding granular Immer patches for `agents.instances` and applying them in one `karton.setState`. Restores per-chunk streaming payload size and keeps untouched history items referentially stable.

- **Bug Fixes**
  - Forward only `agents.*` patches from `AgentStore.update()` and apply them via `applyPatches` inside a single `karton.setState` (co-emits with toolbox diffs).
  - Seed existing agent instances on attach so pre-attach upserts reach Karton; call `enablePatches()` in both `agent-store` and the bridge to avoid load-order coupling.
  - Switch `AgentStore` to `produceWithPatches` and pass `patches` to subscribers.
  - Add tests for granular patch forwarding and structural sharing of untouched history slots.

<sup>Written for commit 26afa14b1953b60fa0a8872332b2679f5c40038e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1256?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Mirroring now forwards only granular state changes (agents subset), reducing redundant updates and improving sync efficiency.
  * State update subscriptions now receive precise change payloads (patches) for targeted handling.

* **Tests**
  * Added tests validating granular mutation forwarding and that subscribers receive detailed change information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->