### PR TITLE
Align sidebar UI

### DIFF
--- a/apps/browser/src/backend/services/toolbox/services/shell/session-manager.test.ts
+++ b/apps/browser/src/backend/services/toolbox/services/shell/session-manager.test.ts
@@ -845,6 +845,7 @@ describe('shell integration scripts', () => {
     // (tied to the $PATH array). The encoder must use `${p:$i:1}` on a
     // plain local var `p`.
     expect(ZSH_INTEGRATION).toContain('local p="$1"');
+    // biome-ignore lint/suspicious/noTemplateCurlyInString: This is expected
     expect(ZSH_INTEGRATION).toContain('${p:$i:1}');
     expect(ZSH_INTEGRATION).not.toContain('local path=');
     expect(ZSH_INTEGRATION).not.toMatch(/\$\{path:i:1\}/);

--- a/apps/browser/src/ui/screens/main/sidebar/agents-list/index.tsx
+++ b/apps/browser/src/ui/screens/main/sidebar/agents-list/index.tsx
@@ -514,15 +514,15 @@ function WorkspaceGroupHeader({
   return (
     <div
       className={cn(
-        'group/workspace-header flex shrink-0 items-center gap-1 py-1 pr-1 text-subtle-foreground text-xs',
-        depth === 0 ? 'pt-5 pl-1 font-medium' : 'pt-2 pl-2.5 font-medium',
+        'group/workspace-header flex shrink-0 items-center gap-1 py-1 pr-1 text-sidebar-foreground text-xs',
+        depth === 0 ? 'pt-5 pl-1 font-normal' : 'pt-2 pl-2.5 font-normal',
       )}
     >
       <button
         type="button"
         className={cn(
           'flex min-w-0 flex-1 items-center gap-1.5 rounded-sm text-left',
-          collapsible && 'hover:text-foreground',
+          collapsible && 'cursor-pointer hover:text-foreground',
         )}
         disabled={!collapsible}
         onClick={collapsible ? onToggle : undefined}
@@ -649,7 +649,7 @@ function AgentListGroupingToggle({
       <MenuTrigger>
         <button
           type="button"
-          className="flex h-5 shrink-0 cursor-pointer items-center gap-1 rounded-md bg-transparent px-1 text-subtle-foreground text-xs transition-colors hover:text-foreground"
+          className="flex h-5 shrink-0 cursor-pointer items-center gap-1 rounded-md bg-transparent px-1 text-sidebar-foreground text-xs transition-colors hover:text-foreground"
           aria-label="Change agent grouping mode"
         >
           <span>{label}</span>
@@ -2079,7 +2079,7 @@ export function AgentsList() {
           contextMenuState={ctxMenuState}
           onClick={handleClick}
           onRename={handleRename}
-          isPinned={false}
+          isPinned={pinnedAgentIdSet.has(agent.id)}
           onTogglePinned={handleTogglePinned}
           cache={previewCacheRef.current}
           isLiveAgent={agent.isLive}
@@ -2093,6 +2093,7 @@ export function AgentsList() {
       handleTogglePinned,
       openAgent,
       previewAgentId,
+      pinnedAgentIdSet,
     ],
   );
 
@@ -2284,7 +2285,7 @@ export function AgentsList() {
                     <Button
                       variant="ghost"
                       size="sm"
-                      className="mt-1 ml-1 h-6 w-[calc(100%-0.25rem)] justify-start px-1.5 text-subtle-foreground text-xs transition-colors hover:bg-foreground/8 hover:text-muted-foreground"
+                      className="mt-1 ml-1 h-6 w-[calc(100%-0.25rem)] justify-start px-1.5 text-sidebar-foreground text-xs transition-colors hover:text-muted-foreground"
                       onClick={() => handleShowMoreWorktrees(repo.key)}
                     >
                       Show more worktrees...
@@ -2349,7 +2350,7 @@ export function AgentsList() {
           />
         </Button>
         <div className="mt-2 flex items-center gap-1.5 rounded-md bg-foreground/5 px-2 py-1.5">
-          <IconMagnifierOutline18 className="size-3.5 shrink-0 text-subtle-foreground" />
+          <IconMagnifierOutline18 className="size-3.5 shrink-0 text-sidebar-foreground" />
           <input
             type="text"
             aria-label="Search agents"
@@ -2363,7 +2364,7 @@ export function AgentsList() {
             onFocus={() => openCommandCenter({ initialMode: 'agents' })}
             onChange={() => {}}
             className={cn(
-              'w-full bg-transparent text-foreground text-sm placeholder:text-subtle-foreground',
+              'w-full bg-transparent text-foreground text-sm placeholder:text-sidebar-foreground',
               'outline-none',
             )}
           />
@@ -2389,7 +2390,7 @@ export function AgentsList() {
         onViewportRef={setScrollViewport}
       >
         <div className="flex shrink-0 items-center pt-0 pr-0 pb-1 pl-1.5">
-          <div className="min-w-0 flex-1 truncate font-medium text-subtle-foreground text-xs">
+          <div className="min-w-0 flex-1 truncate font-normal text-sidebar-foreground text-xs">
             {filteredPinnedAgents.length > 0 ? 'Pinned' : 'Agents'}
           </div>
           <AgentListGroupingToggle
@@ -2503,7 +2504,7 @@ export function AgentsList() {
               return (
                 <div
                   key={`h-${item.label}`}
-                  className="shrink-0 px-1.5 pt-3 pb-1 font-medium text-subtle-foreground text-xs"
+                  className="shrink-0 px-1.5 pt-3 pb-1 font-normal text-sidebar-foreground text-xs"
                 >
                   {item.label}
                 </div>
@@ -2520,7 +2521,7 @@ export function AgentsList() {
           <Button
             variant="ghost"
             size="sm"
-            className="mt-1 w-full justify-start pl-1.5 text-sm text-subtle-foreground transition-colors hover:bg-foreground/8 hover:text-muted-foreground"
+            className="mt-1 w-full justify-start pl-1.5 text-sidebar-foreground text-sm transition-colors hover:bg-foreground/8 hover:text-muted-foreground"
             onClick={handleShowMore}
           >
             Show more...

--- a/apps/browser/src/ui/screens/main/sidebar/agents-list/index.tsx
+++ b/apps/browser/src/ui/screens/main/sidebar/agents-list/index.tsx
@@ -514,7 +514,7 @@ function WorkspaceGroupHeader({
   return (
     <div
       className={cn(
-        'group/workspace-header flex shrink-0 items-center gap-1 py-1 pr-1 text-muted-foreground text-xs',
+        'group/workspace-header flex shrink-0 items-center gap-1 py-1 pr-1 text-subtle-foreground text-xs',
         depth === 0 ? 'pt-5 pl-1 font-medium' : 'pt-2 pl-2.5 font-medium',
       )}
     >
@@ -649,7 +649,7 @@ function AgentListGroupingToggle({
       <MenuTrigger>
         <button
           type="button"
-          className="flex h-5 shrink-0 items-center gap-1 rounded-md px-1 text-muted-foreground text-xs transition-colors hover:bg-foreground/8 hover:text-foreground"
+          className="flex h-5 shrink-0 cursor-pointer items-center gap-1 rounded-md bg-transparent px-1 text-subtle-foreground text-xs transition-colors hover:text-foreground"
           aria-label="Change agent grouping mode"
         >
           <span>{label}</span>
@@ -2284,7 +2284,7 @@ export function AgentsList() {
                     <Button
                       variant="ghost"
                       size="sm"
-                      className="mt-1 ml-1 h-6 w-[calc(100%-0.25rem)] justify-start px-1.5 text-muted-foreground text-xs hover:bg-foreground/8"
+                      className="mt-1 ml-1 h-6 w-[calc(100%-0.25rem)] justify-start px-1.5 text-subtle-foreground text-xs transition-colors hover:bg-foreground/8 hover:text-muted-foreground"
                       onClick={() => handleShowMoreWorktrees(repo.key)}
                     >
                       Show more worktrees...
@@ -2349,7 +2349,7 @@ export function AgentsList() {
           />
         </Button>
         <div className="mt-2 flex items-center gap-1.5 rounded-md bg-foreground/5 px-2 py-1.5">
-          <IconMagnifierOutline18 className="size-3.5 shrink-0 text-muted-foreground" />
+          <IconMagnifierOutline18 className="size-3.5 shrink-0 text-subtle-foreground" />
           <input
             type="text"
             aria-label="Search agents"
@@ -2363,7 +2363,7 @@ export function AgentsList() {
             onFocus={() => openCommandCenter({ initialMode: 'agents' })}
             onChange={() => {}}
             className={cn(
-              'w-full bg-transparent text-foreground text-sm placeholder:text-muted-foreground',
+              'w-full bg-transparent text-foreground text-sm placeholder:text-subtle-foreground',
               'outline-none',
             )}
           />
@@ -2389,7 +2389,7 @@ export function AgentsList() {
         onViewportRef={setScrollViewport}
       >
         <div className="flex shrink-0 items-center pt-0 pr-0 pb-1 pl-1.5">
-          <div className="min-w-0 flex-1 truncate font-medium text-muted-foreground text-xs">
+          <div className="min-w-0 flex-1 truncate font-medium text-subtle-foreground text-xs">
             {filteredPinnedAgents.length > 0 ? 'Pinned' : 'Agents'}
           </div>
           <AgentListGroupingToggle
@@ -2503,7 +2503,7 @@ export function AgentsList() {
               return (
                 <div
                   key={`h-${item.label}`}
-                  className="shrink-0 px-1.5 pt-3 pb-1 font-medium text-muted-foreground text-xs"
+                  className="shrink-0 px-1.5 pt-3 pb-1 font-medium text-subtle-foreground text-xs"
                 >
                   {item.label}
                 </div>
@@ -2520,7 +2520,7 @@ export function AgentsList() {
           <Button
             variant="ghost"
             size="sm"
-            className="mt-1 w-full justify-start pl-1.5 text-muted-foreground text-sm hover:bg-foreground/8"
+            className="mt-1 w-full justify-start pl-1.5 text-sm text-subtle-foreground transition-colors hover:bg-foreground/8 hover:text-muted-foreground"
             onClick={handleShowMore}
           >
             Show more...

--- a/apps/browser/src/ui/screens/main/sidebar/worktree-cleanup-badge.tsx
+++ b/apps/browser/src/ui/screens/main/sidebar/worktree-cleanup-badge.tsx
@@ -91,15 +91,15 @@ export function WorktreeCleanupBadge() {
               <span className="min-w-0 truncate font-medium text-foreground">
                 {candidate.branch ?? getBaseName(candidate.path)}
               </span>
-              <span className="shrink-0 text-subtle-foreground">
+              <span className="shrink-0 text-sidebar-foreground">
                 merged into {candidate.mergedInto}
               </span>
-              <span className="ml-auto shrink-0 text-subtle-foreground">
+              <span className="ml-auto shrink-0 text-sidebar-foreground">
                 {formatLastUsedAge(candidate.lastUsedAt)}
               </span>
             </div>
             <div
-              className="mt-0.5 truncate text-[0.68rem] text-subtle-foreground"
+              className="mt-0.5 truncate text-[0.68rem] text-sidebar-foreground"
               title={candidate.path}
             >
               {candidate.path}

--- a/apps/browser/src/ui/screens/settings/sidebar.tsx
+++ b/apps/browser/src/ui/screens/settings/sidebar.tsx
@@ -3,7 +3,10 @@ import { Button } from '@stagewise/stage-ui/components/button';
 import { cn } from '@ui/utils';
 import { useKartonProcedure, useKartonState } from '@ui/hooks/use-karton';
 import { useUiZoomCounterScale } from '@ui/hooks/use-ui-zoom-counter-scale';
-import { TITLEBAR_HEIGHT } from '@shared/titlebar';
+import {
+  TITLEBAR_HEIGHT,
+  TITLEBAR_ICON_OPTICAL_OFFSET,
+} from '@shared/titlebar';
 import { SidebarTitlebarRow } from '../main/_components/sidebar-titlebar-row';
 import {
   SETTINGS_NAV_GROUPS,
@@ -14,6 +17,7 @@ import type { SettingsRootSection } from './settings-route';
 
 export function SettingsSidebar() {
   const counterScale = useUiZoomCounterScale();
+  const isMacOs = useKartonState((s) => s.appInfo.platform === 'darwin');
   const activeRoute = useKartonState((s) => s.appScreen.settingsRoute);
   const setSettingsRoute = useKartonProcedure(
     (p) => p.appScreen.setSettingsRoute,
@@ -35,6 +39,9 @@ export function SettingsSidebar() {
             variant="ghost"
             size="sm"
             className="app-no-drag shrink-0 px-1.5"
+            style={
+              isMacOs ? { marginTop: TITLEBAR_ICON_OPTICAL_OFFSET } : undefined
+            }
             onClick={() => closeSettings()}
           >
             ← Back
@@ -61,10 +68,10 @@ export function SettingsSidebar() {
                     key={item.section}
                     type="button"
                     className={cn(
-                      'app-no-drag flex h-8 w-full flex-row items-center gap-2 rounded-lg px-1.5 text-left text-sm transition-colors',
+                      'app-no-drag flex h-8 w-full cursor-pointer flex-row items-center gap-2 rounded-lg px-1.5 text-left text-sm transition-colors',
                       active
                         ? 'bg-foreground/5 text-foreground'
-                        : 'text-muted-foreground hover:bg-foreground/8',
+                        : 'text-muted-foreground hover:bg-foreground/8 hover:text-foreground',
                     )}
                     onClick={() => handleSelectSection(item.section)}
                   >

--- a/apps/browser/src/ui/screens/settings/sidebar.tsx
+++ b/apps/browser/src/ui/screens/settings/sidebar.tsx
@@ -57,7 +57,7 @@ export function SettingsSidebar() {
           {SETTINGS_NAV_GROUPS.map((group, gi) => (
             <div key={gi} className="flex flex-col gap-px pt-4 first:pt-0">
               {group.label && (
-                <div className="shrink-0 px-1.5 pb-1 font-semibold text-subtle-foreground text-xs">
+                <div className="shrink-0 px-1.5 pb-1 font-normal text-sidebar-foreground text-xs">
                   {group.label}
                 </div>
               )}

--- a/packages/stage-ui/README.md
+++ b/packages/stage-ui/README.md
@@ -110,6 +110,7 @@ Theme tokens are defined in [`theme.css`](./src/styles/theme.css) and automatica
 | `--color-foreground` | Primary readable text |
 | `--color-muted-foreground` | Secondary/less important text |
 | `--color-subtle-foreground` | Hints, placeholders, disabled text |
+| `--color-sidebar-foreground` | Sidebar-only secondary/label text. Between `subtle` and `muted` (leans muted) for legibility on the blurred sidebar surface |
 | `--color-primary-foreground` | Accent text (links, highlights) |
 | `--color-solid-foreground` | Text on solid/primary backgrounds |
 

--- a/packages/stage-ui/src/styles/theme.css
+++ b/packages/stage-ui/src/styles/theme.css
@@ -8,6 +8,15 @@
   --color-foreground: var(--color-base-900);
   --color-muted-foreground: var(--color-base-500);
   --color-subtle-foreground: var(--color-base-350);
+  /* Sidebar-only text color. Sits between `subtle` and `muted`, leaning
+     toward `muted`, so secondary/label text stays legible on the slightly
+     blurred sidebar surface (notably in dark mode). Defined via color-mix on
+     the mode-aware tokens, so it auto-adapts to light/dark with no override. */
+  --color-sidebar-foreground: color-mix(
+    in oklch,
+    var(--color-muted-foreground) 70%,
+    var(--color-subtle-foreground)
+  );
 
   --color-surface-1: var(--color-base-100);
   --color-surface-2: var(--color-base-150);


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the Main and Settings sidebars and improves label legibility with a new `--color-sidebar-foreground` token in `@stagewise/stage-ui`. Also updates hover/click affordances, aligns the macOS Back icon, fixes pinned agent state, and silences a Biome test warning.

- **Bug Fixes**
  - Pinned agents now display the correct pinned state in the list.

- **Refactors**
  - Introduced `--color-sidebar-foreground` and applied it across sidebar labels (agents list headers, group labels, search icon/placeholder, cleanup badge, “Show more”).
  - Smoothed hover states; kept transparent backgrounds; added `cursor-pointer` to interactive controls (grouping toggle, Settings nav).
  - Thinned workspace/group/time-group labels to `font-normal`.
  - Settings: applied `TITLEBAR_ICON_OPTICAL_OFFSET` on macOS to align Back; raised nav text color on hover.
  - Tests: added a Biome ignore for the expected `${...}` pattern in the ZSH integration test.

<sup>Written for commit fc3b70a3cb3133dce28885e462d646c7eb3448e5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1258?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Refined sidebar UI styling across main and settings screens (headers, toggles, search, list items, buttons) for improved consistency and readability; updated macOS top spacing.
  * Restyled worktree badge and agent list visuals for cohesive sidebar coloring.
* **Documentation**
  * Added a new sidebar foreground color token to the theme and documented its usage.
* **Tests**
  * Suppressed a lint rule in a regression test (no test behavior changed).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->