### PR TITLE
test(agent-core): recover dropped watcher event in mount-registry test

### DIFF
--- a/packages/agent-core/src/services/mount-manager/mount-registry.test.ts
+++ b/packages/agent-core/src/services/mount-manager/mount-registry.test.ts
@@ -354,12 +354,22 @@ describe('MountManager watcher refresh (integration)', () => {
     await new Promise((r) => setTimeout(r, 200));
     writeFileSync(wsMdPath, 'second', 'utf-8');
 
-    // 400 ms debounce + 150 ms awaitWriteFinish stability + slack. chokidar
-    // on Windows CI can lag well beyond the POSIX case, so allow generous slack.
-    const deadline = Date.now() + 8000;
+    // The first `change` event after mount can be dropped on slow CI runners
+    // (notably Windows, where chokidar's fs.watch backend attaches well after
+    // the fixed pre-write settle wait, so the single 'second' write lands
+    // inside the attach window and never fires an event). Re-touch the file
+    // during long quiet intervals to recover a missed initial event, while
+    // leaving >1s of silence between touches so the 400 ms refresh debounce
+    // (+150 ms awaitWriteFinish stability) can actually settle and fire.
+    const deadline = Date.now() + 10000;
+    let lastTouch = Date.now();
     while (Date.now() < deadline) {
       const latest = store.writes[store.writes.length - 1]!;
       if (latest.mounts[0]?.workspaceMdContent === 'second') break;
+      if (Date.now() - lastTouch > 1500) {
+        writeFileSync(wsMdPath, 'second', 'utf-8');
+        lastTouch = Date.now();
+      }
       await new Promise((r) => setTimeout(r, 100));
     }
 
@@ -368,5 +378,5 @@ describe('MountManager watcher refresh (integration)', () => {
     expect(store.writes.length).toBeGreaterThan(writesAfterMount);
 
     await manager.teardownWatchers();
-  }, 15_000);
+  }, 20_000);
 });


### PR DESCRIPTION
The mount-registry watcher-refresh integration test rewrote WORKSPACE.md exactly once and polled for the debounced refresh. On slow CI runners (notably Windows, where chokidar's fs.watch backend attaches well after the fixed pre-write settle wait) that single write can land inside the watcher's attach window and never fire a change event, so the refresh never runs and the assertion sees stale 'first' content.

Re-touch the file during long quiet intervals to recover a missed initial event, leaving >1s of silence between touches so the 400ms refresh debounce (+150ms awaitWriteFinish stability) can settle and fire. Widen the poll deadline (8s->10s) and test timeout (15s->20s) accordingly. The fast POSIX path is unchanged: the event arrives well before the first re-touch, so the loop breaks immediately as before.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes the mount-registry watcher-refresh test on slow runners (notably Windows) by re-touching WORKSPACE.md if the first change event is missed. Extends the poll deadline to 10s and the test timeout to 20s; fast POSIX runs are unchanged.

- **Bug Fixes**
  - Re-touch file every >1.5s during idle to recover a missed initial event while respecting the 400ms debounce + 150ms stability.
  - Increase poll deadline 8s→10s and test timeout 15s→20s to avoid flakes on slow CI.

<sup>Written for commit 14a3c718a20ba50133105d8c8cb26e3829f7dac2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1257?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

