### PR TITLE
Persist code editor scroll state and fix some other small stuff

### DIFF
--- a/apps/browser/src/ui/components/web-contents-bounds-syncer.tsx
+++ b/apps/browser/src/ui/components/web-contents-bounds-syncer.tsx
@@ -179,11 +179,25 @@ export const WebContentsBoundsSyncer = () => {
     const { observer: resizeObserver, disconnect: disconnectResizeObserver } =
       createRafResizeObserver(sendBoundsUpdate);
 
+    // Track all elements we observe so we can unobserve on detach.
+    const observedElements: Element[] = [];
+    const observeEl = (el: Element) => {
+      resizeObserver.observe(el);
+      observedElements.push(el);
+    };
+    const unobserveAll = () => {
+      for (const el of observedElements) {
+        resizeObserver.unobserve(el);
+      }
+      observedElements.length = 0;
+    };
+
     const attachContainer = (el: HTMLElement | null) => {
       if (el === containerElement) return;
 
+      unobserveAll();
+
       if (containerElement) {
-        resizeObserver.unobserve(containerElement);
         containerElement.removeEventListener(
           'transitionend',
           handleTransitionEnd,
@@ -193,8 +207,29 @@ export const WebContentsBoundsSyncer = () => {
       containerElement = el;
 
       if (containerElement) {
-        resizeObserver.observe(containerElement);
+        observeEl(containerElement);
         containerElement.addEventListener('transitionend', handleTransitionEnd);
+
+        // Also observe all panels of every ancestor resizable panel group
+        // (i.e. the container's panel AND its sibling panels). When a
+        // sibling panel resizes while the container's own panel is pinned
+        // at its min size (e.g. dragging the chat handle further shrinks
+        // the file tree), the container MOVES without its own dimensions
+        // changing — neither it nor any ancestor fires a ResizeObserver
+        // event. Any redistribution that moves the container necessarily
+        // resizes at least one panel in some ancestor group, so observing
+        // the sibling panels catches every such case and triggers a
+        // bounds re-check.
+        let current: HTMLElement | null = containerElement.parentElement;
+        while (current) {
+          if (current.dataset.slot === 'resizable-panel-group') {
+            current
+              .querySelectorAll(':scope > [data-slot="resizable-panel"]')
+              .forEach(observeEl);
+          }
+          current = current.parentElement;
+        }
+
         containerVisible = checkOpacity();
       } else {
         containerVisible = false;
@@ -253,6 +288,7 @@ export const WebContentsBoundsSyncer = () => {
         cancelAnimationFrame(pendingFrameId);
         pendingFrameId = null;
       }
+      unobserveAll();
       disconnectResizeObserver();
       mutationObserver.disconnect();
       window.removeEventListener('resize', sendBoundsUpdate);

--- a/apps/browser/src/ui/components/web-contents-bounds-syncer.tsx
+++ b/apps/browser/src/ui/components/web-contents-bounds-syncer.tsx
@@ -193,7 +193,7 @@ export const WebContentsBoundsSyncer = () => {
     };
 
     const attachContainer = (el: HTMLElement | null) => {
-      if (el === containerElement) return;
+      if (el === null && containerElement === null) return;
 
       unobserveAll();
 

--- a/apps/browser/src/ui/screens/main/file-tree/file-preview-tab-content.tsx
+++ b/apps/browser/src/ui/screens/main/file-tree/file-preview-tab-content.tsx
@@ -84,6 +84,15 @@ type CachedPreview = {
   error: string | null;
 };
 
+/** Persists Monaco scroll position across tab switches. */
+const scrollStateStore = new Map<
+  string,
+  { scrollTop: number; scrollLeft: number }
+>();
+
+/** Persists markdown preview/source mode across tab switches. */
+const markdownModeStore = new Map<string, 'preview' | 'source'>();
+
 type EditorActions = {
   save: () => void;
   /** Overwrite the on-disk file, ignoring a detected external modification. */
@@ -132,9 +141,7 @@ function normalizeHexColor(value: string, fallback: string) {
 type SourceLanguage =
   | 'plaintext'
   | 'typescript'
-  | 'typescriptreact'
   | 'javascript'
-  | 'javascriptreact'
   | 'json'
   | 'css'
   | 'scss'
@@ -154,9 +161,7 @@ type SourceLanguage =
 const LANGUAGE_EXT: Record<SourceLanguage, string> = {
   plaintext: '.txt',
   typescript: '.ts',
-  typescriptreact: '.tsx',
   javascript: '.js',
-  javascriptreact: '.jsx',
   json: '.json',
   css: '.css',
   scss: '.scss',
@@ -193,19 +198,9 @@ const SOURCE_LANGUAGE_ITEMS: Array<{
     icon: iconForLanguage('typescript'),
   },
   {
-    value: 'typescriptreact',
-    label: 'TypeScript (JSX)',
-    icon: iconForLanguage('typescriptreact'),
-  },
-  {
     value: 'javascript',
     label: 'JavaScript',
     icon: iconForLanguage('javascript'),
-  },
-  {
-    value: 'javascriptreact',
-    label: 'JavaScript (JSX)',
-    icon: iconForLanguage('javascriptreact'),
   },
   { value: 'json', label: 'JSON', icon: iconForLanguage('json') },
   { value: 'css', label: 'CSS', icon: iconForLanguage('css') },
@@ -236,12 +231,11 @@ function languageFromPath(path: string): SourceLanguage {
     case 'ts':
       return 'typescript';
     case 'tsx':
-      return 'typescriptreact';
+      return 'typescript';
     case 'js':
     case 'mjs':
-      return 'javascript';
     case 'jsx':
-      return 'javascriptreact';
+      return 'javascript';
     case 'json':
       return 'json';
     case 'css':
@@ -1261,8 +1255,28 @@ function TextEditorPreview({
         updateZoom,
         zoomPercentageRef,
       );
+      // Save scroll position on every scroll so it survives tab switches
+      // even if the editor is disposed before the unmount cleanup runs.
+      editor.onDidScrollChange((e) => {
+        scrollStateStore.set(cacheKey, {
+          scrollTop: e.scrollTop,
+          scrollLeft: e.scrollLeft,
+        });
+      });
+      // Restore the last-known scroll position for this file.
+      // Must defer because Monaco produces multiple layout events
+      // during initialisation (content layout, then font-size / option
+      // sync from the React wrapper) — each one resets the scroll.
+      // Keep restoring on every layout event for a settling window.
+      const saved = scrollStateStore.get(cacheKey);
+      if (saved) {
+        const layoutDisposable = editor.onDidLayoutChange(() => {
+          editor.setScrollPosition(saved);
+        });
+        setTimeout(() => layoutDisposable.dispose(), 300);
+      }
     },
-    [markFocused, updateZoom, zoomPercentageRef],
+    [cacheKey, markFocused, updateZoom, zoomPercentageRef],
   );
 
   const handleChange = useCallback(
@@ -1668,7 +1682,9 @@ function SvgPreview({
     preview.workspaceKey,
     preview.relativePath,
   );
-  const [mode, setMode] = useState<'preview' | 'source'>('preview');
+  const [mode, setMode] = useState<'preview' | 'source'>(
+    () => markdownModeStore.get(cacheKey) ?? 'preview',
+  );
   const [text, setText] = useState(
     () => textDraftCache.get(cacheKey) ?? preview.text ?? '',
   );
@@ -1765,11 +1781,19 @@ function SvgPreview({
   modeRef.current = mode;
   const tabUiStateRef = useRef(tabUiState);
   tabUiStateRef.current = tabUiState;
+  const persistMode = useCallback(
+    (next: 'preview' | 'source') => {
+      markdownModeStore.set(cacheKey, next);
+      setMode(next);
+    },
+    [cacheKey],
+  );
+
   const toggleCodeMode = useCallback(() => {
     if (tabUiStateRef.current[tabId]?.focusedPanel !== 'tab-content')
       return false;
-    setMode(modeRef.current === 'source' ? 'preview' : 'source');
-  }, [tabId]);
+    persistMode(modeRef.current === 'source' ? 'preview' : 'source');
+  }, [tabId, persistMode]);
   useHotKeyListener(toggleCodeMode, HotkeyActions.TOGGLE_SVG_CODE_MODE);
 
   const handleMount = useCallback(
@@ -2060,7 +2084,7 @@ function SvgPreview({
                   )}
                   aria-label="Show SVG source"
                   aria-pressed={mode === 'source'}
-                  onClick={() => setMode('source')}
+                  onClick={() => persistMode('source')}
                 >
                   <IconSquareCodeOutline18 className="size-3.5" />
                   {mode === 'source' ? <span>Code</span> : null}
@@ -2079,7 +2103,7 @@ function SvgPreview({
                   )}
                   aria-label="Show SVG preview"
                   aria-pressed={mode === 'preview'}
-                  onClick={() => setMode('preview')}
+                  onClick={() => persistMode('preview')}
                 >
                   <IconEye2Outline18 className="size-3.5" />
                   {mode === 'preview' ? <span>Preview</span> : null}
@@ -2185,7 +2209,9 @@ function MarkdownPreview({
     preview.workspaceKey,
     preview.relativePath,
   );
-  const [mode, setMode] = useState<'preview' | 'source'>('preview');
+  const [mode, setMode] = useState<'preview' | 'source'>(
+    () => markdownModeStore.get(cacheKey) ?? 'preview',
+  );
   const [text, setText] = useState(
     () => textDraftCache.get(cacheKey) ?? preview.text ?? '',
   );
@@ -2204,11 +2230,19 @@ function MarkdownPreview({
   modeRef.current = mode;
   const tabUiStateRef = useRef(tabUiState);
   tabUiStateRef.current = tabUiState;
+  const persistMode = useCallback(
+    (next: 'preview' | 'source') => {
+      markdownModeStore.set(cacheKey, next);
+      setMode(next);
+    },
+    [cacheKey],
+  );
+
   const toggleCodeMode = useCallback(() => {
     if (tabUiStateRef.current[tabId]?.focusedPanel !== 'tab-content')
       return false;
-    setMode(modeRef.current === 'source' ? 'preview' : 'source');
-  }, [tabId]);
+    persistMode(modeRef.current === 'source' ? 'preview' : 'source');
+  }, [tabId, persistMode]);
   useHotKeyListener(toggleCodeMode, HotkeyActions.TOGGLE_MARKDOWN_PREVIEW);
 
   const handleMount = useCallback(
@@ -2223,8 +2257,21 @@ function MarkdownPreview({
         updateZoom,
         zoomPercentageRef,
       );
+      editor.onDidScrollChange((e) => {
+        scrollStateStore.set(cacheKey, {
+          scrollTop: e.scrollTop,
+          scrollLeft: e.scrollLeft,
+        });
+      });
+      const saved = scrollStateStore.get(cacheKey);
+      if (saved) {
+        const layoutDisposable = editor.onDidLayoutChange(() => {
+          editor.setScrollPosition(saved);
+        });
+        setTimeout(() => layoutDisposable.dispose(), 300);
+      }
     },
-    [markFocused, zoomPercentageRef, updateZoom],
+    [cacheKey, markFocused, updateZoom, zoomPercentageRef],
   );
 
   const handleChange = useCallback(
@@ -2264,7 +2311,7 @@ function MarkdownPreview({
                 )}
                 aria-label="Show markdown source"
                 aria-pressed={mode === 'source'}
-                onClick={() => setMode('source')}
+                onClick={() => persistMode('source')}
               >
                 <IconSquareCodeOutline18 className="size-3.5" />
                 {mode === 'source' ? <span>Code</span> : null}
@@ -2283,7 +2330,7 @@ function MarkdownPreview({
                 )}
                 aria-label="Show markdown preview"
                 aria-pressed={mode === 'preview'}
-                onClick={() => setMode('preview')}
+                onClick={() => persistMode('preview')}
               >
                 <IconEye2Outline18 className="size-3.5" />
                 {mode === 'preview' ? <span>Preview</span> : null}

--- a/apps/browser/src/ui/screens/main/file-tree/file-preview-tab-content.tsx
+++ b/apps/browser/src/ui/screens/main/file-tree/file-preview-tab-content.tsx
@@ -1264,12 +1264,15 @@ function TextEditorPreview({
         });
       });
       // Restore the last-known scroll position for this file.
-      // Must defer because Monaco produces multiple layout events
-      // during initialisation (content layout, then font-size / option
-      // sync from the React wrapper) — each one resets the scroll.
-      // Keep restoring on every layout event for a settling window.
+      // Set immediately so the position is correct even if no layout
+      // event fires after mount.  Monaco produces multiple layout
+      // events during initialisation (content layout, then font-size /
+      // option sync from the React wrapper) — each one resets the
+      // scroll, so keep re-restoring on every layout event for a
+      // settling window.
       const saved = scrollStateStore.get(cacheKey);
       if (saved) {
+        editor.setScrollPosition(saved);
         const layoutDisposable = editor.onDidLayoutChange(() => {
           editor.setScrollPosition(saved);
         });
@@ -2263,8 +2266,16 @@ function MarkdownPreview({
           scrollLeft: e.scrollLeft,
         });
       });
+      // Restore the last-known scroll position for this file.
+      // Set immediately so the position is correct even if no layout
+      // event fires after mount.  Monaco produces multiple layout
+      // events during initialisation (content layout, then font-size /
+      // option sync from the React wrapper) — each one resets the
+      // scroll, so keep re-restoring on every layout event for a
+      // settling window.
       const saved = scrollStateStore.get(cacheKey);
       if (saved) {
+        editor.setScrollPosition(saved);
         const layoutDisposable = editor.onDidLayoutChange(() => {
           editor.setScrollPosition(saved);
         });


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Persist editor scroll and preview modes across tab switches, integrate Settings into the main layout, and harden webview bounds syncing. Also fixes JSX/TSX highlighting.

- **New Features**
  - Settings render inside the main layout with a sidebar/content splitter; Mod+, opens Settings, Esc closes it.
  - Reusable sidebar account footer with plan/email and macOS closed‑lid sleep toggle; used in main and Settings sidebars.
  - Editor state persistence: continuously captures Monaco scroll per file and restores it immediately and during initial layout; remembers markdown/SVG preview vs. source mode.

- **Bug Fixes**
  - Restored JSX/TSX highlighting by using Monaco `javascript`/`typescript` language IDs.
  - Disabled main-screen hotkeys while Settings is open; kept the Settings hotkey and Esc-to-close.
  - Fixed webview bounds/visibility desync by observing sibling panels in ancestor resizable groups, refreshing observers on re-attach, and unobserving all on detach.

<sup>Written for commit b1a3b6bfba6c99481be64c8e256d950ce25d1521. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1313?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Editor scroll position now persists when switching between file preview tabs.
  * Markdown and SVG preview/source mode preferences are retained across tab switches.
  * Enhanced layout responsiveness when resizing panels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->