### PR TITLE
feat(stagewise): add windows-support for worktree-setups

### DIFF
--- a/apps/browser/src/backend/main.ts
+++ b/apps/browser/src/backend/main.ts
@@ -33,6 +33,7 @@ import { AgentTypes } from '@shared/karton-contracts/ui/agent';
 import { AutoUpdateService } from './services/auto-update';
 import { LocalPortsScannerService } from './services/local-ports-scanner';
 import { WorktreeSetupSettingsService } from './services/worktree-setup-settings';
+import type { WorktreeSetupScriptVariant } from '@shared/worktree-setup';
 import { DevToolAPIService } from './services/dev-tool-api';
 import { OmniboxSuggestionsService } from './services/omnibox-suggestions';
 import { ensureRipgrepInstalled } from '@stagewise/agent-runtime-node';
@@ -950,8 +951,17 @@ export async function main({ launchOptions: { verbose } }: MainParameters) {
   );
   uiKarton.registerServerProcedureHandler(
     'toolbox.saveWorktreeSetupScript',
-    async (_cid: string, mainWorktreePath: string, content: string) =>
-      worktreeSetupSettingsService.saveScript(mainWorktreePath, content),
+    async (
+      _cid: string,
+      mainWorktreePath: string,
+      variant: WorktreeSetupScriptVariant,
+      content: string,
+    ) =>
+      worktreeSetupSettingsService.saveScript(
+        mainWorktreePath,
+        variant,
+        content,
+      ),
   );
   uiKarton.registerServerProcedureHandler(
     'toolbox.deleteWorktreeSetupWorktree',

--- a/apps/browser/src/backend/services/toolbox/services/mount-manager/worktree-setup-runner.test.ts
+++ b/apps/browser/src/backend/services/toolbox/services/mount-manager/worktree-setup-runner.test.ts
@@ -7,7 +7,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { KartonService } from '@/services/karton';
 import type { Logger } from '@/services/logger';
 import type { TelemetryService } from '@/services/telemetry';
-import { WorktreeSetupRunner } from './worktree-setup-runner';
+import { mergeEnv, WorktreeSetupRunner } from './worktree-setup-runner';
 
 let tempDir: string;
 
@@ -62,6 +62,17 @@ async function writeSetupScript(worktreePath: string, content = 'exit 0') {
   return scriptPath;
 }
 
+async function writePowerShellScript(worktreePath: string, content = 'exit 0') {
+  const scriptPath = path.join(
+    worktreePath,
+    '.stagewise',
+    'worktree-setup.ps1',
+  );
+  await fs.mkdir(path.dirname(scriptPath), { recursive: true });
+  await fs.writeFile(scriptPath, content);
+  return scriptPath;
+}
+
 function createProcess() {
   const child = new EventEmitter() as EventEmitter & {
     stdout: PassThrough;
@@ -90,6 +101,7 @@ type TestRunnerDeps = {
       stdio: ['ignore', 'pipe', 'pipe'];
     },
   ) => TestSpawnProcess;
+  resolvePowerShellCommand?: (env: NodeJS.ProcessEnv) => string;
   timeoutMs?: number;
   platform?: NodeJS.Platform;
 };
@@ -100,6 +112,26 @@ function createRunner(deps: TestRunnerDeps) {
     ...deps,
   });
 }
+
+describe('mergeEnv', () => {
+  it('lets overrides replace base entries that differ only in case', () => {
+    // Simulates Windows: process.env exposes a stale `Path`, the resolved
+    // shell environment exposes the real `PATH` (with pwsh on it).
+    const merged = mergeEnv(
+      { Path: 'C:\\stale', OTHER: 'keep' },
+      { PATH: 'C:\\resolved\\pwsh' },
+    );
+
+    expect(merged.Path).toBeUndefined();
+    expect(merged.PATH).toBe('C:\\resolved\\pwsh');
+    expect(merged.OTHER).toBe('keep');
+    // Only one PATH-like key survives, so the child receives no duplicates.
+    const pathKeys = Object.keys(merged).filter(
+      (key) => key.toLowerCase() === 'path',
+    );
+    expect(pathKeys).toEqual(['PATH']);
+  });
+});
 
 describe('WorktreeSetupRunner', () => {
   it('does not create setup state when the script is missing', async () => {
@@ -283,18 +315,180 @@ describe('WorktreeSetupRunner', () => {
     expect(captureException).not.toHaveBeenCalled();
   });
 
-  it('does not spawn the setup script on Windows', async () => {
+  it('spawns the PowerShell variant on Windows', async () => {
     const mainWorktreePath = path.join(tempDir, 'main');
     const workspacePath = path.join(tempDir, 'worktree');
     await fs.mkdir(workspacePath, { recursive: true });
-    await writeSetupScript(workspacePath);
+    const scriptPath = await writePowerShellScript(workspacePath);
+    const child = createProcess();
     const { state, uiKarton } = createKarton();
-    const spawnProcess = vi.fn();
-    const captureException = vi.fn();
+    const spawnProcess = vi.fn(() => child);
     const runner = createRunner({
       logger: { warn: vi.fn() } as unknown as Logger,
       telemetryService: {
-        captureException,
+        captureException: vi.fn(),
+      } as unknown as TelemetryService,
+      uiKarton,
+      resolvedEnvPromise: Promise.resolve(null),
+      spawnProcess,
+      resolvePowerShellCommand: () => 'powershell.exe',
+      platform: 'win32',
+    });
+
+    await runner.start(metadata(mainWorktreePath, workspacePath));
+
+    expect(spawnProcess).toHaveBeenCalledWith(
+      'powershell.exe',
+      [
+        '-NoProfile',
+        '-NonInteractive',
+        '-ExecutionPolicy',
+        'Bypass',
+        '-File',
+        scriptPath,
+      ],
+      {
+        cwd: workspacePath,
+        env: expect.objectContaining({
+          STAGEWISE_TARGET_WORKTREE_PATH: workspacePath,
+        }),
+        stdio: ['ignore', 'pipe', 'pipe'],
+      },
+    );
+    expect(state.workspaceGitSetup.runsByPath[workspacePath]).toMatchObject({
+      scriptPath,
+      status: 'running',
+    });
+
+    child.emit('close', 0);
+    runner.teardown();
+  });
+
+  it('uses pwsh when the resolver returns it', async () => {
+    const mainWorktreePath = path.join(tempDir, 'main');
+    const workspacePath = path.join(tempDir, 'worktree');
+    await fs.mkdir(workspacePath, { recursive: true });
+    const scriptPath = await writePowerShellScript(workspacePath);
+    const child = createProcess();
+    const { uiKarton } = createKarton();
+    const spawnProcess = vi.fn(() => child);
+    const runner = createRunner({
+      logger: { warn: vi.fn() } as unknown as Logger,
+      telemetryService: {
+        captureException: vi.fn(),
+      } as unknown as TelemetryService,
+      uiKarton,
+      resolvedEnvPromise: Promise.resolve(null),
+      spawnProcess,
+      resolvePowerShellCommand: () => 'pwsh',
+      platform: 'win32',
+    });
+
+    await runner.start(metadata(mainWorktreePath, workspacePath));
+
+    expect(spawnProcess).toHaveBeenCalledWith(
+      'pwsh',
+      expect.arrayContaining(['-File', scriptPath]),
+      expect.objectContaining({ cwd: workspacePath }),
+    );
+
+    child.emit('close', 0);
+    runner.teardown();
+  });
+
+  it('resolves PowerShell using the resolved spawn environment PATH', async () => {
+    const mainWorktreePath = path.join(tempDir, 'main');
+    const workspacePath = path.join(tempDir, 'worktree');
+    await fs.mkdir(workspacePath, { recursive: true });
+    await writePowerShellScript(workspacePath);
+    const child = createProcess();
+    const { uiKarton } = createKarton();
+    const spawnProcess = vi.fn(() => child);
+    const resolvedPath = path.join(tempDir, 'resolved-tools');
+    let resolverEnv: NodeJS.ProcessEnv | null = null;
+    const runner = createRunner({
+      logger: { warn: vi.fn() } as unknown as Logger,
+      telemetryService: {
+        captureException: vi.fn(),
+      } as unknown as TelemetryService,
+      uiKarton,
+      resolvedEnvPromise: Promise.resolve({ PATH: resolvedPath }),
+      spawnProcess,
+      resolvePowerShellCommand: (env) => {
+        resolverEnv = env;
+        return 'pwsh';
+      },
+      platform: 'win32',
+    });
+
+    await runner.start(metadata(mainWorktreePath, workspacePath));
+
+    // The resolver must see the PATH the child process actually receives, not
+    // the (possibly stripped) process.env PATH.
+    expect(resolverEnv).not.toBeNull();
+    expect((resolverEnv as unknown as NodeJS.ProcessEnv).PATH).toBe(
+      resolvedPath,
+    );
+    expect(spawnProcess).toHaveBeenCalledWith(
+      'pwsh',
+      expect.anything(),
+      expect.objectContaining({
+        env: expect.objectContaining({ PATH: resolvedPath }),
+      }),
+    );
+
+    child.emit('close', 0);
+    runner.teardown();
+  });
+
+  it('falls back to the PowerShell script in the main worktree on Windows', async () => {
+    const mainWorktreePath = path.join(tempDir, 'main');
+    const workspacePath = path.join(tempDir, 'worktree');
+    await fs.mkdir(workspacePath, { recursive: true });
+    const scriptPath = await writePowerShellScript(mainWorktreePath);
+    const child = createProcess();
+    const { state, uiKarton } = createKarton();
+    const spawnProcess = vi.fn(() => child);
+    const runner = createRunner({
+      logger: { warn: vi.fn() } as unknown as Logger,
+      telemetryService: {
+        captureException: vi.fn(),
+      } as unknown as TelemetryService,
+      uiKarton,
+      resolvedEnvPromise: Promise.resolve(null),
+      spawnProcess,
+      resolvePowerShellCommand: () => 'powershell.exe',
+      platform: 'win32',
+    });
+
+    await runner.start(metadata(mainWorktreePath, workspacePath));
+
+    expect(spawnProcess).toHaveBeenCalledWith(
+      'powershell.exe',
+      expect.arrayContaining(['-File', scriptPath]),
+      expect.objectContaining({ cwd: workspacePath }),
+    );
+    expect(state.workspaceGitSetup.runsByPath[workspacePath]).toMatchObject({
+      scriptPath,
+      status: 'running',
+    });
+
+    child.emit('close', 0);
+    runner.teardown();
+  });
+
+  it('does not run a POSIX-only script on Windows', async () => {
+    const mainWorktreePath = path.join(tempDir, 'main');
+    const workspacePath = path.join(tempDir, 'worktree');
+    await fs.mkdir(workspacePath, { recursive: true });
+    // Only a .sh script exists; on Windows the runner looks for .ps1.
+    await writeSetupScript(workspacePath);
+    const { state, uiKarton } = createKarton();
+    const spawnProcess = vi.fn();
+    const runner = createRunner({
+      logger: { warn: vi.fn() } as unknown as Logger,
+      telemetryService: {
+        captureException: vi.fn(),
       } as unknown as TelemetryService,
       uiKarton,
       resolvedEnvPromise: Promise.resolve(null),
@@ -305,12 +499,7 @@ describe('WorktreeSetupRunner', () => {
     await runner.start(metadata(mainWorktreePath, workspacePath));
 
     expect(spawnProcess).not.toHaveBeenCalled();
-    expect(state.workspaceGitSetup.runsByPath[workspacePath]).toMatchObject({
-      status: 'failed',
-      exitCode: null,
-      message: 'Worktree setup scripts are not supported on Windows yet.',
-    });
-    expect(captureException).not.toHaveBeenCalled();
+    expect(state.workspaceGitSetup.runsByPath[workspacePath]).toBeUndefined();
   });
 
   it('marks setup failed if environment resolution times out', async () => {

--- a/apps/browser/src/backend/services/toolbox/services/mount-manager/worktree-setup-runner.ts
+++ b/apps/browser/src/backend/services/toolbox/services/mount-manager/worktree-setup-runner.ts
@@ -1,29 +1,93 @@
 import { randomUUID } from 'node:crypto';
+import { existsSync } from 'node:fs';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { spawn } from 'node:child_process';
 import type { Readable } from 'node:stream';
+import {
+  WORKTREE_SETUP_SCRIPT_RELATIVE_PATHS,
+  variantForPlatform,
+} from '@shared/worktree-setup';
 import type { KartonService } from '@/services/karton';
 import type { Logger } from '@/services/logger';
 import type { TelemetryService } from '@/services/telemetry';
 
-const WORKTREE_SETUP_SCRIPT_RELATIVE_PATH = path.join(
-  '.stagewise',
-  'worktree-setup.sh',
-);
 const WORKTREE_SETUP_TIMEOUT_MS = 20 * 60 * 1000;
 const OUTPUT_TAIL_MAX_LENGTH = 12_000;
 const OUTPUT_UPDATE_INTERVAL_MS = 150;
 
 const WORKTREE_SETUP_TIMEOUT_MESSAGE = 'Worktree setup timed out.';
-const WORKTREE_SETUP_WINDOWS_UNSUPPORTED_MESSAGE =
-  'Worktree setup scripts are not supported on Windows yet.';
 
 const EXPECTED_FAILURE_MESSAGES = new Set([
   WORKTREE_SETUP_TIMEOUT_MESSAGE,
-  WORKTREE_SETUP_WINDOWS_UNSUPPORTED_MESSAGE,
   'Worktree setup was interrupted.',
 ]);
+
+/**
+ * Merges `overrides` onto `base` with case-insensitive keys, so an override
+ * replaces any base entry whose name matches case-insensitively.
+ *
+ * Windows treats environment variable names case-insensitively, but a plain
+ * object spread does not: `process.env` may expose `Path` while the resolved
+ * shell environment exposes `PATH`, leaving both keys side by side. That stale
+ * `Path` would then win lookups (it is inserted first) and the spawned child
+ * would receive ambiguous duplicate variables. Collapsing to a single key per
+ * name, with the override taking precedence, avoids both problems.
+ */
+export function mergeEnv(
+  base: NodeJS.ProcessEnv,
+  overrides: Record<string, string>,
+): NodeJS.ProcessEnv {
+  const result: NodeJS.ProcessEnv = { ...base };
+  for (const [key, value] of Object.entries(overrides)) {
+    const lowerKey = key.toLowerCase();
+    for (const existingKey of Object.keys(result)) {
+      if (existingKey !== key && existingKey.toLowerCase() === lowerKey) {
+        delete result[existingKey];
+      }
+    }
+    result[key] = value;
+  }
+  return result;
+}
+
+/**
+ * Reads the PATH value from an environment record. PATH casing is
+ * platform-dependent (Windows commonly exposes it as `Path`), so the lookup is
+ * case-insensitive.
+ */
+function readPathFromEnv(env: NodeJS.ProcessEnv): string {
+  for (const key of Object.keys(env)) {
+    if (key.toLowerCase() === 'path') {
+      return env[key] ?? '';
+    }
+  }
+  return '';
+}
+
+/**
+ * Resolves the PowerShell interpreter to invoke on Windows. Prefers `pwsh`
+ * (PowerShell 7+) when present on PATH, otherwise falls back to
+ * `powershell.exe` (Windows PowerShell 5.1, present on every Windows install).
+ *
+ * The PATH is taken from the resolved spawn environment rather than
+ * `process.env`, because Electron can start with a stripped `process.env` on
+ * Windows while the real user PATH (where `pwsh` lives) is recovered into the
+ * resolved environment that the child process actually receives.
+ */
+function defaultResolvePowerShellCommand(env: NodeJS.ProcessEnv): string {
+  const pathEnv = readPathFromEnv(env);
+  const dirs = pathEnv.split(path.delimiter).filter(Boolean);
+  for (const dir of dirs) {
+    if (
+      existsSync(path.join(dir, 'pwsh.exe')) ||
+      existsSync(path.join(dir, 'pwsh'))
+    ) {
+      return 'pwsh';
+    }
+  }
+  return 'powershell.exe';
+}
 
 type SpawnProcess = {
   stdout: Readable;
@@ -55,6 +119,7 @@ type WorktreeSetupRunnerDeps = {
   uiKarton: KartonService;
   resolvedEnvPromise: Promise<Record<string, string> | null>;
   spawnProcess?: SpawnFn;
+  resolvePowerShellCommand?: (env: NodeJS.ProcessEnv) => string;
   timeoutMs?: number;
   platform?: NodeJS.Platform;
 };
@@ -80,6 +145,7 @@ export class WorktreeSetupRunner {
   private readonly uiKarton: KartonService;
   private readonly resolvedEnvPromise: Promise<Record<string, string> | null>;
   private readonly spawnProcess: SpawnFn;
+  private readonly resolvePowerShellCommand: (env: NodeJS.ProcessEnv) => string;
   private readonly timeoutMs: number;
   private readonly platform: NodeJS.Platform;
   private readonly activeRuns = new Map<string, ActiveRun>();
@@ -91,6 +157,7 @@ export class WorktreeSetupRunner {
     resolvedEnvPromise,
     spawnProcess = (command, args, options) =>
       spawn(command, args, options) as SpawnProcess,
+    resolvePowerShellCommand = defaultResolvePowerShellCommand,
     timeoutMs = WORKTREE_SETUP_TIMEOUT_MS,
     platform = process.platform,
   }: WorktreeSetupRunnerDeps) {
@@ -99,6 +166,7 @@ export class WorktreeSetupRunner {
     this.uiKarton = uiKarton;
     this.resolvedEnvPromise = resolvedEnvPromise;
     this.spawnProcess = spawnProcess;
+    this.resolvePowerShellCommand = resolvePowerShellCommand;
     this.timeoutMs = timeoutMs;
     this.platform = platform;
   }
@@ -106,13 +174,15 @@ export class WorktreeSetupRunner {
   public async start(metadata: WorktreeSetupMetadata): Promise<void> {
     if (this.activeRuns.has(metadata.workspacePath)) return;
 
+    const variant = variantForPlatform(this.platform);
+    const relativeScriptPath = WORKTREE_SETUP_SCRIPT_RELATIVE_PATHS[variant];
     const workspaceScriptPath = path.join(
       metadata.workspacePath,
-      WORKTREE_SETUP_SCRIPT_RELATIVE_PATH,
+      relativeScriptPath,
     );
     const mainWorktreeScriptPath = path.join(
       metadata.mainWorktreePath,
-      WORKTREE_SETUP_SCRIPT_RELATIVE_PATH,
+      relativeScriptPath,
     );
     const scriptPath = (await this.pathExists(workspaceScriptPath))
       ? workspaceScriptPath
@@ -203,11 +273,6 @@ export class WorktreeSetupRunner {
       });
     };
 
-    if (this.platform === 'win32') {
-      finish('failed', null, WORKTREE_SETUP_WINDOWS_UNSUPPORTED_MESSAGE);
-      return;
-    }
-
     let resolvedEnv: Record<string, string> | null;
     try {
       resolvedEnv = await this.resolvedEnvPromise;
@@ -224,16 +289,30 @@ export class WorktreeSetupRunner {
     }
     if (activeRun.settled) return;
 
-    const env: NodeJS.ProcessEnv = {
-      ...process.env,
+    const env: NodeJS.ProcessEnv = mergeEnv(process.env, {
       ...(resolvedEnv ?? {}),
       STAGEWISE_SOURCE_WORKTREE_PATH: metadata.sourceWorktreePath,
       STAGEWISE_TARGET_WORKTREE_PATH: metadata.workspacePath,
       STAGEWISE_MAIN_WORKTREE_PATH: metadata.mainWorktreePath,
-    };
+    });
+
+    const [command, commandArgs] =
+      variant === 'powershell'
+        ? ([
+            this.resolvePowerShellCommand(env),
+            [
+              '-NoProfile',
+              '-NonInteractive',
+              '-ExecutionPolicy',
+              'Bypass',
+              '-File',
+              scriptPath,
+            ],
+          ] as const)
+        : (['/bin/sh', [scriptPath]] as const);
 
     try {
-      activeRun.child = this.spawnProcess('/bin/sh', [scriptPath], {
+      activeRun.child = this.spawnProcess(command, [...commandArgs], {
         cwd: metadata.workspacePath,
         env,
         stdio: ['ignore', 'pipe', 'pipe'],

--- a/apps/browser/src/backend/services/worktree-setup-settings.test.ts
+++ b/apps/browser/src/backend/services/worktree-setup-settings.test.ts
@@ -133,16 +133,37 @@ describe('WorktreeSetupSettingsService', () => {
   it('rejects setup script saves for unknown repositories', async () => {
     const { service } = createService({ recentPaths: [] });
 
-    await expect(service.saveScript(repoPath, '#!/bin/sh')).resolves.toEqual({
+    await expect(
+      service.saveScript(repoPath, 'posix', '#!/bin/sh'),
+    ).resolves.toEqual({
       ok: false,
       message: 'Repository is no longer available.',
+    });
+  });
+
+  it('rejects setup script saves for unknown script variants', async () => {
+    const { service } = createService();
+
+    await expect(
+      service.saveScript(
+        repoPath,
+        'batch' as unknown as Parameters<typeof service.saveScript>[1],
+        '@echo off',
+      ),
+    ).resolves.toEqual({
+      ok: false,
+      message: 'Unknown script variant: batch.',
     });
   });
 
   it('saves setup scripts only under the repository setup script path', async () => {
     const { service } = createService();
 
-    const result = await service.saveScript(repoPath, '#!/bin/sh\necho ok\n');
+    const result = await service.saveScript(
+      repoPath,
+      'posix',
+      '#!/bin/sh\necho ok\n',
+    );
 
     expect(result.ok).toBe(true);
     await expect(
@@ -151,6 +172,31 @@ describe('WorktreeSetupSettingsService', () => {
         'utf8',
       ),
     ).resolves.toBe('#!/bin/sh\necho ok\n');
+  });
+
+  it('saves the PowerShell variant under the .ps1 path', async () => {
+    const { service } = createService();
+
+    const result = await service.saveScript(
+      repoPath,
+      'powershell',
+      "Write-Host 'ok'\n",
+    );
+
+    expect(result.ok).toBe(true);
+    await expect(
+      fs.readFile(
+        path.join(repoPath, '.stagewise', 'worktree-setup.ps1'),
+        'utf8',
+      ),
+    ).resolves.toBe("Write-Host 'ok'\n");
+    if (result.ok) {
+      expect(result.repository.scripts.powershell).toMatchObject({
+        variant: 'powershell',
+        exists: true,
+        content: "Write-Host 'ok'\n",
+      });
+    }
   });
 
   it('returns the saved script state when refresh after save cannot find the repository', async () => {
@@ -196,14 +242,17 @@ describe('WorktreeSetupSettingsService', () => {
     });
     const content = '#!/bin/sh\necho saved\n';
 
-    const result = await service.saveScript(repoPath, content);
+    const result = await service.saveScript(repoPath, 'posix', content);
 
     expect(result.ok).toBe(true);
     if (result.ok) {
       expect(result.repository).toMatchObject({
         mainWorktreePath: repoPath,
-        scriptExists: true,
-        scriptContent: content,
+      });
+      expect(result.repository.scripts.posix).toMatchObject({
+        variant: 'posix',
+        exists: true,
+        content,
       });
     }
   });
@@ -397,7 +446,7 @@ describe('WorktreeSetupSettingsService', () => {
       expect(
         result.repositories.find(
           (repo) => repo.mainWorktreePath === unreadableRepo,
-        )?.scriptExists,
+        )?.scripts.posix.exists,
       ).toBe(false);
     } finally {
       readFileSpy.mockRestore();

--- a/apps/browser/src/backend/services/worktree-setup-settings.ts
+++ b/apps/browser/src/backend/services/worktree-setup-settings.ts
@@ -9,10 +9,15 @@ import type {
   WorktreeSetupManagedWorktree,
   WorktreeSetupRepositoriesResult,
   WorktreeSetupRepositorySettings,
+  WorktreeSetupScriptFile,
   SaveWorktreeSetupScriptResult,
 } from '@shared/karton-contracts/ui';
+import {
+  WORKTREE_SETUP_SCRIPT_RELATIVE_PATHS,
+  WORKTREE_SETUP_SCRIPT_VARIANTS,
+  type WorktreeSetupScriptVariant,
+} from '@shared/worktree-setup';
 
-const SETUP_SCRIPT_RELATIVE_PATH = path.join('.stagewise', 'worktree-setup.sh');
 const MANAGED_WORKTREE_INSPECTION_CONCURRENCY = 4;
 
 type ManagedWorktreeInspection = WorktreeSetupManagedWorktree & {
@@ -116,19 +121,25 @@ export class WorktreeSetupSettingsService {
 
   public async saveScript(
     mainWorktreePath: string,
+    variant: WorktreeSetupScriptVariant,
     content: string,
   ): Promise<SaveWorktreeSetupScriptResult> {
+    if (!WORKTREE_SETUP_SCRIPT_VARIANTS.includes(variant)) {
+      return { ok: false, message: `Unknown script variant: ${variant}.` };
+    }
+
     const repository =
       await this.findRepositoryByMainWorktreePath(mainWorktreePath);
     if (!repository) {
       return { ok: false, message: 'Repository is no longer available.' };
     }
 
+    const scriptPath = repository.scripts[variant].path;
     try {
-      await fs.mkdir(path.dirname(repository.scriptPath), { recursive: true });
-      await fs.writeFile(repository.scriptPath, content, 'utf8');
-      if (process.platform !== 'win32') {
-        await fs.chmod(repository.scriptPath, 0o755);
+      await fs.mkdir(path.dirname(scriptPath), { recursive: true });
+      await fs.writeFile(scriptPath, content, 'utf8');
+      if (variant === 'posix' && process.platform !== 'win32') {
+        await fs.chmod(scriptPath, 0o755);
       }
       const refreshed = await this.findRepositoryByMainWorktreePath(
         repository.mainWorktreePath,
@@ -137,8 +148,15 @@ export class WorktreeSetupSettingsService {
         ok: true,
         repository: refreshed ?? {
           ...repository,
-          scriptExists: true,
-          scriptContent: content,
+          scripts: {
+            ...repository.scripts,
+            [variant]: {
+              variant,
+              path: scriptPath,
+              exists: true,
+              content,
+            },
+          },
         },
       };
     } catch (error) {
@@ -295,16 +313,32 @@ export class WorktreeSetupSettingsService {
     repositoryId: string | null,
     managedWorktrees: ManagedWorktreeInspection[],
   ): Promise<WorktreeSetupRepositorySettings> {
-    const scriptPath = path.join(mainWorktreePath, SETUP_SCRIPT_RELATIVE_PATH);
-    const scriptContent = await this.readScriptContent(scriptPath);
+    const scriptEntries = await Promise.all(
+      WORKTREE_SETUP_SCRIPT_VARIANTS.map(async (variant) => {
+        const scriptPath = path.join(
+          mainWorktreePath,
+          WORKTREE_SETUP_SCRIPT_RELATIVE_PATHS[variant],
+        );
+        const scriptContent = await this.readScriptContent(scriptPath);
+        const file: WorktreeSetupScriptFile = {
+          variant,
+          path: scriptPath,
+          exists: scriptContent !== null,
+          content: scriptContent ?? '',
+        };
+        return [variant, file] as const;
+      }),
+    );
+    const scripts = Object.fromEntries(scriptEntries) as Record<
+      WorktreeSetupScriptVariant,
+      WorktreeSetupScriptFile
+    >;
     return {
       id: repositoryId ?? normalizePathForKey(mainWorktreePath),
       name: path.basename(mainWorktreePath),
       mainWorktreePath,
       repositoryId,
-      scriptPath,
-      scriptExists: scriptContent !== null,
-      scriptContent: scriptContent ?? '',
+      scripts,
       managedWorktrees: this.filterManagedWorktreesForRepository(
         mainWorktreePath,
         repositoryId,

--- a/apps/browser/src/shared/karton-contracts/ui/index.ts
+++ b/apps/browser/src/shared/karton-contracts/ui/index.ts
@@ -18,6 +18,7 @@ import type { ApiClient } from '@stagewise/api-client';
 import type { SelectedElement } from '../../selected-elements';
 import type { FileDiff } from './shared-types';
 import type { QuestionField, QuestionAnswerValue } from './agent/tools/types';
+import type { WorktreeSetupScriptVariant } from '@shared/worktree-setup';
 import type {
   FilePickerRequest,
   GlobalConfig,
@@ -189,14 +190,19 @@ export type WorktreeSetupManagedWorktree = {
   disabledReason: string | null;
 };
 
+export type WorktreeSetupScriptFile = {
+  variant: WorktreeSetupScriptVariant;
+  path: string;
+  exists: boolean;
+  content: string;
+};
+
 export type WorktreeSetupRepositorySettings = {
   id: string;
   name: string;
   mainWorktreePath: string;
   repositoryId: string | null;
-  scriptPath: string;
-  scriptExists: boolean;
-  scriptContent: string;
+  scripts: Record<WorktreeSetupScriptVariant, WorktreeSetupScriptFile>;
   managedWorktrees: WorktreeSetupManagedWorktree[];
 };
 
@@ -1131,6 +1137,7 @@ export type KartonContract = {
       listWorktreeSetupRepositories: () => Promise<WorktreeSetupRepositoriesResult>;
       saveWorktreeSetupScript: (
         mainWorktreePath: string,
+        variant: WorktreeSetupScriptVariant,
         content: string,
       ) => Promise<SaveWorktreeSetupScriptResult>;
       deleteWorktreeSetupWorktree: (

--- a/apps/browser/src/shared/worktree-setup.ts
+++ b/apps/browser/src/shared/worktree-setup.ts
@@ -1,0 +1,48 @@
+/**
+ * Shared definitions for worktree setup scripts.
+ *
+ * Two script variants are supported:
+ * - `posix`      -> `.stagewise/worktree-setup.sh` (executed via `/bin/sh`)
+ * - `powershell` -> `.stagewise/worktree-setup.ps1` (executed via PowerShell)
+ *
+ * The variant that actually runs is determined by the host platform
+ * (see `variantForPlatform`). The settings UI lets users author both.
+ *
+ * NOTE: relative paths use forward slashes so this module stays safe to import
+ * from the renderer (no `node:path` dependency). Backend consumers join these
+ * with `path.join`, which normalizes separators per platform.
+ */
+
+export type WorktreeSetupScriptVariant = 'posix' | 'powershell';
+
+export const WORKTREE_SETUP_SCRIPT_VARIANTS: WorktreeSetupScriptVariant[] = [
+  'posix',
+  'powershell',
+];
+
+export const WORKTREE_SETUP_SCRIPT_RELATIVE_PATHS: Record<
+  WorktreeSetupScriptVariant,
+  string
+> = {
+  posix: '.stagewise/worktree-setup.sh',
+  powershell: '.stagewise/worktree-setup.ps1',
+};
+
+export const WORKTREE_SETUP_SCRIPT_FILENAMES: Record<
+  WorktreeSetupScriptVariant,
+  string
+> = {
+  posix: 'worktree-setup.sh',
+  powershell: 'worktree-setup.ps1',
+};
+
+/**
+ * Determines which script variant runs on a given platform. A POSIX shell
+ * script cannot run on Windows and a PowerShell script cannot run on POSIX, so
+ * the host platform fully determines execution.
+ */
+export function variantForPlatform(
+  platform: NodeJS.Platform,
+): WorktreeSetupScriptVariant {
+  return platform === 'win32' ? 'powershell' : 'posix';
+}

--- a/apps/browser/src/ui/screens/main/command-center/command-center-settings.ts
+++ b/apps/browser/src/ui/screens/main/command-center/command-center-settings.ts
@@ -11,6 +11,7 @@ export type CommandCenterSettingDefinition = Omit<
     | 'provider'
     | 'settings'
     | 'context'
+    | 'worktrees'
     | 'plugins'
     | 'browser'
     | 'history';
@@ -21,6 +22,7 @@ const ROUTE_MODELS_PROVIDERS: SettingsRoute = { section: 'models-providers' };
 const ROUTE_CUSTOM_PROVIDERS: SettingsRoute = { section: 'custom-providers' };
 const ROUTE_AGENT_GENERAL: SettingsRoute = { section: 'agent-general' };
 const ROUTE_SKILLS_CONTEXT: SettingsRoute = { section: 'skills-context' };
+const ROUTE_WORKTREE_SETUP: SettingsRoute = { section: 'worktree-setup' };
 const ROUTE_PLUGINS: SettingsRoute = { section: 'plugins' };
 const ROUTE_BROWSING: SettingsRoute = { section: 'browsing' };
 const ROUTE_HISTORY: SettingsRoute = { section: 'history' };
@@ -80,6 +82,15 @@ export const commandCenterSettings: CommandCenterSettingDefinition[] = [
     url: '',
     settingsRoute: ROUTE_SKILLS_CONTEXT,
     iconName: 'context',
+  },
+  {
+    id: 'setting:worktree-setup',
+    title: 'Worktrees',
+    subtitle: 'Manage worktree setup scripts',
+    keywords: ['worktree', 'worktrees', 'setup', 'script', 'branch'],
+    url: '',
+    settingsRoute: ROUTE_WORKTREE_SETUP,
+    iconName: 'worktrees',
   },
   {
     id: 'setting:plugins',

--- a/apps/browser/src/ui/screens/main/command-center/sources/use-settings-command-items.tsx
+++ b/apps/browser/src/ui/screens/main/command-center/sources/use-settings-command-items.tsx
@@ -6,7 +6,11 @@ import {
   IconNoteFillDuo18,
   IconSpace3dFillDuo18,
 } from 'nucleo-ui-fill-duo-18';
-import { IconKey2Outline18, IconServerOutline18 } from 'nucleo-ui-outline-18';
+import {
+  IconBranchOutOutline18,
+  IconKey2Outline18,
+  IconServerOutline18,
+} from 'nucleo-ui-outline-18';
 import type { SettingCommandItem } from '../command-center-model';
 import {
   commandCenterSettings,
@@ -25,6 +29,8 @@ function iconForSetting(setting: CommandCenterSettingDefinition) {
       return <IconServerOutline18 className={className} />;
     case 'context':
       return <IconNoteFillDuo18 className={className} />;
+    case 'worktrees':
+      return <IconBranchOutOutline18 className={className} />;
     case 'plugins':
       return <IconSpace3dFillDuo18 className={`${className} rotate-180`} />;
     case 'history':

--- a/apps/browser/src/ui/screens/settings/sections/agent-settings.worktree-setup.tsx
+++ b/apps/browser/src/ui/screens/settings/sections/agent-settings.worktree-setup.tsx
@@ -17,8 +17,13 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from '@stagewise/stage-ui/components/tooltip';
+import {
+  Tabs,
+  TabsList,
+  TabsTrigger,
+} from '@stagewise/stage-ui/components/tabs';
 import { toast } from '@stagewise/stage-ui/components/toaster';
-import { useKartonProcedure } from '@ui/hooks/use-karton';
+import { useKartonProcedure, useKartonState } from '@ui/hooks/use-karton';
 import { cn } from '@ui/utils';
 import { useScrollFadeMask } from '@ui/hooks/use-scroll-fade-mask';
 import { SettingsScrollTabs } from '../_components/settings-scroll-tabs';
@@ -28,6 +33,10 @@ import type {
   WorktreeSetupRepositorySettings,
 } from '@shared/karton-contracts/ui';
 import {
+  WORKTREE_SETUP_SCRIPT_FILENAMES,
+  type WorktreeSetupScriptVariant,
+} from '@shared/worktree-setup';
+import {
   IconBranchOutOutline18,
   IconCircleQuestionOutline18,
   IconTrashOutline18,
@@ -35,7 +44,8 @@ import {
 import { FileIcon } from '@ui/components/file-icon';
 import { FileContextMenu } from '@ui/components/file-context-menu';
 
-const SETUP_SCRIPT_TEMPLATE = `#!/bin/sh
+const SETUP_SCRIPT_TEMPLATES: Record<WorktreeSetupScriptVariant, string> = {
+  posix: `#!/bin/sh
 set -e
 
 # Runs after stagewise creates and mounts a new Git worktree.
@@ -43,14 +53,43 @@ set -e
 
 # Example:
 # pnpm install
-`;
+`,
+  powershell: `$ErrorActionPreference = 'Stop'
+
+# Runs after stagewise creates and mounts a new Git worktree.
+# CWD is the new worktree.
+
+# Example:
+# pnpm install
+`,
+};
+
+const VARIANT_TAB_LABELS: Record<WorktreeSetupScriptVariant, string> = {
+  posix: 'Shell (.sh)',
+  powershell: 'PowerShell (.ps1)',
+};
+
+const EMPTY_SCRIPT_DRAFTS: Record<WorktreeSetupScriptVariant, string> = {
+  posix: '',
+  powershell: '',
+};
 
 function getInitialScriptDraft(
   repository: WorktreeSetupRepositorySettings,
+  variant: WorktreeSetupScriptVariant,
 ): string {
-  return repository.scriptExists
-    ? repository.scriptContent
-    : SETUP_SCRIPT_TEMPLATE;
+  const script = repository.scripts[variant];
+  return script.exists ? script.content : SETUP_SCRIPT_TEMPLATES[variant];
+}
+
+function buildScriptDrafts(
+  repository: WorktreeSetupRepositorySettings | null,
+): Record<WorktreeSetupScriptVariant, string> {
+  if (!repository) return { ...EMPTY_SCRIPT_DRAFTS };
+  return {
+    posix: getInitialScriptDraft(repository, 'posix'),
+    powershell: getInitialScriptDraft(repository, 'powershell'),
+  };
 }
 
 function formatRelativeTime(timestamp: number | null): string {
@@ -88,7 +127,14 @@ export function WorktreeSetupSection() {
   const [selectedRepositoryId, setSelectedRepositoryId] = useState<
     string | null
   >(null);
-  const [scriptDraft, setScriptDraft] = useState('');
+  const platform = useKartonState((s) => s.appInfo.platform);
+  const [activeVariant, setActiveVariant] =
+    useState<WorktreeSetupScriptVariant>(
+      platform === 'win32' ? 'powershell' : 'posix',
+    );
+  const [scriptDrafts, setScriptDrafts] = useState<
+    Record<WorktreeSetupScriptVariant, string>
+  >({ ...EMPTY_SCRIPT_DRAFTS });
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [deletingPath, setDeletingPath] = useState<string | null>(null);
@@ -104,9 +150,11 @@ export function WorktreeSetupSection() {
     [repositories, selectedRepositoryId],
   );
 
+  const scriptDraft = scriptDrafts[activeVariant];
+
   const dirty =
     selectedRepository !== null &&
-    scriptDraft !== getInitialScriptDraft(selectedRepository);
+    scriptDraft !== getInitialScriptDraft(selectedRepository, activeVariant);
 
   const refreshRepositories = useCallback(async () => {
     if (refreshInFlightRef.current) {
@@ -159,10 +207,15 @@ export function WorktreeSetupSection() {
     }
 
     previousSelectedRepositoryIdRef.current = selectedRepositoryId;
-    setScriptDraft(
-      selectedRepository ? getInitialScriptDraft(selectedRepository) : '',
-    );
+    setScriptDrafts(buildScriptDrafts(selectedRepository));
   }, [selectedRepository]);
+
+  const handleScriptDraftChange = useCallback(
+    (value: string) => {
+      setScriptDrafts((current) => ({ ...current, [activeVariant]: value }));
+    },
+    [activeVariant],
+  );
 
   const updateRepository = useCallback(
     (repository: WorktreeSetupRepositorySettings) => {
@@ -184,7 +237,8 @@ export function WorktreeSetupSection() {
     try {
       const result = await saveScript(
         selectedRepository.mainWorktreePath,
-        scriptDraft,
+        activeVariant,
+        scriptDrafts[activeVariant],
       );
       if (result.ok) {
         updateRepository(result.repository);
@@ -207,12 +261,21 @@ export function WorktreeSetupSection() {
     } finally {
       setSaving(false);
     }
-  }, [saveScript, scriptDraft, selectedRepository, updateRepository]);
+  }, [
+    saveScript,
+    activeVariant,
+    scriptDrafts,
+    selectedRepository,
+    updateRepository,
+  ]);
 
   const handleReset = useCallback(() => {
     if (!selectedRepository) return;
-    setScriptDraft(getInitialScriptDraft(selectedRepository));
-  }, [selectedRepository]);
+    setScriptDrafts((current) => ({
+      ...current,
+      [activeVariant]: getInitialScriptDraft(selectedRepository, activeVariant),
+    }));
+  }, [activeVariant, selectedRepository]);
 
   const handleConfirmDelete = useCallback(
     async (worktree: WorktreeSetupManagedWorktree) => {
@@ -270,11 +333,13 @@ export function WorktreeSetupSection() {
             {selectedRepository ? (
               <RepositoryDetails
                 repository={selectedRepository}
+                activeVariant={activeVariant}
+                onVariantChange={setActiveVariant}
                 scriptDraft={scriptDraft}
                 dirty={dirty}
                 saving={saving}
                 deletingPath={deletingPath}
-                onScriptDraftChange={setScriptDraft}
+                onScriptDraftChange={handleScriptDraftChange}
                 onReset={handleReset}
                 onSave={handleSave}
                 onConfirmDelete={handleConfirmDelete}
@@ -324,6 +389,8 @@ function RepositoryList({
 
 function RepositoryDetails({
   repository,
+  activeVariant,
+  onVariantChange,
   scriptDraft,
   dirty,
   saving,
@@ -334,6 +401,8 @@ function RepositoryDetails({
   onConfirmDelete,
 }: {
   repository: WorktreeSetupRepositorySettings;
+  activeVariant: WorktreeSetupScriptVariant;
+  onVariantChange: (variant: WorktreeSetupScriptVariant) => void;
   scriptDraft: string;
   dirty: boolean;
   saving: boolean;
@@ -343,6 +412,7 @@ function RepositoryDetails({
   onSave: () => void;
   onConfirmDelete: (worktree: WorktreeSetupManagedWorktree) => Promise<boolean>;
 }) {
+  const activeScript = repository.scripts[activeVariant];
   return (
     <div className="space-y-8">
       <section className="space-y-3">
@@ -354,10 +424,10 @@ function RepositoryDetails({
           <div className="flex items-center justify-between">
             <p className="text-muted-foreground text-xs">
               Runs for new worktrees when the checked-out branch contains this
-              file.
+              file. The variant for the worktree's platform is executed.
             </p>
             <FileContextMenu
-              relativePath={repository.scriptPath}
+              relativePath={activeScript.path}
               resolvePath={(p) => p}
             >
               <Tooltip>
@@ -370,20 +440,44 @@ function RepositoryDetails({
                     )}
                   >
                     <FileIcon
-                      filePath={repository.scriptPath}
+                      filePath={activeScript.path}
                       className="size-4 shrink-0"
                     />
-                    <span>worktree-setup.sh</span>
+                    <span className="shrink-0">
+                      {WORKTREE_SETUP_SCRIPT_FILENAMES[activeVariant]}
+                    </span>
                   </button>
                 </TooltipTrigger>
-                <TooltipContent>{repository.scriptPath}</TooltipContent>
+                <TooltipContent>{activeScript.path}</TooltipContent>
               </Tooltip>
             </FileContextMenu>
           </div>
         </div>
+        <Tabs
+          value={activeVariant}
+          onValueChange={(value) =>
+            onVariantChange(value as WorktreeSetupScriptVariant)
+          }
+        >
+          <TabsList className="w-auto">
+            <TabsTrigger value="posix">{VARIANT_TAB_LABELS.posix}</TabsTrigger>
+            <TabsTrigger value="powershell">
+              {VARIANT_TAB_LABELS.powershell}
+            </TabsTrigger>
+          </TabsList>
+        </Tabs>
         <textarea
           value={scriptDraft}
           onChange={(event) => onScriptDraftChange(event.target.value)}
+          onKeyDown={(event) => {
+            if (
+              (event.metaKey || event.ctrlKey) &&
+              event.key.toLowerCase() === 's'
+            ) {
+              event.preventDefault();
+              if (dirty && !saving) void onSave();
+            }
+          }}
           spellCheck={false}
           className="scrollbar-subtle min-h-72 w-full resize-y rounded-lg border border-derived bg-surface-1 p-3 font-mono text-foreground text-xs outline-none ring-0 transition-colors placeholder:text-subtle-foreground focus:border-derived-strong"
         />
@@ -444,6 +538,13 @@ function SetupVariablesPopover() {
             value="STAGEWISE_MAIN_WORKTREE_PATH"
           />
         </div>
+        <PopoverFooter>
+          <p className="text-muted-foreground text-xs">
+            In POSIX shell scripts, access these via{' '}
+            <code className="font-mono">$STAGEWISE_...</code>. In PowerShell,
+            use <code className="font-mono">$env:STAGEWISE_...</code>.
+          </p>
+        </PopoverFooter>
       </PopoverContent>
     </Popover>
   );


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Windows support for worktree setup with a PowerShell `.ps1` variant and a platform-aware runner. New worktrees run setup via PowerShell on Windows and `/bin/sh` on macOS/Linux.

- **New Features**
  - Platform-aware execution via `variantForPlatform` from `@shared/worktree-setup`; runs `.ps1` on Windows, `.sh` on POSIX.
  - Windows runner resolves the PowerShell command from the child PATH (prefers `pwsh`, falls back to `powershell.exe`) and runs with `-NoProfile -NonInteractive -ExecutionPolicy Bypass -File <script>`.
  - Case-insensitive env merge prevents duplicate `PATH/Path` entries; resolver sees the actual spawn PATH.
  - Script lookup prefers the workspace script, then falls back to the main worktree; `.sh` is ignored on Windows if no `.ps1` exists.
  - Settings/UI: per-variant drafts with Shell/PowerShell tabs (defaults by OS), file name display, env tips for `$STAGEWISE_...` and `$env:STAGEWISE_...`, and a new Command Center “Worktrees” entry.
  - Service applies `chmod 755` only to the `posix` variant.

- **Migration**
  - Karton API: `saveWorktreeSetupScript(mainWorktreePath, variant, content)`.
  - Repository settings now return `scripts: Record<variant, { variant, path, exists, content }>` instead of `scriptPath/scriptExists/scriptContent`.
  - On Windows, `.sh` is ignored; provide a `.ps1` script.

<sup>Written for commit fe28762b7cb93d535e953e5679b59d53d7cf5746. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1267?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added POSIX and PowerShell worktree setup script variants; UI lets you switch, edit, save, and restore per-variant scripts with variant-specific templates.
  * New Worktrees settings page and icon in command palette/settings.

* **Bug Fixes**
  * Windows now runs PowerShell setup scripts (no longer blocked).

* **API**
  * Save operation requires specifying the script variant.

* **Tests**
  * Expanded tests for POSIX and PowerShell behaviors, including script selection and execution paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->