### PR TITLE
fix(browser): use stable fallback constants in useKartonState selecto…

### DIFF
--- a/apps/browser/src/backend/services/window-layout/ui-controller.ts
+++ b/apps/browser/src/backend/services/window-layout/ui-controller.ts
@@ -780,14 +780,25 @@ export class UIController extends EventEmitter<UIControllerEventMap> {
         this.emit('layoutUpdate', bounds);
       },
     );
+    // Primary RPC path: browser.layout.movePanelToForeground
+    // Also register the legacy alias browser.movePanelToForeground (without
+    // the `layout` intermediate namespace) as a defensive fallback — some
+    // production client builds may reference the older flat path under the
+    // `browser` namespace, which would otherwise produce an unregistered-
+    // procedure error.
+    const handleMovePanelToForeground = async (
+      _callingClientId: string,
+      panel: 'stagewise-ui' | 'tab-content',
+    ) => {
+      this.emit('movePanelToForeground', panel);
+    };
     this.uiKarton.registerServerProcedureHandler(
       'browser.layout.movePanelToForeground',
-      async (
-        _callingClientId: string,
-        panel: 'stagewise-ui' | 'tab-content',
-      ) => {
-        this.emit('movePanelToForeground', panel);
-      },
+      handleMovePanelToForeground,
+    );
+    this.uiKarton.registerServerProcedureHandler(
+      'browser.movePanelToForeground',
+      handleMovePanelToForeground,
     );
     this.uiKarton.registerServerProcedureHandler(
       'browser.layout.togglePanelKeyboardFocus',
@@ -1206,6 +1217,7 @@ export class UIController extends EventEmitter<UIControllerEventMap> {
     this.uiKarton.removeServerProcedureHandler(
       'browser.layout.movePanelToForeground',
     );
+    this.uiKarton.removeServerProcedureHandler('browser.movePanelToForeground');
     this.uiKarton.removeServerProcedureHandler(
       'browser.layout.togglePanelKeyboardFocus',
     );

--- a/apps/browser/src/shared/karton-contracts/ui/index.ts
+++ b/apps/browser/src/shared/karton-contracts/ui/index.ts
@@ -1506,6 +1506,14 @@ export type KartonContract = {
       clearFileNotice: (tabId: string) => Promise<void>;
       switchTab: (tabId: string) => Promise<void>;
       reorderTabs: (tabIds: string[]) => Promise<void>;
+      /**
+       * Legacy alias for `browser.layout.movePanelToForeground`. Some
+       * production client builds reference the flat `browser.` path
+       * without the `layout` intermediate namespace.
+       */
+      movePanelToForeground: (
+        panel: 'stagewise-ui' | 'tab-content',
+      ) => Promise<void>;
       layout: {
         // This is called when the webcontents view is resized or moved or whatever. It's used to notify the main window about the new bounds that the webcontents view should have.
         update: (

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/message-part-ui/tools/multi-edit/generic-multi-edit.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/message-part-ui/tools/multi-edit/generic-multi-edit.tsx
@@ -16,6 +16,7 @@ import { useDiffLines } from '@ui/hooks/use-diff-lines';
 import { useMemo, useState } from 'react';
 import { Button } from '@stagewise/stage-ui/components/button';
 import { useKartonState, useKartonProcedure } from '@ui/hooks/use-karton';
+import { EMPTY_MOUNTS } from '@shared/karton-contracts/ui';
 import {
   Tooltip,
   TooltipContent,
@@ -39,7 +40,9 @@ export const GenericMultiEditToolPart = ({
   const openFileTab = useKartonProcedure((p) => p.fileTree.openFileTab);
   const revealInFolder = useKartonProcedure((p) => p.fileTree.revealInFolder);
   const mounts = useKartonState((s) =>
-    openAgent ? (s.toolbox[openAgent]?.workspace?.mounts ?? []) : [],
+    openAgent
+      ? (s.toolbox[openAgent]?.workspace?.mounts ?? EMPTY_MOUNTS)
+      : EMPTY_MOUNTS,
   );
   // Fall back to the global mount registry so "Open file" links still work
   // when the workspace was remounted after the tool ran, or after an agent

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/message-part-ui/tools/write/generic-write.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/message-part-ui/tools/write/generic-write.tsx
@@ -24,6 +24,7 @@ import { useDiffLines } from '@ui/hooks/use-diff-lines';
 import { Button } from '@stagewise/stage-ui/components/button';
 
 import { useKartonState, useKartonProcedure } from '@ui/hooks/use-karton';
+import { EMPTY_MOUNTS } from '@shared/karton-contracts/ui';
 import {
   StreamingCodeBlock,
   getLanguageFromPath,
@@ -37,7 +38,9 @@ export const GenericWriteToolPart = memo(
     const openFileTab = useKartonProcedure((p) => p.fileTree.openFileTab);
     const revealInFolder = useKartonProcedure((p) => p.fileTree.revealInFolder);
     const mounts = useKartonState((s) =>
-      openAgent ? (s.toolbox[openAgent]?.workspace?.mounts ?? []) : [],
+      openAgent
+        ? (s.toolbox[openAgent]?.workspace?.mounts ?? EMPTY_MOUNTS)
+        : EMPTY_MOUNTS,
     );
     const globalMounts = useKartonState((s) => s.workspaceMounts);
     const outputWithDiff = part.output as

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/rich-text/mentions/shell-session-badge.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/rich-text/mentions/shell-session-badge.tsx
@@ -6,6 +6,8 @@ import { useOpenAgent } from '@ui/hooks/use-open-chat';
 import { useKartonState } from '@ui/hooks/use-karton';
 import type { ShellSessionSnapshot } from '@shared/karton-contracts/ui/agent/metadata';
 
+const EMPTY_SESSIONS: ShellSessionSnapshot[] = [];
+
 interface ShellSessionBadgeProps {
   sessionId: string;
   viewOnly?: boolean;
@@ -19,7 +21,7 @@ export function ShellSessionBadge({
 
   const session = useKartonState((s): ShellSessionSnapshot | null => {
     if (!openAgentId) return null;
-    const sessions = s.toolbox[openAgentId]?.shells?.sessions ?? [];
+    const sessions = s.toolbox[openAgentId]?.shells?.sessions ?? EMPTY_SESSIONS;
     return sessions.find((sess) => sess.id === sessionId) ?? null;
   });
 


### PR DESCRIPTION
…rs to prevent infinite re-renders

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent infinite re-renders by using stable fallback arrays in `useKartonState` selectors and restore panel foregrounding on older clients via a legacy RPC alias. This removes UI flicker and fixes unregistered-procedure errors when moving panels to the foreground.

- **Bug Fixes**
  - Use stable fallbacks: `EMPTY_MOUNTS` from `@shared/karton-contracts/ui` in `GenericMultiEditToolPart` and `GenericWriteToolPart`; local `EMPTY_SESSIONS` in `ShellSessionBadge`.
  - Register `browser.movePanelToForeground` as a legacy alias for `browser.layout.movePanelToForeground` using a shared handler; add the alias to `KartonContract`; remove both handlers on dispose.

<sup>Written for commit 17da6b211045e72f67bd57915a358d8ddf40c909. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1304?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized empty/default fallbacks across chat, editor, and badge UI components for more consistent behavior.
* **Bug Fixes**
  * Reintroduced a legacy pathway for moving UI panels to the foreground to preserve compatibility and reliable window behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->