### PR TITLE
fix(agent-core): update flash lite helper model

### DIFF
--- a/packages/agent-core/src/agents/shared/history-compression.test.ts
+++ b/packages/agent-core/src/agents/shared/history-compression.test.ts
@@ -788,7 +788,7 @@ describe('generateSimpleCompressedHistory', () => {
     expect(result).toBe('The user asked the assistant to help with a task.');
     expect(generateTextMock).toHaveBeenCalledTimes(1);
     expect(mps.getWithOptions).toHaveBeenCalledWith(
-      'gemini-3.1-flash-lite-preview',
+      'gemini-3.1-flash-lite',
       'agent-1',
       expect.objectContaining({ $ai_span_name: 'history-compression' }),
     );
@@ -907,13 +907,33 @@ describe('generateSimpleCompressedHistory', () => {
     expect(generateTextMock).toHaveBeenCalledTimes(2);
     expect(mps.getWithOptions).toHaveBeenNthCalledWith(
       1,
-      'gemini-3.1-flash-lite-preview',
+      'gemini-3.1-flash-lite',
       'agent-1',
       expect.any(Object),
     );
     expect(mps.getWithOptions).toHaveBeenNthCalledWith(
       2,
       'gpt-5.4-nano',
+      'agent-1',
+      expect.any(Object),
+    );
+  });
+
+  it('does not start fallbacks when a timed-out model does not settle after abort', async () => {
+    generateTextMock.mockImplementationOnce(() => new Promise(() => {}));
+
+    const mps = makeMockHostModels();
+    const promise = expect(
+      generateSimpleCompressedHistory(makeMessages(4), mps, 'agent-1'),
+    ).rejects.toThrow('timed out and did not settle after abort');
+
+    await vi.advanceTimersByTimeAsync(32_000);
+    await promise;
+    expect(generateTextMock).toHaveBeenCalledTimes(1);
+    expect(mps.getWithOptions).toHaveBeenCalledTimes(1);
+    expect(mps.getWithOptions).toHaveBeenNthCalledWith(
+      1,
+      'gemini-3.1-flash-lite',
       'agent-1',
       expect.any(Object),
     );
@@ -936,7 +956,7 @@ describe('generateSimpleCompressedHistory', () => {
     expect(generateTextMock).toHaveBeenCalledTimes(3);
     expect(mps.getWithOptions).toHaveBeenNthCalledWith(
       1,
-      'gemini-3.1-flash-lite-preview',
+      'gemini-3.1-flash-lite',
       'agent-1',
       expect.any(Object),
     );
@@ -1162,7 +1182,7 @@ describe('generateSimpleCompressedHistory', () => {
     expect(generateTextMock).toHaveBeenCalledTimes(1);
     expect(mps.getWithOptions).toHaveBeenCalledTimes(1);
     expect(mps.getWithOptions).toHaveBeenCalledWith(
-      'gemini-3.1-flash-lite-preview',
+      'gemini-3.1-flash-lite',
       'agent-1',
       expect.any(Object),
     );

--- a/packages/agent-core/src/agents/shared/history-compression/index.ts
+++ b/packages/agent-core/src/agents/shared/history-compression/index.ts
@@ -45,7 +45,7 @@ export {
  * tried in order when the previous one fails or times out.
  */
 const HISTORY_COMPRESSION_MODELS = [
-  'gemini-3.1-flash-lite-preview',
+  'gemini-3.1-flash-lite',
   'gpt-5.4-nano',
   'claude-haiku-4.5',
 ] as const;
@@ -53,8 +53,26 @@ const HISTORY_COMPRESSION_MODELS = [
 /** Maximum time (ms) allowed for a single history compression attempt. */
 const HISTORY_COMPRESSION_TIMEOUT_MS = 30_000;
 
+/**
+ * Grace period after aborting a timed-out compression request.
+ *
+ * If the provider/SDK does not settle the original request within this
+ * window, stop the cascade instead of starting overlapping fallback
+ * requests that can continue billing in the background.
+ */
+const HISTORY_COMPRESSION_ABORT_GRACE_MS = 2_000;
+
 /** Minimum acceptable compression length; shorter results trigger a fallback. */
 const COMPRESSION_MIN_LENGTH = 30;
+
+class HistoryCompressionUnsettledTimeoutError extends Error {
+  constructor(modelId: string) {
+    super(
+      `History compression request for ${modelId} timed out and did not settle after abort`,
+    );
+    this.name = 'HistoryCompressionUnsettledTimeoutError';
+  }
+}
 
 /**
  * Attempts a single compression call against the given model.
@@ -77,13 +95,11 @@ const tryCompressWithModel = async (
   );
 
   const abortController = new AbortController();
-  const timeout = setTimeout(
-    () => abortController.abort(),
-    HISTORY_COMPRESSION_TIMEOUT_MS,
-  );
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  let abortGraceTimeout: ReturnType<typeof setTimeout> | undefined;
 
   try {
-    const compactionResult = await generateText({
+    const generationPromise = generateText({
       model: modelWithOptions.model,
       providerOptions: modelWithOptions.providerOptions,
       headers: modelWithOptions.headers,
@@ -105,6 +121,36 @@ const tryCompressWithModel = async (
       maxOutputTokens: 20000,
     }).then((result) => result.text.trim());
 
+    const timeoutResult = Symbol('history-compression-timeout');
+    const timeoutPromise = new Promise<typeof timeoutResult>((resolve) => {
+      timeout = setTimeout(() => {
+        abortController.abort();
+        resolve(timeoutResult);
+      }, HISTORY_COMPRESSION_TIMEOUT_MS);
+    });
+
+    const racedResult = await Promise.race([generationPromise, timeoutPromise]);
+
+    const compactionResult =
+      racedResult === timeoutResult
+        ? await Promise.race([
+            generationPromise.then(
+              (result) => ({ status: 'fulfilled' as const, result }),
+              (error) => ({ status: 'rejected' as const, error }),
+            ),
+            new Promise<{ status: 'pending' }>((resolve) => {
+              abortGraceTimeout = setTimeout(
+                () => resolve({ status: 'pending' }),
+                HISTORY_COMPRESSION_ABORT_GRACE_MS,
+              );
+            }),
+          ]).then((settled) => {
+            if (settled.status === 'fulfilled') return settled.result;
+            if (settled.status === 'rejected') throw settled.error;
+            throw new HistoryCompressionUnsettledTimeoutError(modelId);
+          })
+        : racedResult;
+
     if (compactionResult.length < COMPRESSION_MIN_LENGTH) {
       throw new Error(
         `Compression too short (${compactionResult.length} chars)`,
@@ -113,7 +159,8 @@ const tryCompressWithModel = async (
 
     return compactionResult;
   } finally {
-    clearTimeout(timeout);
+    if (timeout) clearTimeout(timeout);
+    if (abortGraceTimeout) clearTimeout(abortGraceTimeout);
   }
 };
 
@@ -146,6 +193,9 @@ export const generateSimpleCompressedHistory = async (
       );
     } catch (e) {
       lastError = e as Error;
+      if (lastError instanceof HistoryCompressionUnsettledTimeoutError) {
+        throw lastError;
+      }
       // Continue to the next fallback model
     }
   }
@@ -168,6 +218,9 @@ export const generateSimpleCompressedHistory = async (
       );
     } catch (e) {
       lastError = e as Error;
+      if (lastError instanceof HistoryCompressionUnsettledTimeoutError) {
+        throw lastError;
+      }
     }
   }
 

--- a/packages/agent-core/src/agents/shared/title-generation.test.ts
+++ b/packages/agent-core/src/agents/shared/title-generation.test.ts
@@ -78,7 +78,7 @@ describe('generateSimpleTitle', () => {
     expect(title).toBe('My Title');
     expect(generateTextMock).toHaveBeenCalledTimes(1);
     expect(hm.getWithOptions).toHaveBeenCalledWith(
-      'gemini-3.1-flash-lite-preview',
+      'gemini-3.1-flash-lite',
       'agent-1',
       expect.objectContaining({ $ai_span_name: 'title-generation' }),
     );
@@ -210,7 +210,7 @@ describe('generateSimpleTitle', () => {
     // First model attempted, then fallback
     expect(hm.getWithOptions).toHaveBeenNthCalledWith(
       1,
-      'gemini-3.1-flash-lite-preview',
+      'gemini-3.1-flash-lite',
       'agent-1',
       expect.any(Object),
     );
@@ -240,7 +240,7 @@ describe('generateSimpleTitle', () => {
     expect(generateTextMock).toHaveBeenCalledTimes(3);
     expect(hm.getWithOptions).toHaveBeenNthCalledWith(
       1,
-      'gemini-3.1-flash-lite-preview',
+      'gemini-3.1-flash-lite',
       'agent-1',
       expect.any(Object),
     );

--- a/packages/agent-core/src/agents/shared/title-generation/index.ts
+++ b/packages/agent-core/src/agents/shared/title-generation/index.ts
@@ -10,7 +10,7 @@ import { TITLE_GENERATION_SYSTEM_PROMPT } from './prompt';
  * tried in order when the previous one fails or times out.
  */
 const TITLE_GENERATION_MODELS = [
-  'gemini-3.1-flash-lite-preview',
+  'gemini-3.1-flash-lite',
   'gpt-5.4-nano',
   'claude-haiku-4.5',
 ] as const;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch helper model to `gemini-3.1-flash-lite` and add an abort grace period to stop fallbacks when timed-out requests don’t settle. Prevents hangs and background billing in history compression and title generation.

- **Bug Fixes**
  - Replace `gemini-3.1-flash-lite-preview` with `gemini-3.1-flash-lite` in `history-compression` and `title-generation` model lists and tests.
  - Add Promise.race timeout with abort, a 2s post-abort grace window, `HistoryCompressionUnsettledTimeoutError`, and timer cleanup; include tests to ensure no fallbacks start after an unsettled timeout.

<sup>Written for commit 11cbe7ed380212efddd47fc2a9023ec96ca08b11. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1299?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timeout and abort behavior for history compression and title generation so stalled attempts are detected and fail fast, ensuring more reliable results and timely cleanup.

* **Chores**
  * Switched fallback model references to the updated Gemini model variant used for generation flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->