### PR TITLE
fix(stagewise): persist tutorial progress on restart and fix missing sidebar-panel tutorial anchor

### DIFF
--- a/apps/browser/src/backend/services/experience.ts
+++ b/apps/browser/src/backend/services/experience.ts
@@ -98,10 +98,14 @@ export class UserExperienceService extends DisposableService {
   }
 
   private async initialize() {
-    const hasSeenOnboarding = await this.readOnboardingState();
+    const [hasSeenOnboarding, tutorialState] = await Promise.all([
+      this.readOnboardingState(),
+      this.readTutorialState(),
+    ]);
     this.uiKarton.setState((draft) => {
       draft.userExperience.storedExperienceData.hasSeenOnboardingFlow =
         hasSeenOnboarding;
+      draft.userExperience.storedExperienceData.tutorialState = tutorialState;
     });
 
     this.uiKarton.registerStateChangeCallback(

--- a/apps/browser/src/ui/screens/main/sidebar/index.tsx
+++ b/apps/browser/src/ui/screens/main/sidebar/index.tsx
@@ -72,6 +72,7 @@ export function Sidebar() {
       collapsedSize={0}
       onCollapse={() => setCollapsed(true)}
       onExpand={() => setCollapsed(false)}
+      data-tutorial="sidebar-panel"
       className={`${SIDEBAR_PANEL_CLASS_NAME} data-[panel-size='0.0']:min-w-0`}
     >
       <SidebarTitlebarRow absolute />


### PR DESCRIPTION


- Eagerly load tutorialState alongside onboardingState in initialize() so completed tutorials aren't re-shown after app restart
- Add data-tutorial=sidebar-panel attribute to the Sidebar panel so the initial tutorial step 4 has a DOM target to anchor on

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist tutorial progress across restarts and add the missing sidebar tutorial anchor. Also adds a new, provider-aware Model Thinking UI with a hotkey to quickly cycle levels.

- **New Features**
  - Model Thinking panel in the model picker and Settings to enable/disable thinking and choose provider/level.
  - Provider-aware thinking overrides with automatic option patching for Stagewise/OpenAI/Google/Anthropic (incl. OpenAI-compatible routes).
  - New hotkey: Mod+Alt+Slash to cycle the model thinking level.

- **Bug Fixes**
  - Persist tutorial progress by loading `tutorialState` alongside onboarding on app start.
  - Add `data-tutorial="sidebar-panel"` so the tutorial’s sidebar step anchors correctly.

<sup>Written for commit 0765e81a3cd21a11f012175059e913da32228030. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1319?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Optimized user experience service initialization by loading onboarding and tutorial state data concurrently, improving performance during app startup.
  * Enhanced sidebar component with tutorial support to enable targeted user guidance features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->