### PR TITLE
chore(browser): update worktree setup scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ storybook-static
 
 .stagewise/*
 !.stagewise/worktree-setup.sh
+!.stagewise/worktree-setup.ps1

--- a/.stagewise/worktree-setup.ps1
+++ b/.stagewise/worktree-setup.ps1
@@ -1,0 +1,67 @@
+$ErrorActionPreference = 'Stop'
+
+Write-Host '[stagewise setup] started'
+Write-Host "cwd: $(Get-Location)"
+$sourceWorktreePath = if ([string]::IsNullOrWhiteSpace($env:STAGEWISE_SOURCE_WORKTREE_PATH)) { 'unset' } else { $env:STAGEWISE_SOURCE_WORKTREE_PATH }
+$targetWorktreePath = if ([string]::IsNullOrWhiteSpace($env:STAGEWISE_TARGET_WORKTREE_PATH)) { 'unset' } else { $env:STAGEWISE_TARGET_WORKTREE_PATH }
+$mainWorktreePath = if ([string]::IsNullOrWhiteSpace($env:STAGEWISE_MAIN_WORKTREE_PATH)) { 'unset' } else { $env:STAGEWISE_MAIN_WORKTREE_PATH }
+
+Write-Host "source worktree: $sourceWorktreePath"
+Write-Host "target worktree: $targetWorktreePath"
+Write-Host "main worktree: $mainWorktreePath"
+
+if ([string]::IsNullOrWhiteSpace($env:STAGEWISE_MAIN_WORKTREE_PATH)) {
+  throw 'STAGEWISE_MAIN_WORKTREE_PATH is not set'
+}
+
+if ([string]::IsNullOrWhiteSpace($env:STAGEWISE_TARGET_WORKTREE_PATH)) {
+  throw 'STAGEWISE_TARGET_WORKTREE_PATH is not set'
+}
+
+$mainEnvFile = Join-Path $env:STAGEWISE_MAIN_WORKTREE_PATH '.env.dev'
+$targetEnvFile = Join-Path $env:STAGEWISE_TARGET_WORKTREE_PATH '.env.dev'
+
+if (-not (Test-Path -LiteralPath $mainEnvFile -PathType Leaf)) {
+  throw "Missing $mainEnvFile"
+}
+
+Write-Host '[stagewise setup] copying .env.dev from main worktree'
+Copy-Item -LiteralPath $mainEnvFile -Destination $targetEnvFile -Force
+
+$nucleoLicenseKey = $null
+foreach ($line in Get-Content -LiteralPath $targetEnvFile) {
+  if ($line -match '^\s*(?:export\s+)?NUCLEO_LICENSE_KEY\s*=\s*(.*)\s*$') {
+    $nucleoLicenseKey = $matches[1].Trim()
+    if (
+      ($nucleoLicenseKey.StartsWith('"') -and $nucleoLicenseKey.EndsWith('"')) -or
+      ($nucleoLicenseKey.StartsWith("'") -and $nucleoLicenseKey.EndsWith("'"))
+    ) {
+      $nucleoLicenseKey = $nucleoLicenseKey.Substring(1, $nucleoLicenseKey.Length - 2)
+    } else {
+      $nucleoLicenseKey = ($nucleoLicenseKey -replace '\s+#.*$', '').Trim()
+    }
+    break
+  }
+}
+
+if ([string]::IsNullOrWhiteSpace($nucleoLicenseKey)) {
+  throw 'NUCLEO_LICENSE_KEY is missing in .env.dev'
+}
+
+$env:NUCLEO_LICENSE_KEY = $nucleoLicenseKey
+
+Set-Location -LiteralPath $env:STAGEWISE_TARGET_WORKTREE_PATH
+
+Write-Host '[stagewise setup] running pnpm install'
+pnpm install
+if ($LASTEXITCODE -ne 0) {
+  exit $LASTEXITCODE
+}
+
+Write-Host '[stagewise setup] running pnpm build'
+pnpm build
+if ($LASTEXITCODE -ne 0) {
+  exit $LASTEXITCODE
+}
+
+Write-Host '[stagewise setup] finished'

--- a/.stagewise/worktree-setup.sh
+++ b/.stagewise/worktree-setup.sh
@@ -1,23 +1,63 @@
 #!/bin/sh
 set -eu
 
-echo "[stagewise dummy setup] started"
+echo "[stagewise setup] started"
 echo "cwd: $(pwd)"
 echo "source worktree: ${STAGEWISE_SOURCE_WORKTREE_PATH:-unset}"
 echo "target worktree: ${STAGEWISE_TARGET_WORKTREE_PATH:-unset}"
 echo "main worktree: ${STAGEWISE_MAIN_WORKTREE_PATH:-unset}"
 
-# Make the async setup state visible in the UI.
-sleep 8
+if [ -z "${STAGEWISE_MAIN_WORKTREE_PATH:-}" ]; then
+  echo "[stagewise setup] STAGEWISE_MAIN_WORKTREE_PATH is not set" >&2
+  exit 1
+fi
 
-# Write under .stagewise/ so the generated file stays gitignored and does not
-# dirty the worktree (a dirty worktree would block managed-worktree removal).
-cat > .stagewise/dummy-setup-result.txt <<EOF
-Dummy worktree setup completed at $(date -u +%Y-%m-%dT%H:%M:%SZ)
-Source worktree: ${STAGEWISE_SOURCE_WORKTREE_PATH:-unset}
-Target worktree: ${STAGEWISE_TARGET_WORKTREE_PATH:-unset}
-Main worktree: ${STAGEWISE_MAIN_WORKTREE_PATH:-unset}
-EOF
+if [ -z "${STAGEWISE_TARGET_WORKTREE_PATH:-}" ]; then
+  echo "[stagewise setup] STAGEWISE_TARGET_WORKTREE_PATH is not set" >&2
+  exit 1
+fi
 
-echo "[stagewise dummy setup] wrote .stagewise/dummy-setup-result.txt"
-echo "[stagewise dummy setup] finished"
+main_env_file="$STAGEWISE_MAIN_WORKTREE_PATH/.env.dev"
+target_env_file="$STAGEWISE_TARGET_WORKTREE_PATH/.env.dev"
+
+if [ ! -f "$main_env_file" ]; then
+  echo "[stagewise setup] Missing $main_env_file" >&2
+  exit 1
+fi
+
+echo "[stagewise setup] copying .env.dev from main worktree"
+cp "$main_env_file" "$target_env_file"
+
+NUCLEO_LICENSE_KEY=$(
+  awk '
+    /^[[:space:]]*(export[[:space:]]+)?NUCLEO_LICENSE_KEY[[:space:]]*=/ {
+      sub(/^[[:space:]]*(export[[:space:]]+)?NUCLEO_LICENSE_KEY[[:space:]]*=[[:space:]]*/, "")
+      gsub(/^[[:space:]]+|[[:space:]]+$/, "")
+      if ((substr($0, 1, 1) == "\"" && substr($0, length($0), 1) == "\"") || (substr($0, 1, 1) == "'\''" && substr($0, length($0), 1) == "'\''")) {
+        $0 = substr($0, 2, length($0) - 2)
+      } else {
+        sub(/[[:space:]]+#.*$/, "")
+        gsub(/^[[:space:]]+|[[:space:]]+$/, "")
+      }
+      print
+      exit
+    }
+  ' "$target_env_file"
+)
+
+if [ -z "$NUCLEO_LICENSE_KEY" ]; then
+  echo "[stagewise setup] NUCLEO_LICENSE_KEY is missing in .env.dev" >&2
+  exit 1
+fi
+
+export NUCLEO_LICENSE_KEY
+
+cd "$STAGEWISE_TARGET_WORKTREE_PATH"
+
+echo "[stagewise setup] running pnpm install"
+pnpm install
+
+echo "[stagewise setup] running pnpm build"
+pnpm build
+
+echo "[stagewise setup] finished"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the dummy Stagewise worktree setup with a real cross‑platform setup/build flow. Scripts copy `.env.dev` from the main worktree, extract/export `NUCLEO_LICENSE_KEY`, and run `pnpm install` and `pnpm build` in the target worktree with fail‑fast checks.

- **New Features**
  - Added `.stagewise/worktree-setup.ps1` and allowed it in `.gitignore`.
  - Updated `.stagewise/worktree-setup.sh`; both scripts validate required env vars, ensure `.env.dev` exists, copy it to the target, parse `NUCLEO_LICENSE_KEY` (handles quotes/comments), then run `pnpm install` and `pnpm build`.

<sup>Written for commit 9b197d4ccbe2dd31bc64189c6b2230aa0f4cdc41. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1306?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a cross-platform setup flow (PowerShell + shell) to automate environment initialization, dependency install, and build.
  * Setup now verifies environment files and propagates the required license key into the target environment before building.
* **Bug Fixes**
  * Replaced the prior dummy wait/reporting behavior with real setup validation and clear failure reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->