### PR TITLE
feat(global): add Fable 5 model

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -55,7 +55,7 @@ Für maximale Einfachheit und sofortigen Zugriff auf eine große Modellbibliothe
 
 Enthaltene Modelle:
 
-- **Anthropic**: Opus 4.8, Opus 4.7, Opus 4.6, Sonnet 4.6, Haiku 4.5
+- **Anthropic**: Fable 5, Opus 4.8, Opus 4.7, Opus 4.6, Sonnet 4.6, Haiku 4.5
 - **OpenAI**: GPT-5.5, GPT-5.4, GPT-5.3 Codex, GPT-5.3 Instant, GPT-5.4 mini, GPT-5.4 nano
 - **Google**: Gemini 3.1 Pro (Preview), Gemini 3 Flash, Gemini 3.1 Flash Lite
 - **Moonshot AI**: Kimi K2.6, Kimi K2.5

--- a/README.es.md
+++ b/README.es.md
@@ -55,7 +55,7 @@ Para mayor comodidad y acceso inmediato a una amplia biblioteca de modelos, simp
 
 Modelos incluidos:
 
-- **Anthropic**: Opus 4.8, Opus 4.7, Opus 4.6, Sonnet 4.6, Haiku 4.5
+- **Anthropic**: Fable 5, Opus 4.8, Opus 4.7, Opus 4.6, Sonnet 4.6, Haiku 4.5
 - **OpenAI**: GPT-5.5, GPT-5.4, GPT-5.3 Codex, GPT-5.3 Instant, GPT-5.4 mini, GPT-5.4 nano
 - **Google**: Gemini 3.1 Pro (Preview), Gemini 3 Flash, Gemini 3.1 Flash Lite
 - **Moonshot AI**: Kimi K2.6, Kimi K2.5

--- a/README.ja.md
+++ b/README.ja.md
@@ -55,7 +55,7 @@
 
 利用可能なモデル:
 
-- **Anthropic**: Opus 4.8, Opus 4.7, Opus 4.6, Sonnet 4.6, Haiku 4.5
+- **Anthropic**: Fable 5, Opus 4.8, Opus 4.7, Opus 4.6, Sonnet 4.6, Haiku 4.5
 - **OpenAI**: GPT-5.5, GPT-5.4, GPT-5.3 Codex, GPT-5.3 Instant, GPT-5.4 mini, GPT-5.4 nano
 - **Google**: Gemini 3.1 Pro (Preview), Gemini 3 Flash, Gemini 3.1 Flash Lite
 - **Moonshot AI**: Kimi K2.6, Kimi K2.5

--- a/README.ko.md
+++ b/README.ko.md
@@ -55,7 +55,7 @@
 
 포함된 모델:
 
-- **Anthropic**: Opus 4.8, Opus 4.7, Opus 4.6, Sonnet 4.6, Haiku 4.5
+- **Anthropic**: Fable 5, Opus 4.8, Opus 4.7, Opus 4.6, Sonnet 4.6, Haiku 4.5
 - **OpenAI**: GPT-5.5, GPT-5.4, GPT-5.3 Codex, GPT-5.3 Instant, GPT-5.4 mini, GPT-5.4 nano
 - **Google**: Gemini 3.1 Pro (Preview), Gemini 3 Flash, Gemini 3.1 Flash Lite
 - **Moonshot AI**: Kimi K2.6, Kimi K2.5

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ For ease of use and immediate access to a large library of models, you can simpl
 
 Included models:
 
-- **Anthropic**: Opus 4.8, Opus 4.7, Opus 4.6, Sonnet 4.6, Haiku 4.5
+- **Anthropic**: Fable 5, Opus 4.8, Opus 4.7, Opus 4.6, Sonnet 4.6, Haiku 4.5
 - **OpenAI**: GPT-5.5, GPT-5.4, GPT-5.3 Codex, GPT-5.3 Instant, GPT-5.4 mini, GPT-5.4 nano
 - **Google**: Gemini 3.1 Pro (Preview), Gemini 3 Flash, Gemini 3.1 Flash Lite
 - **Moonshot AI**: Kimi K2.6, Kimi K2.5

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -55,7 +55,7 @@
 
 包含模型：
 
-- **Anthropic**：Opus 4.8、Opus 4.7、Opus 4.6、Sonnet 4.6、Haiku 4.5
+- **Anthropic**：Fable 5、Opus 4.8、Opus 4.7、Opus 4.6、Sonnet 4.6、Haiku 4.5
 - **OpenAI**：GPT-5.5、GPT-5.4、GPT-5.3 Codex、GPT-5.3 Instant、GPT-5.4 mini、GPT-5.4 nano
 - **Google**：Gemini 3.1 Pro（预览）、Gemini 3 Flash、Gemini 3.1 Flash Lite（预览）
 - **Moonshot AI**：Kimi K2.6、Kimi K2.5

--- a/apps/browser/src/shared/available-models.ts
+++ b/apps/browser/src/shared/available-models.ts
@@ -127,6 +127,47 @@ export const availableModels = [
   // Anthropic Models
   {
     officialProvider: 'anthropic',
+    modelId: 'claude-fable-5',
+    modelDisplayName: 'Fable 5',
+    modelDescription:
+      "Anthropic's next-generation frontier model for complex reasoning, long-horizon coding, and agentic workflows.",
+    modelContext: '1M context',
+    modelContextRaw: 1000000,
+    headers: anthropicHeaders,
+    providerOptions: {
+      stagewise: { reasoning: { enabled: true, effort: 'medium' } },
+      anthropic: {
+        thinking: { type: 'adaptive' },
+        effort: 'medium',
+      },
+    },
+    thinkingEnabled: true,
+    pricing: {
+      inputPerMillion: 10.0,
+      outputPerMillion: 50.0,
+      relativeMultiplier: 10.0,
+    },
+    capabilities: {
+      inputModalities: {
+        text: true,
+        audio: false,
+        image: true,
+        video: false,
+        file: true,
+      },
+      outputModalities: {
+        text: true,
+        audio: false,
+        image: false,
+        video: false,
+        file: false,
+      },
+      inputConstraints: ANTHROPIC_INPUT_CONSTRAINTS,
+      toolCalling: true,
+    },
+  },
+  {
+    officialProvider: 'anthropic',
     modelId: 'claude-opus-4.8',
     modelDisplayName: 'Opus 4.8',
     modelDescription:

--- a/apps/website/src/app/(home)/_components/model-provider-showcase.tsx
+++ b/apps/website/src/app/(home)/_components/model-provider-showcase.tsx
@@ -48,6 +48,7 @@ const PROVIDERS: ProviderInfo[] = [
     description:
       'Best-in-class instruction following and long-context reasoning.',
     models: [
+      { name: 'Fable 5', tier: 'frontier' },
       { name: 'Opus 4.8', tier: 'frontier' },
       { name: 'Opus 4.7', tier: 'frontier' },
       { name: 'Opus 4.6', tier: 'frontier' },


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Anthropic Fable 5 as a first-class model with 1M context and reasoning enabled. Updates the website and docs to surface the model.

- New Features
  - Added Fable 5 to available models (id: claude-fable-5) with 1M context, adaptive/medium reasoning, tool calling, and text/image/file input; text output.
  - Pricing: $10/M input, $50/M output (relative multiplier 10.0).
  - Website: shows Fable 5 in the Anthropic provider showcase (frontier tier).
  - Docs: lists Fable 5 under Anthropic across all localized READMEs.

<sup>Written for commit 7b5f60024be6c54cf6cefaf74034d4bba4c17aed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1289?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Anthropic's Fable 5 model is now available in the app and appears alongside existing Anthropic models.

* **Documentation**
  * README translations updated to include Fable 5 in the listed Anthropic models.

* **UI**
  * Fable 5 now shows in the Anthropic provider hover/showcase details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->