### PR TITLE
feat(stagewise): prefer remote base for worktrees

### DIFF
--- a/apps/browser/src/backend/services/git/index.test.ts
+++ b/apps/browser/src/backend/services/git/index.test.ts
@@ -307,6 +307,10 @@ describe('GitService', () => {
         'main\t*',
         'feature/test\t',
       ].join('\n'),
+      'for-each-ref --format=%(refname:short) refs/remotes': [
+        'origin/HEAD',
+        'origin/main',
+      ].join('\n'),
       'worktree list --porcelain': [
         'worktree /repo',
         'HEAD abc123',
@@ -321,25 +325,36 @@ describe('GitService', () => {
     await expect(service.listBranches('/repo')).resolves.toEqual({
       current: 'main',
       defaultBranch: 'main',
+      defaultRemoteBranch: 'origin/main',
       branches: [
         {
           name: 'main',
+          kind: 'local',
           current: true,
           checkedOut: true,
           checkedOutPath: repoPath,
         },
         {
           name: 'feature/test',
+          kind: 'local',
           current: false,
           checkedOut: true,
           checkedOutPath: repoLinkedPath,
+        },
+        {
+          name: 'origin/main',
+          kind: 'remote',
+          remoteName: 'origin',
+          remoteBranchName: 'main',
+          current: false,
+          checkedOut: false,
         },
       ],
     });
   });
 
   it('prefers origin HEAD as the default branch', async () => {
-    const { service } = await createGitService({
+    const { service, readCalls } = await createGitService({
       ...baseReadResponses,
       'rev-parse --show-toplevel --abbrev-ref HEAD HEAD':
         '/repo\ndevelop\nabc123\n',
@@ -349,12 +364,69 @@ describe('GitService', () => {
         'develop\t*',
         'main\t',
       ].join('\n'),
+      'for-each-ref --format=%(refname:short) refs/remotes': [
+        'origin/HEAD',
+        'origin/main',
+      ].join('\n'),
       'symbolic-ref --quiet --short refs/remotes/origin/HEAD': 'origin/main',
     });
 
     await expect(service.listBranches('/repo')).resolves.toMatchObject({
       current: 'develop',
       defaultBranch: 'main',
+      defaultRemoteBranch: 'origin/main',
+    });
+    expect(readCalls).toContain(
+      'symbolic-ref --quiet --short refs/remotes/origin/HEAD',
+    );
+  });
+
+  it('prefers the configured branch remote for remote defaults', async () => {
+    const { service, readCalls } = await createGitService({
+      ...baseReadResponses,
+      'rev-parse --show-toplevel --abbrev-ref HEAD HEAD':
+        '/repo\ndevelop\nabc123\n',
+      'worktree list --porcelain':
+        'worktree /repo\nHEAD abc123\nbranch refs/heads/develop\n',
+      'for-each-ref --format=%(refname:short)%09%(HEAD) refs/heads': [
+        'develop\t*',
+        'main\t',
+      ].join('\n'),
+      'for-each-ref --format=%(refname:short) refs/remotes': [
+        'origin/main',
+        'upstream/main',
+      ].join('\n'),
+      remote: ['origin', 'upstream'].join('\n'),
+      'config --get branch.develop.remote': 'upstream',
+      'symbolic-ref --quiet --short refs/remotes/upstream/HEAD':
+        'upstream/main',
+    });
+
+    await expect(service.listBranches('/repo')).resolves.toMatchObject({
+      current: 'develop',
+      defaultBranch: 'main',
+      defaultRemoteBranch: 'upstream/main',
+    });
+    expect(readCalls).toContain(
+      'symbolic-ref --quiet --short refs/remotes/upstream/HEAD',
+    );
+  });
+
+  it('falls back to the first available remote when origin is unavailable', async () => {
+    const { service } = await createGitService({
+      ...baseReadResponses,
+      'for-each-ref --format=%(refname:short)%09%(HEAD) refs/heads': 'main\t*',
+      'for-each-ref --format=%(refname:short) refs/remotes': [
+        'upstream/main',
+        'fork/main',
+      ].join('\n'),
+      remote: ['upstream', 'fork'].join('\n'),
+      'symbolic-ref --quiet --short refs/remotes/upstream/HEAD':
+        'upstream/main',
+    });
+
+    await expect(service.listBranches('/repo')).resolves.toMatchObject({
+      defaultRemoteBranch: 'upstream/main',
     });
   });
 
@@ -374,6 +446,7 @@ describe('GitService', () => {
     await expect(service.listBranches('/repo')).resolves.toMatchObject({
       current: 'develop',
       defaultBranch: 'main',
+      defaultRemoteBranch: null,
     });
   });
 
@@ -505,6 +578,27 @@ describe('GitService', () => {
         `^worktree add -b new-work ${expectedWorktreePathPattern}${escapeRegExp(path.sep)}[a-f0-9]{12}${escapeRegExp(path.sep)}new-work main$`,
       ),
     );
+  });
+
+  it('fetches remote source branches before creating worktrees', async () => {
+    const { service, mutationCalls } = await createGitService({
+      ...baseReadResponses,
+      'for-each-ref --format=%(refname:short)%09%(HEAD) refs/heads': 'main\t*',
+      'for-each-ref --format=%(refname:short) refs/remotes': 'origin/main',
+    });
+
+    const result = await service.createWorktree('/repo', {
+      worktreeName: 'new-work',
+      sourceBranch: 'origin/main',
+    });
+
+    expect(result.ok).toBe(true);
+    expect(mutationCalls).toContain(
+      'fetch --prune origin refs/heads/main:refs/remotes/origin/main',
+    );
+    expect(
+      mutationCalls.find((call) => call.startsWith('worktree add -b ')),
+    ).toContain('worktree add -b new-work --no-track ');
   });
 
   it('rejects create-worktree branch collisions', async () => {

--- a/apps/browser/src/backend/services/git/index.test.ts
+++ b/apps/browser/src/backend/services/git/index.test.ts
@@ -489,6 +489,24 @@ describe('GitService', () => {
     });
   });
 
+  it('prevents switching to a remote branch ref', async () => {
+    const { service, mutationCalls } = await createGitService({
+      ...baseReadResponses,
+      'for-each-ref --format=%(refname:short)%09%(HEAD) refs/heads': 'main\t*',
+      'for-each-ref --format=%(refname:short) refs/remotes': 'origin/main',
+      remote: 'origin',
+    });
+
+    await expect(service.switchBranch('/repo', 'origin/main')).resolves.toEqual(
+      {
+        ok: false,
+        reason: 'branch-not-found',
+        message: 'Branch origin/main is not a local branch.',
+      },
+    );
+    expect(mutationCalls).not.toContain('checkout origin/main');
+  });
+
   it('prevents switching to a branch checked out in another worktree', async () => {
     const { service } = await createGitService({
       ...baseReadResponses,

--- a/apps/browser/src/backend/services/git/index.ts
+++ b/apps/browser/src/backend/services/git/index.ts
@@ -124,6 +124,36 @@ function parseRemoteList(output: string): GitRepositoryRemoteInfo | null {
   );
 }
 
+function parseRemoteNames(output: string | null): string[] {
+  return (output ?? '')
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+function parseRemoteBranchRef(
+  refName: string,
+  remoteNames: string[],
+): { remoteName: string; branchName: string } | null {
+  const matchingRemote = [...remoteNames]
+    .sort((a, b) => b.length - a.length)
+    .find(
+      (remoteName) =>
+        refName === remoteName || refName.startsWith(`${remoteName}/`),
+    );
+
+  if (matchingRemote) {
+    const branchName = refName.slice(matchingRemote.length + 1);
+    if (!branchName || branchName === 'HEAD') return null;
+    return { remoteName: matchingRemote, branchName };
+  }
+
+  const [remoteName, ...branchParts] = refName.split('/');
+  const branchName = branchParts.join('/');
+  if (!remoteName || !branchName || branchName === 'HEAD') return null;
+  return { remoteName, branchName };
+}
+
 const defaultRunGitCommand: GitCommandRunner = async (cwd, args, env) => {
   const { stdout } = await execFileAsync('git', ['-C', cwd, ...args], {
     encoding: 'utf8',
@@ -341,15 +371,23 @@ export class GitService extends DisposableService {
     const summary = await this.getMountedWorkspaceSummary(workspacePath);
     if (!summary) return null;
 
-    const result = await this.runGit(workspacePath, [
-      'for-each-ref',
-      '--format=%(refname:short)%09%(HEAD)',
-      'refs/heads',
+    const [localResult, remoteResult, remoteNamesResult] = await Promise.all([
+      this.runGit(workspacePath, [
+        'for-each-ref',
+        '--format=%(refname:short)%09%(HEAD)',
+        'refs/heads',
+      ]),
+      this.runGit(workspacePath, [
+        'for-each-ref',
+        '--format=%(refname:short)',
+        'refs/remotes',
+      ]),
+      this.runGit(workspacePath, ['remote']),
     ]);
-    if (result === null) return null;
+    if (localResult === null) return null;
 
     const worktrees = await this.listWorktrees(workspacePath);
-    const branches = result
+    const localBranches = localResult
       .split('\n')
       .map((line) => line.trim())
       .filter(Boolean)
@@ -363,15 +401,46 @@ export class GitService extends DisposableService {
 
         return {
           name,
+          kind: 'local',
           current,
           checkedOut: checkedOutWorktree !== undefined,
           checkedOutPath: checkedOutWorktree?.path,
         };
       });
+    const remoteNames = parseRemoteNames(remoteNamesResult);
+    const remoteBranches = (remoteResult ?? '')
+      .split('\n')
+      .map((line) => line.trim())
+      .map((name) => ({
+        name,
+        parsed: parseRemoteBranchRef(name, remoteNames),
+      }))
+      .filter(({ name, parsed }) => name && parsed)
+      .map(
+        ({ name, parsed }): GitBranchInfo => ({
+          name,
+          kind: 'remote',
+          remoteName: parsed?.remoteName,
+          remoteBranchName: parsed?.branchName,
+          current: false,
+          checkedOut: false,
+        }),
+      );
+    const branches = [...localBranches, ...remoteBranches];
+    const defaultBranch = await this.resolveDefaultBranch(
+      workspacePath,
+      localBranches,
+    );
 
     return {
       current: summary.branch,
-      defaultBranch: await this.resolveDefaultBranch(workspacePath, branches),
+      defaultBranch,
+      defaultRemoteBranch: await this.resolveDefaultRemoteBranch(
+        workspacePath,
+        branches,
+        summary.branch,
+        defaultBranch,
+      ),
       branches,
     };
   }
@@ -400,6 +469,109 @@ export class GitService extends DisposableService {
       branches.find((branch) => branch.current)?.name ??
       branches[0]?.name ??
       null
+    );
+  }
+
+  private async resolveDefaultRemoteBranch(
+    workspacePath: string,
+    branches: GitBranchInfo[],
+    currentBranch: string | null,
+    defaultBranch: string | null,
+  ): Promise<string | null> {
+    const remoteBranches = branches.filter(
+      (branch) => branch.kind === 'remote' && branch.remoteName,
+    );
+    if (remoteBranches.length === 0) return null;
+
+    const remoteNames = Array.from(
+      new Set(remoteBranches.map((branch) => branch.remoteName!)),
+    );
+    const configuredRemote = await this.resolveConfiguredDefaultRemote(
+      workspacePath,
+      [currentBranch, defaultBranch],
+      remoteNames,
+    );
+    const selectedRemote =
+      configuredRemote ??
+      (remoteNames.includes('origin') ? 'origin' : undefined) ??
+      remoteNames[0];
+    if (!selectedRemote) return null;
+
+    return this.resolveRemoteDefaultBranch(
+      workspacePath,
+      selectedRemote,
+      remoteBranches,
+    );
+  }
+
+  private async resolveConfiguredDefaultRemote(
+    workspacePath: string,
+    branchNames: Array<string | null>,
+    remoteNames: string[],
+  ): Promise<string | null> {
+    const uniqueBranchNames = Array.from(
+      new Set(branchNames.filter((name): name is string => Boolean(name))),
+    );
+
+    for (const branchName of uniqueBranchNames) {
+      const remoteName = await this.runGit(workspacePath, [
+        'config',
+        '--get',
+        `branch.${branchName}.remote`,
+      ]);
+      const trimmed = remoteName?.trim();
+      if (trimmed && remoteNames.includes(trimmed)) return trimmed;
+    }
+
+    return null;
+  }
+
+  private async resolveRemoteDefaultBranch(
+    workspacePath: string,
+    remoteName: string,
+    branches: GitBranchInfo[],
+  ): Promise<string | null> {
+    const branchNames = new Set(
+      branches
+        .filter((branch) => branch.remoteName === remoteName)
+        .map((branch) => branch.name),
+    );
+    if (branchNames.size === 0) return null;
+
+    const remoteHead = await this.runGit(workspacePath, [
+      'symbolic-ref',
+      '--quiet',
+      '--short',
+      `refs/remotes/${remoteName}/HEAD`,
+    ]);
+    if (remoteHead && branchNames.has(remoteHead)) return remoteHead;
+
+    for (const candidate of [`${remoteName}/main`, `${remoteName}/master`]) {
+      if (branchNames.has(candidate)) return candidate;
+    }
+
+    return branchNames.values().next().value ?? null;
+  }
+
+  private async fetchRemoteSourceBranch(
+    workspacePath: string,
+    sourceBranch: string,
+  ): Promise<GitActionFailure | null> {
+    const [remoteName, ...branchParts] = sourceBranch.split('/');
+    const branchName = branchParts.join('/');
+    if (!remoteName || !branchName) return null;
+
+    const result = await this.runGitStrict(workspacePath, [
+      'fetch',
+      '--prune',
+      remoteName,
+      `refs/heads/${branchName}:refs/remotes/${remoteName}/${branchName}`,
+    ]);
+    if (result.exitCode === 0) return null;
+
+    return this.failure(
+      'worktree-create-failed',
+      result.stderr || `Failed to update ${sourceBranch} from remote.`,
     );
   }
 
@@ -458,7 +630,9 @@ export class GitService extends DisposableService {
     if (!branches) return { merged: false, target: null };
 
     const availableBranches = new Set(
-      branches.branches.map((branch) => branch.name),
+      branches.branches
+        .filter((branch) => branch.kind === 'local')
+        .map((branch) => branch.name),
     );
     const candidateTargets = [
       branches.defaultBranch,
@@ -599,16 +773,21 @@ export class GitService extends DisposableService {
     if (!branches)
       return this.failure('not-git-repo', 'Workspace is not a Git repo.');
 
-    if (
-      !branches.branches.some((branch) => branch.name === options.sourceBranch)
-    ) {
+    const sourceBranch = branches.branches.find(
+      (branch) => branch.name === options.sourceBranch,
+    );
+    if (!sourceBranch) {
       return this.failure(
         'branch-not-found',
         `Source branch ${options.sourceBranch} does not exist.`,
       );
     }
 
-    if (branches.branches.some((branch) => branch.name === worktreeName)) {
+    if (
+      branches.branches.some(
+        (branch) => branch.kind === 'local' && branch.name === worktreeName,
+      )
+    ) {
       return this.failure(
         'branch-already-exists',
         `Branch ${worktreeName} already exists.`,
@@ -639,11 +818,20 @@ export class GitService extends DisposableService {
       return this.failure('worktree-create-failed', message);
     }
 
+    if (sourceBranch.kind === 'remote') {
+      const fetchFailure = await this.fetchRemoteSourceBranch(
+        workspacePath,
+        sourceBranch.name,
+      );
+      if (fetchFailure) return fetchFailure;
+    }
+
     const result = await this.runGitStrict(workspacePath, [
       'worktree',
       'add',
       '-b',
       worktreeName,
+      ...(sourceBranch.kind === 'remote' ? ['--no-track'] : []),
       targetPath,
       options.sourceBranch,
     ]);

--- a/apps/browser/src/backend/services/git/index.ts
+++ b/apps/browser/src/backend/services/git/index.ts
@@ -866,6 +866,13 @@ export class GitService extends DisposableService {
       );
     }
 
+    if (branch.kind !== 'local') {
+      return this.failure(
+        'branch-not-found',
+        `Branch ${branchName} is not a local branch.`,
+      );
+    }
+
     if (branch.current) return null;
 
     if (branch.checkedOut) {

--- a/apps/browser/src/backend/services/git/types.ts
+++ b/apps/browser/src/backend/services/git/types.ts
@@ -51,8 +51,13 @@ export type GitWorktreeInfo = {
   isMainWorktree: boolean;
 };
 
+export type GitBranchKind = 'local' | 'remote';
+
 export type GitBranchInfo = {
   name: string;
+  kind: GitBranchKind;
+  remoteName?: string;
+  remoteBranchName?: string;
   current: boolean;
   checkedOut: boolean;
   checkedOutPath?: string;
@@ -61,6 +66,7 @@ export type GitBranchInfo = {
 export type GitBranchListResult = {
   current: string | null;
   defaultBranch: string | null;
+  defaultRemoteBranch: string | null;
   branches: GitBranchInfo[];
 };
 

--- a/apps/browser/src/backend/services/toolbox/services/mount-manager/git-path-actions.test.ts
+++ b/apps/browser/src/backend/services/toolbox/services/mount-manager/git-path-actions.test.ts
@@ -80,12 +80,22 @@ function createHarness({ recentPaths = [] }: { recentPaths?: string[] } = {}) {
     listBranches: vi.fn(async (workspacePath: string) => ({
       current: 'main',
       defaultBranch: 'main',
+      defaultRemoteBranch: 'origin/main',
       branches: [
         {
           name: 'main',
+          kind: 'local',
           current: true,
           checkedOut: true,
           checkedOutPath: workspacePath,
+        },
+        {
+          name: 'origin/main',
+          kind: 'remote',
+          remoteName: 'origin',
+          remoteBranchName: 'main',
+          current: false,
+          checkedOut: false,
         },
       ],
     })),

--- a/apps/browser/src/shared/karton-contracts/ui/index.ts
+++ b/apps/browser/src/shared/karton-contracts/ui/index.ts
@@ -70,8 +70,13 @@ import type {
 
 export type { WorkspaceGitSummary } from '@stagewise/agent-core/types/metadata';
 
+export type WorkspaceGitBranchKind = 'local' | 'remote';
+
 export type WorkspaceGitBranchInfo = {
   name: string;
+  kind: WorkspaceGitBranchKind;
+  remoteName?: string;
+  remoteBranchName?: string;
   current: boolean;
   checkedOut: boolean;
   checkedOutPath?: string;
@@ -80,6 +85,7 @@ export type WorkspaceGitBranchInfo = {
 export type WorkspaceGitBranchesResult = {
   current: string | null;
   defaultBranch: string | null;
+  defaultRemoteBranch: string | null;
   branches: WorkspaceGitBranchInfo[];
 };
 

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/panel-footer.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/panel-footer.tsx
@@ -47,6 +47,7 @@ import {
   getBranchSelectItemsFromGit,
   getCurrentBranchValue,
   getDefaultBranchValue,
+  getDefaultSourceBranchValue,
   getWorktreeSelectItems,
   getWorktreeSelectItemsFromGit,
 } from './worktree-utils';
@@ -755,7 +756,7 @@ export const ChatPanelFooter = memo(function ChatPanelFooter() {
             sourceBranchItems,
             worktreeItems,
             checkoutBranchItems,
-            getDefaultBranchValue(branchesResult, fallbackGitRef),
+            getDefaultSourceBranchValue(branchesResult, fallbackGitRef),
             getCurrentBranchValue(branchesResult, fallbackGitRef),
           ),
           sourceBranchItems,

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/workspace-select.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/workspace-select.tsx
@@ -15,6 +15,7 @@ import {
   getBranchSelectItemsFromGit,
   getCurrentBranchValue,
   getDefaultBranchValue,
+  getDefaultSourceBranchValue,
   getWorktreeSelectItems,
   getWorktreeSelectItemsFromGit,
 } from './worktree-utils';
@@ -1854,7 +1855,7 @@ const WorkspaceActionSelect = memo(function WorkspaceActionSelect({
           sourceBranchItems,
           worktreeItems,
           checkoutBranchItems,
-          defaultBranch,
+          getDefaultSourceBranchValue(branchesResult, gitRef),
           checkoutDefaultBranch,
         ),
         sourceBranchItems,
@@ -1896,7 +1897,7 @@ const WorkspaceActionSelect = memo(function WorkspaceActionSelect({
           sourceBranchItems,
           worktreeItems,
           checkoutBranchItems,
-          defaultBranch,
+          getDefaultSourceBranchValue(branchesResult, gitRef),
           checkoutDefaultBranch,
         ),
         sourceBranchItems,
@@ -2498,6 +2499,41 @@ function getSelectItemDisplayText(
   return item?.triggerLabel ?? item?.label ?? value;
 }
 
+function getSelectItemSearchText(item: SelectItem<string>): string {
+  return [item.value, item.label, item.triggerLabel]
+    .filter((value): value is string => typeof value === 'string')
+    .join(' ');
+}
+
+function groupSelectItems(
+  items: SelectItem<string>[],
+): Array<{ group: string | undefined; items: SelectItem<string>[] }> {
+  const groups: Array<{
+    group: string | undefined;
+    items: SelectItem<string>[];
+  }> = [];
+  let currentGroup: string | undefined;
+  let currentItems: SelectItem<string>[] = [];
+
+  for (const item of items) {
+    if (item.group !== currentGroup) {
+      if (currentItems.length > 0) {
+        groups.push({ group: currentGroup, items: currentItems });
+      }
+      currentGroup = item.group;
+      currentItems = [item];
+    } else {
+      currentItems.push(item);
+    }
+  }
+
+  if (currentItems.length > 0) {
+    groups.push({ group: currentGroup, items: currentItems });
+  }
+
+  return groups;
+}
+
 function ActionBranchSelect({
   items,
   value,
@@ -2522,12 +2558,11 @@ function ActionBranchSelect({
   const filtered = useMemo(() => {
     const needle = query.trim().toLowerCase();
     if (!needle) return items;
-    return items.filter((item) => {
-      const haystack =
-        typeof item.label === 'string' ? item.label : String(item.value);
-      return haystack.toLowerCase().includes(needle);
-    });
+    return items.filter((item) =>
+      getSelectItemSearchText(item).toLowerCase().includes(needle),
+    );
   }, [items, query]);
+  const groupedFiltered = useMemo(() => groupSelectItems(filtered), [filtered]);
 
   const handleValueChange = useCallback(
     (next: string | null) => {
@@ -2611,36 +2646,45 @@ function ActionBranchSelect({
                 />
               </div>
               <ComboboxList className="scrollbar-subtle max-h-48 min-w-0 overflow-y-auto">
-                {filtered.map((item) => {
-                  const label =
-                    typeof item.label === 'string'
-                      ? item.label
-                      : String(item.value);
-                  const isSelected = item.value === value;
-                  return (
-                    <ComboboxItem
-                      key={String(item.value)}
-                      value={item.value}
-                      size="xs"
-                      disabled={item.disabled}
-                      onClick={() => {
-                        if (isSelected) onValueChange(item.value);
-                      }}
-                      // Selected item: already the current value, so a
-                      // default cursor signals "no-op". Other rows are
-                      // actionable — keep the pointer cursor.
-                      className={cn(
-                        'min-h-6 text-xs leading-4',
-                        isSelected ? 'cursor-default' : 'cursor-pointer',
-                      )}
-                    >
-                      <ComboboxItemIndicator />
-                      <span className="col-start-2 min-w-0 truncate">
-                        {label}
-                      </span>
-                    </ComboboxItem>
-                  );
-                })}
+                {groupedFiltered.map(({ group, items: groupItems }, index) => (
+                  <div key={group ?? `ungrouped-${index}`}>
+                    {group && (
+                      <div className="px-2 py-1 text-subtle-foreground text-xs">
+                        {group}
+                      </div>
+                    )}
+                    {groupItems.map((item) => {
+                      const label =
+                        typeof item.label === 'string'
+                          ? item.label
+                          : String(item.value);
+                      const isSelected = item.value === value;
+                      return (
+                        <ComboboxItem
+                          key={String(item.value)}
+                          value={item.value}
+                          size="xs"
+                          disabled={item.disabled}
+                          onClick={() => {
+                            if (isSelected) onValueChange(item.value);
+                          }}
+                          // Selected item: already the current value, so a
+                          // default cursor signals "no-op". Other rows are
+                          // actionable — keep the pointer cursor.
+                          className={cn(
+                            'min-h-6 text-xs leading-4',
+                            isSelected ? 'cursor-default' : 'cursor-pointer',
+                          )}
+                        >
+                          <ComboboxItemIndicator />
+                          <span className="col-start-2 min-w-0 truncate">
+                            {label}
+                          </span>
+                        </ComboboxItem>
+                      );
+                    })}
+                  </div>
+                ))}
                 {filtered.length === 0 && (
                   <div className="px-2 py-1.5 text-muted-foreground text-xs">
                     No results
@@ -3040,7 +3084,7 @@ const ConnectWorkspaceSelect = memo(function ConnectWorkspaceSelectInner({
         'checkout-target',
       );
       const worktreeItems = getWorktreeSelectItemsFromGit(worktreesResult);
-      const defaultBranch = getDefaultBranchValue(branchesResult, null);
+      const defaultBranch = getDefaultSourceBranchValue(branchesResult, null);
       const checkoutDefaultBranch = getCurrentBranchValue(branchesResult, null);
       const options = {
         sourceBranchItems,

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/workspace-select.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/workspace-select.tsx
@@ -5,6 +5,8 @@ import { Combobox as ComboboxBase } from '@base-ui/react/combobox';
 import {
   Combobox,
   ComboboxInput,
+  ComboboxGroup,
+  ComboboxGroupLabel,
   ComboboxItem,
   ComboboxItemIndicator,
   ComboboxList,
@@ -1272,7 +1274,6 @@ export function applyMountedWorkspaceActionDefault(
   return {
     ...config,
     selectedAction: 'create-worktree',
-    ...(mount.git.branch ? { createWorktreeFrom: mount.git.branch } : {}),
   };
 }
 
@@ -2647,12 +2648,11 @@ function ActionBranchSelect({
               </div>
               <ComboboxList className="scrollbar-subtle max-h-48 min-w-0 overflow-y-auto">
                 {groupedFiltered.map(({ group, items: groupItems }, index) => (
-                  <div key={group ?? `ungrouped-${index}`}>
-                    {group && (
-                      <div className="px-2 py-1 text-subtle-foreground text-xs">
-                        {group}
-                      </div>
-                    )}
+                  <ComboboxGroup
+                    key={group ?? `ungrouped-${index}`}
+                    className="shrink-0"
+                  >
+                    {group && <ComboboxGroupLabel>{group}</ComboboxGroupLabel>}
                     {groupItems.map((item) => {
                       const label =
                         typeof item.label === 'string'
@@ -2672,18 +2672,18 @@ function ActionBranchSelect({
                           // default cursor signals "no-op". Other rows are
                           // actionable — keep the pointer cursor.
                           className={cn(
-                            'min-h-6 text-xs leading-4',
+                            'min-h-6 shrink-0 items-center text-xs leading-4',
                             isSelected ? 'cursor-default' : 'cursor-pointer',
                           )}
                         >
-                          <ComboboxItemIndicator />
-                          <span className="col-start-2 min-w-0 truncate">
+                          <ComboboxItemIndicator className="self-center" />
+                          <span className="col-start-2 min-w-0 truncate leading-4">
                             {label}
                           </span>
                         </ComboboxItem>
                       );
                     })}
-                  </div>
+                  </ComboboxGroup>
                 ))}
                 {filtered.length === 0 && (
                   <div className="px-2 py-1.5 text-muted-foreground text-xs">

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/worktree-utils.test.ts
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/worktree-utils.test.ts
@@ -4,6 +4,7 @@ import {
   getBranchSelectItemsFromGit,
   getCurrentBranchValue,
   getDefaultBranchValue,
+  getDefaultSourceBranchValue,
   WORKTREE_NAME_ADJECTIVES,
   WORKTREE_NAME_NOUNS,
 } from './worktree-utils';
@@ -73,7 +74,12 @@ describe('getCurrentBranchValue', () => {
   it('uses the backend current branch when available', () => {
     expect(
       getCurrentBranchValue(
-        { current: 'feature/login', defaultBranch: 'develop', branches: [] },
+        {
+          current: 'feature/login',
+          defaultBranch: 'develop',
+          defaultRemoteBranch: 'origin/develop',
+          branches: [],
+        },
         'develop',
       ),
     ).toBe('feature/login');
@@ -82,7 +88,12 @@ describe('getCurrentBranchValue', () => {
   it('falls back to the mounted git ref when current branch is unavailable', () => {
     expect(
       getCurrentBranchValue(
-        { current: null, defaultBranch: 'main', branches: [] },
+        {
+          current: null,
+          defaultBranch: 'main',
+          defaultRemoteBranch: 'origin/main',
+          branches: [],
+        },
         'develop',
       ),
     ).toBe('develop');
@@ -91,7 +102,12 @@ describe('getCurrentBranchValue', () => {
   it('falls back to the default branch when no current branch or git ref exists', () => {
     expect(
       getCurrentBranchValue(
-        { current: null, defaultBranch: 'develop', branches: [] },
+        {
+          current: null,
+          defaultBranch: 'develop',
+          defaultRemoteBranch: 'origin/develop',
+          branches: [],
+        },
         null,
       ),
     ).toBe('develop');
@@ -109,9 +125,11 @@ describe('getBranchSelectItemsFromGit', () => {
         {
           current: 'detached-ref',
           defaultBranch: 'main',
+          defaultRemoteBranch: 'origin/main',
           branches: [
             {
               name: 'main',
+              kind: 'local',
               current: false,
               checkedOut: false,
             },
@@ -129,9 +147,11 @@ describe('getBranchSelectItemsFromGit', () => {
         {
           current: null,
           defaultBranch: 'main',
+          defaultRemoteBranch: 'origin/main',
           branches: [
             {
               name: 'main',
+              kind: 'local',
               current: false,
               checkedOut: false,
             },
@@ -142,13 +162,110 @@ describe('getBranchSelectItemsFromGit', () => {
       ).map((item) => item.value),
     ).toEqual(['main', 'fallback-ref']);
   });
+
+  it('groups source branches by local and remote name', () => {
+    expect(
+      getBranchSelectItemsFromGit(
+        {
+          current: 'main',
+          defaultBranch: 'main',
+          defaultRemoteBranch: 'origin/main',
+          branches: [
+            {
+              name: 'main',
+              kind: 'local',
+              current: true,
+              checkedOut: true,
+            },
+            {
+              name: 'origin/main',
+              kind: 'remote',
+              remoteName: 'origin',
+              remoteBranchName: 'main',
+              current: false,
+              checkedOut: false,
+            },
+            {
+              name: 'upstream/main',
+              kind: 'remote',
+              remoteName: 'upstream',
+              remoteBranchName: 'main',
+              current: false,
+              checkedOut: false,
+            },
+          ],
+        },
+        null,
+        'source',
+      ).map((item) => ({
+        value: item.value,
+        label: item.label,
+        triggerLabel: item.triggerLabel,
+        group: item.group,
+      })),
+    ).toEqual([
+      {
+        value: 'main',
+        label: 'main',
+        triggerLabel: 'main',
+        group: 'Local',
+      },
+      {
+        value: 'origin/main',
+        label: 'main',
+        triggerLabel: 'origin/main',
+        group: 'origin',
+      },
+      {
+        value: 'upstream/main',
+        label: 'main',
+        triggerLabel: 'upstream/main',
+        group: 'upstream',
+      },
+    ]);
+  });
+
+  it('excludes remote branches from checkout choices', () => {
+    expect(
+      getBranchSelectItemsFromGit(
+        {
+          current: 'main',
+          defaultBranch: 'main',
+          defaultRemoteBranch: 'origin/main',
+          branches: [
+            {
+              name: 'main',
+              kind: 'local',
+              current: true,
+              checkedOut: true,
+            },
+            {
+              name: 'origin/main',
+              kind: 'remote',
+              remoteName: 'origin',
+              remoteBranchName: 'main',
+              current: false,
+              checkedOut: false,
+            },
+          ],
+        },
+        null,
+        'checkout-target',
+      ).map((item) => item.value),
+    ).toEqual(['main']);
+  });
 });
 
 describe('getDefaultBranchValue', () => {
   it('uses the backend default branch when available', () => {
     expect(
       getDefaultBranchValue(
-        { current: 'feature/login', defaultBranch: 'develop', branches: [] },
+        {
+          current: 'feature/login',
+          defaultBranch: 'develop',
+          defaultRemoteBranch: 'origin/develop',
+          branches: [],
+        },
         'feature/login',
       ),
     ).toBe('develop');
@@ -160,5 +277,35 @@ describe('getDefaultBranchValue', () => {
 
   it('falls back to main when no branch data or git ref is available', () => {
     expect(getDefaultBranchValue(null, null)).toBe('main');
+  });
+});
+
+describe('getDefaultSourceBranchValue', () => {
+  it('prefers the default remote branch for source branch selection', () => {
+    expect(
+      getDefaultSourceBranchValue(
+        {
+          current: 'feature/login',
+          defaultBranch: 'develop',
+          defaultRemoteBranch: 'origin/develop',
+          branches: [],
+        },
+        'feature/login',
+      ),
+    ).toBe('origin/develop');
+  });
+
+  it('falls back to the default local branch when no remote branch exists', () => {
+    expect(
+      getDefaultSourceBranchValue(
+        {
+          current: 'feature/login',
+          defaultBranch: 'develop',
+          defaultRemoteBranch: null,
+          branches: [],
+        },
+        'feature/login',
+      ),
+    ).toBe('develop');
   });
 });

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/worktree-utils.ts
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/worktree-utils.ts
@@ -1,6 +1,7 @@
 import type { SelectItem } from '@stagewise/stage-ui/components/select';
 import type {
   WorkspaceGitBranchesResult,
+  WorkspaceGitBranchInfo,
   WorkspaceGitWorktreesResult,
 } from '@shared/karton-contracts/ui';
 import { getBaseName } from '@shared/path-utils';
@@ -19,6 +20,24 @@ type GenerateWorktreeNameOptions = {
   reservedNames?: Iterable<string | null | undefined>;
   random?: () => number;
 };
+
+function getRemoteBranchParts(branch: WorkspaceGitBranchInfo): {
+  remoteName: string;
+  branchName: string;
+} | null {
+  if (branch.kind !== 'remote') return null;
+  if (branch.remoteName && branch.remoteBranchName) {
+    return {
+      remoteName: branch.remoteName,
+      branchName: branch.remoteBranchName,
+    };
+  }
+
+  const [remoteName, ...branchNameParts] = branch.name.split('/');
+  const branchName = branchNameParts.join('/');
+  if (!remoteName || !branchName) return null;
+  return { remoteName, branchName };
+}
 
 function normalizeReservedWorktreeName(
   name: string | null | undefined,
@@ -90,6 +109,15 @@ export function getDefaultBranchValue(
   return result?.defaultBranch ?? fallbackGitRef ?? 'main';
 }
 
+export function getDefaultSourceBranchValue(
+  result: WorkspaceGitBranchesResult | null,
+  fallbackGitRef: string | null,
+): string {
+  return (
+    result?.defaultRemoteBranch ?? getDefaultBranchValue(result, fallbackGitRef)
+  );
+}
+
 export function getCurrentBranchValue(
   result: WorkspaceGitBranchesResult | null,
   fallbackGitRef: string | null,
@@ -106,16 +134,31 @@ export function getBranchSelectItemsFromGit(
 ): SelectItem<string>[] {
   if (!result) return getBranchSelectItems(fallbackGitRef);
 
-  const branches: SelectItem<string>[] = result.branches.map((branch) => ({
-    value: branch.name,
-    label: branch.name,
-    disabled:
-      intent === 'checkout-target' && branch.checkedOut && !branch.current,
-  }));
+  const branches: SelectItem<string>[] = result.branches
+    .filter((branch) => intent === 'source' || branch.kind === 'local')
+    .map((branch) => {
+      const remoteParts = getRemoteBranchParts(branch);
+
+      return {
+        value: branch.name,
+        label: remoteParts?.branchName ?? branch.name,
+        triggerLabel: branch.name,
+        group:
+          intent === 'source'
+            ? (remoteParts?.remoteName ?? 'Local')
+            : undefined,
+        disabled:
+          intent === 'checkout-target' && branch.checkedOut && !branch.current,
+      };
+    });
   const currentRef = result.current ?? fallbackGitRef;
 
   if (currentRef && !branches.some((branch) => branch.value === currentRef)) {
-    branches.push({ value: currentRef, label: currentRef });
+    branches.push({
+      value: currentRef,
+      label: currentRef,
+      group: intent === 'source' ? 'Local' : undefined,
+    });
   }
 
   if (branches.length > 0) return branches;


### PR DESCRIPTION
we take local branches as a base for new worktrees but should default to recommend origin/main to have less rebase work

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Default new worktrees to a remote base (e.g., `origin/main`), block remote branch checkouts, and ship a grouped branch picker with better search. The Git service now returns local and remote branches plus `defaultRemoteBranch`; the UI prefers this for worktree source selection.

- **New Features**
  - Backend Git:
    - `listBranches` returns local and remote branches with `kind`, `remoteName`, `remoteBranchName`, and adds `defaultRemoteBranch`.
    - Chooses the remote default via the current/default branch’s configured remote, else `origin` HEAD, else the first remote.
    - When creating from a remote branch, fetches the remote ref first and uses `--no-track`.
    - Only local branches are considered for checkout/merge collisions and targets.
  - UI:
    - Defaults the source branch to `defaultRemoteBranch`, falling back to the local default.
    - Branch picker groups items into “Local” and each remote with headers, shows `origin/foo` as “foo” with `origin/foo` as the trigger label, and improves search across value/label/trigger.
    - Remote branches are excluded from checkout targets.

- **Bug Fixes**
  - Prevent switching to remote branch refs; only local branches can be checked out.

<sup>Written for commit e51b90e78c00243421642245fa134a62935218a0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1265?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Branch list now shows remote branches and provides a selectable default remote-branch for workspace actions.
  * Worktree creation supports remote source branches (fetches remote tip and creates a non-tracking worktree).
  * Branch picker groups items into Local vs Remote and uses remote-aware defaults for source selection.

* **Bug Fixes**
  * Prevents switching/checkout to remote-only branch refs.

* **Tests**
  * Added/updated tests for remote-branch handling and default selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->