### PR TITLE
feat(stagewise): replace upload image button with attach file, gate element selector on browsing tab

### DIFF
--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/chat-input.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/chat-input.tsx
@@ -13,8 +13,8 @@ import {
   ArrowUpIcon,
   SquareIcon,
   SquareDashedMousePointerIcon,
-  ImageUpIcon,
 } from 'lucide-react';
+import { IconPaperclip2Outline18 } from 'nucleo-ui-outline-18';
 import {
   useCallback,
   useMemo,
@@ -935,7 +935,6 @@ export const ChatInputActions = memo(function ChatInputActions({
             type="file"
             multiple
             className="hidden"
-            accept="image/png, image/jpeg, image/gif, image/webp, application/pdf, text/plain"
             id="chat-file-attachment-input-file"
           />
           <Tooltip>
@@ -943,7 +942,7 @@ export const ChatInputActions = memo(function ChatInputActions({
               <Button
                 size="icon-sm"
                 variant="ghost"
-                aria-label="Upload image"
+                aria-label="Attach file"
                 className="mb-1 shrink-0"
                 onClick={() => {
                   const input = document.getElementById(
@@ -960,10 +959,10 @@ export const ChatInputActions = memo(function ChatInputActions({
                   };
                 }}
               >
-                <ImageUpIcon className="size-4" />
+                <IconPaperclip2Outline18 className="size-4" />
               </Button>
             </TooltipTrigger>
-            <TooltipContent>Upload image</TooltipContent>
+            <TooltipContent>Attach file</TooltipContent>
           </Tooltip>
         </>
       )}

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/message-user.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/message-user.tsx
@@ -503,11 +503,29 @@ export const MessageUser = memo(
 
     const hasVisibleBrowsingTab = useMemo(() => {
       if (!activeTab) return false;
+      const ownedByOtherAgent =
+        activeTab.agentInstanceId != null &&
+        activeTab.agentInstanceId !== openAgent;
       return (
         activeTab.type !== 'terminal' &&
-        !activeTab.url?.startsWith('stagewise://internal/')
+        !activeTab.url?.startsWith('stagewise://internal/') &&
+        !ownedByOtherAgent
       );
-    }, [activeTab]);
+    }, [activeTab, openAgent]);
+
+    // Deactivate element selection when the browsing tab disappears
+    const prevHasVisibleBrowsingTabRef = useRef(hasVisibleBrowsingTab);
+    useEffect(() => {
+      const prev = prevHasVisibleBrowsingTabRef.current;
+      prevHasVisibleBrowsingTabRef.current = hasVisibleBrowsingTab;
+      if (prev && !hasVisibleBrowsingTab && elementSelectionActive) {
+        setElementSelectionActive(false);
+      }
+    }, [
+      hasVisibleBrowsingTab,
+      elementSelectionActive,
+      setElementSelectionActive,
+    ]);
 
     const mentionMounts = useKartonState((s) =>
       openAgent

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/message-user.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/message-user.tsx
@@ -501,6 +501,14 @@ export const MessageUser = memo(
       return activeTab?.url?.startsWith('stagewise://internal/') ?? false;
     }, [activeTab?.url]);
 
+    const hasVisibleBrowsingTab = useMemo(() => {
+      if (!activeTab) return false;
+      return (
+        activeTab.type !== 'terminal' &&
+        !activeTab.url?.startsWith('stagewise://internal/')
+      );
+    }, [activeTab]);
+
     const mentionMounts = useKartonState((s) =>
       openAgent
         ? (s.toolbox[openAgent]?.workspace?.mounts ?? EMPTY_MOUNTS)
@@ -688,7 +696,7 @@ export const MessageUser = memo(
                     <div className="relative flex shrink-0 flex-col items-center justify-end gap-1">
                       <ChatInputActions
                         isAgentWorking={false}
-                        showElementSelectorButton
+                        showElementSelectorButton={hasVisibleBrowsingTab}
                         elementSelectionActive={elementSelectionActive}
                         onToggleElementSelection={handleToggleElementSelection}
                         elementSelectorDisabled={hasOpenedInternalPage}

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/message-user.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/message-user.tsx
@@ -42,6 +42,7 @@ import {
   type ChatEditUserMessageRequestedEvent,
 } from '../_lib/chat-edit-user-message-event';
 import { useOpenAgent } from '@ui/hooks/use-open-chat';
+import { useContentCollapsed } from '../../../_components/content-collapsed-context';
 import type { Content } from '@tiptap/core';
 import { IconMagicWandSparkle } from 'nucleo-micro-bold';
 import { MessageUserPlanAction } from './message-user-plan-action';
@@ -65,6 +66,7 @@ export const MessageUser = memo(
     const chatInputRef = useRef<ChatInputHandle>(null);
     const [isEditing, setIsEditing] = useState(false);
     const [openAgent] = useOpenAgent();
+    const { collapsed: contentCollapsed } = useContentCollapsed();
 
     // File attachments via shared hook
     const {
@@ -503,6 +505,7 @@ export const MessageUser = memo(
 
     const hasVisibleBrowsingTab = useMemo(() => {
       if (!activeTab) return false;
+      if (contentCollapsed) return false;
       const ownedByOtherAgent =
         activeTab.agentInstanceId != null &&
         activeTab.agentInstanceId !== openAgent;
@@ -511,7 +514,7 @@ export const MessageUser = memo(
         !activeTab.url?.startsWith('stagewise://internal/') &&
         !ownedByOtherAgent
       );
-    }, [activeTab, openAgent]);
+    }, [activeTab, openAgent, contentCollapsed]);
 
     // Deactivate element selection when the browsing tab disappears
     const prevHasVisibleBrowsingTabRef = useRef(hasVisibleBrowsingTab);

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/panel-footer.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/panel-footer.tsx
@@ -302,15 +302,23 @@ export const ChatPanelFooter = memo(function ChatPanelFooter() {
 
   const activeTabId = useKartonState((s) => s.contentTabs.activeTabId);
 
-  const hasVisibleBrowsingTab = useKartonState((s) => {
+  const activeTabData = useKartonState((s) => {
     const tabId = s.contentTabs.activeTabId;
-    if (!tabId) return false;
-    const tab = s.contentTabs.tabs[tabId];
-    if (!tab) return false;
-    return (
-      tab.type !== 'terminal' && !tab.url?.startsWith('stagewise://internal/')
-    );
+    if (!tabId) return null;
+    return s.contentTabs.tabs[tabId] ?? null;
   });
+
+  const hasVisibleBrowsingTab = useMemo(() => {
+    if (!activeTabData) return false;
+    const ownedByOtherAgent =
+      activeTabData.agentInstanceId != null &&
+      activeTabData.agentInstanceId !== openAgent;
+    return (
+      activeTabData.type !== 'terminal' &&
+      !activeTabData.url?.startsWith('stagewise://internal/') &&
+      !ownedByOtherAgent
+    );
+  }, [activeTabData, openAgent]);
 
   const elementSelectionActive = useMemo(() => {
     if (activeEditMessageId) return false;
@@ -466,6 +474,19 @@ export const ChatPanelFooter = memo(function ChatPanelFooter() {
   const stopContextSelector = useCallback(() => {
     setContextSelectionActive(false);
   }, [setContextSelectionActive]);
+
+  // Deactivate element selection when the browsing tab disappears
+  // (e.g. user switches to terminal or internal page). Without this,
+  // selectionModeActive stays true while the toggle button is hidden,
+  // leaving no way to exit selection mode from the chat input.
+  const prevHasVisibleBrowsingTabRef = useRef(hasVisibleBrowsingTab);
+  useEffect(() => {
+    const prev = prevHasVisibleBrowsingTabRef.current;
+    prevHasVisibleBrowsingTabRef.current = hasVisibleBrowsingTab;
+    if (prev && !hasVisibleBrowsingTab && selectionModeActive) {
+      stopContextSelector();
+    }
+  }, [hasVisibleBrowsingTab, selectionModeActive, stopContextSelector]);
 
   // Pending early-abort revert: deferred until isWorking becomes false
   // so the stream is fully done and won't re-add the assistant message.

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/panel-footer.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/panel-footer.tsx
@@ -60,6 +60,7 @@ import { selectedElementToSwDomElement } from '@shared/selected-elements/swdomel
 import type { AgentMessage } from '@shared/karton-contracts/ui/agent';
 import { EMPTY_MOUNTS, type MountEntry } from '@shared/karton-contracts/ui';
 import { useOpenAgent } from '@ui/hooks/use-open-chat';
+import { useContentCollapsed } from '../../../_components/content-collapsed-context';
 import { availableModels } from '@shared/available-models';
 import { useChatDraft } from '@ui/hooks/use-chat-draft';
 import type { Content } from '@tiptap/core';
@@ -185,6 +186,7 @@ export const ChatPanelFooter = memo(function ChatPanelFooter() {
 
   const [openAgent] = useOpenAgent();
   const { isOpen: isCommandCenterOpen } = useCommandCenter();
+  const { collapsed: contentCollapsed } = useContentCollapsed();
 
   const isWorking = useKartonState((s) =>
     openAgent ? s.agents.instances[openAgent]?.state.isWorking || false : false,
@@ -308,6 +310,7 @@ export const ChatPanelFooter = memo(function ChatPanelFooter() {
 
   const hasVisibleBrowsingTab = useMemo(() => {
     if (!activeTabData) return false;
+    if (contentCollapsed) return false;
     const ownedByOtherAgent =
       activeTabData.agentInstanceId != null &&
       activeTabData.agentInstanceId !== openAgent;
@@ -316,7 +319,7 @@ export const ChatPanelFooter = memo(function ChatPanelFooter() {
       !activeTabData.url?.startsWith('stagewise://internal/') &&
       !ownedByOtherAgent
     );
-  }, [activeTabData, openAgent]);
+  }, [activeTabData, openAgent, contentCollapsed]);
 
   const elementSelectionActive = useMemo(() => {
     if (activeEditMessageId) return false;

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/panel-footer.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/panel-footer.tsx
@@ -300,8 +300,6 @@ export const ChatPanelFooter = memo(function ChatPanelFooter() {
     (s) => s.browsing.contextSelectionMode,
   );
 
-  const activeTabId = useKartonState((s) => s.contentTabs.activeTabId);
-
   const activeTabData = useKartonState((s) => {
     const tabId = s.contentTabs.activeTabId;
     if (!tabId) return null;
@@ -1225,13 +1223,13 @@ export const ChatPanelFooter = memo(function ChatPanelFooter() {
   );
 
   // Cmd+I: toggle context element selection. Always focuses chat input,
-  // never unfocuses. Only works when a browser tab is visible.
+  // never unfocuses. Only works when a browsing tab is visible.
   useHotKeyListener(
     useCallback(async () => {
-      if (!activeTabId) return;
+      if (!hasVisibleBrowsingTab) return;
       if (elementSelectionActive) {
         stopContextSelector();
-      } else if (!activeTabUrl?.startsWith('stagewise://internal/')) {
+      } else {
         startContextSelector();
       }
       if (!chatInputActive) {
@@ -1239,8 +1237,7 @@ export const ChatPanelFooter = memo(function ChatPanelFooter() {
         await togglePanelKeyboardFocus('stagewise-ui');
       }
     }, [
-      activeTabId,
-      activeTabUrl,
+      hasVisibleBrowsingTab,
       elementSelectionActive,
       chatInputActive,
       startContextSelector,

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/panel-footer.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/panel-footer.tsx
@@ -302,6 +302,16 @@ export const ChatPanelFooter = memo(function ChatPanelFooter() {
 
   const activeTabId = useKartonState((s) => s.contentTabs.activeTabId);
 
+  const hasVisibleBrowsingTab = useKartonState((s) => {
+    const tabId = s.contentTabs.activeTabId;
+    if (!tabId) return false;
+    const tab = s.contentTabs.tabs[tabId];
+    if (!tab) return false;
+    return (
+      tab.type !== 'terminal' && !tab.url?.startsWith('stagewise://internal/')
+    );
+  });
+
   const elementSelectionActive = useMemo(() => {
     if (activeEditMessageId) return false;
     return selectionModeActive;
@@ -1669,7 +1679,7 @@ export const ChatPanelFooter = memo(function ChatPanelFooter() {
           isAgentWorking={isWorking}
           hasPendingQuestion={hasPendingQuestion}
           onStop={stableAbortAgent}
-          showElementSelectorButton
+          showElementSelectorButton={hasVisibleBrowsingTab}
           elementSelectionActive={elementSelectionActive}
           onToggleElementSelection={handleToggleElementSelection}
           elementSelectorDisabled={hasOpenedInternalPage}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace the chat input “Upload image” action with a generic “Attach file” button (paperclip from `nucleo-ui-outline-18`) and remove file-type filtering so any file can be attached. Show the element selector only when a visible browsing tab is active (not terminal/internal, not owned by another agent, and not when the content panel is collapsed), auto-exit selection mode on tab switches or when the browsing tab disappears, and gate the Cmd+I hotkey to the same condition.

<sup>Written for commit 4482a7942c94903b33e060eb459b2af8ae871c9b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1292?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Attachment button now supports any file type with updated icon and labeling for a generic "attach file" flow.
  * Element selector button only appears when a valid browsing tab is active; selection mode automatically exits if that browsing context disappears.
  * Keyboard toggle for the element selector (Cmd+I) now only activates when a valid browsing tab is present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->