### PR TITLE
feat(stagewise): add content tab arrow shortcuts

### DIFF
--- a/apps/browser/src/shared/hotkeys.ts
+++ b/apps/browser/src/shared/hotkeys.ts
@@ -35,6 +35,8 @@ export interface HotkeyDefinition {
   macAliases?: string[];
   /** If true, captures in capture phase to override web content handlers */
   captureDominantly?: boolean;
+  /** If true, lets editable elements consume matching native input events */
+  preserveNativeInput?: boolean;
 }
 
 /**
@@ -261,12 +263,17 @@ export const hotkeyDefinitions: Record<HotkeyActions, HotkeyDefinition> = {
     captureDominantly: true,
   },
   // Content-panel tab navigation (per-agent, Mod+Alt prefixes).
+  // macOS follows the VS Code editor-tab convention: Cmd+Option+Arrow.
   [HotkeyActions.NEXT_TAB]: {
     accelerator: 'Mod+Alt+PageDown',
+    mac: 'Mod+Alt+ArrowRight',
+    macAliases: ['Mod+Alt+PageDown'],
     captureDominantly: true,
   },
   [HotkeyActions.PREV_TAB]: {
     accelerator: 'Mod+Alt+PageUp',
+    mac: 'Mod+Alt+ArrowLeft',
+    macAliases: ['Mod+Alt+PageUp'],
     captureDominantly: true,
   },
 

--- a/apps/browser/src/shared/native-input-events.ts
+++ b/apps/browser/src/shared/native-input-events.ts
@@ -45,8 +45,18 @@ export function shouldNativeInputConsumeEvent(e: KeyboardEvent): boolean {
         if (target.isContentEditable && ['b', 'i', 'u'].includes(key))
           return true;
 
-        // 2. Text Navigation (Cmd+Arrows on Mac, Ctrl+Arrows on Win)
-        if (['arrowup', 'arrowdown', 'arrowleft', 'arrowright'].includes(key))
+        // 2. Text Navigation (Cmd+Arrows/Page keys on Mac,
+        // Ctrl+Arrows/Page keys on Win)
+        if (
+          [
+            'arrowup',
+            'arrowdown',
+            'arrowleft',
+            'arrowright',
+            'pageup',
+            'pagedown',
+          ].includes(key)
+        )
           return true;
 
         // 3. Deletion (Cmd+Backspace delete line, Ctrl+Backspace delete word)

--- a/apps/browser/src/ui/hooks/use-hotkey-listener.tsx
+++ b/apps/browser/src/ui/hooks/use-hotkey-listener.tsx
@@ -44,14 +44,17 @@ export function useHotKeyListener(
 
       if (!enabled) return;
 
-      // For non-dominant hotkeys, check if a native editable element should consume the event
-      // This allows standard text editing behavior to work (e.g., Cmd+ArrowLeft in inputs).
+      // For non-dominant hotkeys, check if a native editable element should
+      // consume the event. Dominant hotkeys can opt into the same guard with
+      // preserveNativeInput.
       // STOP_AGENT is selection-aware at the call site: Ctrl+C should still stop
       // the agent from chat input when there is no selected text, but preserve
       // native copy when there is a selection.
+      const shouldPreserveNativeInput =
+        !definition.captureDominantly || definition.preserveNativeInput;
       if (
         hotKeyAction !== HotkeyActions.STOP_AGENT &&
-        !definition.captureDominantly &&
+        shouldPreserveNativeInput &&
         shouldNativeInputConsumeEvent(ev)
       )
         return;

--- a/apps/browser/src/ui/screens/main/_components/agent-hotkey-bindings.tsx
+++ b/apps/browser/src/ui/screens/main/_components/agent-hotkey-bindings.tsx
@@ -112,7 +112,7 @@ export function AgentHotkeyBindings({
     agentHotkeysEnabled,
   );
 
-  // -- Content panel tab navigation (Mod+Alt+PageDown / Mod+Alt+PageUp) --
+  // -- Content panel tab navigation (macOS: Cmd+Option+←/→) -----------
   // Only tabs visible for the current agent (global + agent-attached), in
   // the same order as the rendered tab bar.
   const visibleTabIds = [

--- a/apps/browser/src/web-content-preload/index.ts
+++ b/apps/browser/src/web-content-preload/index.ts
@@ -365,6 +365,8 @@ window.addEventListener(
   (e) => {
     const hotkeyDef = getHotkeyDefinitionForEvent(e);
     if (hotkeyDef?.captureDominantly) {
+      if (hotkeyDef.preserveNativeInput && shouldChromeConsumeEvent(e)) return;
+
       e.preventDefault();
       e.stopImmediatePropagation();
       e.stopPropagation();


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add macOS Cmd+Option+Arrow shortcuts for content-panel tab switching to match VS Code. Preserve native Arrow and PageUp/PageDown text navigation in inputs and web content, even when a hotkey captures dominantly.

- **New Features**
  - macOS: NEXT_TAB = Mod+Alt+ArrowRight (alias Mod+Alt+PageDown); PREV_TAB = Mod+Alt+ArrowLeft (alias Mod+Alt+PageUp).
  - Added preserveNativeInput so editable fields and web content can consume Arrow/PageUp/PageDown and avoid interference from these hotkeys.

<sup>Written for commit ff6d7aa848f53067a30b79063179e78ded33aebd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1314?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added macOS-specific tab navigation shortcuts using Command+Option+Arrow keys.
  * Updated on-screen shortcut descriptions to match macOS key binding conventions.

* **Improvements**
  * Improved hotkey handling to optionally preserve native text input based on the hotkey configuration.
  * Editable-field navigation (including PageUp/PageDown) is now better treated as native input to reduce interference while typing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->