### PR TITLE
Fix UI crash

### DIFF
--- a/apps/browser/src/ui/screens/main/file-tree/file-tree-sidebar.tsx
+++ b/apps/browser/src/ui/screens/main/file-tree/file-tree-sidebar.tsx
@@ -29,11 +29,28 @@ import {
 } from './file-tree-utils';
 import { Tutorial } from '@ui/components/tutorial';
 
+function areFileTreeWorkspaceMountsEqual(
+  a: ReturnType<typeof getFileTreeWorkspaceMountsForAgent>,
+  b: ReturnType<typeof getFileTreeWorkspaceMountsForAgent>,
+): boolean {
+  return (
+    a.length === b.length &&
+    a.every((mount, index) => {
+      const otherMount = b[index];
+      return (
+        otherMount !== undefined &&
+        getFileTreeWorkspaceKey(mount) === getFileTreeWorkspaceKey(otherMount)
+      );
+    })
+  );
+}
+
 export function FileTreeSidebar() {
   const [openAgent] = useOpenAgent();
   const workspaceMounts = useKartonState(
-    useComparingSelector((s) =>
-      getFileTreeWorkspaceMountsForAgent(s, openAgent),
+    useComparingSelector(
+      (s) => getFileTreeWorkspaceMountsForAgent(s, openAgent),
+      areFileTreeWorkspaceMountsEqual,
     ),
   );
   const activeWorkspaceKey = useKartonState(
@@ -54,7 +71,6 @@ export function FileTreeSidebar() {
         key: getFileTreeWorkspaceKey(mount),
         name: getFileTreeWorkspaceName(mount),
         path: mount.path,
-        git: mount.git,
       })),
     [workspaceMounts],
   );

--- a/packages/karton/src/react/client/karton-react-client.tsx
+++ b/packages/karton/src/react/client/karton-react-client.tsx
@@ -157,11 +157,27 @@ export function createKartonReactClient<T>(
     }
 
     const { client, subscribe } = context;
+    const selectorSnapshotRef = useRef<{
+      state: Readonly<KartonState<T>>;
+      selector: StateSelector<T, R>;
+      value: R;
+    } | null>(null);
 
-    const selectorFunc = useCallback(
-      () => selector(client.state),
-      [selector, client.state],
-    );
+    const selectorFunc = useCallback(() => {
+      const state = client.state;
+      const cachedSnapshot = selectorSnapshotRef.current;
+
+      if (
+        cachedSnapshot?.state === state &&
+        cachedSnapshot.selector === selector
+      ) {
+        return cachedSnapshot.value;
+      }
+
+      const value = selector(state);
+      selectorSnapshotRef.current = { state, selector, value };
+      return value;
+    }, [selector, client]);
 
     // Use React's built-in store subscription hook
     const selectedValue = useSyncExternalStore(


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes an infinite re-render that crashed the File Tree sidebar by stabilizing selectors and caching selector results. Improves rendering stability across the app.

- **Bug Fixes**
  - `karton` React client: cache `useKartonState` selector snapshots and stop recreating the selector on each state change.
  - File Tree Sidebar: compare workspace mounts structurally (`areFileTreeWorkspaceMountsEqual`) to avoid spurious updates; drop `git` from mapped props to keep item identity stable.

<sup>Written for commit 1e4ae1f42da71debf407b38c85e450a3793371d5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1311?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved memoization in the React client to reduce unnecessary selector recomputation and re-renders.
  * Reduced file tree sidebar updates by tightening workspace mount comparisons so the sidebar updates less frequently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->