### PR TITLE
feat(stagewise): add intel mac builds

### DIFF
--- a/.github/workflows/_release-browser.yml
+++ b/.github/workflows/_release-browser.yml
@@ -128,6 +128,9 @@ jobs:
           - os: macos-26
             arch: arm64
             artifact: stagewise-macos-arm64
+          - os: macos-13
+            arch: x64
+            artifact: stagewise-macos-x64
           - os: ubuntu-latest
             arch: x64
             artifact: stagewise-linux-x64

--- a/.github/workflows/_release-browser.yml
+++ b/.github/workflows/_release-browser.yml
@@ -128,7 +128,7 @@ jobs:
           - os: macos-26
             arch: arm64
             artifact: stagewise-macos-arm64
-          - os: macos-13
+          - os: macos-26-intel
             arch: x64
             artifact: stagewise-macos-x64
           - os: ubuntu-latest

--- a/.github/workflows/monorepo-ci.yml
+++ b/.github/workflows/monorepo-ci.yml
@@ -181,6 +181,9 @@ jobs:
           - os: macos-26
             platform: darwin-arm64
             arch: arm64
+          - os: macos-13
+            platform: darwin-x64
+            arch: x64
           - os: ubuntu-latest
             platform: linux-x64
             arch: x64
@@ -242,20 +245,22 @@ jobs:
       - name: Smoke Test
         shell: bash
         timeout-minutes: 2
+        env:
+          PLATFORM: ${{ matrix.platform }}
         run: |
           set -euo pipefail
 
-          if [ "${{ runner.os }}" == "macOS" ]; then
-            BINARY="apps/browser/out/dev/stagewise-dev-darwin-arm64/stagewise-dev.app/Contents/MacOS/stagewise-dev"
-          elif [ "${{ runner.os }}" == "Linux" ]; then
+          if [ "$RUNNER_OS" == "macOS" ]; then
+            BINARY="apps/browser/out/dev/stagewise-dev-${PLATFORM}/stagewise-dev.app/Contents/MacOS/stagewise-dev"
+          elif [ "$RUNNER_OS" == "Linux" ]; then
             BINARY="apps/browser/out/dev/stagewise-dev-linux-x64/stagewise-dev"
-          elif [ "${{ runner.os }}" == "Windows" ]; then
+          elif [ "$RUNNER_OS" == "Windows" ]; then
             BINARY="apps/browser/out/dev/stagewise-dev-win32-x64/stagewise-dev.exe"
           fi
 
           echo "Launching smoke test: $BINARY --smoke-test"
 
-          if [ "${{ runner.os }}" == "Linux" ]; then
+          if [ "$RUNNER_OS" == "Linux" ]; then
             xvfb-run --auto-servernum "$BINARY" --no-sandbox --smoke-test
           else
             "$BINARY" --smoke-test

--- a/.github/workflows/monorepo-ci.yml
+++ b/.github/workflows/monorepo-ci.yml
@@ -181,7 +181,7 @@ jobs:
           - os: macos-26
             platform: darwin-arm64
             arch: arm64
-          - os: macos-13
+          - os: macos-26-intel
             platform: darwin-x64
             arch: x64
           - os: ubuntu-latest

--- a/apps/browser/build-constants.ts
+++ b/apps/browser/build-constants.ts
@@ -99,9 +99,23 @@ export const __APP_AUTHOR__ = (() => {
   return 'GENERIC_AUTHOR';
 })();
 
+const readCliOption = (name: string) => {
+  const equalsPrefix = `--${name}=`;
+  const equalsArg = process.argv.find((arg) => arg.startsWith(equalsPrefix));
+  if (equalsArg) return equalsArg.slice(equalsPrefix.length);
+
+  const optionIndex = process.argv.indexOf(`--${name}`);
+  if (optionIndex >= 0) return process.argv[optionIndex + 1];
+
+  return undefined;
+};
+
 export const __APP_PLATFORM__ =
-  process.env.npm_config_platform || process.platform;
-export const __APP_ARCH__ = process.env.npm_config_arch || process.arch;
+  process.env.npm_config_platform ||
+  readCliOption('platform') ||
+  process.platform;
+export const __APP_ARCH__ =
+  process.env.npm_config_arch || readCliOption('arch') || process.arch;
 
 export const __APP_COPYRIGHT__ = `Copyright © ${new Date().getFullYear()} ${__APP_AUTHOR__}`;
 

--- a/apps/browser/build-constants.ts
+++ b/apps/browser/build-constants.ts
@@ -105,7 +105,11 @@ const readCliOption = (name: string) => {
   if (equalsArg) return equalsArg.slice(equalsPrefix.length);
 
   const optionIndex = process.argv.indexOf(`--${name}`);
-  if (optionIndex >= 0) return process.argv[optionIndex + 1];
+  if (optionIndex >= 0) {
+    const nextArg = process.argv[optionIndex + 1];
+    if (!nextArg || nextArg.startsWith('--')) return undefined;
+    return nextArg;
+  }
 
   return undefined;
 };

--- a/apps/browser/forge.config.mts
+++ b/apps/browser/forge.config.mts
@@ -407,7 +407,7 @@ const config: ForgeConfig = {
           x: 192,
           y: 200,
           type: 'file',
-          path: `./out/${buildConstants.__APP_RELEASE_CHANNEL__}/${buildConstants.__APP_BASE_NAME__}-darwin-arm64/${buildConstants.__APP_BASE_NAME__}.app`,
+          path: `./out/${buildConstants.__APP_RELEASE_CHANNEL__}/${buildConstants.__APP_BASE_NAME__}-darwin-${buildConstants.__APP_ARCH__}/${buildConstants.__APP_BASE_NAME__}.app`,
           name: `${buildConstants.__APP_NAME__}.app`,
         },
       ],


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Intel Mac (x64) builds for Stagewise desktop. CI and packaging now build, package, and smoke test both Apple Silicon and Intel on the correct Intel runner.

- **New Features**
  - Added `macos-26-intel` (x64) to release and CI matrices with artifact `stagewise-macos-x64` (kept `macos-26` arm64).
  - Smoke test resolves app paths via `$RUNNER_OS` and matrix `platform` (`darwin-x64`/`darwin-arm64`).
  - `build-constants.ts` accepts `--platform` and `--arch` CLI flags (with env fallbacks) for cross-arch builds.
  - `forge.config.mts` uses `__APP_ARCH__` in the DMG layout path to select the correct `.app`.

<sup>Written for commit 5a1f2b5de877de32adc7fea88fd222f5f7fd5736. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1277?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Produce macOS Intel (x64) release builds alongside existing arm64 builds in CI/release workflows.
  * CI smoke tests and build steps now select artifacts dynamically by platform/architecture variable instead of relying on a hardcoded macOS binary.
  * Packaging now includes and references architecture-specific app bundles for both Intel and Apple Silicon.
  * Build tooling accepts explicit platform/architecture options (CLI or env) with sensible fallbacks to detect the correct artifacts during packaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->