### PR TITLE
fix(stagewise): open historical file mentions

### DIFF
--- a/apps/browser/src/backend/services/file-tree/index.test.ts
+++ b/apps/browser/src/backend/services/file-tree/index.test.ts
@@ -2,6 +2,20 @@ import { mkdtemp, mkdir, realpath, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.hoisted(() => {
+  vi.stubGlobal('__APP_BASE_NAME__', 'stagewise-test');
+  vi.stubGlobal('__APP_NAME__', 'stagewise-test');
+  vi.stubGlobal('__APP_BUNDLE_ID__', 'io.stagewise.test');
+  vi.stubGlobal('__APP_VERSION__', '0.0.0-test');
+  vi.stubGlobal('__APP_PLATFORM__', 'darwin');
+  vi.stubGlobal('__APP_RELEASE_CHANNEL__', 'test');
+  vi.stubGlobal('__APP_AUTHOR__', 'stagewise');
+  vi.stubGlobal('__APP_COPYRIGHT__', 'stagewise');
+  vi.stubGlobal('__APP_HOMEPAGE__', 'https://stagewise.io');
+  vi.stubGlobal('__APP_ARCH__', 'arm64');
+});
+
 import type { Logger } from '../logger';
 import type { KartonService } from '../karton';
 import type { AppState } from '@shared/karton-contracts/ui';

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/rich-text/mentions/mention-node-view.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/rich-text/mentions/mention-node-view.tsx
@@ -8,6 +8,18 @@ import { useKartonProcedure, useKartonState } from '@ui/hooks/use-karton';
 import { useOpenAgent } from '@ui/hooks/use-open-chat';
 import { useMountedPaths } from '@ui/hooks/use-mounted-paths';
 
+function findLastMountByPrefix<T extends { prefix: string }>(
+  mounts: readonly T[] | null,
+  prefix: string,
+): T | undefined {
+  if (!mounts) return undefined;
+  for (let index = mounts.length - 1; index >= 0; index--) {
+    const mount = mounts[index];
+    if (mount?.prefix === prefix) return mount;
+  }
+  return undefined;
+}
+
 export function MentionNodeView(props: InlineNodeViewProps) {
   const attrs = props.node.attrs as MentionAttrs;
   const isEditable = !('viewOnly' in props);
@@ -57,7 +69,7 @@ export function MentionNodeView(props: InlineNodeViewProps) {
     const relativePath = attrs.id.slice(slashIndex + 1);
     const mount =
       mounts.find((item) => item.prefix === prefix) ??
-      historicalMounts?.find((item) => item.prefix === prefix);
+      findLastMountByPrefix(historicalMounts, prefix);
     if (!mount) return;
     const workspaceKey = `${mount.prefix}:${mount.path.replace(/\\/g, '/')}`;
     void openFileTab(workspaceKey, relativePath, openAgent).then((tabId) => {

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/rich-text/mentions/mention-node-view.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/rich-text/mentions/mention-node-view.tsx
@@ -6,6 +6,7 @@ import { TabMentionBadge } from './tab-mention-badge';
 import { FileReferenceBadge } from '@ui/components/file-reference-badge';
 import { useKartonProcedure, useKartonState } from '@ui/hooks/use-karton';
 import { useOpenAgent } from '@ui/hooks/use-open-chat';
+import { useMountedPaths } from '@ui/hooks/use-mounted-paths';
 
 export function MentionNodeView(props: InlineNodeViewProps) {
   const attrs = props.node.attrs as MentionAttrs;
@@ -13,6 +14,7 @@ export function MentionNodeView(props: InlineNodeViewProps) {
   const [openAgent] = useOpenAgent();
   const openFileTab = useKartonProcedure((p) => p.fileTree.openFileTab);
   const revealInFolder = useKartonProcedure((p) => p.fileTree.revealInFolder);
+  const historicalMounts = useMountedPaths();
   const mounts = useKartonState((s) =>
     openAgent ? (s.toolbox[openAgent]?.workspace?.mounts ?? []) : [],
   );
@@ -53,13 +55,23 @@ export function MentionNodeView(props: InlineNodeViewProps) {
     if (slashIndex <= 0) return;
     const prefix = attrs.id.slice(0, slashIndex);
     const relativePath = attrs.id.slice(slashIndex + 1);
-    const mount = mounts.find((item) => item.prefix === prefix);
+    const mount =
+      mounts.find((item) => item.prefix === prefix) ??
+      historicalMounts?.find((item) => item.prefix === prefix);
     if (!mount) return;
     const workspaceKey = `${mount.prefix}:${mount.path.replace(/\\/g, '/')}`;
     void openFileTab(workspaceKey, relativePath, openAgent).then((tabId) => {
       if (!tabId) void revealInFolder(workspaceKey, relativePath);
     });
-  }, [attrs.id, isFile, mounts, openAgent, openFileTab, revealInFolder]);
+  }, [
+    attrs.id,
+    isFile,
+    mounts,
+    historicalMounts,
+    openAgent,
+    openFileTab,
+    revealInFolder,
+  ]);
 
   // View-only file badges get click-to-open plus the context menu.
   if (isFile && !isEditable) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes opening file mentions from past workspaces by falling back to the latest historical mount when the current mount isn’t active. Users can now open view-only file badges even if the original mount was removed.

- **Bug Fixes**
  - Resolves mention mounts by preferring current mounts, then the last matching entry from `@ui/hooks/use-mounted-paths`.
  - Stubs app globals in `file-tree` tests to stabilize the test environment.

<sup>Written for commit a346711ce674e7ceec68b85b6acf4823196db05b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1294?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability for opening referenced files in chat: the app now falls back to historical mount information when current mounts don't match, reducing failures accessing referenced files after system changes.
* **Tests**
  * Stabilized automated tests by seeding consistent application environment values during test runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->