### PR TITLE
fix(browser): add cmd-j terminal toggle shortcut

### DIFF
--- a/apps/browser/src/shared/hotkeys.test.ts
+++ b/apps/browser/src/shared/hotkeys.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect } from 'vitest';
 import {
   isEventMatch,
   getDisplayString,
+  hotkeyDefinitions,
+  HotkeyActions,
   type HotkeyDefinition,
 } from './hotkeys';
 
@@ -175,6 +177,25 @@ describe('isEventMatch', () => {
       const def: HotkeyDefinition = { accelerator: 'Mod+0' };
       const ev = createKeyboardEvent({ code: 'Digit0', ctrlKey: true });
       expect(isEventMatch(ev, def, 'windows')).toBe(true);
+    });
+  });
+
+  describe('terminal toggle shortcuts', () => {
+    const def = hotkeyDefinitions[HotkeyActions.FOCUS_OR_TOGGLE_TERMINAL];
+
+    it('matches Ctrl+Backquote on Mac', () => {
+      const ev = createKeyboardEvent({ code: 'Backquote', ctrlKey: true });
+      expect(isEventMatch(ev, def, 'mac')).toBe(true);
+    });
+
+    it('matches Cmd+J on Mac', () => {
+      const ev = createKeyboardEvent({ code: 'KeyJ', metaKey: true });
+      expect(isEventMatch(ev, def, 'mac')).toBe(true);
+    });
+
+    it('does NOT match Ctrl+J on Windows', () => {
+      const ev = createKeyboardEvent({ code: 'KeyJ', ctrlKey: true });
+      expect(isEventMatch(ev, def, 'windows')).toBe(false);
     });
   });
 

--- a/apps/browser/src/shared/hotkeys.ts
+++ b/apps/browser/src/shared/hotkeys.ts
@@ -248,6 +248,7 @@ export const hotkeyDefinitions: Record<HotkeyActions, HotkeyDefinition> = {
   },
   [HotkeyActions.FOCUS_OR_TOGGLE_TERMINAL]: {
     accelerator: 'Ctrl+Backquote',
+    macAliases: ['Mod+J'],
     captureDominantly: true,
   },
   [HotkeyActions.CLOSE_TAB]: {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add Cmd+J on macOS as a terminal focus/toggle shortcut, alongside the existing Ctrl+` binding. Adds tests to confirm Cmd+J works on Mac and does not trigger on Windows.

<sup>Written for commit 3651d621507d7fce8bf0069d7b3f4921ca5f2341. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1305?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Cmd+J keyboard shortcut for toggling the terminal on macOS, providing an alternative to the existing Ctrl+Backquote shortcut.

* **Tests**
  * Added test coverage for terminal toggle shortcuts to ensure consistent behavior across platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->