### PR TITLE
feat(stagewise): add omnibox focus hotkey

### DIFF
--- a/apps/browser/src/shared/hotkeys.ts
+++ b/apps/browser/src/shared/hotkeys.ts
@@ -120,9 +120,6 @@ export enum HotkeyActions {
   // Dev tools
   DEV_TOOLS = 'dev_tools',
 
-  // Color scheme
-  CYCLE_COLOR_SCHEME = 'cycle_color_scheme',
-
   // Zoom
   ZOOM_IN = 'zoom_in',
   ZOOM_OUT = 'zoom_out',
@@ -392,7 +389,8 @@ export const hotkeyDefinitions: Record<HotkeyActions, HotkeyDefinition> = {
   // URL bar
   [HotkeyActions.FOCUS_URL_BAR]: {
     accelerator: 'Alt+D',
-    aliases: ['F6'],
+    aliases: ['F6', 'Ctrl+Alt+L'],
+    macAliases: ['Mod+Alt+L', 'F6'],
     captureDominantly: true,
   },
 
@@ -428,13 +426,6 @@ export const hotkeyDefinitions: Record<HotkeyActions, HotkeyDefinition> = {
     aliases: ['F12', 'Ctrl+Shift+I', 'Ctrl+Shift+J'],
     mac: 'Mod+Alt+I',
     macAliases: ['F12'],
-    captureDominantly: true,
-  },
-
-  // Color scheme
-  [HotkeyActions.CYCLE_COLOR_SCHEME]: {
-    accelerator: 'Ctrl+Alt+L',
-    mac: 'Mod+Alt+L',
     captureDominantly: true,
   },
 

--- a/apps/browser/src/ui/screens/main/content/_components/browser-tab-hotkeys.tsx
+++ b/apps/browser/src/ui/screens/main/content/_components/browser-tab-hotkeys.tsx
@@ -32,9 +32,6 @@ export function BrowserTabHotkeys({
   const toggleChromeDevTools = useKartonProcedure(
     (p) => p.browser.devTools.chrome.toggle,
   );
-  const cycleColorScheme = useKartonProcedure(
-    (p) => p.browser.cycleColorScheme,
-  );
   const setZoomPercentage = useKartonProcedure(
     (p) => p.browser.setZoomPercentage,
   );
@@ -127,12 +124,6 @@ export function BrowserTabHotkeys({
     if (!activeTabId || isStateOnlyTab) return;
     toggleChromeDevTools(activeTabId);
   }, HotkeyActions.DEV_TOOLS);
-
-  // Color scheme
-  useHotKeyListener(() => {
-    if (!activeTabId || isStateOnlyTab) return;
-    cycleColorScheme(activeTabId);
-  }, HotkeyActions.CYCLE_COLOR_SCHEME);
 
   return null;
 }

--- a/apps/browser/src/ui/screens/main/content/_components/control-buttons/color-scheme.tsx
+++ b/apps/browser/src/ui/screens/main/content/_components/control-buttons/color-scheme.tsx
@@ -1,4 +1,3 @@
-import { HotkeyActions } from '@shared/hotkeys';
 import { useKartonProcedure, useKartonState } from '@ui/hooks/use-karton';
 import { IconSunOutline18, IconMoonOutline18 } from 'nucleo-ui-outline-18';
 import { cn } from '@stagewise/stage-ui/lib/utils';
@@ -10,7 +9,6 @@ import {
   TooltipTrigger,
   TooltipContent,
 } from '@stagewise/stage-ui/components/tooltip';
-import { HotkeyCombo } from '@ui/components/hotkey-combo';
 
 export function ColorSchemeWidget({ tab }: { tab: TabState }) {
   const cycleColorScheme = useKartonProcedure(
@@ -59,10 +57,7 @@ export function ColorSchemeWidget({ tab }: { tab: TabState }) {
         </Button>
       </TooltipTrigger>
       <TooltipContent>
-        <span className="flex items-center gap-1.5">
-          <span>Toggle color scheme</span>
-          <HotkeyCombo action={HotkeyActions.CYCLE_COLOR_SCHEME} size="xs" />
-        </span>
+        <span>Toggle color scheme</span>
         <span className="mt-0.5 block text-muted-foreground text-xs">
           Current:{' '}
           {tab.colorScheme === 'light'


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds cross-platform URL bar focus hotkeys and removes the color scheme cycling hotkey to avoid conflicts. Improves consistency by adding `Ctrl+Alt+L` on Windows/Linux and `Cmd+Alt+L` on macOS.

- **New Features**
  - macOS: `Cmd+Alt+L` and `F6` focus the URL bar.
  - Windows/Linux: `Alt+D`, `F6`, and `Ctrl+Alt+L` focus the URL bar.

- **Refactors**
  - Removed the color scheme hotkey (`CYCLE_COLOR_SCHEME`) and its listener.
  - Removed the hotkey hint from the color scheme tooltip.

<sup>Written for commit ad94d1dd3ad07486f7f6870aa29e38c88e44e4cd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1321?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded the URL bar focus shortcut with additional cross-platform and macOS aliases (including `Ctrl+Alt+L` and `Mod+Alt+L`).

* **Bug Fixes**
  * Removed the color-scheme cycling hotkey and its tab hotkey handling.
  * Removed the hotkey hint from the color scheme toggle tooltip.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->