### PR TITLE
refactor(stagewise): refactor context-skills settings

### DIFF
--- a/apps/browser/src/ui/screens/settings/_components/settings-scroll-tabs.tsx
+++ b/apps/browser/src/ui/screens/settings/_components/settings-scroll-tabs.tsx
@@ -1,0 +1,99 @@
+import { useRef, useState } from 'react';
+import { buttonVariants } from '@stagewise/stage-ui/components/button';
+import { OverlayScrollbar } from '@stagewise/stage-ui/components/overlay-scrollbar';
+import { cn } from '@ui/utils';
+import { useScrollFadeMask } from '@ui/hooks/use-scroll-fade-mask';
+
+export interface SettingsScrollTabItem {
+  id: string;
+  label: string;
+  subLabel?: string;
+}
+
+interface SettingsScrollTabsProps {
+  items: SettingsScrollTabItem[];
+  selectedId: string | null;
+  onSelect: (id: string) => void;
+  /**
+   * Truncate the sub-label from the start (left) and cap the tab width. Use
+   * for path-like sub-labels where the trailing segment is the meaningful
+   * part.
+   */
+  truncateSubLabelFromStart?: boolean;
+}
+
+/**
+ * Horizontally-scrollable single-select tab bar used by settings sections.
+ * Each tab shows a primary label and an optional subtle sub-label, with an
+ * edge fade mask when the row overflows. Shared by the Worktrees and
+ * Skills & Context settings pages so they stay visually in sync.
+ */
+export function SettingsScrollTabs({
+  items,
+  selectedId,
+  onSelect,
+  truncateSubLabelFromStart = false,
+}: SettingsScrollTabsProps) {
+  const [viewport, setViewport] = useState<HTMLElement | null>(null);
+  const viewportRef = useRef<HTMLElement | null>(null);
+  viewportRef.current = viewport;
+  const { maskStyle } = useScrollFadeMask(viewportRef, {
+    axis: 'horizontal',
+    fadeDistance: 24,
+  });
+
+  return (
+    <OverlayScrollbar
+      className="scrollbar-subtle mask-alpha max-w-full"
+      style={maskStyle}
+      options={{ overflow: { x: 'scroll', y: 'hidden' } }}
+      onViewportRef={setViewport}
+      contentClassName="flex gap-2"
+    >
+      <nav className="flex gap-2">
+        {items.map((item) => {
+          const selected = selectedId === item.id;
+          const subLabelColor = selected
+            ? 'text-muted-foreground group-hover/button:text-foreground group-focus-visible/button:text-foreground'
+            : 'text-subtle-foreground group-hover/button:text-muted-foreground group-focus-visible/button:text-muted-foreground';
+          return (
+            <button
+              key={item.id}
+              type="button"
+              onClick={() => onSelect(item.id)}
+              className={cn(
+                buttonVariants({
+                  variant: 'ghost',
+                }),
+                'h-auto shrink-0 flex-col items-start px-3 py-2 text-left first:pl-0',
+                truncateSubLabelFromStart && 'max-w-48',
+                selected && 'font-medium text-foreground',
+              )}
+            >
+              <span className="block max-w-full truncate text-sm">
+                {item.label}
+              </span>
+              {item.subLabel ? (
+                truncateSubLabelFromStart ? (
+                  <span
+                    className={cn(
+                      'block max-w-full truncate text-xs',
+                      subLabelColor,
+                    )}
+                    dir="rtl"
+                  >
+                    <span dir="ltr">{item.subLabel}</span>
+                  </span>
+                ) : (
+                  <span className={cn('block truncate text-xs', subLabelColor)}>
+                    {item.subLabel}
+                  </span>
+                )
+              ) : null}
+            </button>
+          );
+        })}
+      </nav>
+    </OverlayScrollbar>
+  );
+}

--- a/apps/browser/src/ui/screens/settings/sections/agent-settings.worktree-setup.tsx
+++ b/apps/browser/src/ui/screens/settings/sections/agent-settings.worktree-setup.tsx
@@ -21,6 +21,7 @@ import { toast } from '@stagewise/stage-ui/components/toaster';
 import { useKartonProcedure } from '@ui/hooks/use-karton';
 import { cn } from '@ui/utils';
 import { useScrollFadeMask } from '@ui/hooks/use-scroll-fade-mask';
+import { SettingsScrollTabs } from '../_components/settings-scroll-tabs';
 import type {
   KartonContract,
   WorktreeSetupManagedWorktree,
@@ -303,56 +304,21 @@ function RepositoryList({
   selectedRepositoryId: string | null;
   onSelect: (id: string) => void;
 }) {
-  const [viewport, setViewport] = useState<HTMLElement | null>(null);
-  const viewportRef = useRef<HTMLElement | null>(null);
-  viewportRef.current = viewport;
-  const { maskStyle } = useScrollFadeMask(viewportRef, {
-    axis: 'horizontal',
-    fadeDistance: 24,
-  });
-
   return (
-    <OverlayScrollbar
-      className="scrollbar-subtle mask-alpha max-w-full"
-      style={maskStyle}
-      options={{ overflow: { x: 'scroll', y: 'hidden' } }}
-      onViewportRef={setViewport}
-      contentClassName="flex gap-2"
-    >
-      <nav className="flex gap-2">
-        {repositories.map((repository) => {
-          const selected = selectedRepositoryId === repository.id;
-          const worktreeCount = repository.managedWorktrees.length;
-          return (
-            <button
-              key={repository.id}
-              type="button"
-              onClick={() => onSelect(repository.id)}
-              className={cn(
-                buttonVariants({
-                  variant: 'ghost',
-                }),
-                'h-auto shrink-0 flex-col items-start px-3 py-2 text-left first:pl-0',
-                selected && 'font-medium text-foreground',
-              )}
-            >
-              <span className="block truncate text-sm">{repository.name}</span>
-              <span
-                className={cn(
-                  'block truncate text-xs',
-                  selected
-                    ? 'text-muted-foreground group-hover/button:text-foreground group-focus-visible/button:text-foreground'
-                    : 'text-subtle-foreground group-hover/button:text-muted-foreground group-focus-visible/button:text-muted-foreground',
-                )}
-              >
-                {worktreeCount} {worktreeCount === 1 ? 'worktree' : 'worktrees'}{' '}
-                used
-              </span>
-            </button>
-          );
-        })}
-      </nav>
-    </OverlayScrollbar>
+    <SettingsScrollTabs
+      selectedId={selectedRepositoryId}
+      onSelect={onSelect}
+      items={repositories.map((repository) => {
+        const worktreeCount = repository.managedWorktrees.length;
+        return {
+          id: repository.id,
+          label: repository.name,
+          subLabel: `${worktreeCount} ${
+            worktreeCount === 1 ? 'worktree' : 'worktrees'
+          } used`,
+        };
+      })}
+    />
   );
 }
 

--- a/apps/browser/src/ui/screens/settings/sections/skills-context-section.tsx
+++ b/apps/browser/src/ui/screens/settings/sections/skills-context-section.tsx
@@ -28,6 +28,7 @@ import {
   TooltipContent,
 } from '@stagewise/stage-ui/components/tooltip';
 import type { RefObject } from 'react';
+import { SettingsScrollTabs } from '../_components/settings-scroll-tabs';
 
 // =============================================================================
 // Vertical overflow detection (like useIsTruncated but for height)
@@ -57,22 +58,6 @@ function useIsOverflowing(ref: RefObject<HTMLElement | null>) {
 // =============================================================================
 // Workspace Subheader
 // =============================================================================
-
-function WorkspaceSubheader({ workspacePath }: { workspacePath: string }) {
-  const folderName = useMemo(
-    () => getBaseName(workspacePath) || workspacePath,
-    [workspacePath],
-  );
-
-  return (
-    <div className="flex flex-col">
-      <span className="font-medium text-foreground text-sm">{folderName}</span>
-      <span className="truncate text-subtle-foreground text-xs">
-        {workspacePath}
-      </span>
-    </div>
-  );
-}
 
 // =============================================================================
 // Skills Section
@@ -220,46 +205,55 @@ function SkillRow({
   );
 }
 
-function SkillsSection({
-  workspaceMounts,
+function WorkspaceDetails({
+  mount,
+  contextFiles,
 }: {
-  workspaceMounts: Array<{
-    path: string;
-    skills: Array<{ name: string; description: string }>;
-  }>;
+  mount: MountEntry;
+  contextFiles: ContextFilesResult | null;
 }) {
-  const hasSkills = workspaceMounts.some((m) => m.skills.length > 0);
-
   return (
-    <section className="space-y-6">
-      <div>
-        <h2 className="font-medium text-foreground text-lg">Skills</h2>
-        <p className="text-muted-foreground text-sm">
-          Enable or disable skills per workspace.
-        </p>
-      </div>
-      {hasSkills ? (
-        <div className="space-y-4">
-          {workspaceMounts
-            .filter((mount) => mount.skills.length > 0)
-            .map((mount) => (
-              <div key={mount.path} className="space-y-2">
-                <WorkspaceSubheader workspacePath={mount.path} />
-                <WorkspaceSkillsList
-                  workspacePath={mount.path}
-                  skills={mount.skills}
-                />
-              </div>
-            ))}
-        </div>
-      ) : (
-        <div className="rounded-lg border border-derived-subtle p-4">
-          <p className="text-center text-muted-foreground text-sm">
-            No skills detected in any connected workspace.
+    <div className="space-y-8">
+      <section className="space-y-3">
+        <div>
+          <h2 className="font-medium text-foreground text-lg">Skills</h2>
+          <p className="text-muted-foreground text-sm">
+            Enable or disable skills for this workspace.
           </p>
         </div>
-      )}
-    </section>
+        {mount.skills.length > 0 ? (
+          <WorkspaceSkillsList
+            workspacePath={mount.path}
+            skills={mount.skills}
+          />
+        ) : (
+          <div className="rounded-lg border border-derived-subtle p-4">
+            <p className="text-center text-muted-foreground text-sm">
+              No skills detected in this workspace.
+            </p>
+          </div>
+        )}
+      </section>
+      <hr className="border-derived-subtle border-t" />
+      <section className="space-y-3">
+        <div>
+          <h2 className="font-medium text-foreground text-lg">Context files</h2>
+          <p className="text-muted-foreground text-sm">
+            Manage workspace context files used by the AI agent.
+          </p>
+        </div>
+        <WorkspaceContextFilesList
+          workspacePath={mount.path}
+          workspaceMd={
+            contextFiles?.[mount.path]?.workspaceMd ?? {
+              exists: mount.workspaceMdContent !== null,
+              path: null,
+              content: null,
+            }
+          }
+        />
+      </section>
+    </div>
   );
 }
 
@@ -402,54 +396,6 @@ function WorkspaceContextFilesList({
   );
 }
 
-function ContextFilesSection({
-  workspaceMounts,
-  contextFiles,
-}: {
-  workspaceMounts: Array<{
-    path: string;
-    workspaceMdContent: string | null;
-    agentsMdContent: string | null;
-  }>;
-  contextFiles: ContextFilesResult | null;
-}) {
-  return (
-    <section className="space-y-6">
-      <div>
-        <h2 className="font-medium text-foreground text-lg">Context files</h2>
-        <p className="text-muted-foreground text-sm">
-          Manage workspace context files used by the AI agent.
-        </p>
-      </div>
-      {workspaceMounts.length > 0 ? (
-        <div className="space-y-4">
-          {workspaceMounts.map((mount) => (
-            <div key={mount.path} className="space-y-2">
-              <WorkspaceSubheader workspacePath={mount.path} />
-              <WorkspaceContextFilesList
-                workspacePath={mount.path}
-                workspaceMd={
-                  contextFiles?.[mount.path]?.workspaceMd ?? {
-                    exists: mount.workspaceMdContent !== null,
-                    path: null,
-                    content: null,
-                  }
-                }
-              />
-            </div>
-          ))}
-        </div>
-      ) : (
-        <div className="rounded-lg border border-derived-subtle p-4">
-          <p className="text-center text-muted-foreground text-sm">
-            No context files available.
-          </p>
-        </div>
-      )}
-    </section>
-  );
-}
-
 // =============================================================================
 // Main Page Component
 // =============================================================================
@@ -515,6 +461,17 @@ export function SkillsContextSection() {
     }
   }, [workspaceMdGenerating]);
 
+  const [selectedWorkspacePath, setSelectedWorkspacePath] = useState<
+    string | null
+  >(null);
+  const selectedMount = useMemo(
+    () =>
+      workspaceMounts.find((m) => m.path === selectedWorkspacePath) ??
+      workspaceMounts[0] ??
+      null,
+    [workspaceMounts, selectedWorkspacePath],
+  );
+
   const hasWorkspaces = workspaceMounts.length > 0;
 
   return (
@@ -541,12 +498,22 @@ export function SkillsContextSection() {
             </div>
           ) : (
             <div className="space-y-8">
-              <SkillsSection workspaceMounts={workspaceMounts} />
-              <hr className="border-derived-subtle border-t" />
-              <ContextFilesSection
-                workspaceMounts={workspaceMounts}
-                contextFiles={contextFiles}
+              <SettingsScrollTabs
+                selectedId={selectedMount?.path ?? null}
+                onSelect={setSelectedWorkspacePath}
+                truncateSubLabelFromStart
+                items={workspaceMounts.map((mount) => ({
+                  id: mount.path,
+                  label: getBaseName(mount.path) || mount.path,
+                  subLabel: mount.path,
+                }))}
               />
+              {selectedMount ? (
+                <WorkspaceDetails
+                  mount={selectedMount}
+                  contextFiles={contextFiles}
+                />
+              ) : null}
             </div>
           )}
         </div>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Refactored the Skills & Context settings to use a shared horizontal tabs component and consolidated per-workspace skills and context management into a single view. Applied the same tabs to Worktree Setup for consistent navigation and less duplicate code.

- **Refactors**
  - Added `SettingsScrollTabs` with horizontal scroll, edge fade mask, and optional start-truncated sub-labels for long paths.
  - Worktree Setup: replaced custom repo list with `SettingsScrollTabs`; shows worktree count as sub-label.
  - Skills & Context: added workspace tabs and combined Skills and Context Files into one `WorkspaceDetails` panel for the selected workspace.
  - Removed duplicated list/header code and section renderers to simplify maintenance.

<sup>Written for commit 4582392c217596ab3f1d937add838802b7994cc8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1260?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

