### PR TITLE
fix(stagewise): align file fuzzy search

### DIFF
--- a/apps/browser/src/backend/services/file-tree/index.ts
+++ b/apps/browser/src/backend/services/file-tree/index.ts
@@ -24,6 +24,7 @@ import { FILE_SAVE_CONFLICT_CODE } from '@shared/karton-contracts/ui';
 import { inferMimeType } from '@shared/mime-utils';
 import { normalizePath } from '@shared/path-utils';
 import { getRipgrepPath } from '@stagewise/agent-runtime-node';
+import { rankPathFuzzyCandidates } from '@stagewise/agent-core/mount-manager';
 import { DisposableService } from '../disposable';
 import { getRipgrepBasePath } from '@/utils/paths';
 
@@ -35,10 +36,6 @@ const CONTENT_SEARCH_RESULT_LIMIT = 5000;
 const CONTENT_SEARCH_CONCURRENCY = 8;
 const MAX_RIPGREP_JSON_LINE_BYTES = 10 * 1024 * 1024;
 const REVISION_DEBOUNCE_MS = 1000;
-
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-}
 
 const HIDDEN_LISTING_NAMES = new Set(['.git']);
 
@@ -737,7 +734,7 @@ export class FileTreeService extends DisposableService {
       maxResults: number;
       maxDepth: number;
       includeDirectories: boolean;
-      match: (name: string, isDir: boolean) => boolean;
+      match: (name: string, isDir: boolean, relativePath: string) => boolean;
     },
   ): Promise<
     Array<FileSearchResult & { mtimeMs: number; absolutePath: string }>
@@ -815,7 +812,7 @@ export class FileTreeService extends DisposableService {
           if (ig?.ignores(isDir ? `${relPath}/` : relPath)) continue;
 
           const collectible =
-            (isFile || includeDirectories) && match(name, isDir);
+            (isFile || includeDirectories) && match(name, isDir, relPath);
           if (collectible) {
             const uniqueKey = `${workspaceKey}:${relPath}`;
             if (!seen.has(uniqueKey)) {
@@ -848,39 +845,48 @@ export class FileTreeService extends DisposableService {
     includeGitignored: boolean,
     searchInContent = false,
   ): Promise<FileSearchResult[]> {
-    const lowerQuery = query.toLowerCase();
-    const boundaryPattern = new RegExp(`\\b${escapeRegExp(lowerQuery)}`);
+    const trimmedQuery = query.trim();
     const collected = await this.collectWorkspaceEntries(
       workspaceKeys,
       includeGitignored,
       {
-        maxResults: 400,
+        maxResults: 5000,
         maxDepth: 12,
         includeDirectories: true,
-        match: (name) => name.toLowerCase().includes(lowerQuery),
+        match: () => true,
       },
     );
+    const pathMatches = rankPathFuzzyCandidates(trimmedQuery, collected);
 
-    // Rank by name-match quality first, then recency. Exact > prefix >
-    // word-boundary > substring; ties broken by most-recently-modified.
-    const score = (name: string): number => {
-      const lower = name.toLowerCase();
-      if (lower === lowerQuery) return 4;
-      if (lower.startsWith(lowerQuery)) return 3;
-      if (boundaryPattern.test(lower)) return 2;
-      if (lower.includes(lowerQuery)) return 1;
-      return 0;
+    const getPathScore = (
+      result: FileSearchResult & { pathFuzzyScore?: number },
+    ): number =>
+      result.pathFuzzyScore ??
+      rankPathFuzzyCandidates(trimmedQuery, [result])[0]?.pathFuzzyScore ??
+      0;
+    const hasExactPathMatch = (result: FileSearchResult): boolean => {
+      const lowerQuery = trimmedQuery.toLowerCase();
+      const lowerRelativePath = result.relativePath.toLowerCase();
+      const lowerFileName = result.fileName.toLowerCase();
+      return lowerRelativePath === lowerQuery || lowerFileName === lowerQuery;
     };
 
     if (!searchInContent) {
-      return collected
+      return pathMatches
         .sort((a, b) => {
-          const scoreDiff = score(b.fileName) - score(a.fileName);
-          if (scoreDiff !== 0) return scoreDiff;
+          if (b.pathFuzzyScore !== a.pathFuzzyScore) {
+            return b.pathFuzzyScore - a.pathFuzzyScore;
+          }
           return b.mtimeMs - a.mtimeMs;
         })
         .slice(0, 200)
-        .map(({ absolutePath: _absolutePath, ...result }) => result);
+        .map(
+          ({
+            absolutePath: _absolutePath,
+            pathFuzzyScore: _score,
+            ...result
+          }) => result,
+        );
     }
 
     const byKey = new Map<
@@ -888,7 +894,8 @@ export class FileTreeService extends DisposableService {
       FileSearchResult & {
         mtimeMs: number;
         absolutePath: string;
-        nameScore: number;
+        pathScore: number;
+        pathFuzzyScore?: number;
         category: number;
         contentMatchCount: number;
       }
@@ -902,23 +909,25 @@ export class FileTreeService extends DisposableService {
       },
     ) => {
       const key = `${result.workspaceKey}:${result.relativePath}`;
-      const nameScore = score(result.fileName);
+      const pathScore = getPathScore(result);
       const contentMatchCount = result.contentMatchCount ?? 0;
-      const exactNameMatch = nameScore === 4;
-      const category = exactNameMatch ? 3 : contentMatchCount > 0 ? 2 : 1;
+      const exactPathMatch = hasExactPathMatch(result);
+      const category = exactPathMatch ? 3 : contentMatchCount > 0 ? 2 : 1;
       const existing = byKey.get(key);
       byKey.set(key, {
         ...existing,
         ...result,
-        nameScore,
+        pathScore,
         category,
         contentMatchCount,
         contentMatches:
-          category === 2 && nameScore === 0 ? result.contentMatches : undefined,
+          contentMatchCount > 0
+            ? (result.contentMatches ?? existing?.contentMatches)
+            : existing?.contentMatches,
       });
     };
 
-    for (const result of collected) addOrUpdate(result);
+    for (const result of pathMatches) addOrUpdate(result);
     for (const result of await this.searchContentWithRipgrep(
       query,
       workspaceKeys,
@@ -931,22 +940,23 @@ export class FileTreeService extends DisposableService {
 
     return searched
       .filter(
-        ({ nameScore, contentMatchCount }) =>
-          nameScore > 0 || contentMatchCount > 0,
+        ({ pathScore, contentMatchCount }) =>
+          pathScore > 0 || contentMatchCount > 0,
       )
       .sort((a, b) => {
         if (b.category !== a.category) return b.category - a.category;
         if (a.category === 2 && b.contentMatchCount !== a.contentMatchCount) {
           return b.contentMatchCount - a.contentMatchCount;
         }
-        if (b.nameScore !== a.nameScore) return b.nameScore - a.nameScore;
+        if (b.pathScore !== a.pathScore) return b.pathScore - a.pathScore;
         return b.mtimeMs - a.mtimeMs;
       })
       .slice(0, 200)
       .map(
         ({
           absolutePath: _absolutePath,
-          nameScore: _nameScore,
+          pathScore: _pathScore,
+          pathFuzzyScore: _pathFuzzyScore,
           category: _category,
           ...result
         }) => result,

--- a/packages/agent-core/src/services/mount-manager/index.ts
+++ b/packages/agent-core/src/services/mount-manager/index.ts
@@ -15,6 +15,11 @@ export {
   type MentionSearchClientRuntime,
   type MentionSearchToolboxState,
 } from './mention-search';
+export {
+  rankPathFuzzyCandidates,
+  type PathFuzzyCandidate,
+  type PathFuzzyResult,
+} from './path-fuzzy-search';
 export type { MountManagerHostHooks } from './types';
 export { setAgentMounts } from './mount-state';
 export { pickOwningWorkspace } from '../../workspace';

--- a/packages/agent-core/src/services/mount-manager/mention-search.ts
+++ b/packages/agent-core/src/services/mount-manager/mention-search.ts
@@ -1,6 +1,6 @@
-import { hasMatch, score } from 'fzy.js';
 import type { Logger } from '../../host/logger';
 import type { MentionFileCandidate } from '../../types/metadata';
+import { rankPathFuzzyCandidates } from './path-fuzzy-search';
 
 type MountPrefix = string;
 
@@ -134,95 +134,37 @@ export class MentionSearchService {
 
       if (!result.success || result.relativePaths.length === 0) return [];
 
-      const lowerQuery = query.toLowerCase();
-
-      const scoredFiles: Array<{
-        path: string;
-        score: number;
-        isDirectory?: boolean;
-      }> = [];
-      const dirs = new Set<string>();
-
-      for (const relPath of result.relativePaths) {
-        if (hasMatch(lowerQuery, relPath.toLowerCase())) {
-          scoredFiles.push({
-            path: relPath,
-            score: score(lowerQuery, relPath.toLowerCase()),
-          });
+      const directories = new Set<string>();
+      const files = result.relativePaths.map((relativePath) => {
+        let directory = relativePath;
+        let slashIndex = directory.lastIndexOf('/');
+        while (slashIndex > 0) {
+          directory = directory.substring(0, slashIndex);
+          if (directories.has(directory)) break;
+          directories.add(directory);
+          slashIndex = directory.lastIndexOf('/');
         }
 
-        let dir = relPath;
-        let slashIdx = dir.lastIndexOf('/');
-        while (slashIdx > 0) {
-          dir = dir.substring(0, slashIdx);
-          if (dirs.has(dir)) break;
-          dirs.add(dir);
-          slashIdx = dir.lastIndexOf('/');
-        }
-      }
+        return { relativePath, isDirectory: false };
+      });
 
-      const scoredDirs: Array<{
-        path: string;
-        score: number;
-        isDirectory: true;
-      }> = [];
-
-      const querySegs = lowerQuery.split('/').filter((s) => s.length > 0);
-      const lastQuerySeg = querySegs[querySegs.length - 1];
-      const prefixQuerySegs = querySegs.slice(0, -1);
-
-      if (lastQuerySeg !== undefined) {
-        for (const dirPath of dirs) {
-          const pathSegs = dirPath.toLowerCase().split('/');
-          const dirName = pathSegs[pathSegs.length - 1];
-          if (dirName === undefined) continue;
-
-          if (!hasMatch(lastQuerySeg, dirName)) continue;
-          const nameScore = score(lastQuerySeg, dirName);
-
-          if (prefixQuerySegs.length > 0) {
-            const ancestors = pathSegs.slice(0, -1);
-            let ai = 0;
-            let allMatch = true;
-            for (const qSeg of prefixQuerySegs) {
-              let found = false;
-              while (ai < ancestors.length) {
-                const ancestor = ancestors[ai++];
-                if (ancestor !== undefined && hasMatch(qSeg, ancestor)) {
-                  found = true;
-                  break;
-                }
-              }
-              if (!found) {
-                allMatch = false;
-                break;
-              }
-            }
-            if (!allMatch) continue;
-          }
-
-          scoredDirs.push({
-            path: dirPath,
-            score: nameScore,
-            isDirectory: true,
-          });
-        }
-      }
-      scoredDirs.sort((a, b) => b.score - a.score);
-
-      scoredFiles.sort((a, b) => b.score - a.score);
-
-      const topFiles = scoredFiles.slice(
+      const topFiles = rankPathFuzzyCandidates(query, files).slice(
         0,
         MAX_SEARCH_RESULTS_PER_MOUNT - MAX_FOLDER_RESULTS_PER_MOUNT,
       );
-      const topDirs = scoredDirs.slice(0, MAX_FOLDER_RESULTS_PER_MOUNT);
+      const topDirs = rankPathFuzzyCandidates(
+        query,
+        Array.from(directories, (relativePath) => ({
+          relativePath,
+          isDirectory: true as const,
+        })),
+      ).slice(0, MAX_FOLDER_RESULTS_PER_MOUNT);
       const merged = [...topFiles, ...topDirs];
-      merged.sort((a, b) => b.score - a.score);
+      merged.sort((a, b) => b.pathFuzzyScore - a.pathFuzzyScore);
 
       return merged
         .slice(0, MAX_SEARCH_RESULTS_PER_MOUNT)
-        .map(({ path: relPath, isDirectory }) => ({
+        .map(({ relativePath: relPath, isDirectory }) => ({
           providerType: 'file' as const,
           mountedPath: `${mountPrefix}/${relPath}`,
           relativePath: relPath,

--- a/packages/agent-core/src/services/mount-manager/path-fuzzy-search.test.ts
+++ b/packages/agent-core/src/services/mount-manager/path-fuzzy-search.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { rankPathFuzzyCandidates } from './path-fuzzy-search';
+
+const candidates = [
+  { relativePath: 'agent-core/src/README.md' },
+  { relativePath: 'apps/browser/src/index.ts' },
+  { relativePath: 'packages/agent-core/src/services', isDirectory: true },
+  {
+    relativePath: 'packages/agent-core/src/services/mount-manager',
+    isDirectory: true,
+  },
+];
+
+describe('rankPathFuzzyCandidates', () => {
+  it('matches queries across path segments', () => {
+    const results = rankPathFuzzyCandidates('core/READ', candidates);
+
+    expect(results.map((result) => result.relativePath)).toContain(
+      'agent-core/src/README.md',
+    );
+  });
+
+  it('matches basename-only queries', () => {
+    const results = rankPathFuzzyCandidates('index', candidates);
+
+    expect(results.map((result) => result.relativePath)).toContain(
+      'apps/browser/src/index.ts',
+    );
+  });
+
+  it('matches directories with ordered ancestor path segments', () => {
+    const results = rankPathFuzzyCandidates('core/serv', candidates);
+
+    expect(results.map((result) => result.relativePath)).toContain(
+      'packages/agent-core/src/services',
+    );
+  });
+
+  it('excludes non-matching paths', () => {
+    const results = rankPathFuzzyCandidates('zzzz', candidates);
+
+    expect(results).toEqual([]);
+  });
+});

--- a/packages/agent-core/src/services/mount-manager/path-fuzzy-search.ts
+++ b/packages/agent-core/src/services/mount-manager/path-fuzzy-search.ts
@@ -1,0 +1,84 @@
+import { hasMatch, score } from 'fzy.js';
+
+export type PathFuzzyCandidate = {
+  relativePath: string;
+  isDirectory?: boolean;
+};
+
+export type PathFuzzyResult<T extends PathFuzzyCandidate> = T & {
+  pathFuzzyScore: number;
+};
+
+function scoreFilePath(
+  lowerQuery: string,
+  relativePath: string,
+): number | null {
+  const lowerPath = relativePath.toLowerCase();
+  if (!hasMatch(lowerQuery, lowerPath)) return null;
+  return score(lowerQuery, lowerPath);
+}
+
+function scoreDirectoryPath(
+  lowerQuery: string,
+  relativePath: string,
+): number | null {
+  const querySegments = lowerQuery
+    .split('/')
+    .filter((segment) => segment.length);
+  const lastQuerySegment = querySegments[querySegments.length - 1];
+  if (lastQuerySegment === undefined) return null;
+
+  const pathSegments = relativePath.toLowerCase().split('/');
+  const directoryName = pathSegments[pathSegments.length - 1];
+  if (directoryName === undefined) return null;
+  if (!hasMatch(lastQuerySegment, directoryName)) return null;
+
+  if (querySegments.length > 1) {
+    const ancestors = pathSegments.slice(0, -1);
+    let ancestorIndex = 0;
+
+    for (const querySegment of querySegments.slice(0, -1)) {
+      let found = false;
+      while (ancestorIndex < ancestors.length) {
+        const ancestor = ancestors[ancestorIndex++];
+        if (ancestor !== undefined && hasMatch(querySegment, ancestor)) {
+          found = true;
+          break;
+        }
+      }
+      if (!found) return null;
+    }
+  }
+
+  return score(lastQuerySegment, directoryName);
+}
+
+export function rankPathFuzzyCandidates<T extends PathFuzzyCandidate>(
+  query: string,
+  candidates: readonly T[],
+): PathFuzzyResult<T>[] {
+  const lowerQuery = query.toLowerCase();
+  if (!lowerQuery || candidates.length === 0) return [];
+
+  return candidates
+    .map((candidate, index) => {
+      const pathFuzzyScore = candidate.isDirectory
+        ? scoreDirectoryPath(lowerQuery, candidate.relativePath)
+        : scoreFilePath(lowerQuery, candidate.relativePath);
+
+      return pathFuzzyScore === null
+        ? null
+        : { candidate, index, pathFuzzyScore };
+    })
+    .filter((result) => result !== null)
+    .sort((a, b) => {
+      if (b.pathFuzzyScore !== a.pathFuzzyScore) {
+        return b.pathFuzzyScore - a.pathFuzzyScore;
+      }
+      return a.index - b.index;
+    })
+    .map(({ candidate, pathFuzzyScore }) => ({
+      ...candidate,
+      pathFuzzyScore,
+    }));
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * More relevant file search using path-aware fuzzy ranking; results prioritize closer path matches and recency, with improved ordering for content vs. path searches.
  * Mention/file discovery now returns better-separated directory and file candidates per mount and respects per-mount result limits.

* **Tests**
  * Added unit tests covering fuzzy path matching, directory matching, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns fuzzy file/path search across the app using a shared path-aware matcher for more relevant, consistent results. Browser file and mention search now rank by path score with better directory matching and smarter content ranking.

- **New Features**
  - Added `rankPathFuzzyCandidates` with `PathFuzzyCandidate`/`PathFuzzyResult` in `@stagewise/agent-core/mount-manager` and exported for reuse.
  - Replaced custom logic in browser file and mention search; now sorts by path score then mtime. Directories match via ordered ancestor segments; mention search picks top files and folders separately, then merges. Content search prioritizes exact path/name and content hit count. Increased candidate pool to 5,000.
  - Added unit tests for cross-segment, basename-only, directory, and negative matches.

<sup>Written for commit 1f99e2ee824b9beff767a9d4f93b9cf71124c978. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1307?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

