### PR TITLE
feat(stagewise): add tutorial mode with step-by-step UI guides

### DIFF
--- a/apps/browser/src/backend/services/experience.ts
+++ b/apps/browser/src/backend/services/experience.ts
@@ -47,6 +47,9 @@ export class UserExperienceService extends DisposableService {
   private isLoadingStoredExperienceData = false;
   private hasInitializedStoredExperienceData = false;
 
+  // Serialize tutorial step writes to prevent races from fire-and-forget saves
+  private tutorialStepLock: Promise<void> = Promise.resolve();
+
   private constructor(
     logger: Logger,
     uiKarton: KartonService,
@@ -510,6 +513,16 @@ export class UserExperienceService extends DisposableService {
   }
 
   public async setTutorialStep(tutorialId: string, stepIndex: number) {
+    // Serialize writes to prevent concurrent read-modify-write races.
+    // The UI sends these fire-and-forget, so two rapid saves can otherwise
+    // read the same stale state and overwrite each other's progress.
+    const prev = this.tutorialStepLock;
+    let release: () => void;
+    this.tutorialStepLock = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    await prev;
+
     try {
       const currentState = await this.readTutorialState();
       currentState[tutorialId] = stepIndex;
@@ -527,6 +540,8 @@ export class UserExperienceService extends DisposableService {
         `[UserExperienceService] Failed to save tutorial step. Error: ${error}`,
       );
       this.report(error as Error, 'saveTutorialStep');
+    } finally {
+      release!();
     }
   }
 

--- a/apps/browser/src/backend/services/experience.ts
+++ b/apps/browser/src/backend/services/experience.ts
@@ -513,41 +513,40 @@ export class UserExperienceService extends DisposableService {
   }
 
   public async setTutorialStep(tutorialId: string, stepIndex: number) {
-    // Serialize writes to prevent concurrent read-modify-write races.
-    // The UI sends these fire-and-forget, so two rapid saves can otherwise
-    // read the same stale state and overwrite each other's progress.
-    const prev = this.tutorialStepLock;
-    let release: () => void;
-    this.tutorialStepLock = new Promise<void>((resolve) => {
-      release = resolve;
+    // Serialize writes by chaining onto the previous one. The UI sends
+    // these fire-and-forget, so two rapid saves can otherwise read the
+    // same stale state and drop each other's updates. Errors are handled
+    // inside the chained task, so the chain itself never rejects.
+    const run = this.tutorialStepLock.then(async () => {
+      try {
+        const currentState = await this.readTutorialState();
+        // Only move forward — never regress. An older fire-and-forget
+        // save can still arrive *after* a newer one, even when serialized.
+        currentState[tutorialId] = Math.max(
+          currentState[tutorialId] ?? stepIndex,
+          stepIndex,
+        );
+        await this.writeTutorialState(currentState);
+        // Patch only the tutorial slice — rebuilding the whole
+        // storedExperienceData object would hand new references to
+        // unrelated consumers (e.g. recently opened workspaces) and
+        // re-render them on every step advance.
+        this.uiKarton.setState((draft) => {
+          draft.userExperience.storedExperienceData.tutorialState =
+            currentState;
+        });
+        this.logger.debug(
+          `[UserExperienceService] Set tutorial ${tutorialId} step to: ${stepIndex}`,
+        );
+      } catch (error) {
+        this.logger.error(
+          `[UserExperienceService] Failed to save tutorial step. Error: ${error}`,
+        );
+        this.report(error as Error, 'saveTutorialStep');
+      }
     });
-    await prev;
-
-    try {
-      const currentState = await this.readTutorialState();
-      // Only move forward — never regress. An older fire-and-forget
-      // save can still arrive *after* a newer one, even with the lock.
-      currentState[tutorialId] = Math.max(
-        currentState[tutorialId] ?? stepIndex,
-        stepIndex,
-      );
-      await this.writeTutorialState(currentState);
-      // Update UI state with combined data
-      const storedData = await this.getStoredExperienceData();
-      this.uiKarton.setState((draft) => {
-        draft.userExperience.storedExperienceData = storedData;
-      });
-      this.logger.debug(
-        `[UserExperienceService] Set tutorial ${tutorialId} step to: ${stepIndex}`,
-      );
-    } catch (error) {
-      this.logger.error(
-        `[UserExperienceService] Failed to save tutorial step. Error: ${error}`,
-      );
-      this.report(error as Error, 'saveTutorialStep');
-    } finally {
-      release!();
-    }
+    this.tutorialStepLock = run;
+    await run;
   }
 
   private async pruneRecentlyOpenedWorkspaces({

--- a/apps/browser/src/backend/services/experience.ts
+++ b/apps/browser/src/backend/services/experience.ts
@@ -12,6 +12,7 @@ import path from 'node:path';
 import {
   recentlyOpenedWorkspacesArraySchema,
   onboardingStateSchema,
+  tutorialStateSchema,
   type StoredExperienceData,
   type RecentlyOpenedWorkspace,
 } from '@shared/karton-contracts/ui';
@@ -149,6 +150,15 @@ export class UserExperienceService extends DisposableService {
       },
     );
     this.uiKarton.registerServerProcedureHandler(
+      'userExperience.tutorial.setStep',
+      async (
+        _callingClientId: string,
+        { tutorialId, stepIndex }: { tutorialId: string; stepIndex: number },
+      ) => {
+        await this.setTutorialStep(tutorialId, stepIndex);
+      },
+    );
+    this.uiKarton.registerServerProcedureHandler(
       'userExperience.setHasSeenOnboardingFlow',
       async (
         _callingClientId: string,
@@ -176,6 +186,9 @@ export class UserExperienceService extends DisposableService {
     );
     this.uiKarton.removeServerProcedureHandler(
       'userExperience.setHasSeenOnboardingFlow',
+    );
+    this.uiKarton.removeServerProcedureHandler(
+      'userExperience.tutorial.setStep',
     );
     this.logger.debug('[UserExperienceService] Teardown complete');
   }
@@ -397,6 +410,22 @@ export class UserExperienceService extends DisposableService {
     });
   }
 
+  /**
+   * Read the tutorial state from persisted data.
+   */
+  private async readTutorialState(): Promise<Record<string, number>> {
+    return readPersistedData('tutorial-state', tutorialStateSchema, {});
+  }
+
+  /**
+   * Write the tutorial state to persisted data.
+   */
+  private async writeTutorialState(
+    state: Record<string, number>,
+  ): Promise<void> {
+    await writePersistedData('tutorial-state', tutorialStateSchema, state);
+  }
+
   public async saveRecentlyOpenedWorkspace({
     path: workspacePath,
     name,
@@ -437,13 +466,17 @@ export class UserExperienceService extends DisposableService {
    * This combines data from recently-opened-workspaces.json and onboarding-state.json.
    */
   public async getStoredExperienceData(): Promise<StoredExperienceData> {
-    const [recentlyOpenedWorkspaces, hasSeenOnboardingFlow] = await Promise.all(
-      [this.getRecentlyOpenedWorkspaces(), this.readOnboardingState()],
-    );
+    const [recentlyOpenedWorkspaces, hasSeenOnboardingFlow, tutorialState] =
+      await Promise.all([
+        this.getRecentlyOpenedWorkspaces(),
+        this.readOnboardingState(),
+        this.readTutorialState(),
+      ]);
     return {
       recentlyOpenedWorkspaces,
       hasSeenOnboardingFlow,
       lastViewedChats: {},
+      tutorialState,
     };
   }
 
@@ -473,6 +506,27 @@ export class UserExperienceService extends DisposableService {
         `[UserExperienceService] Failed to save hasSeenOnboardingFlow. Error: ${error}`,
       );
       this.report(error as Error, 'saveOnboardingState');
+    }
+  }
+
+  public async setTutorialStep(tutorialId: string, stepIndex: number) {
+    try {
+      const currentState = await this.readTutorialState();
+      currentState[tutorialId] = stepIndex;
+      await this.writeTutorialState(currentState);
+      // Update UI state with combined data
+      const storedData = await this.getStoredExperienceData();
+      this.uiKarton.setState((draft) => {
+        draft.userExperience.storedExperienceData = storedData;
+      });
+      this.logger.debug(
+        `[UserExperienceService] Set tutorial ${tutorialId} step to: ${stepIndex}`,
+      );
+    } catch (error) {
+      this.logger.error(
+        `[UserExperienceService] Failed to save tutorial step. Error: ${error}`,
+      );
+      this.report(error as Error, 'saveTutorialStep');
     }
   }
 

--- a/apps/browser/src/backend/services/experience.ts
+++ b/apps/browser/src/backend/services/experience.ts
@@ -525,7 +525,12 @@ export class UserExperienceService extends DisposableService {
 
     try {
       const currentState = await this.readTutorialState();
-      currentState[tutorialId] = stepIndex;
+      // Only move forward — never regress. An older fire-and-forget
+      // save can still arrive *after* a newer one, even with the lock.
+      currentState[tutorialId] = Math.max(
+        currentState[tutorialId] ?? stepIndex,
+        stepIndex,
+      );
       await this.writeTutorialState(currentState);
       // Update UI state with combined data
       const storedData = await this.getStoredExperienceData();

--- a/apps/browser/src/backend/utils/paths.ts
+++ b/apps/browser/src/backend/utils/paths.ts
@@ -36,7 +36,8 @@ export type JsonName =
   | 'onboarding-state'
   | 'downloads-state'
   | 'window-state'
-  | 'tab-state';
+  | 'tab-state'
+  | 'tutorial-state';
 
 export const getJsonPath = (name: JsonName): string =>
   path.join(getDataRoot(), `${name}.json`);

--- a/apps/browser/src/shared/karton-contracts/ui/index.ts
+++ b/apps/browser/src/shared/karton-contracts/ui/index.ts
@@ -383,12 +383,18 @@ export const downloadsStateSchema = z.object({
 
 export type DownloadsState = z.infer<typeof downloadsStateSchema>;
 
+/** Schema for tutorial state persisted data */
+export const tutorialStateSchema = z.record(z.string(), z.number());
+
+export type TutorialState = z.infer<typeof tutorialStateSchema>;
+
 export const lastViewedChatsSchema = z.record(z.string(), z.number());
 
 export const storedExperienceDataSchema = z.object({
   recentlyOpenedWorkspaces: recentlyOpenedWorkspacesArraySchema,
   hasSeenOnboardingFlow: z.boolean().nullable(),
   lastViewedChats: lastViewedChatsSchema,
+  tutorialState: tutorialStateSchema,
 });
 
 export type StoredExperienceData = z.infer<typeof storedExperienceDataSchema>;
@@ -1447,6 +1453,12 @@ export type KartonContract = {
             },
       ) => Promise<void>;
       clearPendingOnboardingSuggestion: () => Promise<void>;
+      tutorial: {
+        setStep: (input: {
+          tutorialId: string;
+          stepIndex: number;
+        }) => Promise<void>;
+      };
     };
     filePicker: {
       createRequest: (request: FilePickerRequest) => Promise<string[]>;
@@ -2023,6 +2035,7 @@ export const defaultState: KartonContract['state'] = {
       recentlyOpenedWorkspaces: [],
       hasSeenOnboardingFlow: null,
       lastViewedChats: {},
+      tutorialState: {},
     },
     pendingOnboardingSuggestion: null,
     devAppPreview: {

--- a/apps/browser/src/ui/components/context-providers.tsx
+++ b/apps/browser/src/ui/components/context-providers.tsx
@@ -5,6 +5,7 @@ import { TooltipProvider } from '@stagewise/stage-ui/components/tooltip';
 import { PostHogProvider } from '@ui/hooks/use-posthog';
 import { TabStateUIProvider } from '../hooks/use-tab-ui-state';
 import { ErrorBoundary } from './error-boundary';
+import { TutorialProvider } from '@ui/contexts/tutorial';
 
 export function ContextProviders({ children }: { children?: ReactNode }) {
   return (
@@ -12,9 +13,11 @@ export function ContextProviders({ children }: { children?: ReactNode }) {
       <KartonProvider>
         <PostHogProvider>
           <ErrorBoundary>
-            <MessageEditStateProvider>
-              <TabStateUIProvider>{children}</TabStateUIProvider>
-            </MessageEditStateProvider>
+            <TutorialProvider>
+              <MessageEditStateProvider>
+                <TabStateUIProvider>{children}</TabStateUIProvider>
+              </MessageEditStateProvider>
+            </TutorialProvider>
           </ErrorBoundary>
         </PostHogProvider>
       </KartonProvider>

--- a/apps/browser/src/ui/components/tutorial/index.ts
+++ b/apps/browser/src/ui/components/tutorial/index.ts
@@ -1,0 +1,2 @@
+export { Tutorial } from './tutorial';
+export { TutorialOverlay } from './tutorial-overlay';

--- a/apps/browser/src/ui/components/tutorial/tutorial-overlay.tsx
+++ b/apps/browser/src/ui/components/tutorial/tutorial-overlay.tsx
@@ -1,0 +1,430 @@
+import {
+  isValidElement,
+  useEffect,
+  useRef,
+  useState,
+  useCallback,
+  useMemo,
+} from 'react';
+import { createPortal } from 'react-dom';
+import ReactMarkdown from 'react-markdown';
+import { Button } from '@stagewise/stage-ui/components/button';
+import { useTutorial } from '@ui/contexts/tutorial';
+import { cn } from '@ui/utils';
+
+interface CutoutRect {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+  borderRadius: number;
+}
+
+function clamp(value: number, min: number): number {
+  return Math.max(value, min);
+}
+
+/**
+ * Compute the cutout rectangle from a target DOM element.
+ * Expands by 3px on all sides beyond the element's bounding rect.
+ */
+function getCutoutRect(el: HTMLElement): CutoutRect | null {
+  const rect = el.getBoundingClientRect();
+  if (rect.width === 0 || rect.height === 0) return null;
+
+  const style = getComputedStyle(el);
+  const parsedRadius = Number.parseFloat(style.borderRadius);
+  const elRadius = Number.isNaN(parsedRadius) ? 0 : parsedRadius;
+
+  return {
+    left: rect.left - 3,
+    top: rect.top - 3,
+    width: rect.width + 6,
+    height: rect.height + 6,
+    borderRadius: clamp(elRadius + 3, 0),
+  };
+}
+
+interface PopoverPosition {
+  left: number;
+  top: number;
+  origin: 'below' | 'above' | 'right' | 'left' | 'center';
+}
+
+function getPopoverPosition(
+  cutout: CutoutRect,
+  popoverWidth: number,
+  popoverHeight: number,
+): PopoverPosition {
+  const viewportWidth = window.innerWidth;
+  const viewportHeight = window.innerHeight;
+
+  // Prefer below the cutout
+  const belowTop = cutout.top + cutout.height + 12;
+  if (belowTop + popoverHeight <= viewportHeight) {
+    const left = clamp(cutout.left + (cutout.width - popoverWidth) / 2, 12);
+    return {
+      left: Math.min(left, viewportWidth - popoverWidth - 12),
+      top: belowTop,
+      origin: 'below',
+    };
+  }
+
+  // Fallback: above
+  const aboveTop = cutout.top - popoverHeight - 12;
+  if (aboveTop >= 0) {
+    const left = clamp(cutout.left + (cutout.width - popoverWidth) / 2, 12);
+    return {
+      left: Math.min(left, viewportWidth - popoverWidth - 12),
+      top: aboveTop,
+      origin: 'above',
+    };
+  }
+
+  // Fallback: right
+  const rightLeft = cutout.left + cutout.width + 12;
+  if (rightLeft + popoverWidth <= viewportWidth) {
+    const top = clamp(cutout.top + (cutout.height - popoverHeight) / 2, 12);
+    return {
+      left: rightLeft,
+      top: Math.min(top, viewportHeight - popoverHeight - 12),
+      origin: 'right',
+    };
+  }
+
+  // Fallback: left
+  const leftLeft = cutout.left - popoverWidth - 12;
+  const top = clamp(cutout.top + (cutout.height - popoverHeight) / 2, 12);
+  return {
+    left: clamp(leftLeft, 12),
+    top: Math.min(top, viewportHeight - popoverHeight - 12),
+    origin: 'left',
+  };
+}
+
+function getNodeText(children?: React.ReactNode): string {
+  if (children == null || typeof children === 'boolean') return '';
+  if (typeof children === 'string' || typeof children === 'number') {
+    return String(children);
+  }
+  if (Array.isArray(children)) {
+    return children.map((child) => getNodeText(child)).join('');
+  }
+  if (isValidElement(children)) {
+    const props = children.props as { children?: React.ReactNode };
+    return getNodeText(props.children);
+  }
+  return '';
+}
+
+function getStrongTextColorClass(children?: React.ReactNode): string {
+  switch (getNodeText(children).trim().toLowerCase()) {
+    case 'green':
+      return 'text-success-foreground';
+    case 'yellow':
+      return 'text-warning-foreground';
+    case 'blue':
+      return 'text-primary-foreground';
+    case 'red':
+      return 'text-error-foreground';
+    default:
+      return 'text-foreground';
+  }
+}
+
+/** Minimal markdown components for tutorial descriptions */
+const TUTORIAL_MD_COMPONENTS = {
+  p: ({ children }: { children?: React.ReactNode }) => (
+    <p className="mb-1 text-muted-foreground text-sm leading-relaxed last:mb-0">
+      {children}
+    </p>
+  ),
+  strong: ({ children }: { children?: React.ReactNode }) => (
+    <strong className={cn('font-semibold', getStrongTextColorClass(children))}>
+      {children}
+    </strong>
+  ),
+  em: ({ children }: { children?: React.ReactNode }) => (
+    <em className="italic">{children}</em>
+  ),
+  code: ({ children }: { children?: React.ReactNode }) => (
+    <code className="rounded bg-surface-2 px-1 py-px font-mono text-xs">
+      {children}
+    </code>
+  ),
+  a: ({ href, children }: { href?: string; children?: React.ReactNode }) => (
+    <a
+      href={href}
+      className="text-primary-foreground underline hover:no-underline"
+      target="_blank"
+      rel="noreferrer"
+    >
+      {children}
+    </a>
+  ),
+  ul: ({ children }: { children?: React.ReactNode }) => (
+    <ul className="mt-2 space-y-0.5 pl-4 text-muted-foreground text-xs">
+      {children}
+    </ul>
+  ),
+  li: ({ children }: { children?: React.ReactNode }) => (
+    <li className="leading-snug">{children}</li>
+  ),
+};
+
+function StepDescription({ children }: { children: string }) {
+  return (
+    <ReactMarkdown components={TUTORIAL_MD_COMPONENTS}>
+      {children}
+    </ReactMarkdown>
+  );
+}
+
+export function TutorialOverlay() {
+  const {
+    activeTutorial,
+    currentStep,
+    currentStepIndex,
+    totalSteps,
+    goNext,
+    goBack,
+    dismissTutorial,
+  } = useTutorial();
+
+  const popoverRef = useRef<HTMLDivElement>(null);
+  const [cutoutRect, setCutoutRect] = useState<CutoutRect | null>(null);
+  const [popoverPos, setPopoverPos] = useState<PopoverPosition | null>(null);
+
+  const recalc = useCallback(() => {
+    if (!currentStep) {
+      setCutoutRect(null);
+      setPopoverPos(null);
+      return;
+    }
+
+    const targetEl = document.querySelector<HTMLElement>(
+      currentStep.targetSelector,
+    );
+    if (!targetEl) {
+      const popoverEl = popoverRef.current;
+      const pw = popoverEl?.offsetWidth ?? 320;
+      const ph = popoverEl?.offsetHeight ?? 200;
+      setCutoutRect(null);
+      setPopoverPos({
+        left: Math.max((window.innerWidth - pw) / 2, 12),
+        top: Math.max((window.innerHeight - ph) / 2, 12),
+        origin: 'center',
+      });
+      return;
+    }
+
+    const rect = getCutoutRect(targetEl);
+    if (!rect) {
+      const popoverEl = popoverRef.current;
+      const pw = popoverEl?.offsetWidth ?? 320;
+      const ph = popoverEl?.offsetHeight ?? 200;
+      setCutoutRect(null);
+      setPopoverPos({
+        left: Math.max((window.innerWidth - pw) / 2, 12),
+        top: Math.max((window.innerHeight - ph) / 2, 12),
+        origin: 'center',
+      });
+      return;
+    }
+
+    setCutoutRect(rect);
+
+    // Compute popover position after layout settles
+    // Use the popover element's measured size if available, else estimate
+    const popoverEl = popoverRef.current;
+    const pw = popoverEl?.offsetWidth ?? 320;
+    const ph = popoverEl?.offsetHeight ?? 200;
+    setPopoverPos(getPopoverPosition(rect, pw, ph));
+  }, [currentStep]);
+
+  // Recalculate on step change, resize, scroll, and DOM mutations
+  useEffect(() => {
+    recalc();
+
+    const onResizeOrScroll = () => recalc();
+    window.addEventListener('resize', onResizeOrScroll, { passive: true });
+    window.addEventListener('scroll', onResizeOrScroll, {
+      passive: true,
+      capture: true,
+    });
+
+    // Watch for DOM changes so we detect when the target element appears
+    // dynamically (e.g. inside a popover that just opened).
+    const observer = new MutationObserver(() => recalc());
+    observer.observe(document.body, {
+      childList: true,
+      subtree: true,
+    });
+
+    return () => {
+      window.removeEventListener('resize', onResizeOrScroll);
+      window.removeEventListener('scroll', onResizeOrScroll, { capture: true });
+      observer.disconnect();
+    };
+  }, [recalc]);
+
+  // Recalculate popover position once the popover element is measured
+  useEffect(() => {
+    if (!cutoutRect || !popoverRef.current) return;
+    const el = popoverRef.current;
+    const pw = el.offsetWidth;
+    const ph = el.offsetHeight;
+    setPopoverPos(getPopoverPosition(cutoutRect, pw, ph));
+  }, [cutoutRect]);
+
+  // Keyboard navigation
+  useEffect(() => {
+    if (!activeTutorial) return;
+
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        dismissTutorial();
+      } else if (e.key === 'ArrowRight') {
+        goNext();
+      } else if (e.key === 'ArrowLeft') {
+        goBack();
+      }
+    };
+
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [activeTutorial, goNext, goBack, dismissTutorial]);
+
+  const isLastStep = currentStepIndex >= totalSteps - 1;
+  const isSingleStepTutorial = totalSteps <= 1;
+
+  const content = useMemo(() => {
+    if (!activeTutorial || !currentStep) return null;
+
+    return (
+      <div className="pointer-events-none fixed inset-0 z-[9999]">
+        {/* Full-screen click shield — blocks interactivity behind the tutorial */}
+        <div className="pointer-events-auto absolute inset-0 bg-transparent" />
+
+        {/* Cutout element */}
+        {cutoutRect && (
+          <div
+            className="pointer-events-none absolute"
+            style={{
+              left: cutoutRect.left,
+              top: cutoutRect.top,
+              width: cutoutRect.width,
+              height: cutoutRect.height,
+              borderRadius: cutoutRect.borderRadius,
+              boxShadow:
+                '0 0 0 2px var(--color-primary-solid), 0 0 10px 4px oklch(from var(--color-primary-solid) l c h / 0.4), 0 0 0 9999px rgb(0 0 0 / 0.5)',
+            }}
+          />
+        )}
+
+        {/* Fallback overlay when no target element */}
+        {!cutoutRect && (
+          <div className="pointer-events-none absolute inset-0 bg-black/50" />
+        )}
+
+        {/* Popover */}
+        {popoverPos && (
+          <div
+            ref={popoverRef}
+            className={cn(
+              'pointer-events-auto absolute w-80 rounded-xl bg-background p-2.5',
+              'border border-derived shadow-elevation-2',
+            )}
+            style={{
+              left: popoverPos.left,
+              top: popoverPos.top,
+            }}
+          >
+            {!isSingleStepTutorial && (
+              <>
+                {/* Close Button */}
+                <Button
+                  variant="ghost"
+                  size="icon-sm"
+                  onClick={dismissTutorial}
+                  aria-label="Close tutorial"
+                  className="absolute top-2 right-2 z-10"
+                >
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    width="16"
+                    height="16"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  >
+                    <path d="M18 6 6 18" />
+                    <path d="m6 6 12 12" />
+                  </svg>
+                </Button>
+              </>
+            )}
+
+            {/* Title */}
+            <h3 className="mb-2 font-semibold text-foreground text-sm">
+              {currentStep.title}
+            </h3>
+
+            {/* Description */}
+            <div className="mb-3">
+              <StepDescription>{currentStep.description}</StepDescription>
+            </div>
+
+            {/* Footer */}
+            <div className="flex items-center justify-between gap-2">
+              {!isSingleStepTutorial ? (
+                <p className="text-muted-foreground text-xs">
+                  {currentStepIndex + 1}/{totalSteps}
+                </p>
+              ) : (
+                <div />
+              )}
+              <div className="flex items-center justify-end gap-2">
+                {!isSingleStepTutorial && (
+                  <Button
+                    variant="secondary"
+                    size="sm"
+                    disabled={currentStepIndex === 0}
+                    onClick={goBack}
+                  >
+                    Back
+                  </Button>
+                )}
+                <Button variant="primary" size="sm" onClick={goNext}>
+                  {isSingleStepTutorial
+                    ? 'Okay'
+                    : isLastStep
+                      ? 'Finish'
+                      : 'Next'}
+                </Button>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+    );
+  }, [
+    activeTutorial,
+    currentStep,
+    cutoutRect,
+    popoverPos,
+    currentStepIndex,
+    totalSteps,
+    isLastStep,
+    goNext,
+    goBack,
+    dismissTutorial,
+  ]);
+
+  if (!activeTutorial) return null;
+
+  return createPortal(content, document.body);
+}

--- a/apps/browser/src/ui/components/tutorial/tutorial-overlay.tsx
+++ b/apps/browser/src/ui/components/tutorial/tutorial-overlay.tsx
@@ -9,8 +9,23 @@ import {
 import { createPortal } from 'react-dom';
 import ReactMarkdown from 'react-markdown';
 import { Button } from '@stagewise/stage-ui/components/button';
+import { IconXmarkFill18 } from 'nucleo-ui-fill-18';
 import { useTutorial } from '@ui/contexts/tutorial';
 import { cn } from '@ui/utils';
+
+// How long to wait for a step's target element before skipping the step.
+// Guards against stale selectors locking the UI behind the click shield.
+const MISSING_TARGET_SKIP_MS = 3000;
+
+function isEditableTarget(target: EventTarget | null): boolean {
+  return (
+    target instanceof HTMLElement &&
+    (target.isContentEditable ||
+      target.tagName === 'INPUT' ||
+      target.tagName === 'TEXTAREA' ||
+      target.tagName === 'SELECT')
+  );
+}
 
 interface CutoutRect {
   left: number;
@@ -28,6 +43,16 @@ function clamp(value: number, min: number): number {
  * Compute the cutout rectangle from a target DOM element.
  * Expands by 3px on all sides beyond the element's bounding rect.
  */
+function cutoutRectsEqual(a: CutoutRect, b: CutoutRect): boolean {
+  return (
+    a.left === b.left &&
+    a.top === b.top &&
+    a.width === b.width &&
+    a.height === b.height &&
+    a.borderRadius === b.borderRadius
+  );
+}
+
 function getCutoutRect(el: HTMLElement): CutoutRect | null {
   const rect = el.getBoundingClientRect();
   if (rect.width === 0 || rect.height === 0) return null;
@@ -195,12 +220,14 @@ export function TutorialOverlay() {
     totalSteps,
     goNext,
     goBack,
+    skipCurrentStep,
     dismissTutorial,
   } = useTutorial();
 
   const popoverRef = useRef<HTMLDivElement>(null);
   const [cutoutRect, setCutoutRect] = useState<CutoutRect | null>(null);
   const [popoverPos, setPopoverPos] = useState<PopoverPosition | null>(null);
+  const [targetMissing, setTargetMissing] = useState(false);
 
   const recalc = useCallback(() => {
     if (!currentStep) {
@@ -212,41 +239,38 @@ export function TutorialOverlay() {
     const targetEl = document.querySelector<HTMLElement>(
       currentStep.targetSelector,
     );
-    if (!targetEl) {
-      const popoverEl = popoverRef.current;
-      const pw = popoverEl?.offsetWidth ?? 320;
-      const ph = popoverEl?.offsetHeight ?? 200;
-      setCutoutRect(null);
-      setPopoverPos({
-        left: Math.max((window.innerWidth - pw) / 2, 12),
-        top: Math.max((window.innerHeight - ph) / 2, 12),
-        origin: 'center',
-      });
-      return;
-    }
-
-    const rect = getCutoutRect(targetEl);
+    const rect = targetEl ? getCutoutRect(targetEl) : null;
     if (!rect) {
-      const popoverEl = popoverRef.current;
-      const pw = popoverEl?.offsetWidth ?? 320;
-      const ph = popoverEl?.offsetHeight ?? 200;
+      // Don't render a shield/popover for a missing target — that would
+      // lock the whole UI. The skip timer below advances past the step.
       setCutoutRect(null);
-      setPopoverPos({
-        left: Math.max((window.innerWidth - pw) / 2, 12),
-        top: Math.max((window.innerHeight - ph) / 2, 12),
-        origin: 'center',
-      });
+      setPopoverPos(null);
+      setTargetMissing(true);
       return;
     }
+    setTargetMissing(false);
 
-    setCutoutRect(rect);
+    // Guard against no-op updates: recalc runs on every body mutation
+    // (e.g. chat streaming), and fresh object identities would re-render
+    // the overlay continuously.
+    setCutoutRect((prev) =>
+      prev && cutoutRectsEqual(prev, rect) ? prev : rect,
+    );
 
     // Compute popover position after layout settles
     // Use the popover element's measured size if available, else estimate
     const popoverEl = popoverRef.current;
     const pw = popoverEl?.offsetWidth ?? 320;
     const ph = popoverEl?.offsetHeight ?? 200;
-    setPopoverPos(getPopoverPosition(rect, pw, ph));
+    const pos = getPopoverPosition(rect, pw, ph);
+    setPopoverPos((prev) =>
+      prev &&
+      prev.left === pos.left &&
+      prev.top === pos.top &&
+      prev.origin === pos.origin
+        ? prev
+        : pos,
+    );
   }, [currentStep]);
 
   // Recalculate on step change, resize, scroll, and DOM mutations
@@ -290,10 +314,39 @@ export function TutorialOverlay() {
   useEffect(() => {
     if (!cutoutRect || !popoverRef.current) return;
     const el = popoverRef.current;
-    const pw = el.offsetWidth;
-    const ph = el.offsetHeight;
-    setPopoverPos(getPopoverPosition(cutoutRect, pw, ph));
+    const pos = getPopoverPosition(cutoutRect, el.offsetWidth, el.offsetHeight);
+    setPopoverPos((prev) =>
+      prev &&
+      prev.left === pos.left &&
+      prev.top === pos.top &&
+      prev.origin === pos.origin
+        ? prev
+        : pos,
+    );
   }, [cutoutRect]);
+
+  // Auto-skip steps whose target element never appears. Without this, a
+  // stale selector would block the UI behind the click shield forever.
+  useEffect(() => {
+    if (!activeTutorial || !targetMissing) return;
+    const timeout = window.setTimeout(
+      () => skipCurrentStep(),
+      MISSING_TARGET_SKIP_MS,
+    );
+    return () => window.clearTimeout(timeout);
+  }, [activeTutorial, targetMissing, currentStepIndex, skipCurrentStep]);
+
+  // Move focus into the popover once per step so keyboard interaction
+  // targets the tutorial instead of whatever was focused before (e.g. the
+  // chat input — otherwise arrow keys would be swallowed while typing).
+  const lastFocusKeyRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!activeTutorial || !popoverPos || !popoverRef.current) return;
+    const key = `${activeTutorial.id}:${currentStepIndex}`;
+    if (lastFocusKeyRef.current === key) return;
+    lastFocusKeyRef.current = key;
+    popoverRef.current.focus({ preventScroll: true });
+  }, [activeTutorial, currentStepIndex, popoverPos]);
 
   // Keyboard navigation
   useEffect(() => {
@@ -304,7 +357,36 @@ export function TutorialOverlay() {
         e.preventDefault();
         e.stopPropagation();
         dismissTutorial();
-      } else if (e.key === 'ArrowRight') {
+        return;
+      }
+      if (e.key === 'Tab') {
+        // Trap focus inside the popover — the click shield blocks pointer
+        // events, but Tab would otherwise reach the obscured UI behind it.
+        const popover = popoverRef.current;
+        if (!popover) return;
+        const focusables = popover.querySelectorAll<HTMLElement>(
+          'button:not([disabled]), a[href]',
+        );
+        const first = focusables[0];
+        const last = focusables[focusables.length - 1];
+        if (!first || !last) return;
+        const active = document.activeElement;
+        if (!popover.contains(active)) {
+          e.preventDefault();
+          first.focus();
+        } else if (e.shiftKey && active === first) {
+          e.preventDefault();
+          last.focus();
+        } else if (!e.shiftKey && active === last) {
+          e.preventDefault();
+          first.focus();
+        }
+        return;
+      }
+      // Don't hijack arrow keys while the user is typing in an editable
+      // element (cursor movement must keep working).
+      if (isEditableTarget(e.target)) return;
+      if (e.key === 'ArrowRight') {
         e.preventDefault();
         e.stopPropagation();
         goNext();
@@ -323,7 +405,9 @@ export function TutorialOverlay() {
   const isSingleStepTutorial = totalSteps <= 1;
 
   const content = useMemo(() => {
-    if (!activeTutorial || !currentStep) return null;
+    // While the target is missing, render nothing — no shield, no popover.
+    // The auto-skip timer advances past the step if it never appears.
+    if (!activeTutorial || !currentStep || !cutoutRect) return null;
 
     return (
       <div className="pointer-events-none fixed inset-0 z-[9999]">
@@ -331,32 +415,29 @@ export function TutorialOverlay() {
         <div className="pointer-events-auto absolute inset-0 bg-transparent" />
 
         {/* Cutout element */}
-        {cutoutRect && (
-          <div
-            className="pointer-events-none absolute"
-            style={{
-              left: cutoutRect.left,
-              top: cutoutRect.top,
-              width: cutoutRect.width,
-              height: cutoutRect.height,
-              borderRadius: cutoutRect.borderRadius,
-              boxShadow:
-                '0 0 0 2px var(--color-primary-solid), 0 0 10px 4px oklch(from var(--color-primary-solid) l c h / 0.4), 0 0 0 9999px rgb(0 0 0 / 0.5)',
-            }}
-          />
-        )}
-
-        {/* Fallback overlay when no target element */}
-        {!cutoutRect && (
-          <div className="pointer-events-none absolute inset-0 bg-black/50" />
-        )}
+        <div
+          className="pointer-events-none absolute"
+          style={{
+            left: cutoutRect.left,
+            top: cutoutRect.top,
+            width: cutoutRect.width,
+            height: cutoutRect.height,
+            borderRadius: cutoutRect.borderRadius,
+            boxShadow:
+              '0 0 0 2px var(--color-primary-solid), 0 0 10px 4px oklch(from var(--color-primary-solid) l c h / 0.4), 0 0 0 9999px rgb(0 0 0 / 0.5)',
+          }}
+        />
 
         {/* Popover */}
         {popoverPos && (
           <div
             ref={popoverRef}
+            role="dialog"
+            aria-modal="true"
+            aria-label={currentStep.title}
+            tabIndex={-1}
             className={cn(
-              'pointer-events-auto absolute w-80 rounded-xl bg-background p-2.5',
+              'pointer-events-auto absolute w-80 rounded-xl bg-background p-2.5 outline-none',
               'border border-derived shadow-elevation-2',
             )}
             style={{
@@ -365,31 +446,15 @@ export function TutorialOverlay() {
             }}
           >
             {!isSingleStepTutorial && (
-              <>
-                {/* Close Button */}
-                <Button
-                  variant="ghost"
-                  size="icon-sm"
-                  onClick={dismissTutorial}
-                  aria-label="Close tutorial"
-                  className="absolute top-2 right-2 z-10"
-                >
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    width="16"
-                    height="16"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="2"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                  >
-                    <path d="M18 6 6 18" />
-                    <path d="m6 6 12 12" />
-                  </svg>
-                </Button>
-              </>
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                onClick={dismissTutorial}
+                aria-label="Close tutorial"
+                className="absolute top-2 right-2 z-10"
+              >
+                <IconXmarkFill18 className="size-4" />
+              </Button>
             )}
 
             {/* Title */}

--- a/apps/browser/src/ui/components/tutorial/tutorial-overlay.tsx
+++ b/apps/browser/src/ui/components/tutorial/tutorial-overlay.tsx
@@ -262,7 +262,17 @@ export function TutorialOverlay() {
 
     // Watch for DOM changes so we detect when the target element appears
     // dynamically (e.g. inside a popover that just opened).
-    const observer = new MutationObserver(() => recalc());
+    // Throttled via requestAnimationFrame to avoid expensive recalculations
+    // during high-frequency DOM mutations (e.g. chat streaming).
+    let rafId: number | null = null;
+    const observer = new MutationObserver(() => {
+      if (rafId === null) {
+        rafId = requestAnimationFrame(() => {
+          rafId = null;
+          recalc();
+        });
+      }
+    });
     observer.observe(document.body, {
       childList: true,
       subtree: true,
@@ -271,6 +281,7 @@ export function TutorialOverlay() {
     return () => {
       window.removeEventListener('resize', onResizeOrScroll);
       window.removeEventListener('scroll', onResizeOrScroll, { capture: true });
+      if (rafId !== null) cancelAnimationFrame(rafId);
       observer.disconnect();
     };
   }, [recalc]);
@@ -290,10 +301,16 @@ export function TutorialOverlay() {
 
     const onKeyDown = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
+        e.preventDefault();
+        e.stopPropagation();
         dismissTutorial();
       } else if (e.key === 'ArrowRight') {
+        e.preventDefault();
+        e.stopPropagation();
         goNext();
       } else if (e.key === 'ArrowLeft') {
+        e.preventDefault();
+        e.stopPropagation();
         goBack();
       }
     };

--- a/apps/browser/src/ui/components/tutorial/tutorial-overlay.tsx
+++ b/apps/browser/src/ui/components/tutorial/tutorial-overlay.tsx
@@ -59,12 +59,23 @@ function getPopoverPosition(
   const viewportWidth = window.innerWidth;
   const viewportHeight = window.innerHeight;
 
+  // Clamp a position to keep the popover fully inside the viewport.
+  // Uses clamp() for the lower bound and Math.max for the upper bound
+  // to prevent the popover from being pushed offscreen when the viewport
+  // is narrower than the popover plus margins.
+  const clampX = (x: number) =>
+    Math.min(Math.max(x, 12), Math.max(12, viewportWidth - popoverWidth - 12));
+  const clampY = (y: number) =>
+    Math.min(
+      Math.max(y, 12),
+      Math.max(12, viewportHeight - popoverHeight - 12),
+    );
+
   // Prefer below the cutout
   const belowTop = cutout.top + cutout.height + 12;
   if (belowTop + popoverHeight <= viewportHeight) {
-    const left = clamp(cutout.left + (cutout.width - popoverWidth) / 2, 12);
     return {
-      left: Math.min(left, viewportWidth - popoverWidth - 12),
+      left: clampX(cutout.left + (cutout.width - popoverWidth) / 2),
       top: belowTop,
       origin: 'below',
     };
@@ -73,9 +84,8 @@ function getPopoverPosition(
   // Fallback: above
   const aboveTop = cutout.top - popoverHeight - 12;
   if (aboveTop >= 0) {
-    const left = clamp(cutout.left + (cutout.width - popoverWidth) / 2, 12);
     return {
-      left: Math.min(left, viewportWidth - popoverWidth - 12),
+      left: clampX(cutout.left + (cutout.width - popoverWidth) / 2),
       top: aboveTop,
       origin: 'above',
     };
@@ -84,20 +94,17 @@ function getPopoverPosition(
   // Fallback: right
   const rightLeft = cutout.left + cutout.width + 12;
   if (rightLeft + popoverWidth <= viewportWidth) {
-    const top = clamp(cutout.top + (cutout.height - popoverHeight) / 2, 12);
     return {
       left: rightLeft,
-      top: Math.min(top, viewportHeight - popoverHeight - 12),
+      top: clampY(cutout.top + (cutout.height - popoverHeight) / 2),
       origin: 'right',
     };
   }
 
   // Fallback: left
-  const leftLeft = cutout.left - popoverWidth - 12;
-  const top = clamp(cutout.top + (cutout.height - popoverHeight) / 2, 12);
   return {
-    left: clamp(leftLeft, 12),
-    top: Math.min(top, viewportHeight - popoverHeight - 12),
+    left: clampX(cutout.left - popoverWidth - 12),
+    top: clampY(cutout.top + (cutout.height - popoverHeight) / 2),
     origin: 'left',
   };
 }

--- a/apps/browser/src/ui/components/tutorial/tutorial.tsx
+++ b/apps/browser/src/ui/components/tutorial/tutorial.tsx
@@ -1,0 +1,36 @@
+import { useEffect } from 'react';
+import { useTutorial } from '@ui/contexts/tutorial';
+import type { TutorialStep } from '@ui/contexts/tutorial';
+
+interface TutorialProps {
+  /** Unique identifier for this tutorial */
+  tutorialId: string;
+  /** Ordered list of steps */
+  steps: TutorialStep[];
+  /** Whether this tutorial is currently eligible to run */
+  enabled?: boolean;
+}
+
+/**
+ * Place this component inside a feature's render tree. When the feature
+ * renders and the tutorial hasn't been completed, it registers with the
+ * TutorialProvider to show the tutorial overlay.
+ *
+ * Renders nothing — it's purely a trigger.
+ */
+export function Tutorial({ tutorialId, steps, enabled = true }: TutorialProps) {
+  const { activeTutorial, hideTutorial, registerTutorial } = useTutorial();
+
+  useEffect(() => {
+    if (!enabled) return;
+    registerTutorial({ id: tutorialId, steps });
+  }, [enabled, tutorialId, steps, registerTutorial]);
+
+  useEffect(() => {
+    if (!enabled && activeTutorial?.id === tutorialId) {
+      hideTutorial();
+    }
+  }, [enabled, activeTutorial, tutorialId, hideTutorial]);
+
+  return null;
+}

--- a/apps/browser/src/ui/components/tutorial/tutorial.tsx
+++ b/apps/browser/src/ui/components/tutorial/tutorial.tsx
@@ -19,7 +19,8 @@ interface TutorialProps {
  * Renders nothing — it's purely a trigger.
  */
 export function Tutorial({ tutorialId, steps, enabled = true }: TutorialProps) {
-  const { activeTutorial, hideTutorial, registerTutorial } = useTutorial();
+  const { activeTutorial, hideTutorial, registerTutorial, unregisterTutorial } =
+    useTutorial();
 
   useEffect(() => {
     if (!enabled) return;
@@ -31,6 +32,17 @@ export function Tutorial({ tutorialId, steps, enabled = true }: TutorialProps) {
       hideTutorial();
     }
   }, [enabled, activeTutorial, tutorialId, hideTutorial]);
+
+  // Unregister when this tutorial's source unmounts — prevents queued
+  // tutorials from starting after their trigger UI is gone.
+  useEffect(() => {
+    return () => unregisterTutorial(tutorialId);
+  }, [tutorialId, unregisterTutorial]);
+
+  // Also unregister when enabled becomes false (clean up queue entry)
+  useEffect(() => {
+    if (!enabled) unregisterTutorial(tutorialId);
+  }, [enabled, tutorialId, unregisterTutorial]);
 
   return null;
 }

--- a/apps/browser/src/ui/components/tutorial/tutorial.tsx
+++ b/apps/browser/src/ui/components/tutorial/tutorial.tsx
@@ -1,12 +1,14 @@
 import { useEffect, useRef } from 'react';
 import { useTutorial } from '@ui/contexts/tutorial';
-import type { TutorialStep } from '@ui/contexts/tutorial';
+import {
+  TUTORIALS,
+  TUTORIAL_PRIORITY,
+  type TutorialId,
+} from '@ui/tutorial-steps';
 
 interface TutorialProps {
-  /** Unique identifier for this tutorial */
-  tutorialId: string;
-  /** Ordered list of steps */
-  steps: TutorialStep[];
+  /** Which tutorial to trigger — steps and version come from `TUTORIALS` */
+  tutorialId: TutorialId;
   /** Whether this tutorial is currently eligible to run */
   enabled?: boolean;
 }
@@ -18,7 +20,7 @@ interface TutorialProps {
  *
  * Renders nothing — it's purely a trigger.
  */
-export function Tutorial({ tutorialId, steps, enabled = true }: TutorialProps) {
+export function Tutorial({ tutorialId, enabled = true }: TutorialProps) {
   const { activeTutorial, hideTutorial, registerTutorial, unregisterTutorial } =
     useTutorial();
 
@@ -33,8 +35,14 @@ export function Tutorial({ tutorialId, steps, enabled = true }: TutorialProps) {
 
   useEffect(() => {
     if (!enabled) return;
-    registerRef.current({ id: tutorialId, steps });
-  }, [enabled, tutorialId, steps]);
+    const content = TUTORIALS[tutorialId];
+    registerRef.current({
+      id: tutorialId,
+      version: content.version,
+      steps: content.steps,
+      priority: TUTORIAL_PRIORITY.indexOf(tutorialId),
+    });
+  }, [enabled, tutorialId]);
 
   useEffect(() => {
     if (!enabled && activeTutorial?.id === tutorialId) {

--- a/apps/browser/src/ui/components/tutorial/tutorial.tsx
+++ b/apps/browser/src/ui/components/tutorial/tutorial.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { useTutorial } from '@ui/contexts/tutorial';
 import type { TutorialStep } from '@ui/contexts/tutorial';
 
@@ -22,27 +22,36 @@ export function Tutorial({ tutorialId, steps, enabled = true }: TutorialProps) {
   const { activeTutorial, hideTutorial, registerTutorial, unregisterTutorial } =
     useTutorial();
 
+  // Ref-stabilize callbacks so effect cleanups don't re-run when provider
+  // state changes (e.g. tutorial progress updates) give them new identities.
+  const unregisterRef = useRef(unregisterTutorial);
+  unregisterRef.current = unregisterTutorial;
+  const hideRef = useRef(hideTutorial);
+  hideRef.current = hideTutorial;
+  const registerRef = useRef(registerTutorial);
+  registerRef.current = registerTutorial;
+
   useEffect(() => {
     if (!enabled) return;
-    registerTutorial({ id: tutorialId, steps });
-  }, [enabled, tutorialId, steps, registerTutorial]);
+    registerRef.current({ id: tutorialId, steps });
+  }, [enabled, tutorialId, steps]);
 
   useEffect(() => {
     if (!enabled && activeTutorial?.id === tutorialId) {
-      hideTutorial();
+      hideRef.current();
     }
-  }, [enabled, activeTutorial, tutorialId, hideTutorial]);
+  }, [enabled, activeTutorial, tutorialId]);
 
   // Unregister when this tutorial's source unmounts — prevents queued
   // tutorials from starting after their trigger UI is gone.
   useEffect(() => {
-    return () => unregisterTutorial(tutorialId);
-  }, [tutorialId, unregisterTutorial]);
+    return () => unregisterRef.current(tutorialId);
+  }, [tutorialId]);
 
   // Also unregister when enabled becomes false (clean up queue entry)
   useEffect(() => {
-    if (!enabled) unregisterTutorial(tutorialId);
-  }, [enabled, tutorialId, unregisterTutorial]);
+    if (!enabled) unregisterRef.current(tutorialId);
+  }, [enabled, tutorialId]);
 
   return null;
 }

--- a/apps/browser/src/ui/contexts/index.ts
+++ b/apps/browser/src/ui/contexts/index.ts
@@ -11,3 +11,9 @@ export {
   type AccessHandle,
   type Registration,
 } from './web-contents-overlay';
+
+export {
+  TutorialProvider,
+  useTutorial,
+} from './tutorial';
+export type { TutorialStep, TutorialDefinition } from './tutorial';

--- a/apps/browser/src/ui/contexts/tutorial/context.tsx
+++ b/apps/browser/src/ui/contexts/tutorial/context.tsx
@@ -10,7 +10,16 @@ import {
 } from 'react';
 import { useKartonState, useKartonProcedure } from '@ui/hooks/use-karton';
 import type { TutorialDefinition, TutorialStep } from './types';
+import {
+  getTutorialStorageKey,
+  getTutorialStartIndex,
+  insertQueuedTutorial,
+  isTutorialCompleted,
+  takeNextEligibleTutorial,
+} from './tutorial-logic';
 
+// Tutorials explicitly dismissed or completed in this app session.
+// Module-level so a provider remount doesn't resurface them.
 const sessionDismissedTutorialIds = new Set<string>();
 
 interface TutorialContextValue {
@@ -28,7 +37,14 @@ interface TutorialContextValue {
   goNext: () => void;
   /** Go to the previous step */
   goBack: () => void;
-  /** Dismiss the current tutorial (saves progress) */
+  /**
+   * Skip the current step without persisting progress. Used when a step's
+   * target element cannot be found, so the user never gets steps marked as
+   * seen that were never shown. Skipping past the last step hides the
+   * tutorial (it stays eligible for a future session).
+   */
+  skipCurrentStep: () => void;
+  /** Dismiss the current tutorial permanently (persists completion) */
   dismissTutorial: () => void;
   /** Hide the current tutorial without changing persisted progress */
   hideTutorial: () => void;
@@ -61,29 +77,46 @@ export function TutorialProvider({ children }: { children?: ReactNode }) {
     useState<TutorialDefinition | null>(null);
   const [currentStepIndex, setCurrentStepIndex] = useState(0);
 
-  // Queue of tutorials waiting to be shown (deferred when another is active)
+  // Tutorials waiting to be shown (deferred while another is active),
+  // kept sorted by priority.
   const pendingQueueRef = useRef<TutorialDefinition[]>([]);
 
   // Preserved step index when a tutorial is hidden but not dismissed.
   // Re-registration should resume from here rather than from lastSeen + 1.
   const hiddenStepIndicesRef = useRef<Map<string, number>>(new Map());
 
-  // Consume the next queued tutorial if one is waiting
-  const dequeueNext = useCallback(() => {
-    const queue = pendingQueueRef.current;
-    while (queue.length > 0) {
-      const next = queue.shift()!;
-      if (sessionDismissedTutorialIds.has(next.id)) continue;
-      const lastSeen = tutorialState[next.id] ?? -1;
-      if (lastSeen >= next.steps.length - 1) continue;
-      setActiveTutorialId(next.id);
-      setActiveTutorialDef(next);
-      setCurrentStepIndex(lastSeen + 1);
-      return;
-    }
-  }, [tutorialState]);
+  const clearActive = useCallback(() => {
+    setActiveTutorialId(null);
+    setActiveTutorialDef(null);
+    setCurrentStepIndex(0);
+  }, []);
 
-  // Bring stagewise UI to foreground when a tutorial becomes active
+  const activate = useCallback(
+    (def: TutorialDefinition) => {
+      const hiddenStep = hiddenStepIndicesRef.current.get(def.id);
+      hiddenStepIndicesRef.current.delete(def.id);
+      setActiveTutorialId(def.id);
+      setActiveTutorialDef(def);
+      setCurrentStepIndex(
+        getTutorialStartIndex(def, tutorialState, hiddenStep),
+      );
+    },
+    [tutorialState],
+  );
+
+  // Consume the next queued tutorial if one is still eligible
+  const dequeueNext = useCallback(() => {
+    const { next, remaining } = takeNextEligibleTutorial(
+      pendingQueueRef.current,
+      tutorialState,
+      sessionDismissedTutorialIds,
+    );
+    pendingQueueRef.current = remaining;
+    if (next) activate(next);
+  }, [tutorialState, activate]);
+
+  // Bring stagewise UI to foreground when a tutorial becomes active —
+  // the overlay lives in the UI layer and must render above web content.
   const movePanelToForeground = useKartonProcedure(
     (p) => p.browser.layout.movePanelToForeground,
   );
@@ -96,57 +129,48 @@ export function TutorialProvider({ children }: { children?: ReactNode }) {
   const registerTutorial = useCallback(
     (def: TutorialDefinition) => {
       if (sessionDismissedTutorialIds.has(def.id)) return;
-
-      const lastSeenIndex = tutorialState[def.id] ?? -1;
-      // Tutorial already fully seen — don't show
-      if (lastSeenIndex >= def.steps.length - 1) return;
+      if (isTutorialCompleted(def, tutorialState)) return;
 
       // If another tutorial is currently active, queue this one for later.
       // This prevents transient tutorials (like workspace-selection-options)
       // from being permanently lost when they register during an active tutorial.
       if (activeTutorialId !== null) {
-        // Avoid queueing the same tutorial multiple times
-        if (!pendingQueueRef.current.some((d) => d.id === def.id)) {
-          pendingQueueRef.current.push(def);
-        }
+        pendingQueueRef.current = insertQueuedTutorial(
+          pendingQueueRef.current,
+          def,
+        );
         return;
       }
 
-      // Start at the first unseen step, or resume from where the
-      // tutorial was hidden if it was hidden but not dismissed.
-      const hiddenStep = hiddenStepIndicesRef.current.get(def.id);
-      hiddenStepIndicesRef.current.delete(def.id);
-      const startIndex = hiddenStep ?? lastSeenIndex + 1;
-      setActiveTutorialId(def.id);
-      setActiveTutorialDef(def);
-      setCurrentStepIndex(startIndex);
+      activate(def);
     },
-    [activeTutorialId, tutorialState],
+    [activeTutorialId, tutorialState, activate],
   );
 
   const unregisterTutorial = useCallback(
     (tutorialId: string) => {
       // Hide if currently active
       if (activeTutorialId === tutorialId) {
-        setActiveTutorialId(null);
-        setActiveTutorialDef(null);
-        setCurrentStepIndex(0);
+        clearActive();
         dequeueNext();
       }
       // Remove from pending queue
-      const queue = pendingQueueRef.current;
-      const idx = queue.findIndex((d) => d.id === tutorialId);
-      if (idx !== -1) queue.splice(idx, 1);
+      pendingQueueRef.current = pendingQueueRef.current.filter(
+        (d) => d.id !== tutorialId,
+      );
     },
-    [activeTutorialId, dequeueNext],
+    [activeTutorialId, clearActive, dequeueNext],
   );
 
   const persistStep = useCallback(
-    (tutorialId: string, stepIndex: number) => {
-      const lastSeenIndex = tutorialState[tutorialId] ?? -1;
+    (def: TutorialDefinition, stepIndex: number) => {
+      const storageKey = getTutorialStorageKey(def);
+      const lastSeenIndex = tutorialState[storageKey] ?? -1;
       // Only persist if we're advancing (don't persist going backward)
       if (stepIndex > lastSeenIndex) {
-        void setTutorialStep({ tutorialId, stepIndex });
+        // The persistence key is id + version so stale progress is
+        // discarded when tutorial content changes.
+        void setTutorialStep({ tutorialId: storageKey, stepIndex });
       }
     },
     [tutorialState, setTutorialStep],
@@ -157,7 +181,7 @@ export function TutorialProvider({ children }: { children?: ReactNode }) {
       if (!activeTutorialDef) return;
       if (index < 0 || index >= activeTutorialDef.steps.length) return;
       setCurrentStepIndex(index);
-      persistStep(activeTutorialDef.id, index);
+      persistStep(activeTutorialDef, index);
     },
     [activeTutorialDef, persistStep],
   );
@@ -166,18 +190,23 @@ export function TutorialProvider({ children }: { children?: ReactNode }) {
     if (!activeTutorialDef) return;
     const nextIndex = currentStepIndex + 1;
     if (nextIndex >= activeTutorialDef.steps.length) {
-      // On the last step, hitting "next" dismisses with max index saved
-      persistStep(activeTutorialDef.id, activeTutorialDef.steps.length - 1);
+      // Completed the last step — persist full completion and chain to the
+      // next queued tutorial (natural completion keeps the flow going).
+      persistStep(activeTutorialDef, activeTutorialDef.steps.length - 1);
       sessionDismissedTutorialIds.add(activeTutorialDef.id);
-      setActiveTutorialId(null);
-      setActiveTutorialDef(null);
-      setCurrentStepIndex(0);
+      clearActive();
       dequeueNext();
       return;
     }
     setCurrentStepIndex(nextIndex);
-    persistStep(activeTutorialDef.id, nextIndex);
-  }, [activeTutorialDef, currentStepIndex, persistStep, dequeueNext]);
+    persistStep(activeTutorialDef, nextIndex);
+  }, [
+    activeTutorialDef,
+    currentStepIndex,
+    persistStep,
+    clearActive,
+    dequeueNext,
+  ]);
 
   const goBack = useCallback(() => {
     if (currentStepIndex > 0) {
@@ -185,36 +214,39 @@ export function TutorialProvider({ children }: { children?: ReactNode }) {
     }
   }, [currentStepIndex]);
 
+  const skipCurrentStep = useCallback(() => {
+    if (!activeTutorialDef) return;
+    const nextIndex = currentStepIndex + 1;
+    if (nextIndex < activeTutorialDef.steps.length) {
+      // Advance without persisting — the user never saw this step.
+      setCurrentStepIndex(nextIndex);
+      return;
+    }
+    // Nothing left to show — hide without persisting completion so the
+    // tutorial can show again in a future session.
+    hiddenStepIndicesRef.current.set(activeTutorialDef.id, currentStepIndex);
+    clearActive();
+    dequeueNext();
+  }, [activeTutorialDef, currentStepIndex, clearActive, dequeueNext]);
+
   const dismissTutorial = useCallback(() => {
     if (!activeTutorialDef) return;
-    // Save the max of current index or last persisted
-    const lastSeenIndex = tutorialState[activeTutorialDef.id] ?? -1;
-    const saveIndex = Math.max(currentStepIndex, lastSeenIndex);
-    void setTutorialStep({
-      tutorialId: activeTutorialDef.id,
-      stepIndex: saveIndex,
-    });
+    // Explicit dismissal (X / Escape) is permanent: persist full completion
+    // so the tutorial doesn't reappear on the next app start.
+    persistStep(activeTutorialDef, activeTutorialDef.steps.length - 1);
     sessionDismissedTutorialIds.add(activeTutorialDef.id);
-    setActiveTutorialId(null);
-    setActiveTutorialDef(null);
-    setCurrentStepIndex(0);
-    dequeueNext();
-  }, [
-    activeTutorialDef,
-    currentStepIndex,
-    tutorialState,
-    setTutorialStep,
-    dequeueNext,
-  ]);
+    // Don't chain into more popovers right after the user opted out —
+    // queued tutorials stay eligible and can register again later.
+    pendingQueueRef.current = [];
+    clearActive();
+  }, [activeTutorialDef, persistStep, clearActive]);
 
   const hideTutorial = useCallback(() => {
     if (activeTutorialId && activeTutorialDef) {
       hiddenStepIndicesRef.current.set(activeTutorialId, currentStepIndex);
     }
-    setActiveTutorialId(null);
-    setActiveTutorialDef(null);
-    setCurrentStepIndex(0);
-  }, [activeTutorialId, activeTutorialDef, currentStepIndex]);
+    clearActive();
+  }, [activeTutorialId, activeTutorialDef, currentStepIndex, clearActive]);
 
   const currentStep = useMemo(() => {
     if (!activeTutorialDef) return null;
@@ -232,6 +264,7 @@ export function TutorialProvider({ children }: { children?: ReactNode }) {
       goToStep,
       goNext,
       goBack,
+      skipCurrentStep,
       dismissTutorial,
       hideTutorial,
       registerTutorial,
@@ -245,6 +278,7 @@ export function TutorialProvider({ children }: { children?: ReactNode }) {
       goToStep,
       goNext,
       goBack,
+      skipCurrentStep,
       dismissTutorial,
       hideTutorial,
       registerTutorial,

--- a/apps/browser/src/ui/contexts/tutorial/context.tsx
+++ b/apps/browser/src/ui/contexts/tutorial/context.tsx
@@ -85,7 +85,14 @@ export function TutorialProvider({ children }: { children?: ReactNode }) {
   // Re-registration should resume from here rather than from lastSeen + 1.
   const hiddenStepIndicesRef = useRef<Map<string, number>>(new Map());
 
+  // Mirrors activeTutorialId synchronously. Registration must not read the
+  // state value: all <Tutorial> effects of one commit flush before any
+  // re-render, so they would all see the stale pre-update id and overwrite
+  // each other's activation instead of queueing.
+  const activeTutorialIdRef = useRef<string | null>(null);
+
   const clearActive = useCallback(() => {
+    activeTutorialIdRef.current = null;
     setActiveTutorialId(null);
     setActiveTutorialDef(null);
     setCurrentStepIndex(0);
@@ -95,6 +102,7 @@ export function TutorialProvider({ children }: { children?: ReactNode }) {
     (def: TutorialDefinition) => {
       const hiddenStep = hiddenStepIndicesRef.current.get(def.id);
       hiddenStepIndicesRef.current.delete(def.id);
+      activeTutorialIdRef.current = def.id;
       setActiveTutorialId(def.id);
       setActiveTutorialDef(def);
       setCurrentStepIndex(
@@ -126,25 +134,40 @@ export function TutorialProvider({ children }: { children?: ReactNode }) {
     }
   }, [activeTutorialId, movePanelToForeground]);
 
+  // Defers activation to a microtask so all registrations from the same
+  // commit land in the queue first — the highest-priority one then wins,
+  // regardless of component mount/effect order.
+  const activationScheduledRef = useRef(false);
+  const dequeueNextRef = useRef(dequeueNext);
+  dequeueNextRef.current = dequeueNext;
+  const scheduleActivation = useCallback(() => {
+    if (activationScheduledRef.current) return;
+    activationScheduledRef.current = true;
+    queueMicrotask(() => {
+      activationScheduledRef.current = false;
+      if (activeTutorialIdRef.current !== null) return;
+      dequeueNextRef.current();
+    });
+  }, []);
+
   const registerTutorial = useCallback(
     (def: TutorialDefinition) => {
       if (sessionDismissedTutorialIds.has(def.id)) return;
       if (isTutorialCompleted(def, tutorialState)) return;
+      // Already showing — don't queue a second run of the same tutorial.
+      if (activeTutorialIdRef.current === def.id) return;
 
-      // If another tutorial is currently active, queue this one for later.
-      // This prevents transient tutorials (like workspace-selection-options)
-      // from being permanently lost when they register during an active tutorial.
-      if (activeTutorialId !== null) {
-        pendingQueueRef.current = insertQueuedTutorial(
-          pendingQueueRef.current,
-          def,
-        );
-        return;
-      }
-
-      activate(def);
+      // Always queue (sorted by priority, deduplicated), then activate the
+      // best candidate asynchronously. Queueing while another tutorial is
+      // active also prevents transient tutorials (like
+      // workspace-selection-options) from being permanently lost.
+      pendingQueueRef.current = insertQueuedTutorial(
+        pendingQueueRef.current,
+        def,
+      );
+      scheduleActivation();
     },
-    [activeTutorialId, tutorialState, activate],
+    [tutorialState, scheduleActivation],
   );
 
   const unregisterTutorial = useCallback(

--- a/apps/browser/src/ui/contexts/tutorial/context.tsx
+++ b/apps/browser/src/ui/contexts/tutorial/context.tsx
@@ -64,6 +64,10 @@ export function TutorialProvider({ children }: { children?: ReactNode }) {
   // Queue of tutorials waiting to be shown (deferred when another is active)
   const pendingQueueRef = useRef<TutorialDefinition[]>([]);
 
+  // Preserved step index when a tutorial is hidden but not dismissed.
+  // Re-registration should resume from here rather than from lastSeen + 1.
+  const hiddenStepIndicesRef = useRef<Map<string, number>>(new Map());
+
   // Consume the next queued tutorial if one is waiting
   const dequeueNext = useCallback(() => {
     const queue = pendingQueueRef.current;
@@ -108,8 +112,11 @@ export function TutorialProvider({ children }: { children?: ReactNode }) {
         return;
       }
 
-      // Start at the first unseen step
-      const startIndex = lastSeenIndex + 1;
+      // Start at the first unseen step, or resume from where the
+      // tutorial was hidden if it was hidden but not dismissed.
+      const hiddenStep = hiddenStepIndicesRef.current.get(def.id);
+      hiddenStepIndicesRef.current.delete(def.id);
+      const startIndex = hiddenStep ?? lastSeenIndex + 1;
       setActiveTutorialId(def.id);
       setActiveTutorialDef(def);
       setCurrentStepIndex(startIndex);
@@ -201,10 +208,13 @@ export function TutorialProvider({ children }: { children?: ReactNode }) {
   ]);
 
   const hideTutorial = useCallback(() => {
+    if (activeTutorialId && activeTutorialDef) {
+      hiddenStepIndicesRef.current.set(activeTutorialId, currentStepIndex);
+    }
     setActiveTutorialId(null);
     setActiveTutorialDef(null);
     setCurrentStepIndex(0);
-  }, []);
+  }, [activeTutorialId, activeTutorialDef, currentStepIndex]);
 
   const currentStep = useMemo(() => {
     if (!activeTutorialDef) return null;

--- a/apps/browser/src/ui/contexts/tutorial/context.tsx
+++ b/apps/browser/src/ui/contexts/tutorial/context.tsx
@@ -4,6 +4,7 @@ import {
   useContext,
   useEffect,
   useMemo,
+  useRef,
   useState,
   type ReactNode,
 } from 'react';
@@ -58,6 +59,24 @@ export function TutorialProvider({ children }: { children?: ReactNode }) {
     useState<TutorialDefinition | null>(null);
   const [currentStepIndex, setCurrentStepIndex] = useState(0);
 
+  // Queue of tutorials waiting to be shown (deferred when another is active)
+  const pendingQueueRef = useRef<TutorialDefinition[]>([]);
+
+  // Consume the next queued tutorial if one is waiting
+  const dequeueNext = useCallback(() => {
+    const queue = pendingQueueRef.current;
+    while (queue.length > 0) {
+      const next = queue.shift()!;
+      if (sessionDismissedTutorialIds.has(next.id)) continue;
+      const lastSeen = tutorialState[next.id] ?? -1;
+      if (lastSeen >= next.steps.length - 1) continue;
+      setActiveTutorialId(next.id);
+      setActiveTutorialDef(next);
+      setCurrentStepIndex(lastSeen + 1);
+      return;
+    }
+  }, [tutorialState]);
+
   // Bring stagewise UI to foreground when a tutorial becomes active
   const movePanelToForeground = useKartonProcedure(
     (p) => p.browser.layout.movePanelToForeground,
@@ -70,18 +89,22 @@ export function TutorialProvider({ children }: { children?: ReactNode }) {
 
   const registerTutorial = useCallback(
     (def: TutorialDefinition) => {
-      // Don't register if another tutorial is already active or this tutorial
-      // was explicitly dismissed during the current renderer session.
-      if (
-        activeTutorialId !== null ||
-        sessionDismissedTutorialIds.has(def.id)
-      ) {
-        return;
-      }
+      if (sessionDismissedTutorialIds.has(def.id)) return;
 
       const lastSeenIndex = tutorialState[def.id] ?? -1;
       // Tutorial already fully seen — don't show
       if (lastSeenIndex >= def.steps.length - 1) return;
+
+      // If another tutorial is currently active, queue this one for later.
+      // This prevents transient tutorials (like workspace-selection-options)
+      // from being permanently lost when they register during an active tutorial.
+      if (activeTutorialId !== null) {
+        // Avoid queueing the same tutorial multiple times
+        if (!pendingQueueRef.current.some((d) => d.id === def.id)) {
+          pendingQueueRef.current.push(def);
+        }
+        return;
+      }
 
       // Start at the first unseen step
       const startIndex = lastSeenIndex + 1;
@@ -123,11 +146,12 @@ export function TutorialProvider({ children }: { children?: ReactNode }) {
       setActiveTutorialId(null);
       setActiveTutorialDef(null);
       setCurrentStepIndex(0);
+      dequeueNext();
       return;
     }
     setCurrentStepIndex(nextIndex);
     persistStep(activeTutorialDef.id, nextIndex);
-  }, [activeTutorialDef, currentStepIndex, persistStep]);
+  }, [activeTutorialDef, currentStepIndex, persistStep, dequeueNext]);
 
   const goBack = useCallback(() => {
     if (currentStepIndex > 0) {

--- a/apps/browser/src/ui/contexts/tutorial/context.tsx
+++ b/apps/browser/src/ui/contexts/tutorial/context.tsx
@@ -34,6 +34,8 @@ interface TutorialContextValue {
   hideTutorial: () => void;
   /** Register a tutorial as available to show */
   registerTutorial: (def: TutorialDefinition) => void;
+  /** Unregister a tutorial — removes it from the queue and hides if active */
+  unregisterTutorial: (tutorialId: string) => void;
 }
 
 const TutorialContext = createContext<TutorialContextValue | null>(null);
@@ -115,6 +117,23 @@ export function TutorialProvider({ children }: { children?: ReactNode }) {
     [activeTutorialId, tutorialState],
   );
 
+  const unregisterTutorial = useCallback(
+    (tutorialId: string) => {
+      // Hide if currently active
+      if (activeTutorialId === tutorialId) {
+        setActiveTutorialId(null);
+        setActiveTutorialDef(null);
+        setCurrentStepIndex(0);
+        dequeueNext();
+      }
+      // Remove from pending queue
+      const queue = pendingQueueRef.current;
+      const idx = queue.findIndex((d) => d.id === tutorialId);
+      if (idx !== -1) queue.splice(idx, 1);
+    },
+    [activeTutorialId, dequeueNext],
+  );
+
   const persistStep = useCallback(
     (tutorialId: string, stepIndex: number) => {
       const lastSeenIndex = tutorialState[tutorialId] ?? -1;
@@ -172,7 +191,14 @@ export function TutorialProvider({ children }: { children?: ReactNode }) {
     setActiveTutorialId(null);
     setActiveTutorialDef(null);
     setCurrentStepIndex(0);
-  }, [activeTutorialDef, currentStepIndex, tutorialState, setTutorialStep]);
+    dequeueNext();
+  }, [
+    activeTutorialDef,
+    currentStepIndex,
+    tutorialState,
+    setTutorialStep,
+    dequeueNext,
+  ]);
 
   const hideTutorial = useCallback(() => {
     setActiveTutorialId(null);
@@ -199,6 +225,7 @@ export function TutorialProvider({ children }: { children?: ReactNode }) {
       dismissTutorial,
       hideTutorial,
       registerTutorial,
+      unregisterTutorial,
     }),
     [
       activeTutorialDef,
@@ -211,6 +238,7 @@ export function TutorialProvider({ children }: { children?: ReactNode }) {
       dismissTutorial,
       hideTutorial,
       registerTutorial,
+      unregisterTutorial,
     ],
   );
 

--- a/apps/browser/src/ui/contexts/tutorial/context.tsx
+++ b/apps/browser/src/ui/contexts/tutorial/context.tsx
@@ -1,0 +1,198 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from 'react';
+import { useKartonState, useKartonProcedure } from '@ui/hooks/use-karton';
+import type { TutorialDefinition, TutorialStep } from './types';
+
+const sessionDismissedTutorialIds = new Set<string>();
+
+interface TutorialContextValue {
+  /** The currently active tutorial, or null if none is active */
+  activeTutorial: TutorialDefinition | null;
+  /** The currently displayed step, or null */
+  currentStep: TutorialStep | null;
+  /** Current step index within the active tutorial */
+  currentStepIndex: number;
+  /** Total steps in the active tutorial */
+  totalSteps: number;
+  /** Navigate to a specific step index */
+  goToStep: (index: number) => void;
+  /** Go to the next step */
+  goNext: () => void;
+  /** Go to the previous step */
+  goBack: () => void;
+  /** Dismiss the current tutorial (saves progress) */
+  dismissTutorial: () => void;
+  /** Hide the current tutorial without changing persisted progress */
+  hideTutorial: () => void;
+  /** Register a tutorial as available to show */
+  registerTutorial: (def: TutorialDefinition) => void;
+}
+
+const TutorialContext = createContext<TutorialContextValue | null>(null);
+
+export function useTutorial(): TutorialContextValue {
+  const ctx = useContext(TutorialContext);
+  if (!ctx) {
+    throw new Error('useTutorial must be used within a TutorialProvider');
+  }
+  return ctx;
+}
+
+export function TutorialProvider({ children }: { children?: ReactNode }) {
+  const tutorialState = useKartonState(
+    (s) => s.userExperience.storedExperienceData.tutorialState,
+  );
+  const setTutorialStep = useKartonProcedure(
+    (p) => p.userExperience.tutorial.setStep,
+  );
+
+  const [activeTutorialId, setActiveTutorialId] = useState<string | null>(null);
+  const [activeTutorialDef, setActiveTutorialDef] =
+    useState<TutorialDefinition | null>(null);
+  const [currentStepIndex, setCurrentStepIndex] = useState(0);
+
+  // Bring stagewise UI to foreground when a tutorial becomes active
+  const movePanelToForeground = useKartonProcedure(
+    (p) => p.browser.layout.movePanelToForeground,
+  );
+  useEffect(() => {
+    if (activeTutorialId) {
+      void movePanelToForeground('stagewise-ui');
+    }
+  }, [activeTutorialId, movePanelToForeground]);
+
+  const registerTutorial = useCallback(
+    (def: TutorialDefinition) => {
+      // Don't register if another tutorial is already active or this tutorial
+      // was explicitly dismissed during the current renderer session.
+      if (
+        activeTutorialId !== null ||
+        sessionDismissedTutorialIds.has(def.id)
+      ) {
+        return;
+      }
+
+      const lastSeenIndex = tutorialState[def.id] ?? -1;
+      // Tutorial already fully seen — don't show
+      if (lastSeenIndex >= def.steps.length - 1) return;
+
+      // Start at the first unseen step
+      const startIndex = lastSeenIndex + 1;
+      setActiveTutorialId(def.id);
+      setActiveTutorialDef(def);
+      setCurrentStepIndex(startIndex);
+    },
+    [activeTutorialId, tutorialState],
+  );
+
+  const persistStep = useCallback(
+    (tutorialId: string, stepIndex: number) => {
+      const lastSeenIndex = tutorialState[tutorialId] ?? -1;
+      // Only persist if we're advancing (don't persist going backward)
+      if (stepIndex > lastSeenIndex) {
+        void setTutorialStep({ tutorialId, stepIndex });
+      }
+    },
+    [tutorialState, setTutorialStep],
+  );
+
+  const goToStep = useCallback(
+    (index: number) => {
+      if (!activeTutorialDef) return;
+      if (index < 0 || index >= activeTutorialDef.steps.length) return;
+      setCurrentStepIndex(index);
+      persistStep(activeTutorialDef.id, index);
+    },
+    [activeTutorialDef, persistStep],
+  );
+
+  const goNext = useCallback(() => {
+    if (!activeTutorialDef) return;
+    const nextIndex = currentStepIndex + 1;
+    if (nextIndex >= activeTutorialDef.steps.length) {
+      // On the last step, hitting "next" dismisses with max index saved
+      persistStep(activeTutorialDef.id, activeTutorialDef.steps.length - 1);
+      sessionDismissedTutorialIds.add(activeTutorialDef.id);
+      setActiveTutorialId(null);
+      setActiveTutorialDef(null);
+      setCurrentStepIndex(0);
+      return;
+    }
+    setCurrentStepIndex(nextIndex);
+    persistStep(activeTutorialDef.id, nextIndex);
+  }, [activeTutorialDef, currentStepIndex, persistStep]);
+
+  const goBack = useCallback(() => {
+    if (currentStepIndex > 0) {
+      setCurrentStepIndex((i) => i - 1);
+    }
+  }, [currentStepIndex]);
+
+  const dismissTutorial = useCallback(() => {
+    if (!activeTutorialDef) return;
+    // Save the max of current index or last persisted
+    const lastSeenIndex = tutorialState[activeTutorialDef.id] ?? -1;
+    const saveIndex = Math.max(currentStepIndex, lastSeenIndex);
+    void setTutorialStep({
+      tutorialId: activeTutorialDef.id,
+      stepIndex: saveIndex,
+    });
+    sessionDismissedTutorialIds.add(activeTutorialDef.id);
+    setActiveTutorialId(null);
+    setActiveTutorialDef(null);
+    setCurrentStepIndex(0);
+  }, [activeTutorialDef, currentStepIndex, tutorialState, setTutorialStep]);
+
+  const hideTutorial = useCallback(() => {
+    setActiveTutorialId(null);
+    setActiveTutorialDef(null);
+    setCurrentStepIndex(0);
+  }, []);
+
+  const currentStep = useMemo(() => {
+    if (!activeTutorialDef) return null;
+    return activeTutorialDef.steps[currentStepIndex] ?? null;
+  }, [activeTutorialDef, currentStepIndex]);
+
+  const totalSteps = activeTutorialDef?.steps.length ?? 0;
+
+  const value = useMemo<TutorialContextValue>(
+    () => ({
+      activeTutorial: activeTutorialDef,
+      currentStep,
+      currentStepIndex,
+      totalSteps,
+      goToStep,
+      goNext,
+      goBack,
+      dismissTutorial,
+      hideTutorial,
+      registerTutorial,
+    }),
+    [
+      activeTutorialDef,
+      currentStep,
+      currentStepIndex,
+      totalSteps,
+      goToStep,
+      goNext,
+      goBack,
+      dismissTutorial,
+      hideTutorial,
+      registerTutorial,
+    ],
+  );
+
+  return (
+    <TutorialContext.Provider value={value}>
+      {children}
+    </TutorialContext.Provider>
+  );
+}

--- a/apps/browser/src/ui/contexts/tutorial/context.tsx
+++ b/apps/browser/src/ui/contexts/tutorial/context.tsx
@@ -8,6 +8,7 @@ import {
   useState,
   type ReactNode,
 } from 'react';
+import posthog from 'posthog-js';
 import { useKartonState, useKartonProcedure } from '@ui/hooks/use-karton';
 import type { TutorialDefinition, TutorialStep } from './types';
 import {
@@ -212,7 +213,15 @@ export function TutorialProvider({ children }: { children?: ReactNode }) {
   const goNext = useCallback(() => {
     if (!activeTutorialDef) return;
     const nextIndex = currentStepIndex + 1;
-    if (nextIndex >= activeTutorialDef.steps.length) {
+    const finished = nextIndex >= activeTutorialDef.steps.length;
+    posthog.capture('tutorial_clicked_next', {
+      tutorial_id: activeTutorialDef.id,
+      tutorial_name: activeTutorialDef.id,
+      step_index: currentStepIndex,
+      total_steps: activeTutorialDef.steps.length,
+      finished_tutorial: finished,
+    });
+    if (finished) {
       // Completed the last step — persist full completion and chain to the
       // next queued tutorial (natural completion keeps the flow going).
       persistStep(activeTutorialDef, activeTutorialDef.steps.length - 1);
@@ -232,10 +241,16 @@ export function TutorialProvider({ children }: { children?: ReactNode }) {
   ]);
 
   const goBack = useCallback(() => {
-    if (currentStepIndex > 0) {
+    if (currentStepIndex > 0 && activeTutorialDef) {
+      posthog.capture('tutorial_clicked_back', {
+        tutorial_id: activeTutorialDef.id,
+        tutorial_name: activeTutorialDef.id,
+        step_index: currentStepIndex,
+        total_steps: activeTutorialDef.steps.length,
+      });
       setCurrentStepIndex((i) => i - 1);
     }
-  }, [currentStepIndex]);
+  }, [currentStepIndex, activeTutorialDef]);
 
   const skipCurrentStep = useCallback(() => {
     if (!activeTutorialDef) return;
@@ -254,6 +269,12 @@ export function TutorialProvider({ children }: { children?: ReactNode }) {
 
   const dismissTutorial = useCallback(() => {
     if (!activeTutorialDef) return;
+    posthog.capture('tutorial_dismissed', {
+      tutorial_id: activeTutorialDef.id,
+      tutorial_name: activeTutorialDef.id,
+      step_index: currentStepIndex,
+      total_steps: activeTutorialDef.steps.length,
+    });
     // Explicit dismissal (X / Escape) is permanent: persist full completion
     // so the tutorial doesn't reappear on the next app start.
     persistStep(activeTutorialDef, activeTutorialDef.steps.length - 1);
@@ -262,7 +283,7 @@ export function TutorialProvider({ children }: { children?: ReactNode }) {
     // queued tutorials stay eligible and can register again later.
     pendingQueueRef.current = [];
     clearActive();
-  }, [activeTutorialDef, persistStep, clearActive]);
+  }, [activeTutorialDef, currentStepIndex, persistStep, clearActive]);
 
   const hideTutorial = useCallback(() => {
     if (activeTutorialId && activeTutorialDef) {

--- a/apps/browser/src/ui/contexts/tutorial/index.ts
+++ b/apps/browser/src/ui/contexts/tutorial/index.ts
@@ -1,0 +1,5 @@
+export {
+  TutorialProvider,
+  useTutorial,
+} from './context';
+export type { TutorialStep, TutorialDefinition } from './types';

--- a/apps/browser/src/ui/contexts/tutorial/tutorial-logic.test.ts
+++ b/apps/browser/src/ui/contexts/tutorial/tutorial-logic.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getLastSeenStepIndex,
+  getTutorialStartIndex,
+  getTutorialStorageKey,
+  insertQueuedTutorial,
+  isTutorialCompleted,
+  takeNextEligibleTutorial,
+} from './tutorial-logic';
+import type { TutorialDefinition } from './types';
+
+const step = (n: number) => ({
+  targetSelector: `[data-tutorial="step-${n}"]`,
+  title: `Step ${n}`,
+  description: `Description ${n}`,
+});
+
+const makeTutorial = (
+  id: string,
+  stepCount: number,
+  overrides?: Partial<TutorialDefinition>,
+): TutorialDefinition => ({
+  id,
+  version: 1,
+  steps: Array.from({ length: stepCount }, (_, i) => step(i)),
+  ...overrides,
+});
+
+describe('getTutorialStorageKey', () => {
+  it('uses the plain id for version 1 (backwards compatible)', () => {
+    expect(getTutorialStorageKey({ id: 'file-tree', version: 1 })).toBe(
+      'file-tree',
+    );
+  });
+
+  it('namespaces the key for later versions', () => {
+    expect(getTutorialStorageKey({ id: 'file-tree', version: 2 })).toBe(
+      'file-tree@v2',
+    );
+  });
+});
+
+describe('isTutorialCompleted', () => {
+  it('is false when no progress is persisted', () => {
+    expect(isTutorialCompleted(makeTutorial('a', 3), {})).toBe(false);
+  });
+
+  it('is false when only some steps were seen', () => {
+    expect(isTutorialCompleted(makeTutorial('a', 3), { a: 1 })).toBe(false);
+  });
+
+  it('is true when the last step was seen', () => {
+    expect(isTutorialCompleted(makeTutorial('a', 3), { a: 2 })).toBe(true);
+  });
+
+  it('discards stale progress after a version bump', () => {
+    const v2 = makeTutorial('a', 3, { version: 2 });
+    // Progress persisted under the v1 key must not complete the v2 tutorial.
+    expect(isTutorialCompleted(v2, { a: 2 })).toBe(false);
+    expect(isTutorialCompleted(v2, { 'a@v2': 2 })).toBe(true);
+  });
+});
+
+describe('getTutorialStartIndex', () => {
+  const tutorial = makeTutorial('a', 4);
+
+  it('starts at 0 without persisted progress', () => {
+    expect(getTutorialStartIndex(tutorial, {})).toBe(0);
+  });
+
+  it('resumes at the first unseen step', () => {
+    expect(getTutorialStartIndex(tutorial, { a: 1 })).toBe(2);
+  });
+
+  it('prefers the preserved hidden index over persisted progress', () => {
+    expect(getTutorialStartIndex(tutorial, { a: 1 }, 0)).toBe(0);
+  });
+
+  it('clamps to the last step when progress exceeds bounds', () => {
+    expect(getTutorialStartIndex(tutorial, { a: 99 })).toBe(3);
+  });
+
+  it('never returns a negative index', () => {
+    expect(getTutorialStartIndex(tutorial, { a: -5 })).toBe(0);
+  });
+});
+
+describe('getLastSeenStepIndex', () => {
+  it('returns -1 when never shown', () => {
+    expect(getLastSeenStepIndex({ id: 'a', version: 1 }, {})).toBe(-1);
+  });
+
+  it('reads from the versioned key', () => {
+    expect(
+      getLastSeenStepIndex({ id: 'a', version: 2 }, { a: 5, 'a@v2': 1 }),
+    ).toBe(1);
+  });
+});
+
+describe('insertQueuedTutorial', () => {
+  const high = makeTutorial('high', 1, { priority: 0 });
+  const mid = makeTutorial('mid', 1, { priority: 1 });
+  const low = makeTutorial('low', 1, { priority: 2 });
+
+  it('keeps the queue sorted by priority regardless of insertion order', () => {
+    let queue = insertQueuedTutorial([], low);
+    queue = insertQueuedTutorial(queue, high);
+    queue = insertQueuedTutorial(queue, mid);
+    expect(queue.map((d) => d.id)).toEqual(['high', 'mid', 'low']);
+  });
+
+  it('deduplicates by id', () => {
+    let queue = insertQueuedTutorial([], high);
+    queue = insertQueuedTutorial(queue, makeTutorial('high', 1));
+    expect(queue).toHaveLength(1);
+  });
+
+  it('sorts tutorials without a priority last', () => {
+    let queue = insertQueuedTutorial([], makeTutorial('unprioritized', 1));
+    queue = insertQueuedTutorial(queue, low);
+    expect(queue.map((d) => d.id)).toEqual(['low', 'unprioritized']);
+  });
+
+  it('does not mutate the input queue', () => {
+    const original = [high];
+    const next = insertQueuedTutorial(original, low);
+    expect(original).toHaveLength(1);
+    expect(next).toHaveLength(2);
+  });
+});
+
+describe('takeNextEligibleTutorial', () => {
+  const a = makeTutorial('a', 2, { priority: 0 });
+  const b = makeTutorial('b', 2, { priority: 1 });
+  const c = makeTutorial('c', 2, { priority: 2 });
+
+  it('returns the first eligible tutorial and the remaining queue', () => {
+    const { next, remaining } = takeNextEligibleTutorial(
+      [a, b, c],
+      {},
+      new Set(),
+    );
+    expect(next?.id).toBe('a');
+    expect(remaining.map((d) => d.id)).toEqual(['b', 'c']);
+  });
+
+  it('skips tutorials dismissed in this session', () => {
+    const { next } = takeNextEligibleTutorial([a, b], {}, new Set(['a']));
+    expect(next?.id).toBe('b');
+  });
+
+  it('skips completed tutorials', () => {
+    const { next } = takeNextEligibleTutorial([a, b], { a: 1 }, new Set());
+    expect(next?.id).toBe('b');
+  });
+
+  it('returns null when nothing is eligible', () => {
+    const { next, remaining } = takeNextEligibleTutorial(
+      [a, b],
+      { a: 1 },
+      new Set(['b']),
+    );
+    expect(next).toBeNull();
+    expect(remaining).toHaveLength(0);
+  });
+});

--- a/apps/browser/src/ui/contexts/tutorial/tutorial-logic.ts
+++ b/apps/browser/src/ui/contexts/tutorial/tutorial-logic.ts
@@ -1,0 +1,85 @@
+import type { TutorialDefinition } from './types';
+
+/** Persisted tutorial progress: storage key → last seen step index. */
+export type TutorialProgressState = Record<string, number>;
+
+/**
+ * Storage key for persisted progress. Version 1 uses the plain tutorial id
+ * for backwards compatibility with already-persisted state; later versions
+ * get a distinct key so stale step indices are discarded on version bumps.
+ */
+export function getTutorialStorageKey(
+  def: Pick<TutorialDefinition, 'id' | 'version'>,
+): string {
+  return def.version <= 1 ? def.id : `${def.id}@v${def.version}`;
+}
+
+/** Last step index the user has seen, or -1 if never shown. */
+export function getLastSeenStepIndex(
+  def: Pick<TutorialDefinition, 'id' | 'version'>,
+  state: TutorialProgressState,
+): number {
+  return state[getTutorialStorageKey(def)] ?? -1;
+}
+
+/** Whether the user has seen (or dismissed) all steps of a tutorial. */
+export function isTutorialCompleted(
+  def: Pick<TutorialDefinition, 'id' | 'version' | 'steps'>,
+  state: TutorialProgressState,
+): boolean {
+  return getLastSeenStepIndex(def, state) >= def.steps.length - 1;
+}
+
+/**
+ * Step index to start (or resume) a tutorial at. Prefers an explicitly
+ * preserved index (tutorial was hidden mid-flight), otherwise resumes at
+ * the first unseen step. Always clamped to valid step bounds.
+ */
+export function getTutorialStartIndex(
+  def: Pick<TutorialDefinition, 'id' | 'version' | 'steps'>,
+  state: TutorialProgressState,
+  hiddenStepIndex?: number,
+): number {
+  const start = hiddenStepIndex ?? getLastSeenStepIndex(def, state) + 1;
+  return Math.min(Math.max(start, 0), def.steps.length - 1);
+}
+
+/**
+ * Insert a tutorial into the pending queue, deduplicated by id and ordered
+ * by priority (lower first; ties keep insertion order). Returns a new array.
+ */
+export function insertQueuedTutorial(
+  queue: readonly TutorialDefinition[],
+  def: TutorialDefinition,
+): TutorialDefinition[] {
+  if (queue.some((d) => d.id === def.id)) return [...queue];
+  const next = [...queue, def];
+  // Array.prototype.sort is stable, so equal priorities keep insertion order.
+  next.sort(
+    (a, b) =>
+      (a.priority ?? Number.MAX_SAFE_INTEGER) -
+      (b.priority ?? Number.MAX_SAFE_INTEGER),
+  );
+  return next;
+}
+
+/**
+ * Pop the next tutorial from the queue that is still eligible to show
+ * (not dismissed this session, not already completed). Returns the next
+ * tutorial (or null) and the remaining queue.
+ */
+export function takeNextEligibleTutorial(
+  queue: readonly TutorialDefinition[],
+  state: TutorialProgressState,
+  sessionDismissedIds: ReadonlySet<string>,
+): { next: TutorialDefinition | null; remaining: TutorialDefinition[] } {
+  const remaining = [...queue];
+  while (remaining.length > 0) {
+    const candidate = remaining.shift();
+    if (!candidate) break;
+    if (sessionDismissedIds.has(candidate.id)) continue;
+    if (isTutorialCompleted(candidate, state)) continue;
+    return { next: candidate, remaining };
+  }
+  return { next: null, remaining };
+}

--- a/apps/browser/src/ui/contexts/tutorial/types.ts
+++ b/apps/browser/src/ui/contexts/tutorial/types.ts
@@ -10,6 +10,17 @@ export interface TutorialStep {
 export interface TutorialDefinition {
   /** Unique identifier for this tutorial (e.g. "command-center") */
   id: string;
+  /**
+   * Content version. Persisted progress is keyed by id + version, so bump
+   * this whenever steps are reordered, inserted, or removed — otherwise
+   * users with stale step indices would resume at the wrong step.
+   */
+  version: number;
   /** Ordered list of steps */
-  steps: TutorialStep[];
+  steps: readonly TutorialStep[];
+  /**
+   * Display priority when multiple tutorials are queued.
+   * Lower values are shown first. Defaults to lowest priority.
+   */
+  priority?: number;
 }

--- a/apps/browser/src/ui/contexts/tutorial/types.ts
+++ b/apps/browser/src/ui/contexts/tutorial/types.ts
@@ -1,0 +1,15 @@
+export interface TutorialStep {
+  /** CSS selector for the DOM element to highlight */
+  targetSelector: string;
+  /** Step title shown in the popover */
+  title: string;
+  /** Step description in markdown format */
+  description: string;
+}
+
+export interface TutorialDefinition {
+  /** Unique identifier for this tutorial (e.g. "command-center") */
+  id: string;
+  /** Ordered list of steps */
+  steps: TutorialStep[];
+}

--- a/apps/browser/src/ui/screens/index.tsx
+++ b/apps/browser/src/ui/screens/index.tsx
@@ -6,6 +6,7 @@ import {
 } from '@ui/hooks/use-karton';
 import { Logo } from '@ui/components/ui/logo';
 import { WebContentsBoundsSyncer } from '@ui/components/web-contents-bounds-syncer';
+import { TutorialOverlay } from '@ui/components/tutorial/tutorial-overlay';
 
 // Lazy-load the heavy screen trees. Both `DefaultLayout` and `OnboardingWizard`
 // only render *after* the karton connection is established, yet importing them
@@ -78,6 +79,7 @@ export function ScreenRouter() {
           <OnboardingWizard />
         </Suspense>
       )}
+      <TutorialOverlay />
     </div>
   );
 }

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/agent/stories/agent-lifecycle-scenarios.stories.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/agent/stories/agent-lifecycle-scenarios.stories.tsx
@@ -43,6 +43,7 @@ const baseState: Partial<AppState> = {
       recentlyOpenedWorkspaces: [],
       hasSeenOnboardingFlow: false,
       lastViewedChats: {},
+      tutorialState: {},
     },
     devAppPreview: {
       isFullScreen: false,

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/agent/stories/agent-messages.stories.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/agent/stories/agent-messages.stories.tsx
@@ -33,6 +33,7 @@ const createStoryState = (
           recentlyOpenedWorkspaces: [],
           hasSeenOnboardingFlow: false,
           lastViewedChats: {},
+          tutorialState: {},
         },
         devAppPreview: {
           isFullScreen: false,

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/agent/stories/copy-tool.stories.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/agent/stories/copy-tool.stories.tsx
@@ -27,6 +27,7 @@ const createStoryState = (
           recentlyOpenedWorkspaces: [],
           hasSeenOnboardingFlow: false,
           lastViewedChats: {},
+          tutorialState: {},
         },
         devAppPreview: {
           isFullScreen: false,

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/agent/stories/delete-tool.stories.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/agent/stories/delete-tool.stories.tsx
@@ -27,6 +27,7 @@ const createStoryState = (
           recentlyOpenedWorkspaces: [],
           hasSeenOnboardingFlow: false,
           lastViewedChats: {},
+          tutorialState: {},
         },
         devAppPreview: {
           isFullScreen: false,

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/agent/stories/list-files-tool.stories.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/agent/stories/list-files-tool.stories.tsx
@@ -27,6 +27,7 @@ const createStoryState = (
           recentlyOpenedWorkspaces: [],
           hasSeenOnboardingFlow: false,
           lastViewedChats: {},
+          tutorialState: {},
         },
         devAppPreview: {
           isFullScreen: false,

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/agent/stories/mkdir-tool.stories.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/agent/stories/mkdir-tool.stories.tsx
@@ -26,6 +26,7 @@ const createStoryState = (
           recentlyOpenedWorkspaces: [],
           hasSeenOnboardingFlow: false,
           lastViewedChats: {},
+          tutorialState: {},
         },
         devAppPreview: {
           isFullScreen: false,

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/agent/stories/sandbox-tool.stories.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/agent/stories/sandbox-tool.stories.tsx
@@ -26,6 +26,7 @@ const createStoryState = (
           recentlyOpenedWorkspaces: [],
           hasSeenOnboardingFlow: false,
           lastViewedChats: {},
+          tutorialState: {},
         },
         devAppPreview: {
           isFullScreen: false,

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/agent/stories/shell-tool.stories.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/agent/stories/shell-tool.stories.tsx
@@ -32,6 +32,7 @@ const createStoryState = (
           recentlyOpenedWorkspaces: [],
           hasSeenOnboardingFlow: false,
           lastViewedChats: {},
+          tutorialState: {},
         },
         devAppPreview: {
           isFullScreen: false,

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/chat-input.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/chat-input.tsx
@@ -30,6 +30,8 @@ import {
 } from '@stagewise/stage-ui/components/tooltip';
 import { ShortcutCombo } from '@stagewise/stage-ui/components/shortcut-key';
 import { HotkeyCombo } from '@ui/components/hotkey-combo';
+import { Tutorial } from '@ui/components/tutorial';
+import { TUTORIALS } from '@ui/tutorial-steps';
 import {
   configureAttachmentExtensions,
   ALL_ATTACHMENT_NODE_NAMES,
@@ -902,42 +904,49 @@ export const ChatInputActions = memo(function ChatInputActions({
     <div className="flex shrink-0 flex-col items-end justify-end gap-1">
       {/* Element selector and image upload - always shown (can add context to queued messages) */}
       {showElementSelectorButton && (
-        <Tooltip>
-          <TooltipTrigger>
-            <Button
-              size="icon-sm"
-              variant="ghost"
-              disabled={elementSelectorDisabled}
-              className="shrink-0 data-[element-selector-active=true]:bg-primary-foreground/5 data-[element-selector-active=true]:text-primary-foreground"
-              data-element-selector-active={elementSelectionActive}
-              onClick={(e) => {
-                e.preventDefault();
-                e.stopPropagation();
-                onToggleElementSelection?.();
-              }}
-              aria-label="Select context elements"
-            >
-              <SquareDashedMousePointerIcon className="size-3.5 stroke-[2.5px]" />
-            </Button>
-          </TooltipTrigger>
-          <TooltipContent>
-            <span className="flex items-center gap-1.5">
-              <span>
-                {elementSelectionActive
-                  ? 'Stop selecting elements'
-                  : 'Add reference elements'}
+        <>
+          <Tutorial
+            tutorialId="browser-element-selector"
+            steps={TUTORIALS['browser-element-selector']}
+          />
+          <Tooltip>
+            <TooltipTrigger>
+              <Button
+                size="icon-sm"
+                variant="ghost"
+                disabled={elementSelectorDisabled}
+                className="shrink-0 data-[element-selector-active=true]:bg-primary-foreground/5 data-[element-selector-active=true]:text-primary-foreground"
+                data-element-selector-active={elementSelectionActive}
+                data-tutorial="chat-element-selector"
+                onClick={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  onToggleElementSelection?.();
+                }}
+                aria-label="Select context elements"
+              >
+                <SquareDashedMousePointerIcon className="size-3.5 stroke-[2.5px]" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>
+              <span className="flex items-center gap-1.5">
+                <span>
+                  {elementSelectionActive
+                    ? 'Stop selecting elements'
+                    : 'Add reference elements'}
+                </span>
+                {elementSelectionActive ? (
+                  <ShortcutCombo value="Esc" size="xs" />
+                ) : (
+                  <HotkeyCombo
+                    action={HotkeyActions.TOGGLE_CONTEXT_SELECTOR}
+                    size="xs"
+                  />
+                )}
               </span>
-              {elementSelectionActive ? (
-                <ShortcutCombo value="Esc" size="xs" />
-              ) : (
-                <HotkeyCombo
-                  action={HotkeyActions.TOGGLE_CONTEXT_SELECTOR}
-                  size="xs"
-                />
-              )}
-            </span>
-          </TooltipContent>
-        </Tooltip>
+            </TooltipContent>
+          </Tooltip>
+        </>
       )}
       {showImageUploadButton && onAddFileAttachment && (
         <>

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/chat-input.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/chat-input.tsx
@@ -31,7 +31,6 @@ import {
 import { ShortcutCombo } from '@stagewise/stage-ui/components/shortcut-key';
 import { HotkeyCombo } from '@ui/components/hotkey-combo';
 import { Tutorial } from '@ui/components/tutorial';
-import { TUTORIALS } from '@ui/tutorial-steps';
 import {
   configureAttachmentExtensions,
   ALL_ATTACHMENT_NODE_NAMES,
@@ -905,10 +904,7 @@ export const ChatInputActions = memo(function ChatInputActions({
       {/* Element selector and image upload - always shown (can add context to queued messages) */}
       {showElementSelectorButton && (
         <>
-          <Tutorial
-            tutorialId="browser-element-selector"
-            steps={TUTORIALS['browser-element-selector']}
-          />
+          <Tutorial tutorialId="browser-element-selector" />
           <Tooltip>
             <TooltipTrigger>
               <Button

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/panel-footer.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/panel-footer.tsx
@@ -1694,6 +1694,7 @@ export const ChatPanelFooter = memo(function ChatPanelFooter() {
             isDragOver && 'bg-hover-derived!',
           )}
           id="chat-input-container-box"
+          data-tutorial="chat-input"
           data-chat-active={chatInputActive}
           onKeyDown={(e) => {
             // Shift-Tab from chat input → jump to last question in status card form

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/workspace-select.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/workspace-select.tsx
@@ -1942,7 +1942,11 @@ const WorkspaceActionSelect = memo(function WorkspaceActionSelect({
         openChangeTimeoutRef.current = null;
       }
 
-      if (!next && activeTutorial?.id === 'workspace-selection-options') {
+      if (
+        !next &&
+        activeTutorial?.id ===
+          ('workspace-selection-options' satisfies TutorialId)
+      ) {
         return;
       }
 
@@ -3387,6 +3391,7 @@ const ConnectWorkspaceSelect = memo(function ConnectWorkspaceSelectInner({
             variant="ghost"
             size="xs"
             aria-label="Connect workspace"
+            data-tutorial="connect-workspace"
             className="h-6 shrink-0 px-0 text-muted-foreground hover:text-foreground"
           >
             <IconFolder5Outline18 className="size-3 shrink-0" />
@@ -3396,6 +3401,7 @@ const ConnectWorkspaceSelect = memo(function ConnectWorkspaceSelectInner({
           <Button
             variant="ghost"
             size="xs"
+            data-tutorial="connect-workspace"
             className="h-6 shrink-0 px-0 text-muted-foreground hover:text-foreground"
           >
             <IconFolder5Outline18 className="size-3 shrink-0" />
@@ -3923,7 +3929,7 @@ export const WorkspaceSelect = memo(function WorkspaceSelect({
   );
 });
 
-import { TUTORIALS } from '@ui/tutorial-steps';
+import type { TutorialId } from '@ui/tutorial-steps';
 
 function WorkspaceSelectionTutorial({
   enabled,
@@ -3934,14 +3940,9 @@ function WorkspaceSelectionTutorial({
 }) {
   return (
     <>
-      <Tutorial
-        tutorialId="workspace-selection"
-        steps={TUTORIALS['workspace-selection']}
-        enabled={enabled}
-      />
+      <Tutorial tutorialId="workspace-selection" enabled={enabled} />
       <Tutorial
         tutorialId="workspace-selection-options"
-        steps={TUTORIALS['workspace-selection-options']}
         enabled={enabled && showOptionSteps}
       />
     </>

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/workspace-select.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/workspace-select.tsx
@@ -56,6 +56,8 @@ import { CheckIcon, Loader2Icon, XIcon } from 'lucide-react';
 import { useKartonProcedure, useKartonState } from '@ui/hooks/use-karton';
 import { useScrollFadeMask } from '@ui/hooks/use-scroll-fade-mask';
 import { useTrack } from '@ui/hooks/use-track';
+import { Tutorial } from '@ui/components/tutorial';
+import { useTutorial } from '@ui/contexts/tutorial';
 import { useHotKeyListener } from '@ui/hooks/use-hotkey-listener';
 import { nativeFileManagerLabel } from '@ui/utils';
 import { HotkeyActions } from '@shared/hotkeys';
@@ -1649,6 +1651,7 @@ function WorkspaceActionPickerContent({
       <ActionRow
         active={config.selectedAction === 'create-worktree'}
         onSelect={() => onCommit('create-worktree')}
+        tutorialId="action-create-worktree"
       >
         <span className="shrink-0 text-xs">Create worktree</span>
         <NameChip
@@ -1674,6 +1677,7 @@ function WorkspaceActionPickerContent({
       <ActionRow
         active={config.selectedAction === 'switch-worktree'}
         onSelect={() => onCommit('switch-worktree')}
+        tutorialId="action-switch-worktree"
       >
         <span className="shrink-0 text-xs">Use existing worktree</span>
         <ActionBranchSelect
@@ -1692,6 +1696,7 @@ function WorkspaceActionPickerContent({
       <ActionRow
         active={config.selectedAction === 'create-branch'}
         onSelect={() => onCommit('create-branch')}
+        tutorialId="action-create-branch"
       >
         <span className="shrink-0 text-xs">Create branch</span>
         <NameChip
@@ -1717,6 +1722,7 @@ function WorkspaceActionPickerContent({
       <ActionRow
         active={config.selectedAction === 'switch-branch'}
         onSelect={() => onCommit('switch-branch')}
+        tutorialId="action-switch-branch"
       >
         <span className="shrink-0 text-xs">Use existing branch</span>
         <ActionBranchSelect
@@ -1746,12 +1752,14 @@ const WorkspaceActionSelect = memo(function WorkspaceActionSelect({
   onUnmount,
   config: controlledConfig,
   onConfigChange,
+  onOpenChange,
   agentInstanceId,
 }: {
   mount: MountEntry;
   onUnmount: (prefix: string) => void;
   config?: WorkspaceActionConfig;
   onConfigChange?: (mount: MountEntry, config: WorkspaceActionConfig) => void;
+  onOpenChange?: (mountPrefix: string, open: boolean) => void;
   agentInstanceId: string;
 }) {
   const track = useTrack();
@@ -1791,6 +1799,8 @@ const WorkspaceActionSelect = memo(function WorkspaceActionSelect({
     useState<WorkspaceGitWorktreesResult | null>(null);
   const [gitDataLoaded, setGitDataLoaded] = useState(false);
   const popupRef = useRef<HTMLDivElement>(null);
+  const openChangeTimeoutRef = useRef<number | null>(null);
+  const { activeTutorial } = useTutorial();
 
   const sourceBranchItems = useMemo(
     () => getBranchSelectItemsFromGit(branchesResult, gitRef, 'source'),
@@ -1927,13 +1937,41 @@ const WorkspaceActionSelect = memo(function WorkspaceActionSelect({
 
   const handleOpenChange = useCallback(
     (next: boolean) => {
-      setOpen(next);
-      if (next && !gitDataLoaded) {
-        void refreshGitData();
+      if (openChangeTimeoutRef.current !== null) {
+        window.clearTimeout(openChangeTimeoutRef.current);
+        openChangeTimeoutRef.current = null;
       }
+
+      if (!next && activeTutorial?.id === 'workspace-selection-options') {
+        return;
+      }
+
+      setOpen(next);
+
+      if (next) {
+        openChangeTimeoutRef.current = window.setTimeout(() => {
+          onOpenChange?.(mount.prefix, true);
+          openChangeTimeoutRef.current = null;
+        }, 150);
+
+        if (!gitDataLoaded) {
+          void refreshGitData();
+        }
+        return;
+      }
+
+      onOpenChange?.(mount.prefix, false);
     },
-    [gitDataLoaded, refreshGitData],
+    [activeTutorial, gitDataLoaded, mount.prefix, onOpenChange, refreshGitData],
   );
+
+  useEffect(() => {
+    return () => {
+      if (openChangeTimeoutRef.current !== null) {
+        window.clearTimeout(openChangeTimeoutRef.current);
+      }
+    };
+  }, []);
 
   const persistWorkspaceGitActionPreference = useCallback(
     (next: WorkspaceAction, partial: Partial<WorkspaceActionConfig>) => {
@@ -2188,7 +2226,10 @@ const WorkspaceActionSelect = memo(function WorkspaceActionSelect({
   return (
     <Popover open={open} onOpenChange={handleOpenChange}>
       <FileContextMenu relativePath={mount.path} resolvePath={resolveAbsolute}>
-        <div className="group/workspace flex max-w-96 cursor-default items-center justify-start gap-1.5 text-muted-foreground text-xs">
+        <div
+          data-tutorial={mount.git ? 'workspace-badge' : undefined}
+          className="group/workspace flex max-w-96 cursor-default items-center justify-start gap-1.5 text-muted-foreground text-xs"
+        >
           <Tooltip>
             <TooltipTrigger>
               <span
@@ -2236,6 +2277,7 @@ const WorkspaceActionSelect = memo(function WorkspaceActionSelect({
             <Button
               variant="ghost"
               size="xs"
+              data-tutorial="workspace-action-trigger"
               className={cn(
                 'group/action flex min-w-0 justify-start gap-1.5 px-0',
                 'text-muted-foreground hover:text-muted-foreground',
@@ -2334,10 +2376,12 @@ function ActionRow({
   active,
   onSelect,
   children,
+  tutorialId,
 }: {
   active: boolean;
   onSelect: () => void;
   children: React.ReactNode;
+  tutorialId?: string;
 }) {
   return (
     <div
@@ -2345,6 +2389,7 @@ function ActionRow({
       aria-checked={active}
       tabIndex={0}
       data-action-row=""
+      data-tutorial={tutorialId}
       onClick={onSelect}
       onKeyDown={(e) => {
         if (e.key === 'Enter' || e.key === ' ') {
@@ -3550,6 +3595,8 @@ export const WorkspaceSelect = memo(function WorkspaceSelect({
   onWorkspaceActionConfigChange,
 }: WorkspaceSelectProps) {
   const [openAgent] = useOpenAgent();
+  const [openWorkspaceActionPrefixes, setOpenWorkspaceActionPrefixes] =
+    useState<Set<string>>(() => new Set());
 
   const recentlyOpenedWorkspaces = useKartonState(
     (s: KartonState) =>
@@ -3808,6 +3855,11 @@ export const WorkspaceSelect = memo(function WorkspaceSelect({
   const handleUnmount = useCallback(
     (prefix: string) => {
       if (openAgent) {
+        setOpenWorkspaceActionPrefixes((prev) => {
+          const next = new Set(prev);
+          next.delete(prefix);
+          return next;
+        });
         void unmountWorkspace(openAgent, prefix);
         onWorkspaceChange?.();
       }
@@ -3815,37 +3867,83 @@ export const WorkspaceSelect = memo(function WorkspaceSelect({
     [openAgent, unmountWorkspace, onWorkspaceChange],
   );
 
+  const handleWorkspaceActionOpenChange = useCallback(
+    (mountPrefix: string, open: boolean) => {
+      setOpenWorkspaceActionPrefixes((prev) => {
+        const next = new Set(prev);
+        if (open) next.add(mountPrefix);
+        else next.delete(mountPrefix);
+        return next;
+      });
+    },
+    [],
+  );
+
   if (!openAgent) return null;
 
   return (
-    <div className="scrollbar-none flex min-w-0 shrink-0 items-center gap-7 overflow-x-auto px-1 py-0.5">
-      {/* Connected workspaces */}
-      {allMounts.map((mount: MountEntry) => {
-        const useActionSelect = chatIsEmpty && !!mount.git;
-        return useActionSelect ? (
-          <WorkspaceActionSelect
-            key={mount.prefix}
-            mount={mount}
-            onUnmount={handleUnmount}
-            config={workspaceActionConfigs?.get(mount.prefix)}
-            onConfigChange={onWorkspaceActionConfigChange}
-            agentInstanceId={openAgent}
-          />
-        ) : (
-          <WorkspaceBadge
-            key={mount.prefix}
-            mount={mount}
-            onUnmount={handleUnmount}
-            agentInstanceId={openAgent}
-          />
-        );
-      })}
+    <>
+      {allMounts.length > 0 && (
+        <WorkspaceSelectionTutorial
+          enabled={chatIsEmpty && allMounts.some((mount) => !!mount.git)}
+          showOptionSteps={openWorkspaceActionPrefixes.size > 0}
+        />
+      )}
+      <div className="scrollbar-none flex min-w-0 shrink-0 items-center gap-7 overflow-x-auto px-1 py-0.5">
+        {/* Connected workspaces */}
+        {allMounts.map((mount: MountEntry) => {
+          const useActionSelect = chatIsEmpty && !!mount.git;
+          return useActionSelect ? (
+            <WorkspaceActionSelect
+              key={mount.prefix}
+              mount={mount}
+              onUnmount={handleUnmount}
+              config={workspaceActionConfigs?.get(mount.prefix)}
+              onConfigChange={onWorkspaceActionConfigChange}
+              onOpenChange={handleWorkspaceActionOpenChange}
+              agentInstanceId={openAgent}
+            />
+          ) : (
+            <WorkspaceBadge
+              key={mount.prefix}
+              mount={mount}
+              onUnmount={handleUnmount}
+              agentInstanceId={openAgent}
+            />
+          );
+        })}
 
-      <ConnectWorkspaceSelect
-        hasMounts={hasMounts}
-        recentPaths={recentPaths}
-        onMount={handleMount}
-      />
-    </div>
+        <ConnectWorkspaceSelect
+          hasMounts={hasMounts}
+          recentPaths={recentPaths}
+          onMount={handleMount}
+        />
+      </div>
+    </>
   );
 });
+
+import { TUTORIALS } from '@ui/tutorial-steps';
+
+function WorkspaceSelectionTutorial({
+  enabled,
+  showOptionSteps,
+}: {
+  enabled: boolean;
+  showOptionSteps: boolean;
+}) {
+  return (
+    <>
+      <Tutorial
+        tutorialId="workspace-selection"
+        steps={TUTORIALS['workspace-selection']}
+        enabled={enabled}
+      />
+      <Tutorial
+        tutorialId="workspace-selection-options"
+        steps={TUTORIALS['workspace-selection-options']}
+        enabled={enabled && showOptionSteps}
+      />
+    </>
+  );
+}

--- a/apps/browser/src/ui/screens/main/agent-chat/index.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/index.tsx
@@ -122,7 +122,7 @@ export function AgentChat({
     >
       {topRightActions && (
         <div
-          id="new-tab-buttons"
+          data-tutorial="new-tab-buttons"
           className="app-no-drag absolute top-1 right-2 z-20 flex items-center gap-0.5 rounded-xl"
         >
           {topRightActions}

--- a/apps/browser/src/ui/screens/main/agent-chat/index.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/index.tsx
@@ -121,7 +121,10 @@ export function AgentChat({
       className="@container group overflow-visible! relative z-10 flex h-full flex-col items-stretch justify-between bg-background"
     >
       {topRightActions && (
-        <div className="app-no-drag absolute top-1 right-2 z-20 flex items-center gap-0.5">
+        <div
+          id="new-tab-buttons"
+          className="app-no-drag absolute top-1 right-2 z-20 flex items-center gap-0.5 rounded-xl"
+        >
           {topRightActions}
         </div>
       )}

--- a/apps/browser/src/ui/screens/main/content/index.tsx
+++ b/apps/browser/src/ui/screens/main/content/index.tsx
@@ -53,7 +53,7 @@ import {
 import { NewTabButtons } from '../_components/new-tab-buttons';
 import { Tutorial } from '@ui/components/tutorial';
 import { useTutorial } from '@ui/contexts/tutorial';
-import { TUTORIALS } from '@ui/tutorial-steps';
+import type { TutorialId } from '@ui/tutorial-steps';
 import type { KartonContract, TabState } from '@shared/karton-contracts/ui';
 import { HotkeyActions } from '@shared/hotkeys';
 import {
@@ -495,7 +495,8 @@ export function MainSection({
     [effectiveActiveTabId, visibleTabIds],
   );
 
-  const shouldForceTabTutorialActions = activeTutorial?.id === 'content-tabs';
+  const shouldForceTabTutorialActions =
+    activeTutorial?.id === ('content-tabs' satisfies TutorialId);
 
   const tabItems = useMemo<SortableTabItem[]>(() => {
     return visibleTabIds
@@ -715,9 +716,7 @@ export function MainSection({
           {topRightActions}
         </div>
       )}
-      {visibleTabIds.length > 0 && (
-        <Tutorial tutorialId="content-tabs" steps={TUTORIALS['content-tabs']} />
-      )}
+      {visibleTabIds.length > 0 && <Tutorial tutorialId="content-tabs" />}
       <BrowserTabHotkeys
         onFocusUrlBar={handleFocusUrlBar}
         onFocusSearchBar={handleFocusSearchBar}

--- a/apps/browser/src/ui/screens/main/content/index.tsx
+++ b/apps/browser/src/ui/screens/main/content/index.tsx
@@ -51,6 +51,9 @@ import {
   IconPinTackSlashOutline18,
 } from 'nucleo-ui-outline-18';
 import { NewTabButtons } from '../_components/new-tab-buttons';
+import { Tutorial } from '@ui/components/tutorial';
+import { useTutorial } from '@ui/contexts/tutorial';
+import { TUTORIALS } from '@ui/tutorial-steps';
 import type { KartonContract, TabState } from '@shared/karton-contracts/ui';
 import { HotkeyActions } from '@shared/hotkeys';
 import {
@@ -124,7 +127,7 @@ function TabPinIcon({
   return (
     <div className="relative size-full">
       {/* Icon — hidden on group-hover */}
-      <span className="flex size-full items-center justify-center group-hover:opacity-0">
+      <span className="flex size-full items-center justify-center group-hover:opacity-0 group-data-[force-actions-visible=true]:opacity-0">
         <TabFavicon tabState={tab} />
       </span>
       {/* Pin toggle — replaces icon on group-hover.
@@ -139,7 +142,7 @@ function TabPinIcon({
               aria-label={isAttachedToCurrentAgent ? 'Pin globally' : 'Unpin'}
               className={cn(
                 buttonVariants({ variant: 'ghost', size: 'icon-2xs' }),
-                'absolute inset-0 size-full text-subtle-foreground opacity-0 group-hover:opacity-100',
+                'absolute inset-0 size-full text-subtle-foreground opacity-0 group-hover:opacity-100 group-data-[force-actions-visible=true]:opacity-100',
               )}
               onPointerDown={(e: React.PointerEvent) => e.stopPropagation()}
               onClick={handleToggle}
@@ -208,6 +211,7 @@ export function MainSection({
 
   const { setTabUiState, removeTabUiState } = useTabUIState();
   const [openAgent] = useOpenAgent();
+  const { activeTutorial } = useTutorial();
   const [pendingUnsavedClose, setPendingUnsavedClose] =
     useState<FileTabUnsavedEditEntry | null>(null);
 
@@ -486,6 +490,13 @@ export function MainSection({
 
   // Build SortableTabItem[] from optimistic order + Karton tab state
   // ---------------------------------------------------------------------------
+  const tutorialTabId = useMemo(
+    () => effectiveActiveTabId ?? visibleTabIds[0] ?? null,
+    [effectiveActiveTabId, visibleTabIds],
+  );
+
+  const shouldForceTabTutorialActions = activeTutorial?.id === 'content-tabs';
+
   const tabItems = useMemo<SortableTabItem[]>(() => {
     return visibleTabIds
       .map((id): SortableTabItem | null => {
@@ -518,6 +529,9 @@ export function MainSection({
               void promoteFileTab(id);
             }
           },
+          tutorialId: id === tutorialTabId ? 'content-tab-item' : undefined,
+          forceActionsVisible:
+            id === tutorialTabId && shouldForceTabTutorialActions,
           actions:
             tab.type !== 'terminal' && (tab.isPlayingAudio || tab.isMuted) ? (
               <AudioMuteButton tab={tab} />
@@ -545,6 +559,8 @@ export function MainSection({
     tabs,
     activeTabId,
     openAgent,
+    tutorialTabId,
+    shouldForceTabTutorialActions,
     closeTabWithUnsavedCheck,
     promoteFileTab,
   ]);
@@ -698,6 +714,9 @@ export function MainSection({
         <div className="app-no-drag absolute top-1 right-2 z-20 flex items-center gap-0.5">
           {topRightActions}
         </div>
+      )}
+      {visibleTabIds.length > 0 && (
+        <Tutorial tutorialId="content-tabs" steps={TUTORIALS['content-tabs']} />
       )}
       <BrowserTabHotkeys
         onFocusUrlBar={handleFocusUrlBar}

--- a/apps/browser/src/ui/screens/main/file-tree/file-tree-sidebar.tsx
+++ b/apps/browser/src/ui/screens/main/file-tree/file-tree-sidebar.tsx
@@ -27,6 +27,8 @@ import {
   getFileTreeWorkspaceMountsForAgent,
   getFileTreeWorkspaceName,
 } from './file-tree-utils';
+import { Tutorial } from '@ui/components/tutorial';
+import { TUTORIALS } from '@ui/tutorial-steps';
 
 export function FileTreeSidebar() {
   const [openAgent] = useOpenAgent();
@@ -100,14 +102,20 @@ export function FileTreeSidebar() {
   const previewGroupKey = `file-tree-preview:${openAgent ?? 'global'}`;
 
   return (
-    <aside className="flex h-full w-full flex-col bg-background">
+    <aside
+      data-tutorial="file-tree-panel"
+      className="flex h-full w-full flex-col bg-background"
+    >
       <div
         className={cn(
           'flex shrink-0 flex-row items-stretch gap-1 bg-background p-1.5 pr-2.5',
           workspaces.length > 0 && 'border-derived-strong border-b',
         )}
       >
-        <div className="flex min-w-0 flex-1 flex-row items-stretch gap-1 overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+        <div
+          data-tutorial="file-tree-workspace-tabs"
+          className="flex min-w-0 flex-1 flex-row items-stretch gap-1 overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+        >
           {workspaces.map((workspace) => {
             const active = workspace.key === selectedWorkspaceKey;
             return (
@@ -152,7 +160,13 @@ export function FileTreeSidebar() {
         </Tooltip>
       </div>
       {workspaces.length > 0 && (
-        <div className="flex h-9 shrink-0 items-center justify-end gap-0.5 border-derived-strong border-b bg-background pr-1.5 pl-2">
+        <Tutorial tutorialId="file-tree" steps={TUTORIALS['file-tree']} />
+      )}
+      {workspaces.length > 0 && (
+        <div
+          data-tutorial="file-tree-search-bar"
+          className="flex h-9 shrink-0 items-center justify-end gap-0.5 border-derived-strong border-b bg-background pr-1.5 pl-2"
+        >
           {/* Files/Git mode switcher hidden until Git Diff view is functional. */}
           <Tooltip>
             <TooltipTrigger>

--- a/apps/browser/src/ui/screens/main/file-tree/file-tree-sidebar.tsx
+++ b/apps/browser/src/ui/screens/main/file-tree/file-tree-sidebar.tsx
@@ -28,7 +28,6 @@ import {
   getFileTreeWorkspaceName,
 } from './file-tree-utils';
 import { Tutorial } from '@ui/components/tutorial';
-import { TUTORIALS } from '@ui/tutorial-steps';
 
 export function FileTreeSidebar() {
   const [openAgent] = useOpenAgent();
@@ -159,9 +158,7 @@ export function FileTreeSidebar() {
           </TooltipContent>
         </Tooltip>
       </div>
-      {workspaces.length > 0 && (
-        <Tutorial tutorialId="file-tree" steps={TUTORIALS['file-tree']} />
-      )}
+      {workspaces.length > 0 && <Tutorial tutorialId="file-tree" />}
       {workspaces.length > 0 && (
         <div
           data-tutorial="file-tree-search-bar"

--- a/apps/browser/src/ui/screens/main/index.tsx
+++ b/apps/browser/src/ui/screens/main/index.tsx
@@ -26,6 +26,7 @@ import {
 } from './_components/content-collapsed-context';
 import { useTabUIState } from '@ui/hooks/use-tab-ui-state';
 import { ContentToggleButton } from './_components/content-toggle-button';
+import { Tutorial } from '@ui/components/tutorial';
 import { GlobalHotkeyBindings } from './_components/global-hotkey-bindings';
 import { AgentHotkeyBindings } from './_components/agent-hotkey-bindings';
 import {
@@ -91,6 +92,17 @@ export function DefaultLayout({ show }: { show: boolean }) {
         </SidebarCollapsedProvider>
       </ChatDraftProvider>
     </OpenAgentProvider>
+  );
+}
+
+import { TUTORIALS } from '@ui/tutorial-steps';
+
+function GeneralUiExperienceTutorial() {
+  return (
+    <Tutorial
+      tutorialId="general-ui-experience"
+      steps={TUTORIALS['general-ui-experience']}
+    />
   );
 }
 
@@ -267,6 +279,7 @@ function DefaultLayoutInner({ show }: { show: boolean }) {
       )}
       {show && <CommandCenterHotkeys />}
       {show && <CommandCenter />}
+      {show && <GeneralUiExperienceTutorial />}
       <div
         className={cn(
           'root pointer-events-auto relative inset-0 flex size-full flex-row items-stretch justify-between transition-[opacity,filter] delay-150 duration-300 ease-out',

--- a/apps/browser/src/ui/screens/main/index.tsx
+++ b/apps/browser/src/ui/screens/main/index.tsx
@@ -95,17 +95,6 @@ export function DefaultLayout({ show }: { show: boolean }) {
   );
 }
 
-import { TUTORIALS } from '@ui/tutorial-steps';
-
-function GeneralUiExperienceTutorial() {
-  return (
-    <Tutorial
-      tutorialId="general-ui-experience"
-      steps={TUTORIALS['general-ui-experience']}
-    />
-  );
-}
-
 function DefaultLayoutInner({ show }: { show: boolean }) {
   const isMacOs = useKartonState((s) => s.appInfo.platform === 'darwin');
   const isFullScreen = useKartonState((s) => s.appInfo.isFullScreen);
@@ -279,7 +268,7 @@ function DefaultLayoutInner({ show }: { show: boolean }) {
       )}
       {show && <CommandCenterHotkeys />}
       {show && <CommandCenter />}
-      {show && <GeneralUiExperienceTutorial />}
+      {show && <Tutorial tutorialId="general-ui-experience" />}
       <div
         className={cn(
           'root pointer-events-auto relative inset-0 flex size-full flex-row items-stretch justify-between transition-[opacity,filter] delay-150 duration-300 ease-out',

--- a/apps/browser/src/ui/screens/main/sidebar/agents-list/_components/agent-card.tsx
+++ b/apps/browser/src/ui/screens/main/sidebar/agents-list/_components/agent-card.tsx
@@ -146,6 +146,7 @@ export const AgentCard = memo(
             startEditing();
           }
         }}
+        data-tutorial="agent-card"
         className={cn(
           buttonVariants({ variant: 'ghost', size: 'sm' }),
           'group/card relative justify-start gap-1 pr-3.5 pl-2 text-start text-muted-foreground hover:bg-foreground/8',
@@ -165,9 +166,13 @@ export const AgentCard = memo(
                   ? 'bg-success-solid'
                   : null;
           return (
-            <div className="relative flex size-4 shrink-0 items-center justify-center dark:brightness-125">
+            <div
+              data-tutorial="agent-status-indicator"
+              className="relative flex size-4 shrink-0 items-center justify-center dark:brightness-125"
+            >
               {dotColor ? (
                 <div
+                  data-tutorial="agent-status-dot"
                   className={cn(
                     'relative size-2 shrink-0 transition-opacity',
                     onTogglePinned && 'group-hover/card:opacity-0',

--- a/apps/browser/src/ui/tutorial-steps.ts
+++ b/apps/browser/src/ui/tutorial-steps.ts
@@ -1,0 +1,114 @@
+import type { TutorialStep } from '@ui/contexts/tutorial';
+
+export const TUTORIALS = {
+  'general-ui-experience': [
+    {
+      targetSelector: '#chat-input-container-box',
+      title: 'Chat Input',
+      description:
+        'Type messages here. You can also drag files, mention tabs or workspaces with `@`, and use `/` commands.',
+    },
+    {
+      targetSelector: '[aria-label="Connect workspace"]',
+      title: 'Read/Write Access to Workspaces',
+      description:
+        'Connect agents to one or more workspaces, both regular directories and Git repositories.',
+    },
+    {
+      targetSelector: '#new-tab-buttons',
+      title: 'Browser, Terminal & File Tree',
+      description:
+        'Open browser or terminal tabs here, and toggle the file tree to browse workspace files.',
+    },
+    {
+      targetSelector: '#new-sidebar-panel',
+      title: 'Agent Sidebar',
+      description:
+        'This sidebar shows all your agents. Each agent keeps its own chat, tabs, and mounted workspaces.',
+    },
+    {
+      targetSelector: '[data-tutorial="agent-card"]',
+      title: 'Agent Status',
+      description:
+        'This is one agent. Once you start working with an agent, a colored status dot may appear next to its title with one of these colors:\n\n' +
+        '- **Blue** — Working\n' +
+        '- **Green** — Done\n' +
+        '- **Yellow** — Waiting for your response\n' +
+        '- **Red** — Error',
+    },
+  ],
+
+  'workspace-selection': [
+    {
+      targetSelector: '[data-tutorial="workspace-badge"]',
+      title: 'Connected Git Repository',
+      description:
+        'The agent can **read** files, **edit** code, and **run** commands inside this Git repository.',
+    },
+    {
+      targetSelector: '[data-tutorial="workspace-action-trigger"]',
+      title: 'Configure Worktree / Branch Mode',
+      description:
+        'Click this dropdown to choose whether to work with a branch in the repository root, or with a worktree.',
+    },
+  ],
+
+  'workspace-selection-options': [
+    {
+      targetSelector: '[data-tutorial="action-create-worktree"]',
+      title: 'Create new Worktree',
+      description:
+        'Creates a **new worktree** with its own branch for the agent to work in.\n\nYou can choose which source branch to base the new worktree on.',
+    },
+    {
+      targetSelector: '[data-tutorial="action-switch-worktree"]',
+      title: 'Use existing Worktree',
+      description:
+        'Connects the agent to an **already-existing worktree**.\n\nThis makes it easy to let **multiple agents work on the same worktree**.',
+    },
+    {
+      targetSelector: '[data-tutorial="action-create-branch"]',
+      title: 'Create new Branch',
+      description:
+        'Creates a **new branch in the repository root** — simpler than worktrees. Use this when you want to work directly in the repository without creating a worktree.',
+    },
+    {
+      targetSelector: '[data-tutorial="action-switch-branch"]',
+      title: 'Use existing Branch',
+      description:
+        'Switches the agent to an **already-existing branch** in the repository root. The simplest option — just pick a branch and start working.',
+    },
+  ],
+
+  'content-tabs': [
+    {
+      targetSelector: '[data-tutorial="content-tab-item"]',
+      title: 'Opened Tabs',
+      description:
+        'Tabs appear here. The **pin** icon makes a tab global so it stays visible across all agents, and the **close** icon removes it.',
+    },
+  ],
+
+  'browser-element-selector': [
+    {
+      targetSelector: '[data-tutorial="chat-element-selector"]',
+      title: 'Reference Elements',
+      description:
+        'Use this to select elements in the browser and add them to the chat as references.',
+    },
+  ],
+
+  'file-tree': [
+    {
+      targetSelector: '[data-tutorial="file-tree-panel"]',
+      title: 'File Trees',
+      description:
+        'See all files from all workspaces mounted to the current agent. You can browse, open, and preview files right here.',
+    },
+    {
+      targetSelector: '[data-tutorial="file-tree-workspace-tabs"]',
+      title: 'Switch Workspace',
+      description: 'Switch between file trees of the mounted workspaces here.',
+    },
+  ],
+} as const satisfies Record<string, TutorialStep[]>;

--- a/apps/browser/src/ui/tutorial-steps.ts
+++ b/apps/browser/src/ui/tutorial-steps.ts
@@ -1,114 +1,158 @@
 import type { TutorialStep } from '@ui/contexts/tutorial';
 
+interface TutorialContent {
+  /**
+   * Content version. Bump whenever steps are reordered, inserted, or
+   * removed — persisted progress is keyed by id + version, so a bump
+   * discards stale step indices instead of resuming at the wrong step.
+   */
+  version: number;
+  steps: readonly TutorialStep[];
+}
+
+/**
+ * All tutorials, keyed by id. Declaration order doubles as display
+ * priority: when several tutorials queue up, earlier entries show first.
+ *
+ * Target convention: every `targetSelector` uses a `[data-tutorial="…"]`
+ * attribute on the target element — never ids, classes, or aria-labels,
+ * which change for unrelated reasons and break tutorials silently.
+ */
 export const TUTORIALS = {
-  'general-ui-experience': [
-    {
-      targetSelector: '#chat-input-container-box',
-      title: 'Chat Input',
-      description:
-        'Type messages here. You can also drag files, mention tabs or workspaces with `@`, and use `/` commands.',
-    },
-    {
-      targetSelector: '[aria-label="Connect workspace"]',
-      title: 'Read/Write Access to Workspaces',
-      description:
-        'Connect agents to one or more workspaces, both regular directories and Git repositories.',
-    },
-    {
-      targetSelector: '#new-tab-buttons',
-      title: 'Browser, Terminal & File Tree',
-      description:
-        'Open browser or terminal tabs here, and toggle the file tree to browse workspace files.',
-    },
-    {
-      targetSelector: '#new-sidebar-panel',
-      title: 'Agent Sidebar',
-      description:
-        'This sidebar shows all your agents. Each agent keeps its own chat, tabs, and mounted workspaces.',
-    },
-    {
-      targetSelector: '[data-tutorial="agent-card"]',
-      title: 'Agent Status',
-      description:
-        'This is one agent. Once you start working with an agent, a colored status dot may appear next to its title with one of these colors:\n\n' +
-        '- **Blue** — Working\n' +
-        '- **Green** — Done\n' +
-        '- **Yellow** — Waiting for your response\n' +
-        '- **Red** — Error',
-    },
-  ],
+  'general-ui-experience': {
+    version: 1,
+    steps: [
+      {
+        targetSelector: '[data-tutorial="chat-input"]',
+        title: 'Chat Input',
+        description:
+          'Type messages here. You can also drag files, mention tabs or workspaces with `@`, and use `/` commands.',
+      },
+      {
+        targetSelector: '[data-tutorial="connect-workspace"]',
+        title: 'Read/Write Access to Workspaces',
+        description:
+          'Connect agents to one or more workspaces, both regular directories and Git repositories.',
+      },
+      {
+        targetSelector: '[data-tutorial="new-tab-buttons"]',
+        title: 'Browser, Terminal & File Tree',
+        description:
+          'Open browser or terminal tabs here, and toggle the file tree to browse workspace files.',
+      },
+      {
+        targetSelector: '[data-tutorial="sidebar-panel"]',
+        title: 'Agent Sidebar',
+        description:
+          'This sidebar shows all your agents. Each agent keeps its own chat, tabs, and mounted workspaces.',
+      },
+      {
+        targetSelector: '[data-tutorial="agent-card"]',
+        title: 'Agent Status',
+        description:
+          'This is one agent. Once you start working with an agent, a colored status dot may appear next to its title with one of these colors:\n\n' +
+          '- **Blue** — Working\n' +
+          '- **Green** — Done\n' +
+          '- **Yellow** — Waiting for your response\n' +
+          '- **Red** — Error',
+      },
+    ],
+  },
 
-  'workspace-selection': [
-    {
-      targetSelector: '[data-tutorial="workspace-badge"]',
-      title: 'Connected Git Repository',
-      description:
-        'The agent can **read** files, **edit** code, and **run** commands inside this Git repository.',
-    },
-    {
-      targetSelector: '[data-tutorial="workspace-action-trigger"]',
-      title: 'Configure Worktree / Branch Mode',
-      description:
-        'Click this dropdown to choose whether to work with a branch in the repository root, or with a worktree.',
-    },
-  ],
+  'workspace-selection': {
+    version: 1,
+    steps: [
+      {
+        targetSelector: '[data-tutorial="workspace-badge"]',
+        title: 'Connected Git Repository',
+        description:
+          'The agent can **read** files, **edit** code, and **run** commands inside this Git repository.',
+      },
+      {
+        targetSelector: '[data-tutorial="workspace-action-trigger"]',
+        title: 'Configure Worktree / Branch Mode',
+        description:
+          'Click this dropdown to choose whether to work with a branch in the repository root, or with a worktree.',
+      },
+    ],
+  },
 
-  'workspace-selection-options': [
-    {
-      targetSelector: '[data-tutorial="action-create-worktree"]',
-      title: 'Create new Worktree',
-      description:
-        'Creates a **new worktree** with its own branch for the agent to work in.\n\nYou can choose which source branch to base the new worktree on.',
-    },
-    {
-      targetSelector: '[data-tutorial="action-switch-worktree"]',
-      title: 'Use existing Worktree',
-      description:
-        'Connects the agent to an **already-existing worktree**.\n\nThis makes it easy to let **multiple agents work on the same worktree**.',
-    },
-    {
-      targetSelector: '[data-tutorial="action-create-branch"]',
-      title: 'Create new Branch',
-      description:
-        'Creates a **new branch in the repository root** — simpler than worktrees. Use this when you want to work directly in the repository without creating a worktree.',
-    },
-    {
-      targetSelector: '[data-tutorial="action-switch-branch"]',
-      title: 'Use existing Branch',
-      description:
-        'Switches the agent to an **already-existing branch** in the repository root. The simplest option — just pick a branch and start working.',
-    },
-  ],
+  'workspace-selection-options': {
+    version: 1,
+    steps: [
+      {
+        targetSelector: '[data-tutorial="action-create-worktree"]',
+        title: 'Create new Worktree',
+        description:
+          'Creates a **new worktree** with its own branch for the agent to work in.\n\nYou can choose which source branch to base the new worktree on.',
+      },
+      {
+        targetSelector: '[data-tutorial="action-switch-worktree"]',
+        title: 'Use existing Worktree',
+        description:
+          'Connects the agent to an **already-existing worktree**.\n\nThis makes it easy to let **multiple agents work on the same worktree**.',
+      },
+      {
+        targetSelector: '[data-tutorial="action-create-branch"]',
+        title: 'Create new Branch',
+        description:
+          'Creates a **new branch in the repository root** — simpler than worktrees. Use this when you want to work directly in the repository without creating a worktree.',
+      },
+      {
+        targetSelector: '[data-tutorial="action-switch-branch"]',
+        title: 'Use existing Branch',
+        description:
+          'Switches the agent to an **already-existing branch** in the repository root. The simplest option — just pick a branch and start working.',
+      },
+    ],
+  },
 
-  'content-tabs': [
-    {
-      targetSelector: '[data-tutorial="content-tab-item"]',
-      title: 'Opened Tabs',
-      description:
-        'Tabs appear here. The **pin** icon makes a tab global so it stays visible across all agents, and the **close** icon removes it.',
-    },
-  ],
+  'content-tabs': {
+    version: 1,
+    steps: [
+      {
+        targetSelector: '[data-tutorial="content-tab-item"]',
+        title: 'Opened Tabs',
+        description:
+          'Tabs appear here. The **pin** icon makes a tab global so it stays visible across all agents, and the **close** icon removes it.',
+      },
+    ],
+  },
 
-  'browser-element-selector': [
-    {
-      targetSelector: '[data-tutorial="chat-element-selector"]',
-      title: 'Reference Elements',
-      description:
-        'Use this to select elements in the browser and add them to the chat as references.',
-    },
-  ],
+  'browser-element-selector': {
+    version: 1,
+    steps: [
+      {
+        targetSelector: '[data-tutorial="chat-element-selector"]',
+        title: 'Reference Elements',
+        description:
+          'Use this to select elements in the browser and add them to the chat as references.',
+      },
+    ],
+  },
 
-  'file-tree': [
-    {
-      targetSelector: '[data-tutorial="file-tree-panel"]',
-      title: 'File Trees',
-      description:
-        'See all files from all workspaces mounted to the current agent. You can browse, open, and preview files right here.',
-    },
-    {
-      targetSelector: '[data-tutorial="file-tree-workspace-tabs"]',
-      title: 'Switch Workspace',
-      description: 'Switch between file trees of the mounted workspaces here.',
-    },
-  ],
-} as const satisfies Record<string, TutorialStep[]>;
+  'file-tree': {
+    version: 1,
+    steps: [
+      {
+        targetSelector: '[data-tutorial="file-tree-panel"]',
+        title: 'File Trees',
+        description:
+          'See all files from all workspaces mounted to the current agent. You can browse, open, and preview files right here.',
+      },
+      {
+        targetSelector: '[data-tutorial="file-tree-workspace-tabs"]',
+        title: 'Switch Workspace',
+        description:
+          'Switch between file trees of the mounted workspaces here.',
+      },
+    ],
+  },
+} as const satisfies Record<string, TutorialContent>;
+
+export type TutorialId = keyof typeof TUTORIALS;
+
+/** Display priority — index in declaration order; lower shows first. */
+export const TUTORIAL_PRIORITY = Object.keys(
+  TUTORIALS,
+) as readonly TutorialId[];

--- a/packages/stage-ui/src/components/sortable-tabs.tsx
+++ b/packages/stage-ui/src/components/sortable-tabs.tsx
@@ -134,6 +134,16 @@ export interface SortableTabItem {
    */
   wrapTrigger?: (inner: ReactElement) => ReactElement;
   /**
+   * Optional tutorial marker applied to the outer bar trigger wrapper.
+   * Bar variant only.
+   */
+  tutorialId?: string;
+  /**
+   * Forces hover-revealed tab controls (pin/close) visible.
+   * Bar variant only.
+   */
+  forceActionsVisible?: boolean;
+  /**
    * When true, a dot indicator is shown next to the label (hidden on hover).
    * Bar variant only. Use case: unsaved file edits marker.
    */
@@ -207,7 +217,7 @@ function BarTriggerContent({
       onPointerDown={(e) => e.stopPropagation()}
       onClick={item.onClose}
       className={cn(
-        'absolute top-1/2 right-0.5 flex shrink-0 -translate-y-1/2 items-center justify-center p-1 text-muted-foreground opacity-0 transition-colors hover:text-foreground focus-visible:opacity-100 group-hover:opacity-100',
+        'absolute top-1/2 right-0.5 flex shrink-0 -translate-y-1/2 items-center justify-center p-1 text-muted-foreground opacity-0 transition-colors hover:text-foreground focus-visible:opacity-100 group-hover:opacity-100 group-data-[force-actions-visible=true]:opacity-100',
       )}
     >
       <XIcon className="size-3" />
@@ -218,6 +228,8 @@ function BarTriggerContent({
     <div
       onAuxClick={item.onAuxClick}
       onDoubleClick={item.onDoubleClick}
+      data-tutorial={item.tutorialId}
+      data-force-actions-visible={item.forceActionsVisible ? 'true' : undefined}
       className={cn(
         'group relative flex h-7 flex-row items-stretch rounded-md transition-colors duration-150 ease-out',
         isActive ? 'bg-surface-1' : 'bg-transparent hover:bg-surface-1',
@@ -238,7 +250,7 @@ function BarTriggerContent({
         <span
           data-active={isActive}
           className={cn(
-            'mask-alpha mask-l-from-black mask-l-to-black group-hover:mask-l-from-transparent mask-l-from-3 mask-l-to-6 flex-1 truncate text-left font-regular text-muted-foreground data-[active=true]:text-foreground',
+            'mask-alpha mask-l-from-black mask-l-to-black group-hover:mask-l-from-transparent group-data-[force-actions-visible=true]:mask-l-from-transparent mask-l-from-3 mask-l-to-6 flex-1 truncate text-left font-regular text-muted-foreground data-[active=true]:text-foreground',
           )}
         >
           {item.label}
@@ -249,7 +261,7 @@ function BarTriggerContent({
             className={cn(
               '-mr-1 ml-0.5 size-1.5 shrink-0 rounded-full',
               isActive ? 'bg-foreground' : 'bg-muted-foreground',
-              'group-hover:opacity-0',
+              'group-hover:opacity-0 group-data-[force-actions-visible=true]:opacity-0',
             )}
           />
         )}


### PR DESCRIPTION
- Add composable tutorial system with per-ID progress persistence
- Implement overlay with cutout highlighting and markdown popovers
- Add 6 tutorials: general UI, workspace selection (2), content tabs, browser element selector, file tree
- Add enabled/hide lifecycle to prevent focus-loss-driven advancement
- Force tutorial overlay above browser tab content via movePanelToForeground
- Add force-actions-visible support to SortableTabs for tutorial pin/close reveal
- Centralize all tutorial step definitions in tutorial-steps.ts

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a guided tutorial mode with step-by-step overlays and persistent progress to help users learn key parts of the UI. Ships six focused tutorials and strengthens accessibility, prioritization/queueing, and state persistence.

- New Features
  - Tutorial system with `TutorialProvider` and `TutorialOverlay` (cutout highlight, markdown tips, Esc/←/→, focus-trapped popover); overlay raised via `movePanelToForeground('stagewise-ui')`.
  - Progress persisted in `tutorial-state.json` with versioned keys; new RPC `userExperience.tutorial.setStep`; `tutorialState` added to stored experience.
  - App wiring via `<Tutorial>` triggers and `[data-tutorial]` markers; steps centralized in `ui/tutorial-steps.ts` with typed ids (`TutorialId`) and priority ordering (`TUTORIAL_PRIORITY`). `SortableTabs` adds `tutorialId` and `forceActionsVisible` to reveal pin/close controls.
  - Six tutorials: general UI, workspace selection, workspace selection options, content tabs, browser element selector, file tree.
  - Telemetry: capture `tutorial_clicked_next`, `tutorial_clicked_back`, and `tutorial_dismissed` (id, step index, total steps, finished flag).

- Bug Fixes
  - Serialize tutorial step writes to avoid races; only advance with `Math.max`; patch tutorial state slice.
  - Clamp popover to viewport on narrow panels; throttle DOM observer via `requestAnimationFrame`.
  - Queue registrations while another tutorial is active; defer same-commit registrations to a microtask so the highest-priority tutorial wins; drain/clear the queue on finish or dismissal; `unregisterTutorial` removes stale queued entries.
  - Auto-skip steps when targets are missing; preserve hidden step index so hide/re-enable resumes correctly.
  - Trap focus in the popover; suppress default/bubbling on tutorial keys; ignore arrow keys in editable fields; stabilize cleanup using ref-stored callbacks.

<sup>Written for commit 796d6c5c80cb20d1ecbbc27e2a9fdaff85ba88d1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1303?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive, multi-step in-app tutorials with keyboard navigation, smart anchored popovers, queued flows, and persistent per-tutorial progress across sessions.
  * Tutorials integrated across tabs, file tree, chat, workspace controls and agent cards; UI elements expose anchors and can force action visibility.

* **Chores**
  * Storybook mock states updated to include tutorial state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->