### PR TITLE
feat(stagewise): add Kimi K2.7 Code

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -39,7 +39,7 @@ Verbinde eines der folgenden Abos mit einem einzigen API-Schlüssel und erhalte 
 | **Abo** | **Anbieter** | **Featured Models** | **Dashboard** |
 | ------- | ------------ | ------------------- | ------------- |
 | GLM Coding Plan | [Z.ai](https://z.ai) | GLM-5.1, GLM-5V-Turbo | [API-Schlüssel holen](https://z.ai/manage-apikey/apikey-list) |
-| Kimi | [Moonshot AI](https://platform.moonshot.ai) | Kimi K2.6, Kimi K2.5 | [API-Schlüssel holen](https://platform.moonshot.ai/console/api-keys) |
+| Kimi | [Moonshot AI](https://platform.moonshot.ai) | Kimi K2.7 Code, Kimi K2.6, Kimi K2.5 | [API-Schlüssel holen](https://platform.moonshot.ai/console/api-keys) |
 | Qwen Coding Plan | [Alibaba DashScope](https://dashscope.console.aliyun.com) | Qwen3-Coder-30B, Qwen3-32B | [API-Schlüssel holen](https://dashscope.console.aliyun.com/apiKey) |
 | MiniMax | [MiniMax](https://platform.minimax.io) | MiniMax M3, MiniMax M2.7 | [API-Schlüssel holen](https://platform.minimax.io/user-center/basic-information/interface-key) |
 
@@ -58,7 +58,7 @@ Enthaltene Modelle:
 - **Anthropic**: Fable 5, Opus 4.8, Opus 4.7, Opus 4.6, Sonnet 4.6, Haiku 4.5
 - **OpenAI**: GPT-5.5, GPT-5.4, GPT-5.3 Codex, GPT-5.3 Instant, GPT-5.4 mini, GPT-5.4 nano
 - **Google**: Gemini 3.1 Pro (Preview), Gemini 3 Flash, Gemini 3.1 Flash Lite
-- **Moonshot AI**: Kimi K2.6, Kimi K2.5
+- **Moonshot AI**: Kimi K2.7 Code, Kimi K2.6, Kimi K2.5
 - **Alibaba**: Qwen 3-32B, Qwen 3-Coder 30B-A3B
 - **DeepSeek**: DeepSeek V4 Pro, DeepSeek V4 Flash
 - **Z.ai**: GLM 5.1, GLM 5V-Turbo

--- a/README.es.md
+++ b/README.es.md
@@ -39,7 +39,7 @@ Conecta cualquiera de las siguientes suscripciones con una sola clave de API par
 | **Suscripción** | **Proveedor** | **Modelos destacados** | **Panel** |
 | --------------- | ------------- | ---------------------- | --------- |
 | GLM Coding Plan | [Z.ai](https://z.ai) | GLM-5.1, GLM-5V-Turbo | [Obtener clave de API](https://z.ai/manage-apikey/apikey-list) |
-| Kimi | [Moonshot AI](https://platform.moonshot.ai) | Kimi K2.6, Kimi K2.5 | [Obtener clave de API](https://platform.moonshot.ai/console/api-keys) |
+| Kimi | [Moonshot AI](https://platform.moonshot.ai) | Kimi K2.7 Code, Kimi K2.6, Kimi K2.5 | [Obtener clave de API](https://platform.moonshot.ai/console/api-keys) |
 | Qwen Coding Plan | [Alibaba DashScope](https://dashscope.console.aliyun.com) | Qwen3-Coder-30B, Qwen3-32B | [Obtener clave de API](https://dashscope.console.aliyun.com/apiKey) |
 | MiniMax | [MiniMax](https://platform.minimax.io) | MiniMax M3, MiniMax M2.7 | [Obtener clave de API](https://platform.minimax.io/user-center/basic-information/interface-key) |
 
@@ -58,7 +58,7 @@ Modelos incluidos:
 - **Anthropic**: Fable 5, Opus 4.8, Opus 4.7, Opus 4.6, Sonnet 4.6, Haiku 4.5
 - **OpenAI**: GPT-5.5, GPT-5.4, GPT-5.3 Codex, GPT-5.3 Instant, GPT-5.4 mini, GPT-5.4 nano
 - **Google**: Gemini 3.1 Pro (Preview), Gemini 3 Flash, Gemini 3.1 Flash Lite
-- **Moonshot AI**: Kimi K2.6, Kimi K2.5
+- **Moonshot AI**: Kimi K2.7 Code, Kimi K2.6, Kimi K2.5
 - **Alibaba**: Qwen 3-32B, Qwen 3-Coder 30B-A3B
 - **DeepSeek**: DeepSeek V4 Pro, DeepSeek V4 Flash
 - **Z.ai**: GLM 5.1, GLM 5V-Turbo

--- a/README.ja.md
+++ b/README.ja.md
@@ -39,7 +39,7 @@
 | **サブスクリプション** | **プロバイダー** | **注目モデル** | **ダッシュボード** |
 | --------------------- | --------------- | -------------- | ----------------- |
 | GLM Coding Plan | [Z.ai](https://z.ai) | GLM-5.1, GLM-5V-Turbo | [APIキーを取得](https://z.ai/manage-apikey/apikey-list) |
-| Kimi | [Moonshot AI](https://platform.moonshot.ai) | Kimi K2.6, Kimi K2.5 | [APIキーを取得](https://platform.moonshot.ai/console/api-keys) |
+| Kimi | [Moonshot AI](https://platform.moonshot.ai) | Kimi K2.7 Code, Kimi K2.6, Kimi K2.5 | [APIキーを取得](https://platform.moonshot.ai/console/api-keys) |
 | Qwen Coding Plan | [Alibaba DashScope](https://dashscope.console.aliyun.com) | Qwen3-Coder-30B, Qwen3-32B | [APIキーを取得](https://dashscope.console.aliyun.com/apiKey) |
 | MiniMax | [MiniMax](https://platform.minimax.io) | MiniMax M3, MiniMax M2.7 | [APIキーを取得](https://platform.minimax.io/user-center/basic-information/interface-key) |
 
@@ -58,7 +58,7 @@
 - **Anthropic**: Fable 5, Opus 4.8, Opus 4.7, Opus 4.6, Sonnet 4.6, Haiku 4.5
 - **OpenAI**: GPT-5.5, GPT-5.4, GPT-5.3 Codex, GPT-5.3 Instant, GPT-5.4 mini, GPT-5.4 nano
 - **Google**: Gemini 3.1 Pro (Preview), Gemini 3 Flash, Gemini 3.1 Flash Lite
-- **Moonshot AI**: Kimi K2.6, Kimi K2.5
+- **Moonshot AI**: Kimi K2.7 Code, Kimi K2.6, Kimi K2.5
 - **Alibaba**: Qwen 3-32B, Qwen 3-Coder 30B-A3B
 - **DeepSeek**: DeepSeek V4 Pro, DeepSeek V4 Flash
 - **Z.ai**: GLM 5.1, GLM 5V-Turbo

--- a/README.ko.md
+++ b/README.ko.md
@@ -39,7 +39,7 @@
 | **구독** | **공급자** | **주요 모델** | **대시보드** |
 | -------- | ---------- | ------------- | ------------ |
 | GLM Coding Plan | [Z.ai](https://z.ai) | GLM-5.1, GLM-5V-Turbo | [API 키 받기](https://z.ai/manage-apikey/apikey-list) |
-| Kimi | [Moonshot AI](https://platform.moonshot.ai) | Kimi K2.6, Kimi K2.5 | [API 키 받기](https://platform.moonshot.ai/console/api-keys) |
+| Kimi | [Moonshot AI](https://platform.moonshot.ai) | Kimi K2.7 Code, Kimi K2.6, Kimi K2.5 | [API 키 받기](https://platform.moonshot.ai/console/api-keys) |
 | Qwen Coding Plan | [Alibaba DashScope](https://dashscope.console.aliyun.com) | Qwen3-Coder-30B, Qwen3-32B | [API 키 받기](https://dashscope.console.aliyun.com/apiKey) |
 | MiniMax | [MiniMax](https://platform.minimax.io) | MiniMax M3, MiniMax M2.7 | [API 키 받기](https://platform.minimax.io/user-center/basic-information/interface-key) |
 
@@ -58,7 +58,7 @@
 - **Anthropic**: Fable 5, Opus 4.8, Opus 4.7, Opus 4.6, Sonnet 4.6, Haiku 4.5
 - **OpenAI**: GPT-5.5, GPT-5.4, GPT-5.3 Codex, GPT-5.3 Instant, GPT-5.4 mini, GPT-5.4 nano
 - **Google**: Gemini 3.1 Pro (Preview), Gemini 3 Flash, Gemini 3.1 Flash Lite
-- **Moonshot AI**: Kimi K2.6, Kimi K2.5
+- **Moonshot AI**: Kimi K2.7 Code, Kimi K2.6, Kimi K2.5
 - **Alibaba**: Qwen 3-32B, Qwen 3-Coder 30B-A3B
 - **DeepSeek**: DeepSeek V4 Pro, DeepSeek V4 Flash
 - **Z.ai**: GLM 5.1, GLM 5V-Turbo

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Connect any of the following subscriptions with a single API key to unlock all m
 | **Subscription** | **Provider** | **Featured Models** | **Dashboard** |
 | ---------------- | ------------ | ------------------- | ------------- |
 | GLM Coding Plan  | [Z.ai](https://z.ai) | GLM-5.1, GLM-5V-Turbo | [Get API key](https://z.ai/manage-apikey/apikey-list) |
-| Kimi             | [Moonshot AI](https://platform.moonshot.ai) | Kimi K2.6, Kimi K2.5 | [Get API key](https://platform.moonshot.ai/console/api-keys) |
+| Kimi             | [Moonshot AI](https://platform.moonshot.ai) | Kimi K2.7 Code, Kimi K2.6, Kimi K2.5 | [Get API key](https://platform.moonshot.ai/console/api-keys) |
 | Qwen Coding Plan | [Alibaba DashScope](https://dashscope.console.aliyun.com) | Qwen3-Coder-30B, Qwen3-32B | [Get API key](https://dashscope.console.aliyun.com/apiKey) |
 | MiniMax          | [MiniMax](https://platform.minimax.io) | MiniMax M3, MiniMax M2.7 | [Get API key](https://platform.minimax.io/user-center/basic-information/interface-key) |
 
@@ -58,7 +58,7 @@ Included models:
 - **Anthropic**: Fable 5, Opus 4.8, Opus 4.7, Opus 4.6, Sonnet 4.6, Haiku 4.5
 - **OpenAI**: GPT-5.5, GPT-5.4, GPT-5.3 Codex, GPT-5.3 Instant, GPT-5.4 mini, GPT-5.4 nano
 - **Google**: Gemini 3.1 Pro (Preview), Gemini 3 Flash, Gemini 3.1 Flash Lite
-- **Moonshot AI**: Kimi K2.6, Kimi K2.5
+- **Moonshot AI**: Kimi K2.7 Code, Kimi K2.6, Kimi K2.5
 - **Alibaba**: Qwen 3-32B, Qwen 3-Coder 30B-A3B
 - **DeepSeek**: DeepSeek V4 Pro, DeepSeek V4 Flash
 - **Z.ai**: GLM 5.1, GLM 5V-Turbo

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -39,7 +39,7 @@
 | **订阅** | **服务商** | **主推模型** | **控制台** |
 | -------- | ---------- | ------------ | ---------- |
 | GLM 编程计划 | [Z.ai](https://z.ai) | GLM-5.1、GLM-5V-Turbo | [获取 API 密钥](https://z.ai/manage-apikey/apikey-list) |
-| Kimi | [Moonshot AI](https://platform.moonshot.ai) | Kimi K2.6、Kimi K2.5 | [获取 API 密钥](https://platform.moonshot.ai/console/api-keys) |
+| Kimi | [Moonshot AI](https://platform.moonshot.ai) | Kimi K2.7 Code、Kimi K2.6、Kimi K2.5 | [获取 API 密钥](https://platform.moonshot.ai/console/api-keys) |
 | Qwen 编程计划 | [阿里云 DashScope](https://dashscope.console.aliyun.com) | Qwen3-Coder-30B、Qwen3-32B | [获取 API 密钥](https://dashscope.console.aliyun.com/apiKey) |
 | MiniMax | [MiniMax](https://platform.minimax.io) | MiniMax M3, MiniMax M2.7 | [获取 API 密钥](https://platform.minimax.io/user-center/basic-information/interface-key) |
 
@@ -58,7 +58,7 @@
 - **Anthropic**：Fable 5、Opus 4.8、Opus 4.7、Opus 4.6、Sonnet 4.6、Haiku 4.5
 - **OpenAI**：GPT-5.5、GPT-5.4、GPT-5.3 Codex、GPT-5.3 Instant、GPT-5.4 mini、GPT-5.4 nano
 - **Google**：Gemini 3.1 Pro（预览）、Gemini 3 Flash、Gemini 3.1 Flash Lite（预览）
-- **Moonshot AI**：Kimi K2.6、Kimi K2.5
+- **Moonshot AI**：Kimi K2.7 Code、Kimi K2.6、Kimi K2.5
 - **Alibaba**：Qwen 3-32B、Qwen 3-Coder 30B-A3B
 - **DeepSeek**：DeepSeek V4 Pro、DeepSeek V4 Flash
 - **Z.ai**：GLM 5.1、GLM 5V-Turbo

--- a/apps/browser/src/shared/available-models.ts
+++ b/apps/browser/src/shared/available-models.ts
@@ -499,6 +499,47 @@ export const availableModels = [
   },
   {
     officialProvider: 'moonshotai',
+    modelId: 'kimi-k2.7-code',
+    modelDisplayName: 'Kimi K2.7 Code',
+    modelDescription:
+      "Kimi's code-specialized model for agentic coding tasks and long-context software work.",
+    modelContext: '256k context',
+    modelContextRaw: 262144,
+    headers: {},
+    providerOptions: {
+      stagewise: { reasoning: { enabled: true, effort: 'medium' } },
+      moonshotai: {
+        thinking: { type: 'adaptive' },
+        effort: 'medium',
+      },
+    },
+    thinkingEnabled: true,
+    pricing: {
+      inputPerMillion: 0.75,
+      outputPerMillion: 3.5,
+      relativeMultiplier: 0.8,
+    },
+    capabilities: {
+      inputModalities: {
+        text: true,
+        audio: false,
+        image: false,
+        video: false,
+        file: false,
+      },
+      outputModalities: {
+        text: true,
+        audio: false,
+        image: false,
+        video: false,
+        file: false,
+      },
+      inputConstraints: GOOGLE_INPUT_CONSTRAINTS,
+      toolCalling: true,
+    },
+  },
+  {
+    officialProvider: 'moonshotai',
     modelId: 'kimi-k2.6',
     modelDisplayName: 'Kimi K2.6',
     modelDescription:

--- a/apps/browser/src/shared/coding-plans.ts
+++ b/apps/browser/src/shared/coding-plans.ts
@@ -56,7 +56,7 @@ export const CODING_PLANS: Record<CodingPlanId, CodingPlan> = {
     apiKeyUrl: 'https://platform.moonshot.ai/console/api-keys',
     helpText: 'Create one at platform.moonshot.ai → Console → API keys',
     apiKeyPattern: '^sk-[A-Za-z0-9]{48}$',
-    featuredModelIds: ['kimi-k2.6', 'kimi-k2.5'],
+    featuredModelIds: ['kimi-k2.7-code', 'kimi-k2.6', 'kimi-k2.5'],
   },
   'qwen-plan': {
     id: 'qwen-plan',

--- a/apps/website/src/app/(home)/_components/model-provider-showcase.tsx
+++ b/apps/website/src/app/(home)/_components/model-provider-showcase.tsx
@@ -109,6 +109,7 @@ const PROVIDERS: ProviderInfo[] = [
     monoInDark: true,
     description: 'Long-horizon coding and native multimodal input.',
     models: [
+      { name: 'Kimi K2.7 Code', tier: 'frontier' },
       { name: 'Kimi K2.6', tier: 'frontier' },
       { name: 'Kimi K2.5', tier: 'general' },
     ],


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds Moonshot’s Kimi K2.7 Code to the model catalog with StageWise reasoning for long-context coding. It’s now featured in the Kimi plan, website showcase, and docs.

- **New Features**
  - Added `kimi-k2.7-code` (256k context, tool calling, StageWise reasoning on with adaptive thinking). Pricing: $0.75/M input, $3.5/M output.
  - Surfaced in UI and docs: added to Kimi plan featured models, website provider showcase, and all READMEs.

<sup>Written for commit 378b69039a1a4b8ef95cb43ef157bead16ebc05a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1326?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the Kimi K2.7 Code model from Moonshot AI with a 256k context window and tool calling capabilities.

* **Documentation**
  * Updated all language versions of the documentation to include the new Kimi K2.7 Code model and its availability in coding subscription plans.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->