### PR TITLE
Add thinking level controls

### DIFF
--- a/apps/browser/src/backend/agents/model-provider.test.ts
+++ b/apps/browser/src/backend/agents/model-provider.test.ts
@@ -15,22 +15,28 @@ import {
 function createTestModelProviderService({
   providerModes = {},
   modelThinkingOverrides = {},
+  customEndpoints = [],
 }: {
   providerModes?: Record<string, 'stagewise' | 'official' | 'custom'>;
   modelThinkingOverrides?: Record<
     string,
     {
       enabled?: boolean;
-      effort?: 'minimal' | 'low' | 'medium' | 'high' | 'xhigh';
+      value?: 'minimal' | 'low' | 'medium' | 'high' | 'xhigh' | 'max';
     }
   >;
+  customEndpoints?: typeof defaultUserPreferences.customEndpoints;
 } = {}) {
   const preferences = structuredClone(defaultUserPreferences);
   preferences.agent.modelThinkingOverrides = modelThinkingOverrides;
+  preferences.customEndpoints = customEndpoints;
   for (const [provider, mode] of Object.entries(providerModes)) {
-    preferences.providerConfigs[
-      provider as keyof typeof preferences.providerConfigs
-    ].mode = mode;
+    const config =
+      preferences.providerConfigs[
+        provider as keyof typeof preferences.providerConfigs
+      ];
+    config.mode = mode;
+    if (mode === 'custom') config.customProviderId = `${provider}-custom`;
   }
 
   return new ModelProviderService(
@@ -68,7 +74,7 @@ describe('thinking override provider option resolution', () => {
 
   it('does not apply overrides without agent-step request purpose', () => {
     const service = createTestModelProviderService({
-      modelThinkingOverrides: { 'gpt-5.5': { effort: 'high' } },
+      modelThinkingOverrides: { 'gpt-5.5': { value: 'high' } },
     });
 
     const result = service.getModelWithOptions('gpt-5.5', 'trace-1');
@@ -80,7 +86,7 @@ describe('thinking override provider option resolution', () => {
 
   it('applies built-in overrides for agent-step requests', () => {
     const service = createTestModelProviderService({
-      modelThinkingOverrides: { 'gpt-5.5': { effort: 'high' } },
+      modelThinkingOverrides: { 'gpt-5.5': { value: 'high' } },
     });
 
     const result = service.getModelWithOptions(
@@ -90,7 +96,8 @@ describe('thinking override provider option resolution', () => {
     );
 
     expect(result.providerOptions).toMatchObject({
-      stagewise: { reasoning: { enabled: true, effort: 'high' } },
+      stagewise: { reasoning: { enabled: true, effort: 'medium' } },
+      openai: { reasoningEffort: 'high' },
     });
   });
 
@@ -112,7 +119,7 @@ describe('thinking override provider option resolution', () => {
     expect(result.providerOptions?.anthropic).not.toHaveProperty('effort');
   });
 
-  it('disables OpenAI thinking by removing reasoning options', () => {
+  it('disables OpenAI thinking with the provider-native off value', () => {
     const service = createTestModelProviderService({
       providerModes: { openai: 'official' },
       modelThinkingOverrides: { 'gpt-5.5': { enabled: false } },
@@ -124,14 +131,9 @@ describe('thinking override provider option resolution', () => {
       agentStepMetadata,
     );
 
-    expect(result.providerOptions?.openai).not.toHaveProperty(
-      'reasoningEffort',
-    );
-    expect(result.providerOptions?.openai).not.toHaveProperty(
-      'reasoningSummary',
-    );
     expect(result.providerOptions).toMatchObject({
       openai: {
+        reasoningEffort: 'none',
         parallelToolCalls: true,
         strictJsonSchema: true,
       },
@@ -162,7 +164,7 @@ describe('thinking override provider option resolution', () => {
     });
   });
 
-  it('disables stagewise thinking without leaving an effort', () => {
+  it('disables stagewise-routed OpenAI thinking with provider-native options', () => {
     const service = createTestModelProviderService({
       modelThinkingOverrides: { 'gpt-5.5': { enabled: false } },
     });
@@ -174,10 +176,8 @@ describe('thinking override provider option resolution', () => {
     );
 
     expect(result.providerOptions).toMatchObject({
-      stagewise: { reasoning: { enabled: false } },
-    });
-    expect(result.providerOptions?.stagewise).toMatchObject({
-      reasoning: expect.not.objectContaining({ effort: expect.anything() }),
+      stagewise: { reasoning: { enabled: true, effort: 'medium' } },
+      openai: { reasoningEffort: 'none' },
     });
   });
 
@@ -203,7 +203,7 @@ describe('thinking override provider option resolution', () => {
 
   it('preserves unrelated stagewise provider options', () => {
     const service = createTestModelProviderService({
-      modelThinkingOverrides: { 'deepseek-v4-pro': { effort: 'high' } },
+      modelThinkingOverrides: { 'deepseek-v4-pro': { value: 'high' } },
     });
 
     const result = service.getModelWithOptions(
@@ -213,17 +213,36 @@ describe('thinking override provider option resolution', () => {
     );
 
     expect(result.providerOptions).toMatchObject({
+      openai: { reasoningEffort: 'high' },
       stagewise: {
-        reasoning: { enabled: true, effort: 'high' },
+        reasoning: { enabled: true, effort: 'medium' },
         provider: { require_parameters: true },
       },
     });
   });
 
+  it('maps OpenAI-compatible official overrides to the OpenAI provider namespace', () => {
+    const service = createTestModelProviderService({
+      providerModes: { deepseek: 'official' },
+      modelThinkingOverrides: { 'deepseek-v4-pro': { value: 'high' } },
+    });
+
+    const result = service.getModelWithOptions(
+      'deepseek-v4-pro',
+      'trace-1',
+      agentStepMetadata,
+    );
+
+    expect(result.providerOptions?.openai).toMatchObject({
+      reasoningEffort: 'high',
+    });
+    expect(result.providerOptions).not.toHaveProperty('deepseek');
+  });
+
   it('maps OpenAI official overrides while preserving unrelated options', () => {
     const service = createTestModelProviderService({
       providerModes: { openai: 'official' },
-      modelThinkingOverrides: { 'gpt-5.5': { effort: 'high' } },
+      modelThinkingOverrides: { 'gpt-5.5': { value: 'high' } },
     });
 
     const result = service.getModelWithOptions(
@@ -246,7 +265,7 @@ describe('thinking override provider option resolution', () => {
     const service = createTestModelProviderService({
       providerModes: { google: 'official' },
       modelThinkingOverrides: {
-        'gemini-3.1-pro-preview': { effort: 'minimal' },
+        'gemini-3.1-pro-preview': { value: 'low' },
       },
     });
 
@@ -287,7 +306,7 @@ describe('thinking override provider option resolution', () => {
   it('maps Anthropic official overrides while preserving adaptive shape', () => {
     const service = createTestModelProviderService({
       providerModes: { anthropic: 'official' },
-      modelThinkingOverrides: { 'claude-fable-5': { effort: 'high' } },
+      modelThinkingOverrides: { 'claude-fable-5': { value: 'high' } },
     });
 
     const result = service.getModelWithOptions(
@@ -298,6 +317,49 @@ describe('thinking override provider option resolution', () => {
 
     expect(result.providerOptions).toMatchObject({
       anthropic: { thinking: { type: 'adaptive' }, effort: 'high' },
+    });
+  });
+
+  it('maps Stagewise-routed Anthropic overrides to Anthropic options', () => {
+    const service = createTestModelProviderService({
+      modelThinkingOverrides: { 'claude-opus-4.8': { value: 'max' } },
+    });
+
+    const result = service.getModelWithOptions(
+      'claude-opus-4.8',
+      'trace-1',
+      agentStepMetadata,
+    );
+
+    expect(result.providerOptions).toMatchObject({
+      stagewise: { reasoning: { enabled: true, effort: 'medium' } },
+      anthropic: { thinking: { type: 'adaptive' }, effort: 'max' },
+    });
+  });
+
+  it('uses OpenAI-compatible options for custom chat completions endpoints', () => {
+    const service = createTestModelProviderService({
+      providerModes: { openai: 'custom' },
+      modelThinkingOverrides: { 'gpt-5.5': { value: 'xhigh' } },
+      customEndpoints: [
+        {
+          id: 'openai-custom',
+          name: 'OpenAI-compatible',
+          apiSpec: 'openai-chat-completions',
+          baseUrl: 'https://example.com/v1',
+          awsAuthMode: 'access-keys',
+        },
+      ],
+    });
+
+    const result = service.getModelWithOptions(
+      'gpt-5.5',
+      'trace-1',
+      agentStepMetadata,
+    );
+
+    expect(result.providerOptions).toMatchObject({
+      openai: { reasoningEffort: 'medium' },
     });
   });
 });

--- a/apps/browser/src/backend/agents/model-provider.test.ts
+++ b/apps/browser/src/backend/agents/model-provider.test.ts
@@ -1,4 +1,7 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+import { defaultUserPreferences } from '@shared/karton-contracts/ui/shared-types';
+import { MODEL_REQUEST_PURPOSE_METADATA_KEY } from '@stagewise/agent-core/host';
+import { ModelProviderService } from './model-provider';
 import {
   reasoningSignatureSourceSchema,
   type ReasoningSignatureSource,
@@ -8,6 +11,296 @@ import {
   getSemanticProviderForApiSpec,
   reasoningSourcesMatch,
 } from './reasoning-signatures';
+
+function createTestModelProviderService({
+  providerModes = {},
+  modelThinkingOverrides = {},
+}: {
+  providerModes?: Record<string, 'stagewise' | 'official' | 'custom'>;
+  modelThinkingOverrides?: Record<
+    string,
+    {
+      enabled?: boolean;
+      effort?: 'minimal' | 'low' | 'medium' | 'high' | 'xhigh';
+    }
+  >;
+} = {}) {
+  const preferences = structuredClone(defaultUserPreferences);
+  preferences.agent.modelThinkingOverrides = modelThinkingOverrides;
+  for (const [provider, mode] of Object.entries(providerModes)) {
+    preferences.providerConfigs[
+      provider as keyof typeof preferences.providerConfigs
+    ].mode = mode;
+  }
+
+  return new ModelProviderService(
+    {
+      withTracing: vi.fn((model) => model),
+      captureException: vi.fn(),
+    } as any,
+    { accessToken: 'stagewise-token' } as any,
+    {
+      get: vi.fn(() => preferences),
+      decryptProviderApiKey: vi.fn(() => 'provider-api-key'),
+    } as any,
+  );
+}
+
+const agentStepMetadata = {
+  [MODEL_REQUEST_PURPOSE_METADATA_KEY]: 'agent-step',
+};
+
+describe('thinking override provider option resolution', () => {
+  it('returns base provider options unchanged when no override exists', () => {
+    const service = createTestModelProviderService();
+
+    const result = service.getModelWithOptions(
+      'gpt-5.5',
+      'trace-1',
+      agentStepMetadata,
+    );
+
+    expect(result.providerOptions).toMatchObject({
+      stagewise: { reasoning: { enabled: true, effort: 'medium' } },
+      openai: { reasoningEffort: 'medium', reasoningSummary: 'auto' },
+    });
+  });
+
+  it('does not apply overrides without agent-step request purpose', () => {
+    const service = createTestModelProviderService({
+      modelThinkingOverrides: { 'gpt-5.5': { effort: 'high' } },
+    });
+
+    const result = service.getModelWithOptions('gpt-5.5', 'trace-1');
+
+    expect(result.providerOptions).toMatchObject({
+      stagewise: { reasoning: { enabled: true, effort: 'medium' } },
+    });
+  });
+
+  it('applies built-in overrides for agent-step requests', () => {
+    const service = createTestModelProviderService({
+      modelThinkingOverrides: { 'gpt-5.5': { effort: 'high' } },
+    });
+
+    const result = service.getModelWithOptions(
+      'gpt-5.5',
+      'trace-1',
+      agentStepMetadata,
+    );
+
+    expect(result.providerOptions).toMatchObject({
+      stagewise: { reasoning: { enabled: true, effort: 'high' } },
+    });
+  });
+
+  it('produces provider-specific disabled thinking options', () => {
+    const service = createTestModelProviderService({
+      providerModes: { anthropic: 'official' },
+      modelThinkingOverrides: { 'claude-fable-5': { enabled: false } },
+    });
+
+    const result = service.getModelWithOptions(
+      'claude-fable-5',
+      'trace-1',
+      agentStepMetadata,
+    );
+
+    expect(result.providerOptions).toMatchObject({
+      anthropic: { thinking: { type: 'disabled' } },
+    });
+    expect(result.providerOptions?.anthropic).not.toHaveProperty('effort');
+  });
+
+  it('disables OpenAI thinking by removing reasoning options', () => {
+    const service = createTestModelProviderService({
+      providerModes: { openai: 'official' },
+      modelThinkingOverrides: { 'gpt-5.5': { enabled: false } },
+    });
+
+    const result = service.getModelWithOptions(
+      'gpt-5.5',
+      'trace-1',
+      agentStepMetadata,
+    );
+
+    expect(result.providerOptions?.openai).not.toHaveProperty(
+      'reasoningEffort',
+    );
+    expect(result.providerOptions?.openai).not.toHaveProperty(
+      'reasoningSummary',
+    );
+    expect(result.providerOptions).toMatchObject({
+      openai: {
+        parallelToolCalls: true,
+        strictJsonSchema: true,
+      },
+    });
+  });
+
+  it('disables Google thinking without leaving a thinking level', () => {
+    const service = createTestModelProviderService({
+      providerModes: { google: 'official' },
+      modelThinkingOverrides: {
+        'gemini-3.1-pro-preview': { enabled: false },
+      },
+    });
+
+    const result = service.getModelWithOptions(
+      'gemini-3.1-pro-preview',
+      'trace-1',
+      agentStepMetadata,
+    );
+
+    expect(result.providerOptions).toMatchObject({
+      google: { thinkingConfig: { includeThoughts: false } },
+    });
+    expect(result.providerOptions?.google).toMatchObject({
+      thinkingConfig: expect.not.objectContaining({
+        thinkingLevel: expect.anything(),
+      }),
+    });
+  });
+
+  it('disables stagewise thinking without leaving an effort', () => {
+    const service = createTestModelProviderService({
+      modelThinkingOverrides: { 'gpt-5.5': { enabled: false } },
+    });
+
+    const result = service.getModelWithOptions(
+      'gpt-5.5',
+      'trace-1',
+      agentStepMetadata,
+    );
+
+    expect(result.providerOptions).toMatchObject({
+      stagewise: { reasoning: { enabled: false } },
+    });
+    expect(result.providerOptions?.stagewise).toMatchObject({
+      reasoning: expect.not.objectContaining({ effort: expect.anything() }),
+    });
+  });
+
+  it('treats empty override objects as no-ops', () => {
+    const service = createTestModelProviderService({
+      providerModes: { google: 'official' },
+      modelThinkingOverrides: { 'gemini-3.1-pro-preview': {} },
+    });
+
+    const result = service.getModelWithOptions(
+      'gemini-3.1-pro-preview',
+      'trace-1',
+      agentStepMetadata,
+    );
+
+    expect(result.providerOptions).toMatchObject({
+      stagewise: { reasoning: { enabled: true, effort: 'medium' } },
+      google: {
+        thinkingConfig: { includeThoughts: true, thinkingLevel: 'high' },
+      },
+    });
+  });
+
+  it('preserves unrelated stagewise provider options', () => {
+    const service = createTestModelProviderService({
+      modelThinkingOverrides: { 'deepseek-v4-pro': { effort: 'high' } },
+    });
+
+    const result = service.getModelWithOptions(
+      'deepseek-v4-pro',
+      'trace-1',
+      agentStepMetadata,
+    );
+
+    expect(result.providerOptions).toMatchObject({
+      stagewise: {
+        reasoning: { enabled: true, effort: 'high' },
+        provider: { require_parameters: true },
+      },
+    });
+  });
+
+  it('maps OpenAI official overrides while preserving unrelated options', () => {
+    const service = createTestModelProviderService({
+      providerModes: { openai: 'official' },
+      modelThinkingOverrides: { 'gpt-5.5': { effort: 'high' } },
+    });
+
+    const result = service.getModelWithOptions(
+      'gpt-5.5',
+      'trace-1',
+      agentStepMetadata,
+    );
+
+    expect(result.providerOptions).toMatchObject({
+      openai: {
+        reasoningEffort: 'high',
+        reasoningSummary: 'auto',
+        parallelToolCalls: true,
+        strictJsonSchema: true,
+      },
+    });
+  });
+
+  it('maps Google official overrides while preserving thinking config', () => {
+    const service = createTestModelProviderService({
+      providerModes: { google: 'official' },
+      modelThinkingOverrides: {
+        'gemini-3.1-pro-preview': { effort: 'minimal' },
+      },
+    });
+
+    const result = service.getModelWithOptions(
+      'gemini-3.1-pro-preview',
+      'trace-1',
+      agentStepMetadata,
+    );
+
+    expect(result.providerOptions).toMatchObject({
+      google: {
+        thinkingConfig: { includeThoughts: true, thinkingLevel: 'low' },
+      },
+    });
+  });
+
+  it('uses active provider defaults when enabling without effort', () => {
+    const service = createTestModelProviderService({
+      providerModes: { google: 'official' },
+      modelThinkingOverrides: {
+        'gemini-3.1-pro-preview': { enabled: true },
+      },
+    });
+
+    const result = service.getModelWithOptions(
+      'gemini-3.1-pro-preview',
+      'trace-1',
+      agentStepMetadata,
+    );
+
+    expect(result.providerOptions).toMatchObject({
+      google: {
+        thinkingConfig: { includeThoughts: true, thinkingLevel: 'high' },
+      },
+    });
+  });
+
+  it('maps Anthropic official overrides while preserving adaptive shape', () => {
+    const service = createTestModelProviderService({
+      providerModes: { anthropic: 'official' },
+      modelThinkingOverrides: { 'claude-fable-5': { effort: 'high' } },
+    });
+
+    const result = service.getModelWithOptions(
+      'claude-fable-5',
+      'trace-1',
+      agentStepMetadata,
+    );
+
+    expect(result.providerOptions).toMatchObject({
+      anthropic: { thinking: { type: 'adaptive' }, effort: 'high' },
+    });
+  });
+});
 
 describe('reasoning signature source helpers', () => {
   it('maps custom endpoint API specs to semantic providers', () => {

--- a/apps/browser/src/backend/agents/model-provider.ts
+++ b/apps/browser/src/backend/agents/model-provider.ts
@@ -6,7 +6,6 @@ import type {
   CustomModel,
   CustomEndpoint,
   ModelThinkingOverride,
-  ThinkingEffort,
 } from '@shared/karton-contracts/ui/shared-types';
 import type { ReasoningSignatureSource } from '@shared/karton-contracts/ui/agent/metadata';
 import {
@@ -29,6 +28,7 @@ import type { PreferencesService } from '@/services/preferences';
 import type { streamText, LanguageModelMiddleware } from 'ai';
 import { wrapLanguageModel } from 'ai';
 import { MODEL_REQUEST_PURPOSE_METADATA_KEY } from '@stagewise/agent-core/host';
+import { createThinkingProviderOptionsPatch } from '@shared/model-thinking-capabilities';
 
 type ProviderOptions = Parameters<typeof streamText>[0]['providerOptions'];
 type BuiltInModelSettings = (typeof availableModels)[number];
@@ -453,6 +453,7 @@ export class ModelProviderService {
             semanticProvider: getSemanticProviderForApiSpec(
               resolved.customEndpoint.apiSpec,
             ),
+            customEndpointApiSpec: resolved.customEndpoint.apiSpec,
             requestMetadata: otherPostHogProperties,
           }) as Record<string, unknown>,
           headers,
@@ -1005,44 +1006,13 @@ export class ModelProviderService {
 // Thinking override utilities
 // =============================================================================
 
-const STAGEWISE_EFFORTS: Record<ThinkingEffort, string> = {
-  minimal: 'minimal',
-  low: 'low',
-  medium: 'medium',
-  high: 'high',
-  xhigh: 'xhigh',
-};
-
-const OPENAI_EFFORTS: Record<ThinkingEffort, string> = {
-  minimal: 'minimal',
-  low: 'low',
-  medium: 'medium',
-  high: 'high',
-  xhigh: 'high',
-};
-
-const GOOGLE_EFFORTS: Record<ThinkingEffort, string> = {
-  minimal: 'low',
-  low: 'low',
-  medium: 'medium',
-  high: 'high',
-  xhigh: 'high',
-};
-
-const ANTHROPIC_BUDGET_TOKENS: Record<ThinkingEffort, number> = {
-  minimal: 4_000,
-  low: 6_000,
-  medium: 10_000,
-  high: 16_000,
-  xhigh: 24_000,
-};
-
 type ThinkingProviderOptionsInput = {
   baseProviderOptions: Record<string, unknown>;
   modelSettings: BuiltInModelSettings;
   override?: ModelThinkingOverride;
   providerMode: ProviderMode;
   semanticProvider: ModelProvider;
+  customEndpointApiSpec?: ApiSpec;
   requestMetadata?: Record<string, unknown>;
 };
 
@@ -1052,236 +1022,30 @@ function resolveThinkingProviderOptions({
   override,
   providerMode,
   semanticProvider,
+  customEndpointApiSpec,
   requestMetadata,
 }: ThinkingProviderOptionsInput): ProviderOptions {
   if (requestMetadata?.[MODEL_REQUEST_PURPOSE_METADATA_KEY] !== 'agent-step') {
     return baseProviderOptions as ProviderOptions;
   }
 
-  if (
-    !modelSettings.thinkingEnabled ||
-    !override ||
-    !hasExplicitThinkingOverride(override)
-  ) {
+  if (!modelSettings.thinkingEnabled || !override) {
     return baseProviderOptions as ProviderOptions;
   }
 
-  const effort =
-    override.effort ??
-    getDefaultThinkingEffort(
-      baseProviderOptions,
-      providerMode,
-      semanticProvider,
-    );
-
   const patch = createThinkingProviderOptionsPatch({
-    baseProviderOptions,
+    model: modelSettings,
     override,
-    effort,
-    providerMode,
-    semanticProvider,
+    route: {
+      providerMode,
+      modelProvider: semanticProvider,
+      customEndpointApiSpec,
+    },
   });
 
   if (!patch) return baseProviderOptions as ProviderOptions;
 
   return deepMergeProviderOptions(baseProviderOptions, patch);
-}
-
-type ThinkingProviderOptionsPatchInput = Pick<
-  ThinkingProviderOptionsInput,
-  'baseProviderOptions' | 'providerMode' | 'semanticProvider'
-> & {
-  override: ModelThinkingOverride;
-  effort: ThinkingEffort;
-};
-
-function createThinkingProviderOptionsPatch({
-  baseProviderOptions,
-  override,
-  effort,
-  providerMode,
-  semanticProvider,
-}: ThinkingProviderOptionsPatchInput): Record<string, unknown> | undefined {
-  const enabled = override.enabled ?? true;
-
-  if (providerMode === 'stagewise') {
-    return {
-      stagewise: {
-        reasoning: {
-          enabled,
-          effort: enabled ? STAGEWISE_EFFORTS[effort] : undefined,
-        },
-      },
-    };
-  }
-
-  switch (semanticProvider) {
-    case 'openai':
-    case 'moonshotai':
-    case 'alibaba':
-    case 'deepseek':
-    case 'z-ai':
-    case 'minimax':
-      return {
-        openai: enabled
-          ? { reasoningEffort: OPENAI_EFFORTS[effort] }
-          : { reasoningEffort: undefined, reasoningSummary: undefined },
-      };
-    case 'google':
-      return {
-        google: {
-          thinkingConfig: {
-            includeThoughts: enabled,
-            thinkingLevel: enabled ? GOOGLE_EFFORTS[effort] : undefined,
-          },
-        },
-      };
-    case 'anthropic':
-      return {
-        anthropic: createAnthropicThinkingPatch(
-          baseProviderOptions.anthropic,
-          enabled,
-          effort,
-        ),
-      };
-    default: {
-      const _exhaustive: never = semanticProvider;
-      return _exhaustive;
-    }
-  }
-}
-
-function createAnthropicThinkingPatch(
-  baseAnthropicOptions: unknown,
-  enabled: boolean,
-  effort: ThinkingEffort,
-): Record<string, unknown> {
-  if (!enabled) {
-    return { thinking: { type: 'disabled' }, effort: undefined };
-  }
-
-  const thinking = isPlainObject(baseAnthropicOptions)
-    ? baseAnthropicOptions.thinking
-    : undefined;
-  if (
-    isPlainObject(thinking) &&
-    typeof thinking.type === 'string' &&
-    thinking.type !== 'adaptive'
-  ) {
-    return {
-      thinking: {
-        ...thinking,
-        type: 'enabled',
-        budgetTokens: ANTHROPIC_BUDGET_TOKENS[effort],
-      },
-    };
-  }
-
-  return {
-    thinking: { type: 'adaptive' },
-    effort,
-  };
-}
-
-function getDefaultThinkingEffort(
-  providerOptions: Record<string, unknown>,
-  providerMode: ProviderMode,
-  semanticProvider: ModelProvider,
-): ThinkingEffort {
-  const providerEffort = getProviderSpecificThinkingEffort(
-    providerOptions,
-    semanticProvider,
-  );
-  if (providerMode !== 'stagewise' && providerEffort) {
-    return providerEffort;
-  }
-
-  const stagewiseEffort = getStagewiseThinkingEffort(providerOptions);
-  return stagewiseEffort ?? providerEffort ?? 'medium';
-}
-
-function getStagewiseThinkingEffort(
-  providerOptions: Record<string, unknown>,
-): ThinkingEffort | undefined {
-  const stagewise = providerOptions.stagewise;
-  if (!isPlainObject(stagewise)) return undefined;
-
-  const reasoning = stagewise.reasoning;
-  if (isPlainObject(reasoning) && isThinkingEffort(reasoning.effort)) {
-    return reasoning.effort;
-  }
-
-  return undefined;
-}
-
-function getProviderSpecificThinkingEffort(
-  providerOptions: Record<string, unknown>,
-  semanticProvider: ModelProvider,
-): ThinkingEffort | undefined {
-  switch (semanticProvider) {
-    case 'openai':
-    case 'moonshotai':
-    case 'alibaba':
-    case 'deepseek':
-    case 'z-ai':
-    case 'minimax': {
-      const openai = providerOptions.openai;
-      if (!isPlainObject(openai)) return undefined;
-      return isThinkingEffort(openai.reasoningEffort)
-        ? openai.reasoningEffort
-        : undefined;
-    }
-    case 'google': {
-      const google = providerOptions.google;
-      if (!isPlainObject(google)) return undefined;
-      const thinkingConfig = google.thinkingConfig;
-      if (!isPlainObject(thinkingConfig)) return undefined;
-      return toThinkingEffort(thinkingConfig.thinkingLevel);
-    }
-    case 'anthropic': {
-      const anthropic = providerOptions.anthropic;
-      if (!isPlainObject(anthropic)) return undefined;
-      if (isThinkingEffort(anthropic.effort)) return anthropic.effort;
-      const thinking = anthropic.thinking;
-      if (!isPlainObject(thinking)) return undefined;
-      return getThinkingEffortFromAnthropicBudget(thinking.budgetTokens);
-    }
-    default: {
-      const _exhaustive: never = semanticProvider;
-      return _exhaustive;
-    }
-  }
-}
-
-function toThinkingEffort(value: unknown): ThinkingEffort | undefined {
-  if (isThinkingEffort(value)) return value;
-  if (value === 'low' || value === 'medium' || value === 'high') return value;
-  return undefined;
-}
-
-function getThinkingEffortFromAnthropicBudget(
-  budgetTokens: unknown,
-): ThinkingEffort | undefined {
-  if (typeof budgetTokens !== 'number') return undefined;
-
-  let closestEffort: ThinkingEffort = 'medium';
-  let closestDistance = Number.POSITIVE_INFINITY;
-  for (const [effort, budget] of Object.entries(ANTHROPIC_BUDGET_TOKENS) as [
-    ThinkingEffort,
-    number,
-  ][]) {
-    const distance = Math.abs(budgetTokens - budget);
-    if (distance < closestDistance) {
-      closestEffort = effort;
-      closestDistance = distance;
-    }
-  }
-
-  return closestEffort;
-}
-
-function hasExplicitThinkingOverride(override: ModelThinkingOverride): boolean {
-  return override.enabled !== undefined || override.effort !== undefined;
 }
 
 function omitModelRequestMetadata(
@@ -1294,16 +1058,6 @@ function omitModelRequestMetadata(
   const { [MODEL_REQUEST_PURPOSE_METADATA_KEY]: _purpose, ...telemetry } =
     metadata;
   return telemetry;
-}
-
-function isThinkingEffort(value: unknown): value is ThinkingEffort {
-  return (
-    value === 'minimal' ||
-    value === 'low' ||
-    value === 'medium' ||
-    value === 'high' ||
-    value === 'xhigh'
-  );
 }
 
 // =============================================================================

--- a/apps/browser/src/backend/agents/model-provider.ts
+++ b/apps/browser/src/backend/agents/model-provider.ts
@@ -5,6 +5,8 @@ import type {
   ApiSpec,
   CustomModel,
   CustomEndpoint,
+  ModelThinkingOverride,
+  ThinkingEffort,
 } from '@shared/karton-contracts/ui/shared-types';
 import type { ReasoningSignatureSource } from '@shared/karton-contracts/ui/agent/metadata';
 import {
@@ -26,8 +28,10 @@ import type { AuthService } from '@/services/auth';
 import type { PreferencesService } from '@/services/preferences';
 import type { streamText, LanguageModelMiddleware } from 'ai';
 import { wrapLanguageModel } from 'ai';
+import { MODEL_REQUEST_PURPOSE_METADATA_KEY } from '@stagewise/agent-core/host';
 
 type ProviderOptions = Parameters<typeof streamText>[0]['providerOptions'];
+type BuiltInModelSettings = (typeof availableModels)[number];
 
 /**
  * Converts an OpenRouter-style Anthropic model ID (dots in version, e.g.
@@ -336,7 +340,7 @@ export class ModelProviderService {
   }
 
   private createBuiltInModelWithOptions(
-    modelSettings: (typeof availableModels)[number],
+    modelSettings: BuiltInModelSettings,
     traceId: string,
     otherPostHogProperties?: Record<string, unknown>,
   ): ModelWithOptions {
@@ -348,13 +352,18 @@ export class ModelProviderService {
       : { apiKey: '', baseURL: undefined, mode: 'stagewise' as const };
     const { apiKey, baseURL, mode } = resolved;
     const headers = modelSettings.headers ?? {};
+    const baseProviderOptions = modelSettings.providerOptions as Record<
+      string,
+      unknown
+    >;
+    const posthogProperties = omitModelRequestMetadata(otherPostHogProperties);
 
     const posthogConfig = {
       posthogTraceId: traceId,
       posthogProperties: {
         posthogTraceId: traceId,
         modelId: modelSettings.modelId,
-        ...otherPostHogProperties,
+        ...posthogProperties,
       },
     };
 
@@ -386,9 +395,17 @@ export class ModelProviderService {
       return {
         model: this.telemetryService.withTracing(model, posthogConfig),
         headers,
-        providerOptions: modelSettings.providerOptions as Parameters<
-          typeof streamText
-        >[0]['providerOptions'],
+        providerOptions: resolveThinkingProviderOptions({
+          baseProviderOptions,
+          modelSettings,
+          override:
+            this.preferencesService.get().agent.modelThinkingOverrides[
+              modelSettings.modelId
+            ],
+          providerMode: 'stagewise',
+          semanticProvider: officialProvider,
+          requestMetadata: otherPostHogProperties,
+        }),
         contextWindowSize: modelSettings.modelContextRaw,
         providerMode: 'stagewise',
         reasoningSignatureSource: createReasoningSignatureSource(
@@ -425,7 +442,19 @@ export class ModelProviderService {
         ...this.createModelViaEndpoint(
           resolved.customEndpoint,
           remappedModelId,
-          modelSettings.providerOptions as Record<string, unknown>,
+          resolveThinkingProviderOptions({
+            baseProviderOptions,
+            modelSettings,
+            override:
+              this.preferencesService.get().agent.modelThinkingOverrides[
+                modelSettings.modelId
+              ],
+            providerMode: 'custom',
+            semanticProvider: getSemanticProviderForApiSpec(
+              resolved.customEndpoint.apiSpec,
+            ),
+            requestMetadata: otherPostHogProperties,
+          }) as Record<string, unknown>,
           headers,
           modelSettings.modelContextRaw,
           posthogConfig,
@@ -447,7 +476,17 @@ export class ModelProviderService {
         apiKey,
         baseURL,
         modelSettings.modelId,
-        modelSettings.providerOptions as Record<string, unknown>,
+        resolveThinkingProviderOptions({
+          baseProviderOptions,
+          modelSettings,
+          override:
+            this.preferencesService.get().agent.modelThinkingOverrides[
+              modelSettings.modelId
+            ],
+          providerMode: 'official',
+          semanticProvider: officialProvider,
+          requestMetadata: otherPostHogProperties,
+        }) as Record<string, unknown>,
         headers,
         modelSettings.modelContextRaw,
         posthogConfig,
@@ -799,6 +838,7 @@ export class ModelProviderService {
       customModel.endpointId,
     );
     const headers = customModel.headers ?? {};
+    const posthogProperties = omitModelRequestMetadata(otherPostHogProperties);
 
     const posthogConfig = {
       posthogTraceId: traceId,
@@ -806,7 +846,7 @@ export class ModelProviderService {
         posthogTraceId: traceId,
         modelId: customModel.modelId,
         isCustomModel: true,
-        ...otherPostHogProperties,
+        ...posthogProperties,
       },
     };
 
@@ -962,6 +1002,311 @@ export class ModelProviderService {
 }
 
 // =============================================================================
+// Thinking override utilities
+// =============================================================================
+
+const STAGEWISE_EFFORTS: Record<ThinkingEffort, string> = {
+  minimal: 'minimal',
+  low: 'low',
+  medium: 'medium',
+  high: 'high',
+  xhigh: 'xhigh',
+};
+
+const OPENAI_EFFORTS: Record<ThinkingEffort, string> = {
+  minimal: 'minimal',
+  low: 'low',
+  medium: 'medium',
+  high: 'high',
+  xhigh: 'high',
+};
+
+const GOOGLE_EFFORTS: Record<ThinkingEffort, string> = {
+  minimal: 'low',
+  low: 'low',
+  medium: 'medium',
+  high: 'high',
+  xhigh: 'high',
+};
+
+const ANTHROPIC_BUDGET_TOKENS: Record<ThinkingEffort, number> = {
+  minimal: 4_000,
+  low: 6_000,
+  medium: 10_000,
+  high: 16_000,
+  xhigh: 24_000,
+};
+
+type ThinkingProviderOptionsInput = {
+  baseProviderOptions: Record<string, unknown>;
+  modelSettings: BuiltInModelSettings;
+  override?: ModelThinkingOverride;
+  providerMode: ProviderMode;
+  semanticProvider: ModelProvider;
+  requestMetadata?: Record<string, unknown>;
+};
+
+function resolveThinkingProviderOptions({
+  baseProviderOptions,
+  modelSettings,
+  override,
+  providerMode,
+  semanticProvider,
+  requestMetadata,
+}: ThinkingProviderOptionsInput): ProviderOptions {
+  if (requestMetadata?.[MODEL_REQUEST_PURPOSE_METADATA_KEY] !== 'agent-step') {
+    return baseProviderOptions as ProviderOptions;
+  }
+
+  if (
+    !modelSettings.thinkingEnabled ||
+    !override ||
+    !hasExplicitThinkingOverride(override)
+  ) {
+    return baseProviderOptions as ProviderOptions;
+  }
+
+  const effort =
+    override.effort ??
+    getDefaultThinkingEffort(
+      baseProviderOptions,
+      providerMode,
+      semanticProvider,
+    );
+
+  const patch = createThinkingProviderOptionsPatch({
+    baseProviderOptions,
+    override,
+    effort,
+    providerMode,
+    semanticProvider,
+  });
+
+  if (!patch) return baseProviderOptions as ProviderOptions;
+
+  return deepMergeProviderOptions(baseProviderOptions, patch);
+}
+
+type ThinkingProviderOptionsPatchInput = Pick<
+  ThinkingProviderOptionsInput,
+  'baseProviderOptions' | 'providerMode' | 'semanticProvider'
+> & {
+  override: ModelThinkingOverride;
+  effort: ThinkingEffort;
+};
+
+function createThinkingProviderOptionsPatch({
+  baseProviderOptions,
+  override,
+  effort,
+  providerMode,
+  semanticProvider,
+}: ThinkingProviderOptionsPatchInput): Record<string, unknown> | undefined {
+  const enabled = override.enabled ?? true;
+
+  if (providerMode === 'stagewise') {
+    return {
+      stagewise: {
+        reasoning: {
+          enabled,
+          effort: enabled ? STAGEWISE_EFFORTS[effort] : undefined,
+        },
+      },
+    };
+  }
+
+  switch (semanticProvider) {
+    case 'openai':
+    case 'moonshotai':
+    case 'alibaba':
+    case 'deepseek':
+    case 'z-ai':
+    case 'minimax':
+      return {
+        openai: enabled
+          ? { reasoningEffort: OPENAI_EFFORTS[effort] }
+          : { reasoningEffort: undefined, reasoningSummary: undefined },
+      };
+    case 'google':
+      return {
+        google: {
+          thinkingConfig: {
+            includeThoughts: enabled,
+            thinkingLevel: enabled ? GOOGLE_EFFORTS[effort] : undefined,
+          },
+        },
+      };
+    case 'anthropic':
+      return {
+        anthropic: createAnthropicThinkingPatch(
+          baseProviderOptions.anthropic,
+          enabled,
+          effort,
+        ),
+      };
+    default: {
+      const _exhaustive: never = semanticProvider;
+      return _exhaustive;
+    }
+  }
+}
+
+function createAnthropicThinkingPatch(
+  baseAnthropicOptions: unknown,
+  enabled: boolean,
+  effort: ThinkingEffort,
+): Record<string, unknown> {
+  if (!enabled) {
+    return { thinking: { type: 'disabled' }, effort: undefined };
+  }
+
+  const thinking = isPlainObject(baseAnthropicOptions)
+    ? baseAnthropicOptions.thinking
+    : undefined;
+  if (
+    isPlainObject(thinking) &&
+    typeof thinking.type === 'string' &&
+    thinking.type !== 'adaptive'
+  ) {
+    return {
+      thinking: {
+        ...thinking,
+        type: 'enabled',
+        budgetTokens: ANTHROPIC_BUDGET_TOKENS[effort],
+      },
+    };
+  }
+
+  return {
+    thinking: { type: 'adaptive' },
+    effort,
+  };
+}
+
+function getDefaultThinkingEffort(
+  providerOptions: Record<string, unknown>,
+  providerMode: ProviderMode,
+  semanticProvider: ModelProvider,
+): ThinkingEffort {
+  const providerEffort = getProviderSpecificThinkingEffort(
+    providerOptions,
+    semanticProvider,
+  );
+  if (providerMode !== 'stagewise' && providerEffort) {
+    return providerEffort;
+  }
+
+  const stagewiseEffort = getStagewiseThinkingEffort(providerOptions);
+  return stagewiseEffort ?? providerEffort ?? 'medium';
+}
+
+function getStagewiseThinkingEffort(
+  providerOptions: Record<string, unknown>,
+): ThinkingEffort | undefined {
+  const stagewise = providerOptions.stagewise;
+  if (!isPlainObject(stagewise)) return undefined;
+
+  const reasoning = stagewise.reasoning;
+  if (isPlainObject(reasoning) && isThinkingEffort(reasoning.effort)) {
+    return reasoning.effort;
+  }
+
+  return undefined;
+}
+
+function getProviderSpecificThinkingEffort(
+  providerOptions: Record<string, unknown>,
+  semanticProvider: ModelProvider,
+): ThinkingEffort | undefined {
+  switch (semanticProvider) {
+    case 'openai':
+    case 'moonshotai':
+    case 'alibaba':
+    case 'deepseek':
+    case 'z-ai':
+    case 'minimax': {
+      const openai = providerOptions.openai;
+      if (!isPlainObject(openai)) return undefined;
+      return isThinkingEffort(openai.reasoningEffort)
+        ? openai.reasoningEffort
+        : undefined;
+    }
+    case 'google': {
+      const google = providerOptions.google;
+      if (!isPlainObject(google)) return undefined;
+      const thinkingConfig = google.thinkingConfig;
+      if (!isPlainObject(thinkingConfig)) return undefined;
+      return toThinkingEffort(thinkingConfig.thinkingLevel);
+    }
+    case 'anthropic': {
+      const anthropic = providerOptions.anthropic;
+      if (!isPlainObject(anthropic)) return undefined;
+      if (isThinkingEffort(anthropic.effort)) return anthropic.effort;
+      const thinking = anthropic.thinking;
+      if (!isPlainObject(thinking)) return undefined;
+      return getThinkingEffortFromAnthropicBudget(thinking.budgetTokens);
+    }
+    default: {
+      const _exhaustive: never = semanticProvider;
+      return _exhaustive;
+    }
+  }
+}
+
+function toThinkingEffort(value: unknown): ThinkingEffort | undefined {
+  if (isThinkingEffort(value)) return value;
+  if (value === 'low' || value === 'medium' || value === 'high') return value;
+  return undefined;
+}
+
+function getThinkingEffortFromAnthropicBudget(
+  budgetTokens: unknown,
+): ThinkingEffort | undefined {
+  if (typeof budgetTokens !== 'number') return undefined;
+
+  let closestEffort: ThinkingEffort = 'medium';
+  let closestDistance = Number.POSITIVE_INFINITY;
+  for (const [effort, budget] of Object.entries(ANTHROPIC_BUDGET_TOKENS) as [
+    ThinkingEffort,
+    number,
+  ][]) {
+    const distance = Math.abs(budgetTokens - budget);
+    if (distance < closestDistance) {
+      closestEffort = effort;
+      closestDistance = distance;
+    }
+  }
+
+  return closestEffort;
+}
+
+function hasExplicitThinkingOverride(override: ModelThinkingOverride): boolean {
+  return override.enabled !== undefined || override.effort !== undefined;
+}
+
+function omitModelRequestMetadata(
+  metadata: Record<string, unknown> | undefined,
+): Record<string, unknown> | undefined {
+  if (!metadata || !(MODEL_REQUEST_PURPOSE_METADATA_KEY in metadata)) {
+    return metadata;
+  }
+
+  const { [MODEL_REQUEST_PURPOSE_METADATA_KEY]: _purpose, ...telemetry } =
+    metadata;
+  return telemetry;
+}
+
+function isThinkingEffort(value: unknown): value is ThinkingEffort {
+  return (
+    value === 'minimal' ||
+    value === 'low' ||
+    value === 'medium' ||
+    value === 'high' ||
+    value === 'xhigh'
+  );
+}
+
+// =============================================================================
 // Deep-merge utility for provider options
 // =============================================================================
 
@@ -990,7 +1335,9 @@ export function deepMergeProviderOptions(
   for (const source of sources) {
     if (!source) continue;
     for (const [key, value] of Object.entries(source)) {
-      if (isPlainObject(value) && isPlainObject(result[key])) {
+      if (value === undefined) {
+        delete result[key];
+      } else if (isPlainObject(value) && isPlainObject(result[key])) {
         result[key] = deepMergeProviderOptions(
           result[key] as Record<string, unknown>,
           value,

--- a/apps/browser/src/shared/available-models.ts
+++ b/apps/browser/src/shared/available-models.ts
@@ -715,7 +715,9 @@ export const availableModels = [
     headers: googleHeaders,
     providerOptions: {
       stagewise: { reasoning: { enabled: true, effort: 'medium' } },
-      anthropic: { thinking: { type: 'enabled', budgetTokens: 10000 } },
+      google: {
+        thinkingConfig: { includeThoughts: true, thinkingLevel: 'medium' },
+      },
     },
     thinkingEnabled: true,
     pricing: {
@@ -791,7 +793,9 @@ export const availableModels = [
     headers: googleHeaders,
     providerOptions: {
       stagewise: { reasoning: { enabled: true, effort: 'medium' } },
-      anthropic: { thinking: { type: 'enabled', budgetTokens: 10000 } },
+      google: {
+        thinkingConfig: { includeThoughts: true, thinkingLevel: 'medium' },
+      },
     },
     thinkingEnabled: true,
     pricing: {

--- a/apps/browser/src/shared/hotkeys.test.ts
+++ b/apps/browser/src/shared/hotkeys.test.ts
@@ -200,6 +200,41 @@ describe('isEventMatch', () => {
   });
 
   describe('layout-dependent symbol keys', () => {
+    it('uses Mod+Alt+Slash for cycling model thinking effort', () => {
+      const def = hotkeyDefinitions[HotkeyActions.CYCLE_MODEL_THINKING_EFFORT];
+      const ev = createKeyboardEvent({
+        code: 'Slash',
+        key: '÷',
+        metaKey: true,
+        altKey: true,
+      });
+
+      expect(isEventMatch(ev, def, 'mac')).toBe(true);
+    });
+
+    it('does NOT match physical Slash without Alt when it produces another character', () => {
+      const def: HotkeyDefinition = { accelerator: 'Mod+Slash' };
+      const ev = createKeyboardEvent({
+        code: 'Slash',
+        key: '-',
+        metaKey: true,
+      });
+
+      expect(isEventMatch(ev, def, 'mac')).toBe(false);
+    });
+
+    it('keeps shifted Slash available for Open Model Select layouts', () => {
+      const def = hotkeyDefinitions[HotkeyActions.OPEN_MODEL_SELECT];
+      const ev = createKeyboardEvent({
+        code: 'Digit7',
+        key: '/',
+        metaKey: true,
+        shiftKey: true,
+      });
+
+      expect(isEventMatch(ev, def, 'mac')).toBe(true);
+    });
+
     it('matches Slash by produced character', () => {
       const def: HotkeyDefinition = { accelerator: 'Mod+Slash' };
       const ev = createKeyboardEvent({
@@ -210,26 +245,13 @@ describe('isEventMatch', () => {
       expect(isEventMatch(ev, def, 'mac')).toBe(true);
     });
 
-    it('does NOT match Slash by physical key when it produces minus', () => {
-      const def: HotkeyDefinition = { accelerator: 'Mod+Slash' };
+    it('matches physical Slash with Alt when it produces another character', () => {
+      const def: HotkeyDefinition = { accelerator: 'Mod+Alt+Slash' };
       const ev = createKeyboardEvent({
         code: 'Slash',
-        key: '-',
+        key: '÷',
         metaKey: true,
-      });
-      expect(isEventMatch(ev, def, 'mac')).toBe(false);
-    });
-
-    it('matches shifted Slash aliases on QWERTZ-style layouts', () => {
-      const def: HotkeyDefinition = {
-        accelerator: 'Mod+Slash',
-        aliases: ['Mod+Shift+Slash'],
-      };
-      const ev = createKeyboardEvent({
-        code: 'Digit7',
-        key: '/',
-        metaKey: true,
-        shiftKey: true,
+        altKey: true,
       });
       expect(isEventMatch(ev, def, 'mac')).toBe(true);
     });
@@ -260,6 +282,11 @@ describe('getDisplayString', () => {
     const def: HotkeyDefinition = { accelerator: 'Mod+Shift+T' };
     // Modifiers appear in accelerator string order (Shift before Cmd symbol)
     expect(getDisplayString(def, 'mac')).toBe('⇧⌘T');
+  });
+
+  it('displays cycle model thinking effort as Cmd+Alt+Slash on Mac', () => {
+    const def = hotkeyDefinitions[HotkeyActions.CYCLE_MODEL_THINKING_EFFORT];
+    expect(getDisplayString(def, 'mac')).toBe('⌥⌘/');
   });
 
   it('returns Alt symbol on Mac', () => {

--- a/apps/browser/src/shared/hotkeys.ts
+++ b/apps/browser/src/shared/hotkeys.ts
@@ -50,6 +50,7 @@ export enum HotkeyActions {
   EDIT_NEAREST_USER_MESSAGE = 'edit_nearest_user_message',
   OPEN_WORKSPACE_SELECT = 'open_workspace_select',
   OPEN_MODEL_SELECT = 'open_model_select',
+  CYCLE_MODEL_THINKING_EFFORT = 'cycle_model_thinking_effort',
   OPEN_COMMAND_CENTER = 'open_command_center',
   OPEN_FILE_SEARCH = 'open_file_search',
   OPEN_CONTENT_FILE_SEARCH = 'open_content_file_search',
@@ -180,6 +181,10 @@ export const hotkeyDefinitions: Record<HotkeyActions, HotkeyDefinition> = {
   [HotkeyActions.OPEN_MODEL_SELECT]: {
     accelerator: 'Mod+Slash',
     aliases: ['Mod+Shift+Slash'],
+    captureDominantly: true,
+  },
+  [HotkeyActions.CYCLE_MODEL_THINKING_EFFORT]: {
+    accelerator: 'Mod+Alt+Slash',
     captureDominantly: true,
   },
   [HotkeyActions.OPEN_COMMAND_CENTER]: {
@@ -551,7 +556,11 @@ function parseAccelerator(accelerator: string): ParsedAccelerator {
  * Matches the key part of an accelerator against a KeyboardEvent.
  * Handles letters, digits, function keys, arrows, and special keys.
  */
-function matchKeyToken(ev: KeyboardEvent, token: string): boolean {
+function matchKeyToken(
+  ev: KeyboardEvent,
+  token: string,
+  options: { allowPhysicalSlash?: boolean } = {},
+): boolean {
   // Handle single letters (A-Z)
   if (token.length === 1 && /^[A-Z]$/.test(token))
     return ev.code === `Key${token}`;
@@ -628,7 +637,14 @@ function matchKeyToken(ev: KeyboardEvent, token: string): boolean {
     case 'PERIOD':
       return ev.code === 'Period';
     case 'SLASH':
-      return ev.key === '/' || ev.code === 'NumpadDivide';
+      // Match produced `/` for layout portability (QWERTZ uses Shift+7),
+      // but allow the physical slash key for Option/Alt shortcuts because
+      // macOS mutates the produced character (e.g. Option+/ -> `÷`).
+      return (
+        ev.key === '/' ||
+        ev.code === 'NumpadDivide' ||
+        (options.allowPhysicalSlash === true && ev.code === 'Slash')
+      );
 
     // Function keys (F1-F24)
     default:
@@ -667,7 +683,9 @@ function matchAccelerator(
 
   // Match the key
   if (!parsed.keyToken) return false;
-  return matchKeyToken(ev, parsed.keyToken);
+  return matchKeyToken(ev, parsed.keyToken, {
+    allowPhysicalSlash: requiredAlt,
+  });
 }
 
 /**

--- a/apps/browser/src/shared/karton-contracts/ui/shared-types.test.ts
+++ b/apps/browser/src/shared/karton-contracts/ui/shared-types.test.ts
@@ -134,6 +134,54 @@ describe('userPreferencesSchema worktree cleanup snooze defaults', () => {
   });
 });
 
+describe('userPreferencesSchema model thinking override defaults', () => {
+  it('defaults model thinking overrides when missing', () => {
+    const parsed = userPreferencesSchema.parse({
+      agent: {
+        workspaceSettings: {},
+        disabledModelIds: [],
+        disabledPluginIds: [],
+        workspaceGitActionPreferences: { general: {}, repositories: {} },
+        workspaceGitCleanup: { dismissedCandidates: {} },
+      },
+    });
+
+    expect(parsed.agent.modelThinkingOverrides).toEqual({});
+  });
+
+  it('preserves valid model thinking overrides', () => {
+    const parsed = userPreferencesSchema.parse({
+      agent: {
+        modelThinkingOverrides: {
+          'gpt-5.5': { enabled: true, effort: 'high' },
+          'claude-sonnet-4.6': { enabled: false },
+        },
+      },
+    });
+
+    expect(parsed.agent.modelThinkingOverrides).toEqual({
+      'gpt-5.5': { enabled: true, effort: 'high' },
+      'claude-sonnet-4.6': { enabled: false },
+    });
+  });
+
+  it('sanitizes invalid model thinking override entries', () => {
+    const parsed = userPreferencesSchema.parse({
+      agent: {
+        modelThinkingOverrides: {
+          'gpt-5.5': { enabled: true, effort: 'invalid' },
+          'claude-sonnet-4.6': null,
+        },
+      },
+    });
+
+    expect(parsed.agent.modelThinkingOverrides).toEqual({
+      'gpt-5.5': {},
+      'claude-sonnet-4.6': {},
+    });
+  });
+});
+
 describe('userPreferencesSchema workspace Git action defaults', () => {
   it('defaults workspace Git action preferences when missing', () => {
     const parsed = userPreferencesSchema.parse({

--- a/apps/browser/src/shared/karton-contracts/ui/shared-types.test.ts
+++ b/apps/browser/src/shared/karton-contracts/ui/shared-types.test.ts
@@ -153,31 +153,33 @@ describe('userPreferencesSchema model thinking override defaults', () => {
     const parsed = userPreferencesSchema.parse({
       agent: {
         modelThinkingOverrides: {
-          'gpt-5.5': { enabled: true, effort: 'high' },
-          'claude-sonnet-4.6': { enabled: false },
+          'gpt-5.5': { enabled: true, provider: 'openai', value: 'high' },
+          'claude-opus-4.8': { enabled: false, provider: 'anthropic' },
         },
       },
     });
 
     expect(parsed.agent.modelThinkingOverrides).toEqual({
-      'gpt-5.5': { enabled: true, effort: 'high' },
-      'claude-sonnet-4.6': { enabled: false },
+      'gpt-5.5': { enabled: true, provider: 'openai', value: 'high' },
+      'claude-opus-4.8': { enabled: false, provider: 'anthropic' },
     });
   });
 
-  it('sanitizes invalid model thinking override entries', () => {
+  it('sanitizes invalid model thinking override entries field-by-field', () => {
     const parsed = userPreferencesSchema.parse({
       agent: {
         modelThinkingOverrides: {
-          'gpt-5.5': { enabled: true, effort: 'invalid' },
-          'claude-sonnet-4.6': null,
+          'gpt-5.5': { enabled: true, provider: 'invalid', value: 'high' },
+          'claude-opus-4.8': { enabled: 'nope', provider: 'anthropic' },
+          'gemini-3.1-pro-preview': null,
         },
       },
     });
 
     expect(parsed.agent.modelThinkingOverrides).toEqual({
-      'gpt-5.5': {},
-      'claude-sonnet-4.6': {},
+      'gpt-5.5': { enabled: true, value: 'high' },
+      'claude-opus-4.8': { provider: 'anthropic' },
+      'gemini-3.1-pro-preview': {},
     });
   });
 });

--- a/apps/browser/src/shared/karton-contracts/ui/shared-types.ts
+++ b/apps/browser/src/shared/karton-contracts/ui/shared-types.ts
@@ -216,23 +216,36 @@ export const PROVIDER_DISPLAY_INFO: Record<
   },
 };
 
-export const thinkingEffortSchema = z.enum([
-  'minimal',
-  'low',
-  'medium',
-  'high',
-  'xhigh',
+export const thinkingProviderSchema = z.enum([
+  'stagewise',
+  'openai',
+  'google',
+  'anthropic',
+  'openai-compatible',
 ]);
-export type ThinkingEffort = z.infer<typeof thinkingEffortSchema>;
+export type ThinkingProvider = z.infer<typeof thinkingProviderSchema>;
 
-export const modelThinkingOverrideSchema = z
-  .object({
-    enabled: z.boolean().optional(),
-    effort: thinkingEffortSchema.optional(),
-  })
-  .default({})
-  .catch({});
+export const modelThinkingOverrideSchema = z.unknown().transform((value) => {
+  if (!isPlainRecord(value)) return {};
+
+  return {
+    ...(typeof value.enabled === 'boolean' ? { enabled: value.enabled } : {}),
+    ...(thinkingProviderSchema.safeParse(value.provider).success
+      ? { provider: value.provider as ThinkingProvider }
+      : {}),
+    ...(typeof value.value === 'string' ? { value: value.value } : {}),
+  };
+});
 export type ModelThinkingOverride = z.infer<typeof modelThinkingOverrideSchema>;
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    !Array.isArray(value) &&
+    Object.getPrototypeOf(value) === Object.prototype
+  );
+}
 
 /**
  * GLOBAL CONFIG CAPABILITIES

--- a/apps/browser/src/shared/karton-contracts/ui/shared-types.ts
+++ b/apps/browser/src/shared/karton-contracts/ui/shared-types.ts
@@ -216,6 +216,24 @@ export const PROVIDER_DISPLAY_INFO: Record<
   },
 };
 
+export const thinkingEffortSchema = z.enum([
+  'minimal',
+  'low',
+  'medium',
+  'high',
+  'xhigh',
+]);
+export type ThinkingEffort = z.infer<typeof thinkingEffortSchema>;
+
+export const modelThinkingOverrideSchema = z
+  .object({
+    enabled: z.boolean().optional(),
+    effort: thinkingEffortSchema.optional(),
+  })
+  .default({})
+  .catch({});
+export type ModelThinkingOverride = z.infer<typeof modelThinkingOverrideSchema>;
+
 /**
  * GLOBAL CONFIG CAPABILITIES
  */
@@ -495,6 +513,11 @@ export const userPreferencesSchema = z.object({
       workspaceGitActionPreferences: workspaceGitActionPreferencesSchema,
       /** Snoozed worktree cleanup candidates keyed by worktree path */
       workspaceGitCleanup: workspaceGitCleanupPreferencesSchema,
+      /** Per-built-in-model thinking overrides keyed by model ID */
+      modelThinkingOverrides: z
+        .record(z.string(), modelThinkingOverrideSchema)
+        .default({})
+        .catch({}),
     })
     .default({
       workspaceSettings: {},
@@ -502,6 +525,7 @@ export const userPreferencesSchema = z.object({
       disabledPluginIds: [],
       workspaceGitActionPreferences: defaultWorkspaceGitActionPreferences,
       workspaceGitCleanup: defaultWorkspaceGitCleanupPreferences,
+      modelThinkingOverrides: {},
     }),
   /** LLM provider endpoint configurations (API keys, custom URLs) */
   providerConfigs: providerConfigsSchema.default({
@@ -613,6 +637,7 @@ export const defaultUserPreferences: UserPreferences = {
     disabledPluginIds: [],
     workspaceGitActionPreferences: defaultWorkspaceGitActionPreferences,
     workspaceGitCleanup: defaultWorkspaceGitCleanupPreferences,
+    modelThinkingOverrides: {},
   },
   providerConfigs: {
     anthropic: { mode: 'stagewise' },

--- a/apps/browser/src/shared/model-thinking-capabilities.test.ts
+++ b/apps/browser/src/shared/model-thinking-capabilities.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createThinkingProviderOptionsPatch,
+  getEffectiveThinkingSelection,
+  getSupportedThinkingOptions,
+  type ThinkingCapableModel,
+} from './model-thinking-capabilities';
+
+const openAiModel: ThinkingCapableModel = {
+  modelId: 'gpt-5.5',
+  officialProvider: 'openai',
+  thinkingEnabled: true,
+  providerOptions: {
+    stagewise: { reasoning: { enabled: true, effort: 'medium' } },
+    openai: { reasoningEffort: 'medium', reasoningSummary: 'auto' },
+  },
+};
+
+const googleProModel: ThinkingCapableModel = {
+  modelId: 'gemini-3.1-pro-preview',
+  officialProvider: 'google',
+  thinkingEnabled: true,
+  providerOptions: {
+    stagewise: { reasoning: { enabled: true, effort: 'medium' } },
+    google: {
+      thinkingConfig: { includeThoughts: true, thinkingLevel: 'high' },
+    },
+  },
+};
+
+const googleFlashModel: ThinkingCapableModel = {
+  modelId: 'gemini-3-flash-preview',
+  officialProvider: 'google',
+  thinkingEnabled: true,
+  providerOptions: {
+    stagewise: { reasoning: { enabled: true, effort: 'medium' } },
+    google: {
+      thinkingConfig: { includeThoughts: true, thinkingLevel: 'medium' },
+    },
+  },
+};
+
+const anthropicOpusModel: ThinkingCapableModel = {
+  modelId: 'claude-opus-4.8',
+  officialProvider: 'anthropic',
+  thinkingEnabled: true,
+  providerOptions: {
+    stagewise: { reasoning: { enabled: true, effort: 'medium' } },
+    anthropic: { thinking: { type: 'adaptive' }, effort: 'medium' },
+  },
+};
+
+const anthropicConservativeModel: ThinkingCapableModel = {
+  modelId: 'claude-opus-4.6',
+  officialProvider: 'anthropic',
+  thinkingEnabled: true,
+  providerOptions: {
+    stagewise: { reasoning: { enabled: true, effort: 'medium' } },
+    anthropic: { thinking: { type: 'adaptive' }, effort: 'medium' },
+  },
+};
+
+describe('model thinking capabilities', () => {
+  it('coerces unsupported OpenAI minimal away from provider options', () => {
+    expect(
+      createThinkingProviderOptionsPatch({
+        model: openAiModel,
+        route: { providerMode: 'official', modelProvider: 'openai' },
+        override: { enabled: true, provider: 'openai', value: 'minimal' },
+      }),
+    ).toEqual({ openai: { reasoningEffort: 'medium' } });
+  });
+
+  it('emits OpenAI none when gpt-5.5 thinking is disabled', () => {
+    expect(
+      createThinkingProviderOptionsPatch({
+        model: openAiModel,
+        route: { providerMode: 'official', modelProvider: 'openai' },
+        override: { enabled: false, provider: 'openai', value: 'high' },
+      }),
+    ).toEqual({
+      openai: { reasoningEffort: 'none', reasoningSummary: undefined },
+    });
+  });
+
+  it('emits OpenAI xhigh for gpt-5.5 extra high', () => {
+    expect(
+      createThinkingProviderOptionsPatch({
+        model: openAiModel,
+        route: { providerMode: 'official', modelProvider: 'openai' },
+        override: { enabled: true, provider: 'openai', value: 'xhigh' },
+      }),
+    ).toEqual({ openai: { reasoningEffort: 'xhigh' } });
+  });
+
+  it('uses model-specific Google thinking option sets', () => {
+    expect(
+      getSupportedThinkingOptions(googleProModel, {
+        providerMode: 'official',
+        modelProvider: 'google',
+      }).map((option) => option.value),
+    ).toEqual(['low', 'medium', 'high']);
+
+    expect(
+      getSupportedThinkingOptions(googleFlashModel, {
+        providerMode: 'official',
+        modelProvider: 'google',
+      }).map((option) => option.value),
+    ).toEqual(['minimal', 'low', 'medium', 'high']);
+  });
+
+  it('never emits Google xhigh', () => {
+    expect(
+      createThinkingProviderOptionsPatch({
+        model: googleProModel,
+        route: { providerMode: 'official', modelProvider: 'google' },
+        override: { enabled: true, provider: 'google', value: 'xhigh' },
+      }),
+    ).toEqual({
+      google: {
+        thinkingConfig: { includeThoughts: true, thinkingLevel: 'high' },
+      },
+    });
+  });
+
+  it('filters Anthropic advanced values by model family', () => {
+    expect(
+      getSupportedThinkingOptions(anthropicOpusModel, {
+        providerMode: 'official',
+        modelProvider: 'anthropic',
+      }).map((option) => option.value),
+    ).toEqual(['low', 'medium', 'high', 'xhigh', 'max']);
+
+    expect(
+      getSupportedThinkingOptions(anthropicConservativeModel, {
+        providerMode: 'official',
+        modelProvider: 'anthropic',
+      }).map((option) => option.value),
+    ).toEqual(['low', 'medium', 'high', 'max']);
+  });
+
+  it('emits Anthropic max for supported adaptive models', () => {
+    expect(
+      createThinkingProviderOptionsPatch({
+        model: anthropicOpusModel,
+        route: { providerMode: 'official', modelProvider: 'anthropic' },
+        override: { enabled: true, provider: 'anthropic', value: 'max' },
+      }),
+    ).toEqual({ anthropic: { thinking: { type: 'adaptive' }, effort: 'max' } });
+  });
+
+  it('uses Anthropic-native options for Stagewise-routed Claude models', () => {
+    expect(
+      getSupportedThinkingOptions(anthropicOpusModel, {
+        providerMode: 'stagewise',
+        modelProvider: 'anthropic',
+      }).map((option) => option.value),
+    ).toEqual(['low', 'medium', 'high', 'xhigh', 'max']);
+  });
+
+  it('emits Anthropic patches for Stagewise-routed Claude overrides', () => {
+    expect(
+      createThinkingProviderOptionsPatch({
+        model: anthropicOpusModel,
+        route: { providerMode: 'stagewise', modelProvider: 'anthropic' },
+        override: { enabled: true, provider: 'anthropic', value: 'max' },
+      }),
+    ).toEqual({ anthropic: { thinking: { type: 'adaptive' }, effort: 'max' } });
+  });
+
+  it('applies valid legacy Stagewise overrides in Stagewise provider-native mode', () => {
+    expect(
+      getEffectiveThinkingSelection(
+        anthropicOpusModel,
+        { enabled: true, provider: 'stagewise', value: 'high' },
+        { providerMode: 'stagewise', modelProvider: 'anthropic' },
+      ),
+    ).toMatchObject({ provider: 'anthropic', value: 'high' });
+  });
+
+  it('falls back for invalid legacy Stagewise overrides in provider-native mode', () => {
+    expect(
+      getEffectiveThinkingSelection(
+        anthropicOpusModel,
+        { enabled: true, provider: 'stagewise', value: 'minimal' },
+        { providerMode: 'stagewise', modelProvider: 'anthropic' },
+      ),
+    ).toMatchObject({ provider: 'anthropic', value: 'medium' });
+  });
+
+  it('uses conservative values for OpenAI-compatible providers', () => {
+    expect(
+      getSupportedThinkingOptions('kimi-k2-thinking', {
+        providerMode: 'official',
+        modelProvider: 'moonshotai',
+      }).map((option) => option.value),
+    ).toEqual(['low', 'medium', 'high']);
+  });
+
+  it('uses OpenAI-compatible values for custom chat completions endpoints', () => {
+    expect(
+      getSupportedThinkingOptions('gpt-5.5', {
+        providerMode: 'custom',
+        modelProvider: 'openai',
+        customEndpointApiSpec: 'openai-chat-completions',
+      }).map((option) => option.value),
+    ).toEqual(['low', 'medium', 'high']);
+  });
+});

--- a/apps/browser/src/shared/model-thinking-capabilities.ts
+++ b/apps/browser/src/shared/model-thinking-capabilities.ts
@@ -1,0 +1,567 @@
+import type {
+  ApiSpec,
+  ModelProvider,
+  ModelThinkingOverride,
+  ProviderEndpointMode,
+} from './karton-contracts/ui/shared-types';
+
+export type ThinkingProvider =
+  | 'stagewise'
+  | 'openai'
+  | 'google'
+  | 'anthropic'
+  | 'openai-compatible';
+
+export type ThinkingOption = {
+  provider: ThinkingProvider;
+  value: string;
+  label: string;
+  enabled: boolean;
+};
+
+export type ThinkingSelection = {
+  provider: ThinkingProvider;
+  value: string;
+  label: string;
+  enabled: boolean;
+};
+
+export type ThinkingRoute = {
+  providerMode?: ProviderEndpointMode;
+  modelProvider?: ModelProvider;
+  customEndpointApiSpec?: ApiSpec;
+};
+
+export type ThinkingCapableModel = {
+  modelId: string;
+  providerOptions: unknown;
+  officialProvider?: ModelProvider;
+  thinkingEnabled?: boolean;
+};
+
+const STAGEWISE_OPTIONS = createOptions('stagewise', [
+  ['minimal', 'Minimal', true],
+  ['low', 'Low', true],
+  ['medium', 'Medium', true],
+  ['high', 'High', true],
+  ['xhigh', 'Extra high', true],
+]);
+
+const OPENAI_GPT_5_OPTIONS = createOptions('openai', [
+  ['none', 'Off', false],
+  ['low', 'Low', true],
+  ['medium', 'Medium', true],
+  ['high', 'High', true],
+  ['xhigh', 'Extra high', true],
+]);
+
+const OPENAI_CONSERVATIVE_OPTIONS = createOptions('openai', [
+  ['low', 'Low', true],
+  ['medium', 'Medium', true],
+  ['high', 'High', true],
+]);
+
+const OPENAI_COMPATIBLE_OPTIONS = createOptions('openai-compatible', [
+  ['low', 'Low', true],
+  ['medium', 'Medium', true],
+  ['high', 'High', true],
+]);
+
+const GOOGLE_FULL_OPTIONS = createOptions('google', [
+  ['minimal', 'Minimal', true],
+  ['low', 'Low', true],
+  ['medium', 'Medium', true],
+  ['high', 'High', true],
+]);
+
+const GOOGLE_PRO_OPTIONS = createOptions('google', [
+  ['low', 'Low', true],
+  ['medium', 'Medium', true],
+  ['high', 'High', true],
+]);
+
+const GOOGLE_PRO_STRICT_OPTIONS = createOptions('google', [
+  ['low', 'Low', true],
+  ['high', 'High', true],
+]);
+
+const ANTHROPIC_CONSERVATIVE_OPTIONS = createOptions('anthropic', [
+  ['low', 'Low', true],
+  ['medium', 'Medium', true],
+  ['high', 'High', true],
+]);
+
+const ANTHROPIC_ADAPTIVE_MAX_OPTIONS = createOptions('anthropic', [
+  ['low', 'Low', true],
+  ['medium', 'Medium', true],
+  ['high', 'High', true],
+  ['max', 'Max', true],
+]);
+
+const ANTHROPIC_OPUS_47_OPTIONS = createOptions('anthropic', [
+  ['low', 'Low', true],
+  ['medium', 'Medium', true],
+  ['high', 'High', true],
+  ['xhigh', 'Extra high', true],
+  ['max', 'Max', true],
+]);
+
+const ANTHROPIC_BUDGET_TOKENS: Record<string, number> = {
+  low: 6_000,
+  medium: 10_000,
+  high: 16_000,
+  xhigh: 24_000,
+  max: 32_000,
+};
+
+function createOptions(
+  provider: ThinkingProvider,
+  entries: Array<[value: string, label: string, enabled: boolean]>,
+): ThinkingOption[] {
+  return entries.map(([value, label, enabled]) => ({
+    provider,
+    value,
+    label,
+    enabled,
+  }));
+}
+
+export function getThinkingProviderForRoute({
+  providerMode = 'stagewise',
+  modelProvider,
+  customEndpointApiSpec,
+}: ThinkingRoute): ThinkingProvider {
+  if (providerMode === 'custom' && customEndpointApiSpec) {
+    switch (customEndpointApiSpec) {
+      case 'anthropic':
+      case 'amazon-bedrock':
+        return 'anthropic';
+      case 'google':
+      case 'google-vertex':
+        return 'google';
+      case 'openai-responses':
+      case 'azure':
+        return 'openai';
+      case 'openai-chat-completions':
+        return 'openai-compatible';
+    }
+  }
+
+  switch (modelProvider) {
+    case 'anthropic':
+      return 'anthropic';
+    case 'google':
+      return 'google';
+    case 'openai':
+      return 'openai';
+    case 'moonshotai':
+    case 'alibaba':
+    case 'deepseek':
+    case 'z-ai':
+    case 'minimax':
+      return 'openai-compatible';
+    default:
+      return providerMode === 'stagewise' ? 'stagewise' : 'stagewise';
+  }
+}
+
+export function getSupportedThinkingOptions(
+  modelOrId: ThinkingCapableModel | string,
+  route?: ThinkingRoute,
+): ThinkingOption[] {
+  const modelId = typeof modelOrId === 'string' ? modelOrId : modelOrId.modelId;
+  const provider = getThinkingProviderForRoute({
+    modelProvider:
+      typeof modelOrId === 'string'
+        ? route?.modelProvider
+        : modelOrId.officialProvider,
+    ...route,
+  });
+
+  switch (provider) {
+    case 'stagewise':
+      return STAGEWISE_OPTIONS;
+    case 'openai':
+      return isKnownOpenAiGpt5Model(modelId)
+        ? OPENAI_GPT_5_OPTIONS
+        : OPENAI_CONSERVATIVE_OPTIONS;
+    case 'openai-compatible':
+      return OPENAI_COMPATIBLE_OPTIONS;
+    case 'google':
+      return getGoogleOptions(modelId);
+    case 'anthropic':
+      return getAnthropicOptions(modelId);
+  }
+}
+
+export function getDefaultThinkingSelection(
+  model: ThinkingCapableModel,
+  route?: ThinkingRoute,
+): ThinkingSelection {
+  const options = getSupportedThinkingOptions(model, route);
+  const provider = options[0]?.provider ?? 'stagewise';
+  const providerDefault = getProviderDefaultValue(
+    model.providerOptions,
+    provider,
+  );
+  const stagewiseDefault = getProviderDefaultValue(
+    model.providerOptions,
+    'stagewise',
+  );
+  const preferredValue =
+    provider === 'stagewise'
+      ? (stagewiseDefault ?? providerDefault)
+      : (providerDefault ?? stagewiseDefault);
+
+  const option =
+    findSupportedOption(options, preferredValue) ??
+    findSupportedOption(options, 'medium') ??
+    firstEnabledOption(options) ??
+    options[0];
+
+  return toSelection(
+    option ?? {
+      provider,
+      value: 'medium',
+      label: 'Medium',
+      enabled: true,
+    },
+  );
+}
+
+export function getEffectiveThinkingSelection(
+  model: ThinkingCapableModel,
+  override?: ModelThinkingOverride,
+  route?: ThinkingRoute,
+): ThinkingSelection | null {
+  if (!isThinkingCapableModel(model)) return null;
+
+  const options = getSupportedThinkingOptions(model, route);
+  const provider =
+    options[0]?.provider ?? getThinkingProviderForRoute(route ?? {});
+  const defaultSelection = getDefaultThinkingSelection(model, route);
+  const hasOverride = hasExplicitThinkingOverride(override);
+
+  if (!hasOverride) return defaultSelection;
+
+  if (override?.enabled === false) {
+    return toDisabledSelection(
+      options,
+      provider,
+      findSupportedOption(options, override.value)?.value ??
+        defaultSelection.value,
+    );
+  }
+
+  const matchingOverride = isMatchingOverrideProvider(
+    override?.provider,
+    provider,
+    route,
+  );
+  const option = matchingOverride
+    ? findSupportedOption(options, override?.value)
+    : undefined;
+
+  return toSelection(option ?? defaultSelection);
+}
+
+export function isExplicitThinkingOverride(
+  override: ModelThinkingOverride | undefined,
+): boolean {
+  return hasExplicitThinkingOverride(override);
+}
+
+export function getNextThinkingSelection(
+  model: ThinkingCapableModel,
+  current: ThinkingSelection,
+  route?: ThinkingRoute,
+): ThinkingSelection {
+  const options = getSupportedThinkingOptions(model, route);
+  const currentIndex = options.findIndex(
+    (option) => option.value === current.value,
+  );
+  const nextIndex =
+    currentIndex === -1 ? 0 : (currentIndex + 1) % options.length;
+
+  return toSelection(options[nextIndex] ?? current);
+}
+
+export function createThinkingProviderOptionsPatch({
+  model,
+  route,
+  override,
+}: {
+  model: ThinkingCapableModel;
+  route?: ThinkingRoute;
+  override?: ModelThinkingOverride;
+}): Record<string, unknown> | undefined {
+  if (
+    !isThinkingCapableModel(model) ||
+    !hasExplicitThinkingOverride(override)
+  ) {
+    return undefined;
+  }
+
+  const selection = getEffectiveThinkingSelection(model, override, route);
+  if (!selection) return undefined;
+
+  switch (selection.provider) {
+    case 'stagewise':
+      return {
+        stagewise: {
+          reasoning: {
+            enabled: selection.enabled,
+            effort: selection.enabled ? selection.value : undefined,
+          },
+        },
+      };
+    case 'openai':
+      return {
+        openai: selection.enabled
+          ? { reasoningEffort: selection.value }
+          : { reasoningEffort: 'none', reasoningSummary: undefined },
+      };
+    case 'openai-compatible':
+      return {
+        openai: selection.enabled
+          ? { reasoningEffort: selection.value }
+          : { reasoningEffort: undefined, reasoningSummary: undefined },
+      };
+    case 'google':
+      return {
+        google: {
+          thinkingConfig: {
+            includeThoughts: selection.enabled,
+            thinkingLevel: selection.enabled ? selection.value : undefined,
+          },
+        },
+      };
+    case 'anthropic':
+      return {
+        anthropic: createAnthropicThinkingPatch(
+          model.providerOptions,
+          selection.enabled,
+          selection.value,
+        ),
+      };
+  }
+}
+
+export function toModelThinkingOverride(
+  selection: Pick<ThinkingSelection, 'provider' | 'value' | 'enabled'>,
+): ModelThinkingOverride {
+  return {
+    enabled: selection.enabled,
+    provider: selection.provider,
+    value: selection.value,
+  };
+}
+
+function isMatchingOverrideProvider(
+  overrideProvider: ModelThinkingOverride['provider'] | undefined,
+  provider: ThinkingProvider,
+  route: ThinkingRoute | undefined,
+): boolean {
+  return (
+    overrideProvider === provider ||
+    overrideProvider === undefined ||
+    (route?.providerMode === 'stagewise' && overrideProvider === 'stagewise')
+  );
+}
+
+function getGoogleOptions(modelId: string): ThinkingOption[] {
+  if (modelId.startsWith('gemini-3.1-pro')) return GOOGLE_PRO_OPTIONS;
+  if (modelId.startsWith('gemini-3-pro')) return GOOGLE_PRO_STRICT_OPTIONS;
+  if (modelId.startsWith('gemini-3') && modelId.includes('flash')) {
+    return GOOGLE_FULL_OPTIONS;
+  }
+  return GOOGLE_PRO_OPTIONS;
+}
+
+function getAnthropicOptions(modelId: string): ThinkingOption[] {
+  if (
+    modelId.startsWith('claude-fable-5') ||
+    modelId.startsWith('claude-mythos-5') ||
+    modelId.startsWith('claude-mythos-preview') ||
+    modelId.startsWith('claude-opus-4.7') ||
+    modelId.startsWith('claude-opus-4.8')
+  ) {
+    return ANTHROPIC_OPUS_47_OPTIONS;
+  }
+
+  if (
+    modelId.startsWith('claude-opus-4.6') ||
+    modelId.startsWith('claude-sonnet-4.6')
+  ) {
+    return ANTHROPIC_ADAPTIVE_MAX_OPTIONS;
+  }
+
+  return ANTHROPIC_CONSERVATIVE_OPTIONS;
+}
+
+function isKnownOpenAiGpt5Model(modelId: string): boolean {
+  return /^gpt-5\.[1-5](?:$|-)/.test(modelId) || modelId === 'gpt-5';
+}
+
+function findSupportedOption(
+  options: ThinkingOption[],
+  value: unknown,
+): ThinkingOption | undefined {
+  if (typeof value !== 'string') return undefined;
+  return options.find((option) => option.value === value);
+}
+
+function firstEnabledOption(
+  options: ThinkingOption[],
+): ThinkingOption | undefined {
+  return options.find((option) => option.enabled);
+}
+
+function toSelection(
+  option: ThinkingOption | ThinkingSelection,
+): ThinkingSelection {
+  return {
+    provider: option.provider,
+    value: option.value,
+    label: option.label,
+    enabled: option.enabled,
+  };
+}
+
+function toDisabledSelection(
+  options: ThinkingOption[],
+  provider: ThinkingProvider,
+  fallbackValue: string,
+): ThinkingSelection {
+  const offOption = options.find((option) => !option.enabled);
+  if (offOption) return toSelection(offOption);
+
+  return {
+    provider,
+    value: fallbackValue,
+    label: 'Off',
+    enabled: false,
+  };
+}
+
+function getProviderDefaultValue(
+  providerOptions: unknown,
+  provider: ThinkingProvider,
+): string | undefined {
+  if (!isPlainObject(providerOptions)) return undefined;
+
+  switch (provider) {
+    case 'stagewise': {
+      const stagewise = providerOptions.stagewise;
+      if (!isPlainObject(stagewise)) return undefined;
+      const reasoning = stagewise.reasoning;
+      if (!isPlainObject(reasoning)) return undefined;
+      return typeof reasoning.effort === 'string'
+        ? reasoning.effort
+        : undefined;
+    }
+    case 'openai':
+    case 'openai-compatible': {
+      const openai = providerOptions.openai;
+      if (!isPlainObject(openai)) return undefined;
+      return typeof openai.reasoningEffort === 'string'
+        ? openai.reasoningEffort
+        : undefined;
+    }
+    case 'google': {
+      const google = providerOptions.google;
+      if (!isPlainObject(google)) return undefined;
+      const thinkingConfig = google.thinkingConfig;
+      if (!isPlainObject(thinkingConfig)) return undefined;
+      return typeof thinkingConfig.thinkingLevel === 'string'
+        ? thinkingConfig.thinkingLevel
+        : undefined;
+    }
+    case 'anthropic': {
+      const anthropic = providerOptions.anthropic;
+      if (!isPlainObject(anthropic)) return undefined;
+      if (typeof anthropic.effort === 'string') return anthropic.effort;
+      const thinking = anthropic.thinking;
+      if (!isPlainObject(thinking)) return undefined;
+      return getThinkingValueFromAnthropicBudget(thinking.budgetTokens);
+    }
+  }
+}
+
+function createAnthropicThinkingPatch(
+  modelProviderOptions: unknown,
+  enabled: boolean,
+  value: string,
+): Record<string, unknown> {
+  if (!enabled) {
+    return { thinking: { type: 'disabled' }, effort: undefined };
+  }
+
+  const baseAnthropicOptions = isPlainObject(modelProviderOptions)
+    ? modelProviderOptions.anthropic
+    : undefined;
+  const thinking = isPlainObject(baseAnthropicOptions)
+    ? baseAnthropicOptions.thinking
+    : undefined;
+
+  if (
+    isPlainObject(thinking) &&
+    typeof thinking.type === 'string' &&
+    thinking.type !== 'adaptive'
+  ) {
+    return {
+      thinking: {
+        ...thinking,
+        type: 'enabled',
+        budgetTokens:
+          ANTHROPIC_BUDGET_TOKENS[value] ?? ANTHROPIC_BUDGET_TOKENS.medium,
+      },
+    };
+  }
+
+  return {
+    thinking: { type: 'adaptive' },
+    effort: value,
+  };
+}
+
+function getThinkingValueFromAnthropicBudget(
+  budgetTokens: unknown,
+): string | undefined {
+  if (typeof budgetTokens !== 'number') return undefined;
+
+  let closestValue = 'medium';
+  let closestDistance = Number.POSITIVE_INFINITY;
+  for (const [value, budget] of Object.entries(ANTHROPIC_BUDGET_TOKENS)) {
+    const distance = Math.abs(budgetTokens - budget);
+    if (distance < closestDistance) {
+      closestValue = value;
+      closestDistance = distance;
+    }
+  }
+
+  return closestValue;
+}
+
+function isThinkingCapableModel(model: ThinkingCapableModel): boolean {
+  return model.thinkingEnabled === true;
+}
+
+function hasExplicitThinkingOverride(
+  override: ModelThinkingOverride | undefined,
+): boolean {
+  return (
+    override?.enabled !== undefined ||
+    override?.provider !== undefined ||
+    override?.value !== undefined
+  );
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    !Array.isArray(value) &&
+    Object.getPrototypeOf(value) === Object.prototype
+  );
+}

--- a/apps/browser/src/ui/components/model-thinking-panel.tsx
+++ b/apps/browser/src/ui/components/model-thinking-panel.tsx
@@ -1,0 +1,133 @@
+import { Button } from '@stagewise/stage-ui/components/button';
+import {
+  Radio,
+  RadioGroup,
+  RadioLabel,
+} from '@stagewise/stage-ui/components/radio';
+import { Switch } from '@stagewise/stage-ui/components/switch';
+import type { availableModels } from '@shared/available-models';
+import type { ModelThinkingOverride } from '@shared/karton-contracts/ui/shared-types';
+import { useId } from 'react';
+import { cn } from '@ui/utils';
+import {
+  getDefaultThinkingOption,
+  getModelThinkingDisplayState,
+  getModelThinkingOptions,
+  type ModelThinkingDefaultOptions,
+} from '@ui/utils/model-thinking';
+
+export function ModelThinkingPanel({
+  model,
+  override,
+  defaultOptions,
+  onClose,
+  onEnabledChange,
+  onValueChange,
+  onReset,
+}: {
+  model: (typeof availableModels)[number];
+  override: ModelThinkingOverride | undefined;
+  defaultOptions?: ModelThinkingDefaultOptions;
+  onClose?: () => void;
+  onEnabledChange: (enabled: boolean) => void;
+  onValueChange: (value: string) => void;
+  onReset: () => void;
+}) {
+  const labelId = useId();
+  const display = getModelThinkingDisplayState(model, override, defaultOptions);
+  if (!display) return null;
+
+  const options = getModelThinkingOptions(model, defaultOptions);
+  const defaultOption = getDefaultThinkingOption(model, defaultOptions);
+  const hasOverride = display.isOverride;
+
+  return (
+    <>
+      <div className="flex items-start justify-between gap-2 border-derived-subtle border-b px-2.5 py-2">
+        <div className="min-w-0">
+          <h4 className="truncate font-semibold text-foreground">Thinking</h4>
+          <p className="truncate text-muted-foreground">
+            {model.modelDisplayName}
+          </p>
+        </div>
+        {onClose && (
+          <Button
+            type="button"
+            variant="ghost"
+            size="xs"
+            className="h-5 px-1.5"
+            onClick={onClose}
+          >
+            Close
+          </Button>
+        )}
+      </div>
+
+      <div className="space-y-3 px-2.5 pt-2.5 pb-1">
+        <div className="flex items-center justify-between gap-3">
+          <button
+            type="button"
+            className="min-w-0 cursor-pointer text-left"
+            onClick={() => onEnabledChange(!display.enabled)}
+          >
+            <p id={labelId} className="font-medium text-foreground">
+              Enable thinking
+            </p>
+            <p className="text-muted-foreground">Current: {display.label}</p>
+          </button>
+          <Switch
+            checked={display.enabled}
+            onCheckedChange={onEnabledChange}
+            size="xs"
+            aria-labelledby={labelId}
+          />
+        </div>
+
+        <div
+          className={cn(
+            'space-y-2 transition-opacity',
+            !display.enabled && 'opacity-50',
+          )}
+        >
+          <div>
+            <p className="font-medium text-foreground">Effort</p>
+            <p className="text-muted-foreground">
+              Default: {defaultOption.label}
+            </p>
+          </div>
+          <RadioGroup
+            value={display.value}
+            onValueChange={(value) => {
+              if (typeof value === 'string') onValueChange(value);
+            }}
+            disabled={!display.enabled}
+            className="gap-1.5"
+          >
+            {options.map((option) => (
+              <RadioLabel key={option.value} size="xs">
+                <Radio value={option.value} size="xs" />
+                <span>{option.label}</span>
+                {option.value === defaultOption.value && (
+                  <span className="text-muted-foreground">Default</span>
+                )}
+              </RadioLabel>
+            ))}
+          </RadioGroup>
+        </div>
+      </div>
+
+      <div className="flex justify-end px-2.5 pb-2.5">
+        <Button
+          type="button"
+          variant="ghost"
+          size="xs"
+          className="h-auto px-0 py-0 leading-none"
+          disabled={!hasOverride}
+          onClick={onReset}
+        >
+          Reset to default
+        </Button>
+      </div>
+    </>
+  );
+}

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/index.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/index.tsx
@@ -8,7 +8,7 @@ import {
 } from 'react';
 import { ChatHistory } from './chat-history';
 import { ChatPanelFooter } from './panel-footer';
-import { useKartonState } from '@ui/hooks/use-karton';
+import { useComparingSelector, useKartonState } from '@ui/hooks/use-karton';
 import { cn } from '@ui/utils';
 import {
   useOpenAgent,
@@ -22,19 +22,24 @@ export function ChatPanel() {
 
   // Narrow selectors: only extract primitive/stable values so streaming
   // chunks on unrelated agents don't trigger a re-render.
-  const openAgentExists = useKartonState((s) =>
-    openAgent ? !!s.agents.instances[openAgent] : false,
+  const agentHistoryLengths = useKartonState(
+    useComparingSelector((s) =>
+      Object.fromEntries(
+        Object.entries(s.agents.instances).map(([id, agent]) => [
+          id,
+          agent.state.history?.length ?? 0,
+        ]),
+      ),
+    ),
   );
+  const openAgentExists = openAgent ? openAgent in agentHistoryLengths : false;
   // Defer heavy chat rendering so the sidebar updates instantly while the
   // chat area stays empty during the transition.
   const deferredAgent = useDeferredValue(openAgent);
   const isTransitioning = openAgent !== deferredAgent;
-
-  const deferredAgentHistoryLen = useKartonState((s) =>
-    deferredAgent
-      ? (s.agents.instances[deferredAgent]?.state.history?.length ?? 0)
-      : 0,
-  );
+  const deferredAgentHistoryLen = deferredAgent
+    ? (agentHistoryLengths[deferredAgent] ?? 0)
+    : 0;
 
   // Auto-selecting the first agent when openAgent is null is handled
   // centrally by `useAutoSelectFirstAgent` at the main layout root —

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/model-select.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/model-select.tsx
@@ -3,7 +3,9 @@ import {
   IconArrowUpOutline18,
   IconArrowDownOutline18,
   IconXmarkOutline18,
+  IconBrainOutline18,
 } from 'nucleo-ui-outline-18';
+import { Button } from '@stagewise/stage-ui/components/button';
 import {
   Combobox,
   ComboboxGroup,
@@ -19,7 +21,6 @@ import {
   TooltipTrigger,
 } from '@stagewise/stage-ui/components/tooltip';
 import type { ModelId } from '@shared/available-models';
-import { IconBrainOutline18 } from 'nucleo-ui-outline-18';
 import { IconChevronDownFill18 } from 'nucleo-ui-fill-18';
 import { availableModels } from '@shared/available-models';
 import { HotkeyActions } from '@shared/hotkeys';
@@ -38,6 +39,17 @@ import { cn } from '@ui/utils';
 import { useScrollFadeMask } from '@ui/hooks/use-scroll-fade-mask';
 import { useHotKeyListener } from '@ui/hooks/use-hotkey-listener';
 import { HotkeyCombo } from '@ui/components/hotkey-combo';
+import { ModelThinkingPanel } from '@ui/components/model-thinking-panel';
+import {
+  getEnabledModelThinkingOption,
+  getModelThinkingDisplayState,
+  getNextModelThinkingOption,
+  getModelThinkingOptions,
+} from '@ui/utils/model-thinking';
+import type { UserPreferences } from '@shared/karton-contracts/ui/shared-types';
+import { enablePatches, produceWithPatches } from 'immer';
+
+enablePatches();
 
 interface ModelOption {
   modelId: string;
@@ -45,6 +57,8 @@ interface ModelOption {
   description: string;
   context: string;
   thinkingEnabled: boolean;
+  thinkingLabel?: string;
+  catalogModel?: (typeof availableModels)[number];
   pricingMultiplier?: number;
   group?: string;
 }
@@ -84,9 +98,36 @@ interface ModelSelectProps {
   onModelChange?: () => void;
 }
 
+function getThinkingDefaultOptionsForModel(
+  model: (typeof availableModels)[number],
+  preferences: UserPreferences,
+): Parameters<typeof getModelThinkingDisplayState>[2] {
+  const provider = model.officialProvider;
+  if (!provider) return { providerMode: 'stagewise' };
+
+  const config = preferences.providerConfigs[provider];
+  if (config.mode !== 'custom') return { providerMode: config.mode };
+
+  const endpoint = preferences.customEndpoints.find(
+    (item) => item.id === config.customProviderId,
+  );
+  if (!endpoint) return { providerMode: 'stagewise' };
+
+  return {
+    providerMode: 'custom',
+    customEndpointApiSpec: endpoint.apiSpec,
+  };
+}
+
 // Sentinel value for the "Open model settings" row. Picked to be
 // impossible to collide with any real `ModelId` (leading `@@` + spaces).
 const OPEN_MODEL_SETTINGS_VALUE = '@@open model settings@@';
+
+const EMPTY_CUSTOM_MODELS: UserPreferences['customModels'] = [];
+const EMPTY_DISABLED_MODEL_IDS: UserPreferences['agent']['disabledModelIds'] =
+  [];
+const EMPTY_MODEL_THINKING_OVERRIDES: UserPreferences['agent']['modelThinkingOverrides'] =
+  {};
 
 export const ModelSelect = memo(function ModelSelect({
   onModelChange,
@@ -97,9 +138,18 @@ export const ModelSelect = memo(function ModelSelect({
   );
   const setSelectedModel = useKartonProcedure((p) => p.agents.setActiveModelId);
   const openSettings = useKartonProcedure((p) => p.appScreen.openSettings);
-  const customModels = useKartonState((s) => s.preferences.customModels);
+  const updatePreferences = useKartonProcedure((p) => p.preferences.update);
+  const preferences = useKartonState((s) => s.preferences);
+  const customModels = useKartonState(
+    (s) => s.preferences.customModels ?? EMPTY_CUSTOM_MODELS,
+  );
   const disabledModelIds = useKartonState(
-    (s) => s.preferences.agent.disabledModelIds,
+    (s) => s.preferences.agent.disabledModelIds ?? EMPTY_DISABLED_MODEL_IDS,
+  );
+  const modelThinkingOverrides = useKartonState(
+    (s) =>
+      s.preferences.agent.modelThinkingOverrides ??
+      EMPTY_MODEL_THINKING_OVERRIDES,
   );
 
   // Build flat model options list
@@ -107,14 +157,24 @@ export const ModelSelect = memo(function ModelSelect({
     const disabled = new Set(disabledModelIds);
     const builtIn: ModelOption[] = availableModels
       .filter((m) => !disabled.has(m.modelId))
-      .map((model) => ({
-        modelId: model.modelId,
-        displayName: model.modelDisplayName,
-        description: model.modelDescription,
-        context: model.modelContext,
-        thinkingEnabled: 'thinkingEnabled' in model && !!model.thinkingEnabled,
-        pricingMultiplier: model.pricing?.relativeMultiplier,
-      }));
+      .map((model) => {
+        const thinkingDisplay = getModelThinkingDisplayState(
+          model,
+          modelThinkingOverrides[model.modelId],
+          getThinkingDefaultOptionsForModel(model, preferences),
+        );
+
+        return {
+          modelId: model.modelId,
+          displayName: model.modelDisplayName,
+          description: model.modelDescription,
+          context: model.modelContext,
+          thinkingEnabled: thinkingDisplay !== null,
+          thinkingLabel: thinkingDisplay?.label,
+          catalogModel: model,
+          pricingMultiplier: model.pricing?.relativeMultiplier,
+        };
+      });
 
     const custom: ModelOption[] = customModels
       .filter((m) => !disabled.has(m.modelId))
@@ -124,11 +184,12 @@ export const ModelSelect = memo(function ModelSelect({
         description: model.description,
         context: `${Math.round(model.contextWindowSize / 1000)}k context`,
         thinkingEnabled: !!model.thinkingEnabled,
+        thinkingLabel: model.thinkingEnabled ? 'Thinking' : undefined,
         group: 'Custom',
       }));
 
     return [...builtIn, ...custom];
-  }, [customModels, disabledModelIds]);
+  }, [customModels, disabledModelIds, modelThinkingOverrides, preferences]);
 
   // Index by modelId for fast lookups
   const modelMap = useMemo(() => {
@@ -185,10 +246,15 @@ export const ModelSelect = memo(function ModelSelect({
     (g) => g.models.length > 0,
   );
 
-  // Display label for the trigger
+  // Display labels for the trigger
   const selectedDisplayName = useMemo(() => {
     if (!selectedModel) return 'Select model';
     return modelMap.get(selectedModel)?.displayName ?? selectedModel;
+  }, [modelMap, selectedModel]);
+
+  const selectedThinkingLabel = useMemo(() => {
+    if (!selectedModel) return undefined;
+    return modelMap.get(selectedModel)?.thinkingLabel;
   }, [modelMap, selectedModel]);
 
   const inputRef = useRef<HTMLInputElement>(null);
@@ -197,14 +263,42 @@ export const ModelSelect = memo(function ModelSelect({
   const containerRef = useRef<HTMLDivElement>(null);
   const sidePanelRef = useRef<HTMLDivElement>(null);
   const [hoveredModel, setHoveredModel] = useState<ModelOption | null>(null);
+  const [editingThinkingModelId, setEditingThinkingModelId] = useState<
+    string | null
+  >(null);
   const [itemCenterY, setItemCenterY] = useState(0);
   const [sidePanelOffset, setSidePanelOffset] = useState(0);
+  const clearTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+
+  const cancelPendingClear = useCallback(() => {
+    if (clearTimerRef.current !== undefined) {
+      clearTimeout(clearTimerRef.current);
+      clearTimerRef.current = undefined;
+    }
+  }, []);
+
+  const scheduleClear = useCallback(() => {
+    cancelPendingClear();
+    clearTimerRef.current = setTimeout(() => {
+      setHoveredModel(null);
+      setEditingThinkingModelId(null);
+      clearTimerRef.current = undefined;
+    }, 150);
+  }, [cancelPendingClear]);
+
+  useEffect(() => () => cancelPendingClear(), [cancelPendingClear]);
 
   const listScrollRef = useRef<HTMLDivElement>(null);
   const { maskStyle: listMaskStyle } = useScrollFadeMask(listScrollRef, {
     axis: 'vertical',
     fadeDistance: 16,
   });
+
+  const editingThinkingModel = useMemo(
+    () =>
+      availableModels.find((model) => model.modelId === editingThinkingModelId),
+    [editingThinkingModelId],
+  );
 
   useLayoutEffect(() => {
     if (!hoveredModel || !sidePanelRef.current || !containerRef.current) return;
@@ -213,16 +307,20 @@ export const ModelSelect = memo(function ModelSelect({
 
     let offset = itemCenterY - panelHeight / 2;
     offset = Math.max(0, offset);
-    offset = Math.min(offset, containerHeight - panelHeight);
+    offset = Math.min(offset, Math.max(0, containerHeight - panelHeight));
 
     setSidePanelOffset(offset);
-  }, [hoveredModel, itemCenterY]);
+  }, [hoveredModel, itemCenterY, editingThinkingModelId]);
 
   const handleItemHover = useCallback(
     (model: ModelOption, element: HTMLElement) => {
+      cancelPendingClear();
       const container = containerRef.current;
       if (!container) {
         setHoveredModel(model);
+        setEditingThinkingModelId((current) =>
+          current === model.modelId ? current : null,
+        );
         return;
       }
 
@@ -232,8 +330,11 @@ export const ModelSelect = memo(function ModelSelect({
 
       setItemCenterY(centerY);
       setHoveredModel(model);
+      setEditingThinkingModelId((current) =>
+        current === model.modelId ? current : null,
+      );
     },
-    [],
+    [cancelPendingClear],
   );
 
   const handleValueChange = useCallback(
@@ -250,13 +351,119 @@ export const ModelSelect = memo(function ModelSelect({
     [openAgent, openSettings, setSelectedModel, onModelChange],
   );
 
-  const handleOpenChange = useCallback((nextOpen: boolean) => {
-    setOpen(nextOpen);
-    if (!nextOpen) {
-      setHoveredModel(null);
-      setQuery('');
-    }
-  }, []);
+  const handleOpenChange = useCallback(
+    (nextOpen: boolean) => {
+      setOpen(nextOpen);
+      if (!nextOpen) {
+        cancelPendingClear();
+        setHoveredModel(null);
+        setEditingThinkingModelId(null);
+        setQuery('');
+      }
+    },
+    [cancelPendingClear],
+  );
+
+  const handleEditThinking = useCallback(
+    (modelId: string, event: React.MouseEvent<HTMLElement>) => {
+      event.preventDefault();
+      event.stopPropagation();
+      setEditingThinkingModelId((current) =>
+        current === modelId ? null : modelId,
+      );
+    },
+    [],
+  );
+
+  const handleSetThinkingEnabled = useCallback(
+    async (modelId: string, enabled: boolean) => {
+      const model = availableModels.find((item) => item.modelId === modelId);
+      if (!model) return;
+
+      const route = getThinkingDefaultOptionsForModel(model, preferences);
+      const option = enabled
+        ? getEnabledModelThinkingOption(
+            model,
+            modelThinkingOverrides[modelId]?.value,
+            route,
+          )
+        : (getModelThinkingOptions(model, route).find(
+            (item) => item.value === modelThinkingOverrides[modelId]?.value,
+          ) ?? getModelThinkingOptions(model, route)[0]);
+      if (!option) return;
+
+      const [, patches] = produceWithPatches(preferences, (draft) => {
+        draft.agent.modelThinkingOverrides[modelId] = {
+          ...draft.agent.modelThinkingOverrides[modelId],
+          enabled,
+          provider: option.provider,
+          value: option.value,
+        };
+      });
+      await updatePreferences(patches);
+    },
+    [modelThinkingOverrides, preferences, updatePreferences],
+  );
+
+  const handleSetThinkingValue = useCallback(
+    async (modelId: string, value: string) => {
+      const model = availableModels.find((item) => item.modelId === modelId);
+      if (!model) return;
+
+      const route = getThinkingDefaultOptionsForModel(model, preferences);
+      const option = getModelThinkingOptions(model, route).find(
+        (item) => item.value === value,
+      );
+      if (!option) return;
+
+      const [, patches] = produceWithPatches(preferences, (draft) => {
+        draft.agent.modelThinkingOverrides[modelId] = {
+          enabled: true,
+          provider: option.provider,
+          value: option.value,
+        };
+      });
+      await updatePreferences(patches);
+    },
+    [preferences, updatePreferences],
+  );
+
+  const handleResetThinkingOverride = useCallback(
+    async (modelId: string) => {
+      const [, patches] = produceWithPatches(preferences, (draft) => {
+        delete draft.agent.modelThinkingOverrides[modelId];
+      });
+      await updatePreferences(patches);
+    },
+    [preferences, updatePreferences],
+  );
+
+  const handleCycleThinkingEffort = useCallback(() => {
+    if (!selectedModel) return false;
+
+    const model = availableModels.find(
+      (item) => item.modelId === selectedModel,
+    );
+    if (!model) return false;
+
+    const display = getModelThinkingDisplayState(
+      model,
+      modelThinkingOverrides[model.modelId],
+      getThinkingDefaultOptionsForModel(model, preferences),
+    );
+    if (!display) return false;
+
+    const route = getThinkingDefaultOptionsForModel(model, preferences);
+    const nextOption = getNextModelThinkingOption(model, display.value, route);
+    const [, patches] = produceWithPatches(preferences, (draft) => {
+      draft.agent.modelThinkingOverrides[model.modelId] = {
+        enabled: true,
+        provider: nextOption.provider,
+        value: nextOption.value,
+      };
+    });
+    void updatePreferences(patches);
+  }, [modelThinkingOverrides, preferences, selectedModel, updatePreferences]);
 
   useHotKeyListener(
     useCallback(() => {
@@ -268,6 +475,11 @@ export const ModelSelect = memo(function ModelSelect({
       });
     }, []),
     HotkeyActions.OPEN_MODEL_SELECT,
+  );
+
+  useHotKeyListener(
+    handleCycleThinkingEffort,
+    HotkeyActions.CYCLE_MODEL_THINKING_EFFORT,
   );
 
   return (
@@ -282,24 +494,38 @@ export const ModelSelect = memo(function ModelSelect({
         <TooltipTrigger>
           <ComboboxBase.Trigger
             className={cn(
-              'inline-flex min-w-0 max-w-full cursor-pointer items-center justify-between gap-1 rounded-lg p-0 font-normal text-xs shadow-none transition-colors',
+              'group/trigger inline-flex min-w-0 max-w-full cursor-pointer items-center justify-between gap-1 rounded-lg p-0 font-normal text-xs shadow-none transition-colors',
               'focus-visible:outline-1 focus-visible:outline-muted-foreground/35 focus-visible:-outline-offset-2',
               'has-disabled:pointer-events-none has-disabled:opacity-50',
               'bg-transparent text-muted-foreground hover:text-foreground data-popup-open:text-foreground',
               'h-4 w-auto',
             )}
           >
-            <span className="truncate">{selectedDisplayName}</span>
+            <span className="min-w-0 truncate">{selectedDisplayName}</span>
+            {selectedThinkingLabel && (
+              <span className="shrink-0 text-subtle-foreground transition-colors group-hover/trigger:text-muted-foreground group-data-[popup-open]/trigger:text-muted-foreground">
+                {selectedThinkingLabel}
+              </span>
+            )}
             <ComboboxBase.Icon className="shrink-0">
               <IconChevronDownFill18 className="size-3" />
             </ComboboxBase.Icon>
           </ComboboxBase.Trigger>
         </TooltipTrigger>
         <TooltipContent side="top">
-          <span className="flex items-center gap-1.5">
-            <span>Switch model</span>
-            <HotkeyCombo action={HotkeyActions.OPEN_MODEL_SELECT} size="xs" />
-          </span>
+          <div className="flex flex-col gap-1">
+            <span className="flex items-center justify-between gap-2">
+              <span>Switch model</span>
+              <HotkeyCombo action={HotkeyActions.OPEN_MODEL_SELECT} size="xs" />
+            </span>
+            <span className="flex items-center justify-between gap-2">
+              <span>Change reasoning effort</span>
+              <HotkeyCombo
+                action={HotkeyActions.CYCLE_MODEL_THINKING_EFFORT}
+                size="xs"
+              />
+            </span>
+          </div>
         </TooltipContent>
       </Tooltip>
 
@@ -314,7 +540,7 @@ export const ModelSelect = memo(function ModelSelect({
           <div
             ref={containerRef}
             className="relative flex flex-row items-start gap-1"
-            onMouseLeave={() => setHoveredModel(null)}
+            onMouseLeave={scheduleClear}
           >
             <ComboboxBase.Popup
               className={cn(
@@ -350,6 +576,7 @@ export const ModelSelect = memo(function ModelSelect({
                             key={model.modelId}
                             model={model}
                             onHighlight={handleItemHover}
+                            onEditThinking={handleEditThinking}
                           />
                         ))}
                       </ComboboxGroup>
@@ -359,6 +586,7 @@ export const ModelSelect = memo(function ModelSelect({
                           key={model.modelId}
                           model={model}
                           onHighlight={handleItemHover}
+                          onEditThinking={handleEditThinking}
                         />
                       ))
                     ),
@@ -382,18 +610,49 @@ export const ModelSelect = memo(function ModelSelect({
             {hoveredModel && (
               <div
                 ref={sidePanelRef}
+                onMouseEnter={cancelPendingClear}
                 className={cn(
-                  'absolute left-full ml-1 flex max-w-64 flex-col gap-1 rounded-lg border border-derived bg-background p-2.5 text-foreground text-xs shadow-lg transition-[top] duration-100 ease-out',
+                  'absolute left-full ml-1 flex w-64 flex-col rounded-lg border border-derived bg-background text-foreground text-xs shadow-lg transition-[top] duration-100 ease-out',
                   'fade-in-0 slide-in-from-left-1 animate-in duration-150',
                 )}
                 style={{ top: sidePanelOffset }}
               >
-                <ModelTooltipContent
-                  model={hoveredModel.displayName}
-                  description={hoveredModel.description}
-                  context={hoveredModel.context}
-                  pricingMultiplier={hoveredModel.pricingMultiplier}
-                />
+                {editingThinkingModel ? (
+                  <ModelThinkingPanel
+                    model={editingThinkingModel}
+                    override={
+                      modelThinkingOverrides[editingThinkingModel.modelId]
+                    }
+                    defaultOptions={getThinkingDefaultOptionsForModel(
+                      editingThinkingModel,
+                      preferences,
+                    )}
+                    onEnabledChange={(enabled) =>
+                      handleSetThinkingEnabled(
+                        editingThinkingModel.modelId,
+                        enabled,
+                      )
+                    }
+                    onValueChange={(value) =>
+                      handleSetThinkingValue(
+                        editingThinkingModel.modelId,
+                        value,
+                      )
+                    }
+                    onReset={() =>
+                      handleResetThinkingOverride(editingThinkingModel.modelId)
+                    }
+                  />
+                ) : (
+                  <div className="p-2.5">
+                    <ModelTooltipContent
+                      model={hoveredModel.displayName}
+                      description={hoveredModel.description}
+                      context={hoveredModel.context}
+                      pricingMultiplier={hoveredModel.pricingMultiplier}
+                    />
+                  </div>
+                )}
               </div>
             )}
           </div>
@@ -406,9 +665,14 @@ export const ModelSelect = memo(function ModelSelect({
 const ModelItem = memo(function ModelItem({
   model,
   onHighlight,
+  onEditThinking,
 }: {
   model: ModelOption;
   onHighlight: (model: ModelOption, element: HTMLElement) => void;
+  onEditThinking: (
+    modelId: string,
+    event: React.MouseEvent<HTMLElement>,
+  ) => void;
 }) {
   const PriceIcon =
     model.pricingMultiplier != null
@@ -450,10 +714,24 @@ const ModelItem = memo(function ModelItem({
             </span>
           )}
         </div>
-        {model.thinkingEnabled && (
-          <div className="flex size-4 shrink-0 items-center justify-center">
-            <IconBrainOutline18 className="size-3 text-muted-foreground" />
-          </div>
+        {model.thinkingLabel && (
+          <span className="relative flex h-4 min-w-14 shrink-0 items-center justify-end text-[10px]">
+            <span className="inline-flex items-center gap-1 text-subtle-foreground group-data-[highlighted]/item:opacity-0">
+              <IconBrainOutline18 className="size-2.75" />
+              {model.thinkingLabel}
+            </span>
+            {model.catalogModel && (
+              <Button
+                type="button"
+                variant="ghost"
+                size="xs"
+                className="absolute right-0 h-auto px-0 py-0 text-[10px] opacity-0 group-data-[highlighted]/item:opacity-100"
+                onClick={(event) => onEditThinking(model.modelId, event)}
+              >
+                Edit
+              </Button>
+            )}
+          </span>
         )}
       </span>
     </ComboboxItem>

--- a/apps/browser/src/ui/screens/settings/sections/models-providers-section.tsx
+++ b/apps/browser/src/ui/screens/settings/sections/models-providers-section.tsx
@@ -12,15 +12,30 @@ import type {
   ModelCapabilities,
   ModelProvider,
   ProviderEndpointMode,
+  UserPreferences,
 } from '@shared/karton-contracts/ui/shared-types';
 import {
   PROVIDER_DISPLAY_INFO,
   PROVIDER_OFFICIAL_URLS,
 } from '@shared/karton-contracts/ui/shared-types';
 import { availableModels } from '@shared/available-models';
+import {
+  getEnabledModelThinkingOption,
+  getModelThinkingDisplayState,
+  getModelThinkingOptions,
+  type ModelThinkingDisplayState,
+} from '@ui/utils/model-thinking';
+import { ModelThinkingPanel } from '@ui/components/model-thinking-panel';
 import { CODING_PLANS, type CodingPlan } from '@shared/coding-plans';
 import { CodingPlanCard } from '@ui/components/coding-plan-card';
-import { useEffect, useState, useMemo, useCallback, useRef } from 'react';
+import {
+  useEffect,
+  useState,
+  useMemo,
+  useCallback,
+  useRef,
+  useLayoutEffect,
+} from 'react';
 
 import { cn } from '@ui/utils';
 import { useIsTruncated } from '@ui/hooks/use-is-truncated';
@@ -56,6 +71,11 @@ import {
 
 enablePatches();
 
+const EMPTY_CUSTOM_MODELS: UserPreferences['customModels'] = [];
+const EMPTY_CUSTOM_ENDPOINTS: UserPreferences['customEndpoints'] = [];
+const EMPTY_MODEL_THINKING_OVERRIDES: UserPreferences['agent']['modelThinkingOverrides'] =
+  {};
+
 // =============================================================================
 // Model Provider Configuration
 // =============================================================================
@@ -70,6 +90,27 @@ const PROVIDERS: ModelProvider[] = [
   'z-ai',
   'minimax',
 ];
+
+function getThinkingDefaultOptionsForModel(
+  model: (typeof availableModels)[number],
+  preferences: UserPreferences,
+): Parameters<typeof getModelThinkingDisplayState>[2] {
+  const provider = model.officialProvider;
+  if (!provider) return { providerMode: 'stagewise' };
+
+  const config = preferences.providerConfigs[provider];
+  if (config.mode !== 'custom') return { providerMode: config.mode };
+
+  const endpoint = preferences.customEndpoints.find(
+    (item) => item.id === config.customProviderId,
+  );
+  if (!endpoint) return { providerMode: 'stagewise' };
+
+  return {
+    providerMode: 'custom',
+    customEndpointApiSpec: endpoint.apiSpec,
+  };
+}
 
 function ProviderConfigCard({ provider }: { provider: ModelProvider }) {
   const setSettingsRoute = useKartonProcedure(
@@ -92,7 +133,8 @@ function ProviderConfigCard({ provider }: { provider: ModelProvider }) {
   };
   const displayInfo = PROVIDER_DISPLAY_INFO[provider];
   const officialUrl = PROVIDER_OFFICIAL_URLS[provider];
-  const customEndpoints = preferences?.customEndpoints ?? [];
+  const customEndpoints =
+    preferences?.customEndpoints ?? EMPTY_CUSTOM_ENDPOINTS;
 
   const [apiKeyInput, setApiKeyInput] = useState('');
   const [isSavingKey, setIsSavingKey] = useState(false);
@@ -923,16 +965,21 @@ function CustomModelDialog({
 function BuiltInModelCard({
   model,
   isEnabled,
+  thinkingDisplay,
   onToggle,
+  onEditThinking,
 }: {
   model: (typeof availableModels)[number];
   isEnabled: boolean;
+  thinkingDisplay: ModelThinkingDisplayState | null;
   onToggle: () => void;
+  onEditThinking: (event: React.MouseEvent<HTMLElement>) => void;
 }) {
   return (
     <div
+      data-model-card
       className={cn(
-        'cursor-pointer rounded-lg border border-derived bg-surface-1 p-3',
+        'group/model-card cursor-pointer rounded-lg border border-derived bg-surface-1 p-3',
         !isEnabled && 'opacity-60',
       )}
       onClick={onToggle}
@@ -941,6 +988,11 @@ function BuiltInModelCard({
         <div className="-mt-1 min-w-0 flex-1">
           <h3 className="font-medium text-foreground text-sm">
             {model.modelDisplayName}
+            {thinkingDisplay && (
+              <span className="ml-1.5 font-normal text-subtle-foreground">
+                {thinkingDisplay.label}
+              </span>
+            )}
           </h3>
           <p className="text-muted-foreground text-xs">
             {model.modelId} &middot;{' '}
@@ -969,10 +1021,23 @@ function BuiltInModelCard({
           className="flex shrink-0 items-center gap-2"
           onClick={(e) => e.stopPropagation()}
         >
+          {thinkingDisplay && (
+            <Button
+              type="button"
+              variant="ghost"
+              size="xs"
+              data-thinking-edit-trigger
+              className="h-5 px-1.5 opacity-0 transition-opacity group-focus-within/model-card:opacity-100 group-hover/model-card:opacity-100"
+              onClick={onEditThinking}
+            >
+              Edit
+            </Button>
+          )}
           <Switch
             checked={isEnabled}
             onCheckedChange={() => onToggle()}
             size="xs"
+            aria-label={`${isEnabled ? 'Disable' : 'Enable'} ${model.modelDisplayName}`}
           />
         </div>
       </div>
@@ -1042,6 +1107,7 @@ function CustomModelCard({
             checked={isEnabled}
             onCheckedChange={() => onToggle()}
             size="xs"
+            aria-label={`${isEnabled ? 'Disable' : 'Enable'} ${model.displayName}`}
           />
         </div>
       </div>
@@ -1053,12 +1119,15 @@ function CustomModelsSection() {
   const preferences = useKartonState((s) => s.preferences);
   const updatePreferences = useKartonProcedure((p) => p.preferences.update);
 
-  const customModels = preferences?.customModels ?? [];
-  const customEndpoints = preferences?.customEndpoints ?? [];
+  const customModels = preferences?.customModels ?? EMPTY_CUSTOM_MODELS;
+  const customEndpoints =
+    preferences?.customEndpoints ?? EMPTY_CUSTOM_ENDPOINTS;
   const disabledModelIds = useMemo(
-    () => new Set(preferences?.agent.disabledModelIds ?? []),
-    [preferences?.agent.disabledModelIds],
+    () => new Set(preferences.agent.disabledModelIds),
+    [preferences.agent.disabledModelIds],
   );
+  const thinkingOverrides =
+    preferences.agent.modelThinkingOverrides ?? EMPTY_MODEL_THINKING_OVERRIDES;
 
   const [dialogOpen, setDialogOpen] = useState(false);
   const [editingModel, setEditingModel] = useState<CustomModel | undefined>(
@@ -1123,6 +1192,131 @@ function CustomModelsSection() {
     fadeDistance: 24,
   });
 
+  const listContainerRef = useRef<HTMLDivElement>(null);
+  const thinkingPanelRef = useRef<HTMLDivElement>(null);
+  const thinkingPanelAnchorRef = useRef<HTMLElement | null>(null);
+  const [thinkingPanelModelId, setThinkingPanelModelId] = useState<
+    string | null
+  >(null);
+  const [thinkingPanelCenterY, setThinkingPanelCenterY] = useState(0);
+  const [thinkingPanelOffset, setThinkingPanelOffset] = useState(0);
+  const [thinkingPanelLeft, setThinkingPanelLeft] = useState(0);
+  const [thinkingPanelSide, setThinkingPanelSide] = useState<'left' | 'right'>(
+    'right',
+  );
+
+  const thinkingPanelModel = useMemo(
+    () => availableModels.find((m) => m.modelId === thinkingPanelModelId),
+    [thinkingPanelModelId],
+  );
+
+  const updateThinkingPanelOffset = useCallback(() => {
+    if (
+      !thinkingPanelModelId ||
+      !thinkingPanelRef.current ||
+      !listContainerRef.current
+    ) {
+      return;
+    }
+
+    const panel = thinkingPanelRef.current;
+    const panelHeight = panel.offsetHeight;
+    const panelWidth = panel.offsetWidth;
+    const container = listContainerRef.current;
+    const containerHeight = container.offsetHeight;
+    const anchorRect = thinkingPanelAnchorRef.current?.getBoundingClientRect();
+    const containerRect = container.getBoundingClientRect();
+    const panelGap = 4;
+
+    if (anchorRect) {
+      const rightSpace = window.innerWidth - anchorRect.right;
+      const leftSpace = anchorRect.left;
+      const side =
+        rightSpace >= panelWidth + panelGap || rightSpace >= leftSpace
+          ? 'right'
+          : 'left';
+      const rawLeft =
+        side === 'right'
+          ? anchorRect.right - containerRect.left + panelGap
+          : anchorRect.left - containerRect.left - panelWidth - panelGap;
+      const minLeft = panelGap - containerRect.left;
+      const maxLeft =
+        window.innerWidth - containerRect.left - panelWidth - panelGap;
+
+      setThinkingPanelSide(side);
+      setThinkingPanelLeft(Math.min(Math.max(rawLeft, minLeft), maxLeft));
+    }
+    const centerY = anchorRect
+      ? anchorRect.top + anchorRect.height / 2 - containerRect.top
+      : thinkingPanelCenterY;
+    let offset = centerY - panelHeight / 2;
+    offset = Math.max(0, offset);
+    offset = Math.min(offset, Math.max(0, containerHeight - panelHeight));
+    setThinkingPanelOffset(offset);
+  }, [thinkingPanelCenterY, thinkingPanelModelId]);
+
+  useLayoutEffect(() => {
+    updateThinkingPanelOffset();
+  }, [updateThinkingPanelOffset]);
+
+  useEffect(() => {
+    if (
+      !thinkingPanelModelId ||
+      !thinkingPanelRef.current ||
+      !listContainerRef.current
+    ) {
+      return;
+    }
+
+    const observer = new ResizeObserver(() => updateThinkingPanelOffset());
+    observer.observe(thinkingPanelRef.current);
+    observer.observe(listContainerRef.current);
+    listScrollViewport?.addEventListener('scroll', updateThinkingPanelOffset);
+    window.addEventListener('resize', updateThinkingPanelOffset);
+    updateThinkingPanelOffset();
+
+    return () => {
+      observer.disconnect();
+      listScrollViewport?.removeEventListener(
+        'scroll',
+        updateThinkingPanelOffset,
+      );
+      window.removeEventListener('resize', updateThinkingPanelOffset);
+    };
+  }, [listScrollViewport, thinkingPanelModelId, updateThinkingPanelOffset]);
+
+  useEffect(() => {
+    if (!thinkingPanelModelId) return;
+    if (
+      filteredBuiltIn.some((model) => model.modelId === thinkingPanelModelId)
+    ) {
+      return;
+    }
+    setThinkingPanelModelId(null);
+  }, [filteredBuiltIn, thinkingPanelModelId]);
+
+  useEffect(() => {
+    if (!thinkingPanelModelId) return;
+
+    const handlePointerDown = (event: PointerEvent) => {
+      const target = event.target;
+      if (!(target instanceof Node)) return;
+      if (thinkingPanelRef.current?.contains(target)) return;
+      if (
+        target instanceof Element &&
+        target.closest('[data-thinking-edit-trigger]')
+      ) {
+        return;
+      }
+      setThinkingPanelModelId(null);
+    };
+
+    document.addEventListener('pointerdown', handlePointerDown);
+    return () => {
+      document.removeEventListener('pointerdown', handlePointerDown);
+    };
+  }, [thinkingPanelModelId]);
+
   const handleAdd = useCallback(() => {
     setEditingModel(undefined);
     setDialogOpen(true);
@@ -1132,6 +1326,98 @@ function CustomModelsSection() {
     setEditingModel(m);
     setDialogOpen(true);
   }, []);
+
+  const handleEditThinking = useCallback(
+    (modelId: string, event: React.MouseEvent<HTMLElement>) => {
+      event.stopPropagation();
+      event.preventDefault();
+
+      const container = listContainerRef.current;
+      const target = event.currentTarget;
+      const anchor = target.closest<HTMLElement>('[data-model-card]') ?? target;
+      thinkingPanelAnchorRef.current = target;
+
+      if (container) {
+        const containerRect = container.getBoundingClientRect();
+        const itemRect = anchor.getBoundingClientRect();
+        setThinkingPanelCenterY(
+          itemRect.top + itemRect.height / 2 - containerRect.top,
+        );
+      }
+
+      setThinkingPanelModelId((current) => {
+        if (current === modelId) {
+          thinkingPanelAnchorRef.current = null;
+          return null;
+        }
+        return modelId;
+      });
+    },
+    [],
+  );
+
+  const handleSetThinkingEnabled = useCallback(
+    async (modelId: string, enabled: boolean) => {
+      const model = availableModels.find((item) => item.modelId === modelId);
+      if (!model) return;
+
+      const route = getThinkingDefaultOptionsForModel(model, preferences);
+      const option = enabled
+        ? getEnabledModelThinkingOption(
+            model,
+            thinkingOverrides[modelId]?.value,
+            route,
+          )
+        : (getModelThinkingOptions(model, route).find(
+            (item) => item.value === thinkingOverrides[modelId]?.value,
+          ) ?? getModelThinkingOptions(model, route)[0]);
+      if (!option) return;
+
+      const [, patches] = produceWithPatches(preferences, (draft) => {
+        draft.agent.modelThinkingOverrides[modelId] = {
+          ...draft.agent.modelThinkingOverrides[modelId],
+          enabled,
+          provider: option.provider,
+          value: option.value,
+        };
+      });
+      await updatePreferences(patches);
+    },
+    [preferences, thinkingOverrides, updatePreferences],
+  );
+
+  const handleSetThinkingValue = useCallback(
+    async (modelId: string, value: string) => {
+      const model = availableModels.find((item) => item.modelId === modelId);
+      if (!model) return;
+
+      const route = getThinkingDefaultOptionsForModel(model, preferences);
+      const option = getModelThinkingOptions(model, route).find(
+        (item) => item.value === value,
+      );
+      if (!option) return;
+
+      const [, patches] = produceWithPatches(preferences, (draft) => {
+        draft.agent.modelThinkingOverrides[modelId] = {
+          enabled: true,
+          provider: option.provider,
+          value: option.value,
+        };
+      });
+      await updatePreferences(patches);
+    },
+    [preferences, updatePreferences],
+  );
+
+  const handleResetThinkingOverride = useCallback(
+    async (modelId: string) => {
+      const [, patches] = produceWithPatches(preferences, (draft) => {
+        delete draft.agent.modelThinkingOverrides[modelId];
+      });
+      await updatePreferences(patches);
+    },
+    [preferences, updatePreferences],
+  );
 
   const handleSave = useCallback(
     async (
@@ -1209,41 +1495,82 @@ function CustomModelsSection() {
         </Button>
       </div>
 
-      <OverlayScrollbar
-        className="mask-alpha h-96"
-        style={listMaskStyle}
-        onViewportRef={setListScrollViewport}
-        contentClassName="space-y-3"
-      >
-        {filteredBuiltIn.map((model) => (
-          <BuiltInModelCard
-            key={model.modelId}
-            model={model}
-            isEnabled={!disabledModelIds.has(model.modelId)}
-            onToggle={() => handleToggleModel(model.modelId)}
-          />
-        ))}
+      <div ref={listContainerRef} className="relative">
+        <OverlayScrollbar
+          className="mask-alpha h-96"
+          style={listMaskStyle}
+          onViewportRef={setListScrollViewport}
+          contentClassName="space-y-3"
+        >
+          {filteredBuiltIn.map((model) => (
+            <BuiltInModelCard
+              key={model.modelId}
+              model={model}
+              isEnabled={!disabledModelIds.has(model.modelId)}
+              thinkingDisplay={getModelThinkingDisplayState(
+                model,
+                thinkingOverrides[model.modelId],
+                getThinkingDefaultOptionsForModel(model, preferences),
+              )}
+              onToggle={() => handleToggleModel(model.modelId)}
+              onEditThinking={(event) =>
+                handleEditThinking(model.modelId, event)
+              }
+            />
+          ))}
 
-        {filteredCustom.map((model) => (
-          <CustomModelCard
-            key={model.modelId}
-            model={model}
-            endpointName={resolveEndpointName(model.endpointId)}
-            isEnabled={!disabledModelIds.has(model.modelId)}
-            onToggle={() => handleToggleModel(model.modelId)}
-            onEdit={() => handleEdit(model)}
-            onDelete={() => handleDelete(model.modelId)}
-          />
-        ))}
+          {filteredCustom.map((model) => (
+            <CustomModelCard
+              key={model.modelId}
+              model={model}
+              endpointName={resolveEndpointName(model.endpointId)}
+              isEnabled={!disabledModelIds.has(model.modelId)}
+              onToggle={() => handleToggleModel(model.modelId)}
+              onEdit={() => handleEdit(model)}
+              onDelete={() => handleDelete(model.modelId)}
+            />
+          ))}
 
-        {noResults && (
-          <div className="rounded-lg border border-derived-subtle p-4">
-            <p className="text-center text-muted-foreground text-sm">
-              No models match your filter.
-            </p>
+          {noResults && (
+            <div className="rounded-lg border border-derived-subtle p-4">
+              <p className="text-center text-muted-foreground text-sm">
+                No models match your filter.
+              </p>
+            </div>
+          )}
+        </OverlayScrollbar>
+
+        {thinkingPanelModel && (
+          <div
+            ref={thinkingPanelRef}
+            className={cn(
+              'absolute z-10 flex w-64 flex-col rounded-lg border border-derived bg-background text-foreground text-xs shadow-lg transition-[top] duration-100 ease-out',
+              thinkingPanelSide === 'right'
+                ? 'fade-in-0 slide-in-from-left-1 animate-in duration-150'
+                : 'fade-in-0 slide-in-from-right-1 animate-in duration-150',
+            )}
+            style={{ top: thinkingPanelOffset, left: thinkingPanelLeft }}
+          >
+            <ModelThinkingPanel
+              model={thinkingPanelModel}
+              override={thinkingOverrides[thinkingPanelModel.modelId]}
+              defaultOptions={getThinkingDefaultOptionsForModel(
+                thinkingPanelModel,
+                preferences,
+              )}
+              onEnabledChange={(enabled) =>
+                handleSetThinkingEnabled(thinkingPanelModel.modelId, enabled)
+              }
+              onValueChange={(value) =>
+                handleSetThinkingValue(thinkingPanelModel.modelId, value)
+              }
+              onReset={() =>
+                handleResetThinkingOverride(thinkingPanelModel.modelId)
+              }
+            />
           </div>
         )}
-      </OverlayScrollbar>
+      </div>
 
       <CustomModelDialog
         model={editingModel}

--- a/apps/browser/src/ui/utils/model-thinking.test.ts
+++ b/apps/browser/src/ui/utils/model-thinking.test.ts
@@ -1,0 +1,353 @@
+import { describe, expect, it } from 'vitest';
+import type { BuiltInModelForThinking } from './model-thinking';
+import {
+  getDefaultThinkingOption,
+  getEnabledModelThinkingOption,
+  getModelThinkingDisplayState,
+  getModelThinkingOptions,
+  getNextModelThinkingOption,
+} from './model-thinking';
+
+const thinkingModel = {
+  modelId: 'thinking-model',
+  modelDisplayName: 'Thinking Model',
+  modelDescription: 'A model with thinking support.',
+  modelContext: '100k context',
+  officialProvider: 'anthropic',
+  thinkingEnabled: true,
+  providerOptions: {
+    stagewise: {
+      reasoning: {
+        enabled: true,
+        effort: 'high',
+      },
+    },
+  },
+} as unknown as BuiltInModelForThinking;
+
+const nonThinkingModel = {
+  modelId: 'standard-model',
+  modelDisplayName: 'Standard Model',
+  modelDescription: 'A model without thinking support.',
+  modelContext: '100k context',
+  officialProvider: 'openai',
+  providerOptions: {},
+} as unknown as BuiltInModelForThinking;
+
+const googleThinkingModel = {
+  modelId: 'gemini-3.1-pro-preview',
+  modelDisplayName: 'Google Thinking Model',
+  modelDescription: 'A Google model with provider-specific thinking defaults.',
+  modelContext: '1M context',
+  officialProvider: 'google',
+  thinkingEnabled: true,
+  providerOptions: {
+    stagewise: {
+      reasoning: {
+        enabled: true,
+        effort: 'medium',
+      },
+    },
+    google: {
+      thinkingConfig: {
+        includeThoughts: true,
+        thinkingLevel: 'high',
+      },
+    },
+  },
+} as unknown as BuiltInModelForThinking;
+
+const anthropicMaxThinkingModel = {
+  modelId: 'claude-opus-4.8',
+  modelDisplayName: 'Claude Opus 4.8',
+  modelDescription: 'Anthropic adaptive reasoning model.',
+  modelContext: '1M context',
+  officialProvider: 'anthropic',
+  thinkingEnabled: true,
+  providerOptions: {
+    stagewise: {
+      reasoning: {
+        enabled: true,
+        effort: 'medium',
+      },
+    },
+    anthropic: {
+      thinking: { type: 'adaptive' },
+      effort: 'medium',
+    },
+  },
+} as unknown as BuiltInModelForThinking;
+
+const openAiThinkingModel = {
+  modelId: 'gpt-5.5',
+  modelDisplayName: 'GPT-5.5',
+  modelDescription: 'OpenAI reasoning model.',
+  modelContext: '1M context',
+  officialProvider: 'openai',
+  thinkingEnabled: true,
+  providerOptions: {
+    stagewise: {
+      reasoning: {
+        enabled: true,
+        effort: 'medium',
+      },
+    },
+    openai: {
+      reasoningEffort: 'medium',
+    },
+  },
+} as unknown as BuiltInModelForThinking;
+
+describe('model thinking display helpers', () => {
+  it('returns null for models without thinking support', () => {
+    expect(getModelThinkingDisplayState(nonThinkingModel)).toBeNull();
+  });
+
+  it('uses the catalog default value when no override exists', () => {
+    expect(getModelThinkingDisplayState(thinkingModel)).toEqual({
+      enabled: true,
+      provider: 'anthropic',
+      value: 'high',
+      label: 'High',
+      isOverride: false,
+    });
+  });
+
+  it('uses active provider-specific defaults outside stagewise mode', () => {
+    expect(
+      getModelThinkingDisplayState(googleThinkingModel, undefined, {
+        providerMode: 'official',
+      }),
+    ).toEqual({
+      enabled: true,
+      provider: 'google',
+      value: 'high',
+      label: 'High',
+      isOverride: false,
+    });
+  });
+
+  it('uses provider-native defaults in stagewise mode for known providers', () => {
+    expect(
+      getModelThinkingDisplayState(googleThinkingModel, undefined, {
+        providerMode: 'stagewise',
+      }),
+    ).toEqual({
+      enabled: true,
+      provider: 'google',
+      value: 'high',
+      label: 'High',
+      isOverride: false,
+    });
+  });
+
+  it('uses the override value when present', () => {
+    expect(
+      getModelThinkingDisplayState(thinkingModel, {
+        provider: 'stagewise',
+        value: 'high',
+      }),
+    ).toEqual({
+      enabled: true,
+      provider: 'anthropic',
+      value: 'high',
+      label: 'High',
+      isOverride: true,
+    });
+  });
+
+  it('shows disabled overrides as off', () => {
+    expect(
+      getModelThinkingDisplayState(thinkingModel, {
+        enabled: false,
+        provider: 'stagewise',
+        value: 'low',
+      }),
+    ).toEqual({
+      enabled: false,
+      provider: 'anthropic',
+      value: 'low',
+      label: 'Off',
+      isOverride: true,
+    });
+  });
+
+  it('treats empty overrides as defaults', () => {
+    expect(getModelThinkingDisplayState(thinkingModel, {})).toEqual({
+      enabled: true,
+      provider: 'anthropic',
+      value: 'high',
+      label: 'High',
+      isOverride: false,
+    });
+  });
+
+  it('cycles thinking values in provider-supported display order', () => {
+    expect(
+      getNextModelThinkingOption(openAiThinkingModel, 'none', {
+        providerMode: 'official',
+      }).value,
+    ).toBe('low');
+    expect(
+      getNextModelThinkingOption(openAiThinkingModel, 'low', {
+        providerMode: 'official',
+      }).value,
+    ).toBe('medium');
+    expect(
+      getNextModelThinkingOption(openAiThinkingModel, 'medium', {
+        providerMode: 'official',
+      }).value,
+    ).toBe('high');
+    expect(
+      getNextModelThinkingOption(openAiThinkingModel, 'high', {
+        providerMode: 'official',
+      }).value,
+    ).toBe('xhigh');
+    expect(
+      getNextModelThinkingOption(openAiThinkingModel, 'xhigh', {
+        providerMode: 'official',
+      }).value,
+    ).toBe('none');
+  });
+
+  it('maps Anthropic budget token defaults to the closest value', () => {
+    const model = {
+      ...thinkingModel,
+      providerOptions: {
+        stagewise: {
+          reasoning: {
+            enabled: true,
+            effort: 'medium',
+          },
+        },
+        anthropic: {
+          thinking: {
+            type: 'enabled',
+            budgetTokens: 20000,
+          },
+        },
+      },
+    } as unknown as BuiltInModelForThinking;
+
+    expect(
+      getDefaultThinkingOption(model, { providerMode: 'official' }),
+    ).toMatchObject({
+      provider: 'anthropic',
+      value: 'high',
+    });
+  });
+
+  it('falls back to medium when the catalog default is not supported', () => {
+    const model = {
+      ...thinkingModel,
+      providerOptions: {
+        stagewise: {
+          reasoning: {
+            enabled: true,
+            effort: 'extreme',
+          },
+        },
+      },
+    } as unknown as BuiltInModelForThinking;
+
+    expect(getDefaultThinkingOption(model)).toMatchObject({
+      provider: 'anthropic',
+      value: 'medium',
+    });
+    expect(getModelThinkingDisplayState(model)).toEqual({
+      enabled: true,
+      provider: 'anthropic',
+      value: 'medium',
+      label: 'Medium',
+      isOverride: false,
+    });
+  });
+
+  it('does not expose OpenAI minimal for gpt-5.5', () => {
+    const values = getModelThinkingOptions(openAiThinkingModel, {
+      providerMode: 'official',
+    }).map((option) => option.value);
+
+    expect(values).toEqual(['none', 'low', 'medium', 'high', 'xhigh']);
+    expect(values).not.toContain('minimal');
+  });
+
+  it('uses an enabled fallback when enabling GPT-5 thinking', () => {
+    expect(
+      getEnabledModelThinkingOption(openAiThinkingModel, undefined, {
+        providerMode: 'official',
+      }),
+    ).toMatchObject({ provider: 'openai', value: 'medium', enabled: true });
+
+    expect(
+      getEnabledModelThinkingOption(openAiThinkingModel, 'none', {
+        providerMode: 'official',
+      }),
+    ).toMatchObject({ provider: 'openai', value: 'medium', enabled: true });
+  });
+
+  it('exposes Anthropic max for supported Claude models', () => {
+    const expectedOptions = [
+      ['low', 'Low'],
+      ['medium', 'Medium'],
+      ['high', 'High'],
+      ['xhigh', 'Extra high'],
+      ['max', 'Max'],
+    ];
+
+    expect(
+      getModelThinkingOptions(anthropicMaxThinkingModel, {
+        providerMode: 'official',
+      }).map((option) => [option.value, option.label]),
+    ).toEqual(expectedOptions);
+    expect(
+      getModelThinkingOptions(anthropicMaxThinkingModel, {
+        providerMode: 'stagewise',
+      }).map((option) => [option.value, option.label]),
+    ).toEqual(expectedOptions);
+    expect(
+      getModelThinkingDisplayState(
+        anthropicMaxThinkingModel,
+        { enabled: true, provider: 'anthropic', value: 'max' },
+        { providerMode: 'stagewise' },
+      ),
+    ).toEqual({
+      enabled: true,
+      provider: 'anthropic',
+      value: 'max',
+      label: 'Max',
+      isOverride: true,
+    });
+  });
+
+  it('does not expose Google xhigh', () => {
+    const values = getModelThinkingOptions(googleThinkingModel, {
+      providerMode: 'official',
+    }).map((option) => option.value);
+
+    expect(values).toEqual(['low', 'medium', 'high']);
+    expect(values).not.toContain('xhigh');
+  });
+
+  it('falls back safely for unsupported persisted values', () => {
+    expect(
+      getModelThinkingDisplayState(
+        openAiThinkingModel,
+        {
+          enabled: true,
+          provider: 'openai',
+          value: 'minimal',
+        },
+        {
+          providerMode: 'official',
+        },
+      ),
+    ).toEqual({
+      enabled: true,
+      provider: 'openai',
+      value: 'medium',
+      label: 'Medium',
+      isOverride: true,
+    });
+  });
+});

--- a/apps/browser/src/ui/utils/model-thinking.ts
+++ b/apps/browser/src/ui/utils/model-thinking.ts
@@ -1,0 +1,102 @@
+import type { availableModels } from '@shared/available-models';
+import {
+  getDefaultThinkingSelection,
+  getEffectiveThinkingSelection,
+  getNextThinkingSelection,
+  getSupportedThinkingOptions,
+  isExplicitThinkingOverride,
+  type ThinkingOption,
+} from '@shared/model-thinking-capabilities';
+import type {
+  ApiSpec,
+  ModelThinkingOverride,
+  ProviderEndpointMode,
+} from '@shared/karton-contracts/ui/shared-types';
+
+export type BuiltInModelForThinking = (typeof availableModels)[number];
+
+export type ModelThinkingDisplayState = {
+  enabled: boolean;
+  provider: ThinkingOption['provider'];
+  value: string;
+  label: string;
+  isOverride: boolean;
+};
+
+export type ModelThinkingDefaultOptions = {
+  providerMode?: ProviderEndpointMode;
+  customEndpointApiSpec?: ApiSpec;
+};
+
+export function getModelThinkingDisplayState(
+  model: BuiltInModelForThinking,
+  override?: ModelThinkingOverride,
+  options?: ModelThinkingDefaultOptions,
+): ModelThinkingDisplayState | null {
+  const selection = getEffectiveThinkingSelection(model, override, {
+    modelProvider: model.officialProvider,
+    ...options,
+  });
+  if (!selection) return null;
+
+  return {
+    enabled: selection.enabled,
+    provider: selection.provider,
+    value: selection.value,
+    label: selection.enabled ? selection.label : 'Off',
+    isOverride: isExplicitThinkingOverride(override),
+  };
+}
+
+export function getDefaultThinkingOption(
+  model: BuiltInModelForThinking,
+  options?: ModelThinkingDefaultOptions,
+): ThinkingOption {
+  return getDefaultThinkingSelection(model, {
+    modelProvider: model.officialProvider,
+    ...options,
+  });
+}
+
+export function getModelThinkingOptions(
+  model: BuiltInModelForThinking,
+  options?: ModelThinkingDefaultOptions,
+): ThinkingOption[] {
+  return getSupportedThinkingOptions(model, {
+    modelProvider: model.officialProvider,
+    ...options,
+  });
+}
+
+export function getEnabledModelThinkingOption(
+  model: BuiltInModelForThinking,
+  currentValue: string | undefined,
+  options?: ModelThinkingDefaultOptions,
+): ThinkingOption | undefined {
+  const thinkingOptions = getModelThinkingOptions(model, options);
+  const currentOption = thinkingOptions.find(
+    (option) => option.value === currentValue,
+  );
+  if (currentOption?.enabled) return currentOption;
+
+  const defaultOption = getDefaultThinkingOption(model, options);
+  if (defaultOption.enabled) return defaultOption;
+
+  return thinkingOptions.find((option) => option.enabled);
+}
+
+export function getNextModelThinkingOption(
+  model: BuiltInModelForThinking,
+  currentValue: string,
+  options?: ModelThinkingDefaultOptions,
+): ThinkingOption {
+  const current =
+    getModelThinkingOptions(model, options).find(
+      (option) => option.value === currentValue,
+    ) ?? getDefaultThinkingOption(model, options);
+
+  return getNextThinkingSelection(model, current, {
+    modelProvider: model.officialProvider,
+    ...options,
+  });
+}

--- a/packages/agent-core/src/agents/base-agent.ts
+++ b/packages/agent-core/src/agents/base-agent.ts
@@ -26,7 +26,10 @@ import type { AgentTypes } from '../types/agent';
 import type { ModelCapabilities } from '../types/models';
 import type { AgentStateMutations } from '../services/agent-manager/state-mutations';
 import type { AgentHost } from '../host/host';
-import type { ModelWithOptions } from '../host/models';
+import {
+  MODEL_REQUEST_PURPOSE_METADATA_KEY,
+  type ModelWithOptions,
+} from '../host/models';
 import type { AgentCtor, AgentTypeRegistry } from './agents-registry';
 
 /**
@@ -1599,6 +1602,7 @@ export abstract class BaseAgent<
         {
           $ai_span_name: `${this.agentType}-history`,
           $ai_parent_id: this.instanceId,
+          [MODEL_REQUEST_PURPOSE_METADATA_KEY]: 'agent-step',
         },
       );
       this._stepProviderMode = modelWithOptions.providerMode;

--- a/packages/agent-core/src/host/index.ts
+++ b/packages/agent-core/src/host/index.ts
@@ -21,7 +21,13 @@ export type {
   WorkspaceAgentSettingsEntry,
 } from './environment-sources';
 export type { Logger } from './logger';
-export type { HostModels, ModelWithOptions, ProviderMode } from './models';
+export {
+  MODEL_REQUEST_PURPOSE_METADATA_KEY,
+  type HostModels,
+  type ModelRequestPurpose,
+  type ModelWithOptions,
+  type ProviderMode,
+} from './models';
 export type { ModelCapabilities } from '../types/models';
 export type { HostPaths } from './paths';
 export type { TelemetrySink } from './telemetry';

--- a/packages/agent-core/src/host/models.ts
+++ b/packages/agent-core/src/host/models.ts
@@ -13,6 +13,17 @@ import type { ReasoningSignatureSource } from '../types/metadata';
 export type ProviderMode = 'stagewise' | 'official' | 'custom';
 
 /**
+ * Purpose for a host model resolution request.
+ *
+ * Hosts may use this metadata to decide whether user-facing runtime
+ * preferences should affect the returned provider options. Missing purpose
+ * should be treated as `internal` for backward compatibility.
+ */
+export type ModelRequestPurpose = 'agent-step' | 'internal';
+
+export const MODEL_REQUEST_PURPOSE_METADATA_KEY = '$model_request_purpose';
+
+/**
  * Fully-resolved model with all the options `BaseAgent` needs to
  * invoke `streamText` / `generateText`.
  *
@@ -78,8 +89,10 @@ export interface HostModels {
    * `traceId` is passed through so the host can attach it to any
    * telemetry/middleware it wraps around the returned model.
    * `metadata` carries optional host-specific trace properties
-   * (currently used for PostHog) and must not change the returned
-   * model's semantics.
+   * (currently used for PostHog). Hosts may also read the reserved
+   * {@link MODEL_REQUEST_PURPOSE_METADATA_KEY} key to distinguish
+   * user-facing agent steps from internal utility calls. Missing purpose
+   * must be treated as `internal` for backward compatibility.
    */
   getWithOptions(
     modelId: string,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds per‑model “thinking” controls with a compact UI and a hotkey. Applies provider‑aware reasoning options only to agent‑step requests; other calls are unchanged and telemetry omits the request‑purpose flag.

- **New Features**
  - Per-model overrides: store `{ enabled, provider, value }` under `preferences.agent.modelThinkingOverrides` with defaults/sanitization in `@shared/karton-contracts`.
  - UI: Model Select shows the current thinking label with inline Edit and a floating details panel; Settings → Models adds an anchored Thinking panel with enable/disable, level radios, and Reset to default.
  - Hotkey: cycle thinking level with `Mod+Alt+Slash` (Model Select remains on `Mod+Slash`); improved Slash handling across layouts and with Alt.
  - Runtime mapping: centralized in `@shared/model-thinking-capabilities` to patch provider options for Stagewise, OpenAI and OpenAI‑compatible, Google (`thinkingConfig.includeThoughts` + `thinkingLevel`), and Anthropic; disabling removes provider‑specific fields; deep‑merge supports deletion via `undefined`.
  - Defaults: choose the default level from the active provider mode (`stagewise`, `official`, or custom endpoint `ApiSpec`), including mapping Anthropic budget tokens to the nearest level.
  - Request scoping: only apply overrides when metadata includes ``MODEL_REQUEST_PURPOSE_METADATA_KEY: 'agent-step'`` (`@stagewise/agent-core`); `BaseAgent` sets this; the key is stripped from telemetry.

<sup>Written for commit bc0bb2d97803857f8241a9da5d0c1e42564e83c4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1315?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-model “thinking” (reasoning) controls with five effort levels (minimal→xhigh) exposed in model select, settings, and a floating panel; selections persist and show an “thinking label.”
  * Provider-aware behavior applies defaults and official mappings, including off/disabled handling.

* **Bug Fixes**
  * Improved override behavior so disabling specific thinking fields reliably removes provider options.
  * Updated telemetry to stop emitting internal request-purpose metadata.

* **Tests**
  * Added coverage for defaults, overrides (including “off”), cycling, display state, UI, and keyboard handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->