### PR TITLE
Add git diff view

### DIFF
--- a/apps/browser/src/backend/main.ts
+++ b/apps/browser/src/backend/main.ts
@@ -923,6 +923,10 @@ export async function main({ launchOptions: { verbose } }: MainParameters) {
       fileTreeService.setActiveWorkspace(workspaceKey),
   );
   uiKarton.registerServerProcedureHandler(
+    'fileTree.setViewMode',
+    async (_cid, mode: 'files' | 'diff') => fileTreeService.setViewMode(mode),
+  );
+  uiKarton.registerServerProcedureHandler(
     'fileTree.setDirectoryExpanded',
     async (
       _cid,

--- a/apps/browser/src/backend/services/file-tree/index.test.ts
+++ b/apps/browser/src/backend/services/file-tree/index.test.ts
@@ -77,6 +77,7 @@ function createState(root: string): MutableState {
     fileTree: {
       visible: false,
       activeWorkspaceKey: null,
+      viewMode: 'files' as const,
       expandedDirectoriesByWorkspaceKey: {},
       workspaceRevisions: {},
       directoryRevisions: {},

--- a/apps/browser/src/backend/services/file-tree/index.ts
+++ b/apps/browser/src/backend/services/file-tree/index.ts
@@ -1425,10 +1425,11 @@ export class FileTreeService extends DisposableService {
           for (const directoryPath of affectedDirectories) {
             revisions[directoryPath] = (revisions[directoryPath] ?? 0) + 1;
           }
-          return;
+        } else {
+          this.invalidateWorkspaceCache(workspaceKey);
         }
-
-        this.invalidateWorkspaceCache(workspaceKey);
+        // Always bump the workspace-level revision so consumers
+        // (diff view, toggle button) can react to any file change.
         draft.fileTree.workspaceRevisions[workspaceKey] =
           (draft.fileTree.workspaceRevisions[workspaceKey] ?? 0) + 1;
       });

--- a/apps/browser/src/backend/services/file-tree/index.ts
+++ b/apps/browser/src/backend/services/file-tree/index.ts
@@ -1223,6 +1223,12 @@ export class FileTreeService extends DisposableService {
     });
   }
 
+  setViewMode(mode: 'files' | 'diff'): void {
+    this.uiKarton.setState((draft) => {
+      draft.fileTree.viewMode = mode;
+    });
+  }
+
   setDirectoryExpanded(
     workspaceKey: string,
     directoryPath: string,

--- a/apps/browser/src/backend/services/git/index.test.ts
+++ b/apps/browser/src/backend/services/git/index.test.ts
@@ -1159,6 +1159,61 @@ describe('GitService', () => {
         expect(result?.totalAdded).toBe(8);
         expect(result?.totalDeleted).toBe(0);
       });
+
+      it('updates deleted entry when untracked file recreated at same path', async () => {
+        // staged D + recreated untracked: file was deleted and staged,
+        // then recreated on disk before committing.
+        const { service } = await createGitService({
+          ...diffBaseResponses,
+          'diff --find-renames --numstat': '',
+          'diff --find-renames --name-status': '',
+          'diff --cached --find-renames --numstat': '0\t15\treborn.ts',
+          'diff --cached --find-renames --name-status': 'D\treborn.ts',
+          'ls-files --others --exclude-standard -z': 'reborn.ts\0other.ts\0',
+        });
+
+        const countSpy = vi
+          .spyOn(
+            service as unknown as {
+              countFileLines: (p: string) => Promise<number>;
+            },
+            'countFileLines',
+          )
+          .mockImplementation(async (absPath: string) => {
+            if (absPath.endsWith('reborn.ts')) return 22;
+            if (absPath.endsWith('other.ts')) return 5;
+            return 0;
+          });
+
+        const result = await service.getDiffNumstat('/repo');
+
+        countSpy.mockRestore();
+
+        // reborn.ts: staged D (15 deleted lines) + untracked (22 new lines)
+        // → merged entry shows both, changeType promoted from deleted to
+        // modified so the Diff view allows clicking.
+        expect(result?.entries).toHaveLength(2);
+        expect(result?.entries).toEqual(
+          expect.arrayContaining([
+            {
+              path: 'reborn.ts',
+              added: 22,
+              deleted: 15,
+              changeType: 'modified',
+              staged: true,
+            },
+            {
+              path: 'other.ts',
+              added: 5,
+              deleted: 0,
+              changeType: 'untracked',
+              staged: false,
+            },
+          ]),
+        );
+        expect(result?.totalAdded).toBe(27);
+        expect(result?.totalDeleted).toBe(15);
+      });
     });
 
     describe('split staged/unstaged status', () => {

--- a/apps/browser/src/backend/services/git/index.test.ts
+++ b/apps/browser/src/backend/services/git/index.test.ts
@@ -773,4 +773,286 @@ describe('GitService', () => {
       message: 'Worktree name is invalid.',
     });
   });
+
+  describe('getDiffNumstat', () => {
+    const diffBaseResponses = {
+      'rev-parse --show-toplevel --git-common-dir': `${repoPath}\n${repoGitDir}\n`,
+      'diff --cached --numstat': null,
+      'ls-files --others --exclude-standard -z': null,
+      'diff --cached --name-status': null,
+    };
+
+    it('returns null when not a git repository', async () => {
+      const { service } = await createGitService({});
+      await expect(service.getDiffNumstat('/not-a-repo')).resolves.toBeNull();
+    });
+
+    it('returns empty summary when all git commands produce empty output', async () => {
+      const { service } = await createGitService({
+        ...diffBaseResponses,
+        'diff --numstat': '',
+        'diff --name-status': '',
+      });
+      await expect(service.getDiffNumstat('/repo')).resolves.toEqual({
+        entries: [],
+        totalAdded: 0,
+        totalDeleted: 0,
+      });
+    });
+
+    describe('rename detection', () => {
+      it('parses compact rename at root: {old => new}/file.ts', async () => {
+        const { service } = await createGitService({
+          ...diffBaseResponses,
+          'diff --numstat': '3\t2\t{old-name => new-name}.ts',
+          'diff --name-status': 'R100\told-name.ts\tnew-name.ts',
+        });
+
+        const result = await service.getDiffNumstat('/repo');
+        expect(result?.entries).toEqual([
+          {
+            path: 'new-name.ts',
+            added: 3,
+            deleted: 2,
+            changeType: 'renamed',
+            oldPath: 'old-name.ts',
+            staged: false,
+          },
+        ]);
+        expect(result?.totalAdded).toBe(3);
+        expect(result?.totalDeleted).toBe(2);
+      });
+
+      it('parses compact rename with directory prefix: src/{old => new}/file.ts', async () => {
+        const { service } = await createGitService({
+          ...diffBaseResponses,
+          'diff --numstat': '5\t3\tsrc/{old-dir => new-dir}/utils.ts',
+          'diff --name-status':
+            'R100\tsrc/old-dir/utils.ts\tsrc/new-dir/utils.ts',
+        });
+
+        const result = await service.getDiffNumstat('/repo');
+        expect(result?.entries).toEqual([
+          {
+            path: 'src/new-dir/utils.ts',
+            added: 5,
+            deleted: 3,
+            changeType: 'renamed',
+            oldPath: 'src/old-dir/utils.ts',
+            staged: false,
+          },
+        ]);
+      });
+
+      it('parses compact rename with no prefix/suffix: {old => new}', async () => {
+        const { service } = await createGitService({
+          ...diffBaseResponses,
+          'diff --numstat': '0\t0\t{legacy => modern}',
+          'diff --name-status': 'R100\tlegacy\tmodern',
+        });
+
+        const result = await service.getDiffNumstat('/repo');
+        expect(result?.entries).toEqual([
+          {
+            path: 'modern',
+            added: 0,
+            deleted: 0,
+            changeType: 'renamed',
+            oldPath: 'legacy',
+            staged: false,
+          },
+        ]);
+      });
+
+      it('parses full-path rename: old/file.ts => new/file.ts', async () => {
+        const { service } = await createGitService({
+          ...diffBaseResponses,
+          'diff --numstat': '1\t1\told/path/file.ts => new/path/file.ts',
+          'diff --name-status': 'R100\told/path/file.ts\tnew/path/file.ts',
+        });
+
+        const result = await service.getDiffNumstat('/repo');
+        expect(result?.entries).toEqual([
+          {
+            path: 'new/path/file.ts',
+            added: 1,
+            deleted: 1,
+            changeType: 'renamed',
+            oldPath: 'old/path/file.ts',
+            staged: false,
+          },
+        ]);
+      });
+
+      it('parses rename with content changes (non-zero added/deleted)', async () => {
+        const { service } = await createGitService({
+          ...diffBaseResponses,
+          'diff --numstat': '10\t5\t{old => new}/README.md',
+          'diff --name-status': 'R078\told/README.md\tnew/README.md',
+        });
+
+        const result = await service.getDiffNumstat('/repo');
+        expect(result?.entries).toEqual([
+          {
+            path: 'new/README.md',
+            added: 10,
+            deleted: 5,
+            changeType: 'renamed',
+            oldPath: 'old/README.md',
+            staged: false,
+          },
+        ]);
+      });
+    });
+
+    describe('changeType from name-status', () => {
+      it('labels modified files correctly via name-status (not count-based)', async () => {
+        // Pure additions (5/0) — would be 'added' by count logic,
+        // but name-status says 'M' (modified).
+        const { service } = await createGitService({
+          ...diffBaseResponses,
+          'diff --numstat': '5\t0\tREADME.md',
+          'diff --name-status': 'M\tREADME.md',
+        });
+
+        const result = await service.getDiffNumstat('/repo');
+        expect(result?.entries).toEqual([
+          {
+            path: 'README.md',
+            added: 5,
+            deleted: 0,
+            changeType: 'modified',
+            staged: false,
+          },
+        ]);
+      });
+
+      it('labels deleted files via name-status (not count-based)', async () => {
+        // Modified file with only deletions (0/3) — would be 'deleted'
+        // by count logic, but name-status says 'M'.
+        const { service } = await createGitService({
+          ...diffBaseResponses,
+          'diff --numstat': '0\t3\tDEPRECATED.ts',
+          'diff --name-status': 'M\tDEPRECATED.ts',
+        });
+
+        const result = await service.getDiffNumstat('/repo');
+        expect(result?.entries).toEqual([
+          {
+            path: 'DEPRECATED.ts',
+            added: 0,
+            deleted: 3,
+            changeType: 'modified',
+            staged: false,
+          },
+        ]);
+      });
+
+      it('labels fully deleted files via name-status', async () => {
+        const { service } = await createGitService({
+          ...diffBaseResponses,
+          'diff --numstat': '0\t42\tremoved.ts',
+          'diff --name-status': 'D\tremoved.ts',
+        });
+
+        const result = await service.getDiffNumstat('/repo');
+        expect(result?.entries).toEqual([
+          {
+            path: 'removed.ts',
+            added: 0,
+            deleted: 42,
+            changeType: 'deleted',
+            staged: false,
+          },
+        ]);
+      });
+
+      it('labels added files via name-status', async () => {
+        const { service } = await createGitService({
+          ...diffBaseResponses,
+          'diff --numstat': '100\t0\tnew-file.ts',
+          'diff --name-status': 'A\tnew-file.ts',
+        });
+
+        const result = await service.getDiffNumstat('/repo');
+        expect(result?.entries).toEqual([
+          {
+            path: 'new-file.ts',
+            added: 100,
+            deleted: 0,
+            changeType: 'added',
+            staged: false,
+          },
+        ]);
+      });
+
+      it('falls back to count-based inference when name-status is empty', async () => {
+        const { service } = await createGitService({
+          ...diffBaseResponses,
+          'diff --numstat':
+            '8\t0\tadded.ts\n0\t6\tdeleted.ts\n4\t2\tmodified.ts',
+          'diff --name-status': '',
+        });
+
+        const result = await service.getDiffNumstat('/repo');
+        expect(result?.entries).toEqual([
+          {
+            path: 'added.ts',
+            added: 8,
+            deleted: 0,
+            changeType: 'added',
+            staged: false,
+          },
+          {
+            path: 'deleted.ts',
+            added: 0,
+            deleted: 6,
+            changeType: 'deleted',
+            staged: false,
+          },
+          {
+            path: 'modified.ts',
+            added: 4,
+            deleted: 2,
+            changeType: 'modified',
+            staged: false,
+          },
+        ]);
+      });
+
+      it('merges staged and unstaged entries for the same file', async () => {
+        const { service } = await createGitService({
+          ...diffBaseResponses,
+          'diff --numstat': '3\t0\tboth.ts',
+          'diff --name-status': 'M\tboth.ts',
+          'diff --cached --numstat': '0\t2\tboth.ts',
+          'diff --cached --name-status': 'M\tboth.ts',
+        });
+
+        const result = await service.getDiffNumstat('/repo');
+        expect(result?.entries).toEqual([
+          {
+            path: 'both.ts',
+            added: 3,
+            deleted: 2,
+            // staged=true because at least one side is staged
+            changeType: 'modified',
+            staged: true,
+          },
+        ]);
+      });
+
+      it('accumulates totals across all entries', async () => {
+        const { service } = await createGitService({
+          ...diffBaseResponses,
+          'diff --numstat': '10\t5\ta.ts\n3\t0\tb.ts\n0\t1\tc.ts',
+          'diff --name-status': 'M\ta.ts\nA\tb.ts\nD\tc.ts',
+        });
+
+        const result = await service.getDiffNumstat('/repo');
+        expect(result?.totalAdded).toBe(13);
+        expect(result?.totalDeleted).toBe(6);
+      });
+    });
+  });
 });

--- a/apps/browser/src/backend/services/git/index.test.ts
+++ b/apps/browser/src/backend/services/git/index.test.ts
@@ -1179,8 +1179,8 @@ describe('GitService', () => {
         const result = await service.getDiffNumstat('/repo');
 
         // The unstaged deletion lines (42) and staged addition lines (10)
-        // should both be present. The merge keeps the first-seen (staged)
-        // changeType for the merged entry.
+        // should both be present. When either side reports deleted, the
+        // merged entry must be deleted so the Diff view disables clicks.
         expect(result?.totalAdded).toBe(10);
         expect(result?.totalDeleted).toBe(42);
         expect(result?.entries).toHaveLength(1);
@@ -1188,6 +1188,7 @@ describe('GitService', () => {
           path: 'split.ts',
           added: 10,
           deleted: 42,
+          changeType: 'deleted',
           staged: true,
         });
       });

--- a/apps/browser/src/backend/services/git/index.test.ts
+++ b/apps/browser/src/backend/services/git/index.test.ts
@@ -777,9 +777,9 @@ describe('GitService', () => {
   describe('getDiffNumstat', () => {
     const diffBaseResponses = {
       'rev-parse --show-toplevel --git-common-dir': `${repoPath}\n${repoGitDir}\n`,
-      'diff --cached --numstat': null,
+      'diff --cached --find-renames --numstat': null,
       'ls-files --others --exclude-standard -z': null,
-      'diff --cached --name-status': null,
+      'diff --cached --find-renames --name-status': null,
     };
 
     it('returns null when not a git repository', async () => {
@@ -790,8 +790,8 @@ describe('GitService', () => {
     it('returns empty summary when all git commands produce empty output', async () => {
       const { service } = await createGitService({
         ...diffBaseResponses,
-        'diff --numstat': '',
-        'diff --name-status': '',
+        'diff --find-renames --numstat': '',
+        'diff --find-renames --name-status': '',
       });
       await expect(service.getDiffNumstat('/repo')).resolves.toEqual({
         entries: [],
@@ -804,8 +804,8 @@ describe('GitService', () => {
       it('parses compact rename at root: {old => new}/file.ts', async () => {
         const { service } = await createGitService({
           ...diffBaseResponses,
-          'diff --numstat': '3\t2\t{old-name => new-name}.ts',
-          'diff --name-status': 'R100\told-name.ts\tnew-name.ts',
+          'diff --find-renames --numstat': '3\t2\t{old-name => new-name}.ts',
+          'diff --find-renames --name-status': 'R100\told-name.ts\tnew-name.ts',
         });
 
         const result = await service.getDiffNumstat('/repo');
@@ -826,8 +826,9 @@ describe('GitService', () => {
       it('parses compact rename with directory prefix: src/{old => new}/file.ts', async () => {
         const { service } = await createGitService({
           ...diffBaseResponses,
-          'diff --numstat': '5\t3\tsrc/{old-dir => new-dir}/utils.ts',
-          'diff --name-status':
+          'diff --find-renames --numstat':
+            '5\t3\tsrc/{old-dir => new-dir}/utils.ts',
+          'diff --find-renames --name-status':
             'R100\tsrc/old-dir/utils.ts\tsrc/new-dir/utils.ts',
         });
 
@@ -847,8 +848,8 @@ describe('GitService', () => {
       it('parses compact rename with no prefix/suffix: {old => new}', async () => {
         const { service } = await createGitService({
           ...diffBaseResponses,
-          'diff --numstat': '0\t0\t{legacy => modern}',
-          'diff --name-status': 'R100\tlegacy\tmodern',
+          'diff --find-renames --numstat': '0\t0\t{legacy => modern}',
+          'diff --find-renames --name-status': 'R100\tlegacy\tmodern',
         });
 
         const result = await service.getDiffNumstat('/repo');
@@ -867,8 +868,10 @@ describe('GitService', () => {
       it('parses full-path rename: old/file.ts => new/file.ts', async () => {
         const { service } = await createGitService({
           ...diffBaseResponses,
-          'diff --numstat': '1\t1\told/path/file.ts => new/path/file.ts',
-          'diff --name-status': 'R100\told/path/file.ts\tnew/path/file.ts',
+          'diff --find-renames --numstat':
+            '1\t1\told/path/file.ts => new/path/file.ts',
+          'diff --find-renames --name-status':
+            'R100\told/path/file.ts\tnew/path/file.ts',
         });
 
         const result = await service.getDiffNumstat('/repo');
@@ -887,8 +890,9 @@ describe('GitService', () => {
       it('parses rename with content changes (non-zero added/deleted)', async () => {
         const { service } = await createGitService({
           ...diffBaseResponses,
-          'diff --numstat': '10\t5\t{old => new}/README.md',
-          'diff --name-status': 'R078\told/README.md\tnew/README.md',
+          'diff --find-renames --numstat': '10\t5\t{old => new}/README.md',
+          'diff --find-renames --name-status':
+            'R078\told/README.md\tnew/README.md',
         });
 
         const result = await service.getDiffNumstat('/repo');
@@ -911,8 +915,8 @@ describe('GitService', () => {
         // but name-status says 'M' (modified).
         const { service } = await createGitService({
           ...diffBaseResponses,
-          'diff --numstat': '5\t0\tREADME.md',
-          'diff --name-status': 'M\tREADME.md',
+          'diff --find-renames --numstat': '5\t0\tREADME.md',
+          'diff --find-renames --name-status': 'M\tREADME.md',
         });
 
         const result = await service.getDiffNumstat('/repo');
@@ -932,8 +936,8 @@ describe('GitService', () => {
         // by count logic, but name-status says 'M'.
         const { service } = await createGitService({
           ...diffBaseResponses,
-          'diff --numstat': '0\t3\tDEPRECATED.ts',
-          'diff --name-status': 'M\tDEPRECATED.ts',
+          'diff --find-renames --numstat': '0\t3\tDEPRECATED.ts',
+          'diff --find-renames --name-status': 'M\tDEPRECATED.ts',
         });
 
         const result = await service.getDiffNumstat('/repo');
@@ -951,8 +955,8 @@ describe('GitService', () => {
       it('labels fully deleted files via name-status', async () => {
         const { service } = await createGitService({
           ...diffBaseResponses,
-          'diff --numstat': '0\t42\tremoved.ts',
-          'diff --name-status': 'D\tremoved.ts',
+          'diff --find-renames --numstat': '0\t42\tremoved.ts',
+          'diff --find-renames --name-status': 'D\tremoved.ts',
         });
 
         const result = await service.getDiffNumstat('/repo');
@@ -970,8 +974,8 @@ describe('GitService', () => {
       it('labels added files via name-status', async () => {
         const { service } = await createGitService({
           ...diffBaseResponses,
-          'diff --numstat': '100\t0\tnew-file.ts',
-          'diff --name-status': 'A\tnew-file.ts',
+          'diff --find-renames --numstat': '100\t0\tnew-file.ts',
+          'diff --find-renames --name-status': 'A\tnew-file.ts',
         });
 
         const result = await service.getDiffNumstat('/repo');
@@ -989,9 +993,9 @@ describe('GitService', () => {
       it('falls back to count-based inference when name-status is empty', async () => {
         const { service } = await createGitService({
           ...diffBaseResponses,
-          'diff --numstat':
+          'diff --find-renames --numstat':
             '8\t0\tadded.ts\n0\t6\tdeleted.ts\n4\t2\tmodified.ts',
-          'diff --name-status': '',
+          'diff --find-renames --name-status': '',
         });
 
         const result = await service.getDiffNumstat('/repo');
@@ -1023,10 +1027,10 @@ describe('GitService', () => {
       it('merges staged and unstaged entries for the same file', async () => {
         const { service } = await createGitService({
           ...diffBaseResponses,
-          'diff --numstat': '3\t0\tboth.ts',
-          'diff --name-status': 'M\tboth.ts',
-          'diff --cached --numstat': '0\t2\tboth.ts',
-          'diff --cached --name-status': 'M\tboth.ts',
+          'diff --find-renames --numstat': '3\t0\tboth.ts',
+          'diff --find-renames --name-status': 'M\tboth.ts',
+          'diff --cached --find-renames --numstat': '0\t2\tboth.ts',
+          'diff --cached --find-renames --name-status': 'M\tboth.ts',
         });
 
         const result = await service.getDiffNumstat('/repo');
@@ -1045,13 +1049,147 @@ describe('GitService', () => {
       it('accumulates totals across all entries', async () => {
         const { service } = await createGitService({
           ...diffBaseResponses,
-          'diff --numstat': '10\t5\ta.ts\n3\t0\tb.ts\n0\t1\tc.ts',
-          'diff --name-status': 'M\ta.ts\nA\tb.ts\nD\tc.ts',
+          'diff --find-renames --numstat':
+            '10\t5\ta.ts\n3\t0\tb.ts\n0\t1\tc.ts',
+          'diff --find-renames --name-status': 'M\ta.ts\nA\tb.ts\nD\tc.ts',
         });
 
         const result = await service.getDiffNumstat('/repo');
         expect(result?.totalAdded).toBe(13);
         expect(result?.totalDeleted).toBe(6);
+      });
+    });
+
+    describe('untracked files', () => {
+      it('includes untracked files with line counts and totals', async () => {
+        const { service } = await createGitService({
+          ...diffBaseResponses,
+          'diff --find-renames --numstat': '',
+          'diff --find-renames --name-status': '',
+          'ls-files --others --exclude-standard -z':
+            'new-file.ts\0unlisted.md\0',
+        });
+
+        // Spy on private countFileLines to return known line counts
+        // without touching the filesystem.
+        const countSpy = vi
+          .spyOn(
+            service as unknown as {
+              countFileLines: (p: string) => Promise<number>;
+            },
+            'countFileLines',
+          )
+          .mockImplementation(async (absPath: string) => {
+            if (absPath.endsWith('new-file.ts')) return 42;
+            if (absPath.endsWith('unlisted.md')) return 7;
+            return 0;
+          });
+
+        const result = await service.getDiffNumstat('/repo');
+
+        expect(countSpy).toHaveBeenCalledTimes(2);
+        countSpy.mockRestore();
+
+        expect(result?.entries).toEqual([
+          {
+            path: 'new-file.ts',
+            added: 42,
+            deleted: 0,
+            changeType: 'untracked',
+            staged: false,
+          },
+          {
+            path: 'unlisted.md',
+            added: 7,
+            deleted: 0,
+            changeType: 'untracked',
+            staged: false,
+          },
+        ]);
+        expect(result?.totalAdded).toBe(49);
+        expect(result?.totalDeleted).toBe(0);
+      });
+
+      it('skips untracked paths already present in diff entries', async () => {
+        const { service } = await createGitService({
+          ...diffBaseResponses,
+          'diff --find-renames --numstat': '5\t0\tshared.ts',
+          'diff --find-renames --name-status': 'A\tshared.ts',
+          'ls-files --others --exclude-standard -z': 'shared.ts\0only-new.ts\0',
+        });
+
+        const countSpy = vi
+          .spyOn(
+            service as unknown as {
+              countFileLines: (p: string) => Promise<number>;
+            },
+            'countFileLines',
+          )
+          .mockImplementation(async (absPath: string) => {
+            if (absPath.endsWith('only-new.ts')) return 3;
+            return 0;
+          });
+
+        const result = await service.getDiffNumstat('/repo');
+
+        // shared.ts is already covered by the diff; only only-new.ts
+        // should trigger a countFileLines call.
+        expect(countSpy).toHaveBeenCalledTimes(1);
+        countSpy.mockRestore();
+
+        expect(result?.entries).toHaveLength(2);
+        expect(result?.entries).toEqual(
+          expect.arrayContaining([
+            {
+              path: 'shared.ts',
+              added: 5,
+              deleted: 0,
+              changeType: 'added',
+              staged: false,
+            },
+            {
+              path: 'only-new.ts',
+              added: 3,
+              deleted: 0,
+              changeType: 'untracked',
+              staged: false,
+            },
+          ]),
+        );
+        expect(result?.totalAdded).toBe(8);
+        expect(result?.totalDeleted).toBe(0);
+      });
+    });
+
+    describe('split staged/unstaged status', () => {
+      it('preserves per-side changeType when a file appears in both', async () => {
+        // staged: M (modified), unstaged: D (deleted)
+        // Without separate status maps the staged 'M' would overwrite
+        // unstaged 'D', hiding that the working-tree file was deleted.
+        const { service } = await createGitService({
+          ...diffBaseResponses,
+          // Unstaged: file deleted in working tree
+          'diff --find-renames --numstat': '0\t42\tsplit.ts',
+          'diff --find-renames --name-status': 'D\tsplit.ts',
+          // Staged: file modified and staged
+          'diff --cached --find-renames --numstat': '10\t0\tsplit.ts',
+          'diff --cached --find-renames --name-status': 'M\tsplit.ts',
+        });
+
+        const result = await service.getDiffNumstat('/repo');
+
+        // The unstaged deletion lines (42) and staged addition lines (10)
+        // should both be present. The merge keeps the first-seen (staged)
+        // changeType for the merged entry.
+        expect(result?.totalAdded).toBe(10);
+        expect(result?.totalDeleted).toBe(42);
+        expect(result?.entries).toHaveLength(1);
+        expect(result!.entries![0]).toMatchObject({
+          path: 'split.ts',
+          added: 10,
+          deleted: 42,
+          staged: true,
+        });
       });
     });
   });

--- a/apps/browser/src/backend/services/git/index.ts
+++ b/apps/browser/src/backend/services/git/index.ts
@@ -13,6 +13,8 @@ import type {
   GitCreateBranchOptions,
   GitCreateWorktreeOptions,
   GitCreateWorktreeResult,
+  GitDiffNumstatEntry,
+  GitDiffNumstatSummary,
   GitMutationResult,
   GitMergedTargetResult,
   GitRepositoryInfo,
@@ -36,6 +38,8 @@ export type {
   GitCreateBranchOptions,
   GitCreateWorktreeOptions,
   GitCreateWorktreeResult,
+  GitDiffNumstatEntry,
+  GitDiffNumstatSummary,
   GitMutationResult,
   GitMergedTargetResult,
   GitRepositoryInfo,
@@ -931,6 +935,88 @@ export class GitService extends DisposableService {
     message: string,
   ): GitActionFailure {
     return { ok: false, reason, message };
+  }
+
+  public async getDiffNumstat(
+    workspacePath: string,
+  ): Promise<GitDiffNumstatSummary | null> {
+    const repositoryInfo = await this.getRepositoryInfo(workspacePath);
+    if (!repositoryInfo) return null;
+
+    const [unstagedRaw, stagedRaw] = await Promise.all([
+      this.runGit(workspacePath, ['diff', '--numstat']),
+      this.runGit(workspacePath, ['diff', '--cached', '--numstat']),
+    ]);
+
+    if (unstagedRaw === null && stagedRaw === null) return null;
+
+    const stagedEntries = stagedRaw ? this.parseNumstat(stagedRaw, true) : [];
+    const unstagedEntries = unstagedRaw
+      ? this.parseNumstat(unstagedRaw, false)
+      : [];
+
+    // Merge staged + unstaged entries for the same file.
+    const merged = new Map<string, GitDiffNumstatEntry>();
+
+    for (const entry of [...stagedEntries, ...unstagedEntries]) {
+      const existing = merged.get(entry.path);
+      if (existing) {
+        existing.added += entry.added;
+        existing.deleted += entry.deleted;
+        existing.staged = existing.staged || entry.staged;
+      } else {
+        merged.set(entry.path, { ...entry });
+      }
+    }
+
+    const entries = [...merged.values()];
+    const totalAdded = entries.reduce((sum, e) => sum + e.added, 0);
+    const totalDeleted = entries.reduce((sum, e) => sum + e.deleted, 0);
+
+    return { entries, totalAdded, totalDeleted };
+  }
+
+  private parseNumstat(raw: string, staged: boolean): GitDiffNumstatEntry[] {
+    const entries: GitDiffNumstatEntry[] = [];
+    for (const line of raw.split('\n')) {
+      if (!line) continue;
+      const parts = line.split('\t');
+      if (parts.length === 3) {
+        const [addedStr, deletedStr, pathStr] = parts;
+        const added =
+          addedStr === '-' ? 0 : Number.parseInt(addedStr!, 10) || 0;
+        const deleted =
+          deletedStr === '-' ? 0 : Number.parseInt(deletedStr!, 10) || 0;
+
+        // Handle renamed files: numstat format for renames is
+        // {added}\t{deleted}\t{oldPath => newPath}
+        const renameMatch = pathStr!.match(/^(.+)\s*=>\s*(.+)$/);
+        if (renameMatch) {
+          entries.push({
+            path: renameMatch[2]!,
+            added,
+            deleted,
+            changeType: 'renamed' as const,
+            oldPath: renameMatch[1]!,
+            staged,
+          });
+        } else {
+          // Determine changeType from (added,deleted).
+          let changeType: GitDiffNumstatEntry['changeType'] = 'modified';
+          if (added === 0 && deleted > 0) changeType = 'deleted';
+          else if (deleted === 0 && added > 0) changeType = 'added';
+
+          entries.push({
+            path: pathStr!,
+            added,
+            deleted,
+            changeType,
+            staged,
+          });
+        }
+      }
+    }
+    return entries;
   }
 
   private async getStatusSummary(

--- a/apps/browser/src/backend/services/git/index.ts
+++ b/apps/browser/src/backend/services/git/index.ts
@@ -950,16 +950,26 @@ export class GitService extends DisposableService {
       unstagedStatusRaw,
       stagedStatusRaw,
     ] = await Promise.all([
-      this.runGit(workspacePath, ['diff', '--numstat']),
-      this.runGit(workspacePath, ['diff', '--cached', '--numstat']),
+      this.runGit(workspacePath, ['diff', '--find-renames', '--numstat']),
+      this.runGit(workspacePath, [
+        'diff',
+        '--cached',
+        '--find-renames',
+        '--numstat',
+      ]),
       this.runGit(workspacePath, [
         'ls-files',
         '--others',
         '--exclude-standard',
         '-z',
       ]),
-      this.runGit(workspacePath, ['diff', '--name-status']),
-      this.runGit(workspacePath, ['diff', '--cached', '--name-status']),
+      this.runGit(workspacePath, ['diff', '--find-renames', '--name-status']),
+      this.runGit(workspacePath, [
+        'diff',
+        '--cached',
+        '--find-renames',
+        '--name-status',
+      ]),
     ]);
 
     if (unstagedRaw === null && stagedRaw === null && !untrackedRaw)

--- a/apps/browser/src/backend/services/git/index.ts
+++ b/apps/browser/src/backend/services/git/index.ts
@@ -943,7 +943,13 @@ export class GitService extends DisposableService {
     const repositoryInfo = await this.getRepositoryInfo(workspacePath);
     if (!repositoryInfo) return null;
 
-    const [unstagedRaw, stagedRaw, untrackedRaw] = await Promise.all([
+    const [
+      unstagedRaw,
+      stagedRaw,
+      untrackedRaw,
+      unstagedStatusRaw,
+      stagedStatusRaw,
+    ] = await Promise.all([
       this.runGit(workspacePath, ['diff', '--numstat']),
       this.runGit(workspacePath, ['diff', '--cached', '--numstat']),
       this.runGit(workspacePath, [
@@ -952,14 +958,38 @@ export class GitService extends DisposableService {
         '--exclude-standard',
         '-z',
       ]),
+      this.runGit(workspacePath, ['diff', '--name-status']),
+      this.runGit(workspacePath, ['diff', '--cached', '--name-status']),
     ]);
 
     if (unstagedRaw === null && stagedRaw === null && !untrackedRaw)
       return null;
 
-    const stagedEntries = stagedRaw ? this.parseNumstat(stagedRaw, true) : [];
+    // Build a map from file path to git status code (M, A, D, R).
+    // For renames (R100\told\tnew), key by the new path.
+    const statusMap = new Map<string, string>();
+    const addStatusEntries = (raw: string | null) => {
+      if (!raw) return;
+      for (const line of raw.split('\n')) {
+        if (!line) continue;
+        const [code, ...rest] = line.split('\t');
+        if (!code) continue;
+        if (code.startsWith('R') && rest.length >= 2) {
+          // R100\told\tnew — key by new path
+          statusMap.set(rest[1]!, code[0]!);
+        } else if (rest.length >= 1) {
+          statusMap.set(rest[0]!, code[0]!);
+        }
+      }
+    };
+    addStatusEntries(unstagedStatusRaw);
+    addStatusEntries(stagedStatusRaw);
+
+    const stagedEntries = stagedRaw
+      ? this.parseNumstat(stagedRaw, true, statusMap)
+      : [];
     const unstagedEntries = unstagedRaw
-      ? this.parseNumstat(unstagedRaw, false)
+      ? this.parseNumstat(unstagedRaw, false, statusMap)
       : [];
 
     // Merge staged + unstaged entries for the same file.
@@ -979,10 +1009,14 @@ export class GitService extends DisposableService {
     // Add untracked files (not in git): every line counts as "added".
     if (untrackedRaw) {
       const untrackedPaths = untrackedRaw.split('\0').filter(Boolean);
-      for (const relPath of untrackedPaths) {
-        if (merged.has(relPath)) continue;
-        const absPath = path.join(workspacePath, relPath);
-        const added = await this.countFileLines(absPath);
+      const newPaths = untrackedPaths.filter((p) => !merged.has(p));
+      const lineCounts = await Promise.all(
+        newPaths.map(async (relPath) => ({
+          relPath,
+          added: await this.countFileLines(path.join(workspacePath, relPath)),
+        })),
+      );
+      for (const { relPath, added } of lineCounts) {
         merged.set(relPath, {
           path: relPath,
           added,
@@ -1000,7 +1034,11 @@ export class GitService extends DisposableService {
     return { entries, totalAdded, totalDeleted };
   }
 
-  private parseNumstat(raw: string, staged: boolean): GitDiffNumstatEntry[] {
+  private parseNumstat(
+    raw: string,
+    staged: boolean,
+    statusMap: Map<string, string>,
+  ): GitDiffNumstatEntry[] {
     const entries: GitDiffNumstatEntry[] = [];
     for (const line of raw.split('\n')) {
       if (!line) continue;
@@ -1014,12 +1052,20 @@ export class GitService extends DisposableService {
 
         // Handle renamed files. Git numstat emits two rename formats:
         //   Full path:   old/dir/file => new/dir/file
-        //   Compact:     {old => new}/common/file
+        //   Compact:     prefix{old => new}suffix
         // Try compact first (has '{... => ...}'), then full-path.
-        const compactMatch = pathStr!.match(/^\{([^}]+)\s*=>\s*([^}]+)\}(.*)$/);
+        const compactMatch = pathStr!.match(
+          /^(.*?)\{([^}]+)\s*=>\s*([^}]+)\}(.*)$/,
+        );
         if (compactMatch) {
-          const oldPath = compactMatch[1]! + compactMatch[3]!;
-          const newPath = compactMatch[2]! + compactMatch[3]!;
+          const prefix = compactMatch[1]!;
+          // Greedy [^}]+ capture groups may include whitespace around =>.
+          // Trim to get clean path segments.
+          const oldPart = compactMatch[2]!.trim();
+          const newPart = compactMatch[3]!.trim();
+          const suffix = compactMatch[4]!;
+          const oldPath = prefix + oldPart + suffix;
+          const newPath = prefix + newPart + suffix;
           entries.push({
             path: newPath,
             added,
@@ -1032,18 +1078,32 @@ export class GitService extends DisposableService {
           const renameMatch = pathStr!.match(/^(.+)\s*=>\s*(.+)$/);
           if (renameMatch) {
             entries.push({
-              path: renameMatch[2]!,
+              path: renameMatch[2]!.trim(),
               added,
               deleted,
               changeType: 'renamed' as const,
-              oldPath: renameMatch[1]!,
+              oldPath: renameMatch[1]!.trim(),
               staged,
             });
           } else {
-            // Determine changeType from (added,deleted).
-            let changeType: GitDiffNumstatEntry['changeType'] = 'modified';
-            if (added === 0 && deleted > 0) changeType = 'deleted';
-            else if (deleted === 0 && added > 0) changeType = 'added';
+            // Use git name-status as the authoritative source for changeType.
+            // Numstat counts alone can't distinguish "file deleted" from
+            // "file modified with only deletions" (both show 0/N counts).
+            const statusCode = statusMap.get(pathStr!);
+            const changeType: GitDiffNumstatEntry['changeType'] =
+              statusCode === 'M'
+                ? 'modified'
+                : statusCode === 'A'
+                  ? 'added'
+                  : statusCode === 'D'
+                    ? 'deleted'
+                    : statusCode === 'R'
+                      ? 'renamed'
+                      : added === 0 && deleted > 0
+                        ? 'deleted'
+                        : deleted === 0 && added > 0
+                          ? 'added'
+                          : 'modified';
 
             entries.push({
               path: pathStr!,
@@ -1062,11 +1122,14 @@ export class GitService extends DisposableService {
   private async countFileLines(absPath: string): Promise<number> {
     try {
       const buf = await fs.readFile(absPath);
-      // Count \n bytes. Empty files have 0 lines.
+      if (buf.length === 0) return 0;
+      // Count \n bytes.
       let count = 0;
       for (const byte of buf) {
         if (byte === 0x0a) count++;
       }
+      // If the file doesn't end with a newline, the last line still counts.
+      if (buf[buf.length - 1] !== 0x0a) count++;
       return count;
     } catch {
       return 0;

--- a/apps/browser/src/backend/services/git/index.ts
+++ b/apps/browser/src/backend/services/git/index.ts
@@ -1030,9 +1030,16 @@ export class GitService extends DisposableService {
     }
 
     // Add untracked files (not in git): every line counts as "added".
+    // Normally untracked paths that already exist in merged are skipped,
+    // but when a tracked file was staged for deletion and then recreated
+    // at the same path, the untracked file represents the new content.
+    // In that case update the existing deleted entry instead of dropping
+    // the recreated file.
     if (untrackedRaw) {
       const untrackedPaths = untrackedRaw.split('\0').filter(Boolean);
-      const newPaths = untrackedPaths.filter((p) => !merged.has(p));
+      const newPaths = untrackedPaths.filter(
+        (p) => !merged.has(p) || merged.get(p)?.changeType === 'deleted',
+      );
       const lineCounts = await Promise.all(
         newPaths.map(async (relPath) => ({
           relPath,
@@ -1040,13 +1047,19 @@ export class GitService extends DisposableService {
         })),
       );
       for (const { relPath, added } of lineCounts) {
-        merged.set(relPath, {
-          path: relPath,
-          added,
-          deleted: 0,
-          changeType: 'untracked',
-          staged: false,
-        });
+        const existing = merged.get(relPath);
+        if (existing?.changeType === 'deleted') {
+          existing.added += added;
+          existing.changeType = 'modified';
+        } else {
+          merged.set(relPath, {
+            path: relPath,
+            added,
+            deleted: 0,
+            changeType: 'untracked',
+            staged: false,
+          });
+        }
       }
     }
 

--- a/apps/browser/src/backend/services/git/index.ts
+++ b/apps/browser/src/backend/services/git/index.ts
@@ -943,12 +943,19 @@ export class GitService extends DisposableService {
     const repositoryInfo = await this.getRepositoryInfo(workspacePath);
     if (!repositoryInfo) return null;
 
-    const [unstagedRaw, stagedRaw] = await Promise.all([
+    const [unstagedRaw, stagedRaw, untrackedRaw] = await Promise.all([
       this.runGit(workspacePath, ['diff', '--numstat']),
       this.runGit(workspacePath, ['diff', '--cached', '--numstat']),
+      this.runGit(workspacePath, [
+        'ls-files',
+        '--others',
+        '--exclude-standard',
+        '-z',
+      ]),
     ]);
 
-    if (unstagedRaw === null && stagedRaw === null) return null;
+    if (unstagedRaw === null && stagedRaw === null && !untrackedRaw)
+      return null;
 
     const stagedEntries = stagedRaw ? this.parseNumstat(stagedRaw, true) : [];
     const unstagedEntries = unstagedRaw
@@ -966,6 +973,23 @@ export class GitService extends DisposableService {
         existing.staged = existing.staged || entry.staged;
       } else {
         merged.set(entry.path, { ...entry });
+      }
+    }
+
+    // Add untracked files (not in git): every line counts as "added".
+    if (untrackedRaw) {
+      const untrackedPaths = untrackedRaw.split('\0').filter(Boolean);
+      for (const relPath of untrackedPaths) {
+        if (merged.has(relPath)) continue;
+        const absPath = path.join(workspacePath, relPath);
+        const added = await this.countFileLines(absPath);
+        merged.set(relPath, {
+          path: relPath,
+          added,
+          deleted: 0,
+          changeType: 'untracked',
+          staged: false,
+        });
       }
     }
 
@@ -988,35 +1012,65 @@ export class GitService extends DisposableService {
         const deleted =
           deletedStr === '-' ? 0 : Number.parseInt(deletedStr!, 10) || 0;
 
-        // Handle renamed files: numstat format for renames is
-        // {added}\t{deleted}\t{oldPath => newPath}
-        const renameMatch = pathStr!.match(/^(.+)\s*=>\s*(.+)$/);
-        if (renameMatch) {
+        // Handle renamed files. Git numstat emits two rename formats:
+        //   Full path:   old/dir/file => new/dir/file
+        //   Compact:     {old => new}/common/file
+        // Try compact first (has '{... => ...}'), then full-path.
+        const compactMatch = pathStr!.match(/^\{([^}]+)\s*=>\s*([^}]+)\}(.*)$/);
+        if (compactMatch) {
+          const oldPath = compactMatch[1]! + compactMatch[3]!;
+          const newPath = compactMatch[2]! + compactMatch[3]!;
           entries.push({
-            path: renameMatch[2]!,
+            path: newPath,
             added,
             deleted,
             changeType: 'renamed' as const,
-            oldPath: renameMatch[1]!,
+            oldPath,
             staged,
           });
         } else {
-          // Determine changeType from (added,deleted).
-          let changeType: GitDiffNumstatEntry['changeType'] = 'modified';
-          if (added === 0 && deleted > 0) changeType = 'deleted';
-          else if (deleted === 0 && added > 0) changeType = 'added';
+          const renameMatch = pathStr!.match(/^(.+)\s*=>\s*(.+)$/);
+          if (renameMatch) {
+            entries.push({
+              path: renameMatch[2]!,
+              added,
+              deleted,
+              changeType: 'renamed' as const,
+              oldPath: renameMatch[1]!,
+              staged,
+            });
+          } else {
+            // Determine changeType from (added,deleted).
+            let changeType: GitDiffNumstatEntry['changeType'] = 'modified';
+            if (added === 0 && deleted > 0) changeType = 'deleted';
+            else if (deleted === 0 && added > 0) changeType = 'added';
 
-          entries.push({
-            path: pathStr!,
-            added,
-            deleted,
-            changeType,
-            staged,
-          });
+            entries.push({
+              path: pathStr!,
+              added,
+              deleted,
+              changeType,
+              staged,
+            });
+          }
         }
       }
     }
     return entries;
+  }
+
+  private async countFileLines(absPath: string): Promise<number> {
+    try {
+      const buf = await fs.readFile(absPath);
+      // Count \n bytes. Empty files have 0 lines.
+      let count = 0;
+      for (const byte of buf) {
+        if (byte === 0x0a) count++;
+      }
+      return count;
+    } catch {
+      return 0;
+    }
   }
 
   private async getStatusSummary(

--- a/apps/browser/src/backend/services/git/index.ts
+++ b/apps/browser/src/backend/services/git/index.ts
@@ -1008,6 +1008,11 @@ export class GitService extends DisposableService {
       : [];
 
     // Merge staged + unstaged entries for the same file.
+    // When a path appears on both sides, sum the line counts and
+    // keep staged = true if either side is staged.  If either side
+    // reports the file as deleted the merged entry must be deleted
+    // too — the Diff view disables clicks for deleted files, and
+    // clicking a file that no longer exists on disk is broken UX.
     const merged = new Map<string, GitDiffNumstatEntry>();
 
     for (const entry of [...stagedEntries, ...unstagedEntries]) {
@@ -1016,6 +1021,9 @@ export class GitService extends DisposableService {
         existing.added += entry.added;
         existing.deleted += entry.deleted;
         existing.staged = existing.staged || entry.staged;
+        if (entry.changeType === 'deleted') {
+          existing.changeType = 'deleted';
+        }
       } else {
         merged.set(entry.path, { ...entry });
       }

--- a/apps/browser/src/backend/services/git/index.ts
+++ b/apps/browser/src/backend/services/git/index.ts
@@ -975,31 +975,36 @@ export class GitService extends DisposableService {
     if (unstagedRaw === null && stagedRaw === null && !untrackedRaw)
       return null;
 
-    // Build a map from file path to git status code (M, A, D, R).
-    // For renames (R100\told\tnew), key by the new path.
-    const statusMap = new Map<string, string>();
-    const addStatusEntries = (raw: string | null) => {
-      if (!raw) return;
+    // Build separate status maps for staged and unstaged so that
+    // a file appearing in both (e.g. staged M + unstaged D) keeps
+    // the correct per-side change type instead of having staged
+    // status overwrite unstaged.
+    // Keys are file paths; for renames (R100\told\tnew), key by
+    // the new path.
+    const buildStatusMap = (raw: string | null): Map<string, string> => {
+      const map = new Map<string, string>();
+      if (!raw) return map;
       for (const line of raw.split('\n')) {
         if (!line) continue;
         const [code, ...rest] = line.split('\t');
         if (!code) continue;
         if (code.startsWith('R') && rest.length >= 2) {
           // R100\told\tnew — key by new path
-          statusMap.set(rest[1]!, code[0]!);
+          map.set(rest[1]!, code[0]!);
         } else if (rest.length >= 1) {
-          statusMap.set(rest[0]!, code[0]!);
+          map.set(rest[0]!, code[0]!);
         }
       }
+      return map;
     };
-    addStatusEntries(unstagedStatusRaw);
-    addStatusEntries(stagedStatusRaw);
+    const stagedStatusMap = buildStatusMap(stagedStatusRaw);
+    const unstagedStatusMap = buildStatusMap(unstagedStatusRaw);
 
     const stagedEntries = stagedRaw
-      ? this.parseNumstat(stagedRaw, true, statusMap)
+      ? this.parseNumstat(stagedRaw, true, stagedStatusMap)
       : [];
     const unstagedEntries = unstagedRaw
-      ? this.parseNumstat(unstagedRaw, false, statusMap)
+      ? this.parseNumstat(unstagedRaw, false, unstagedStatusMap)
       : [];
 
     // Merge staged + unstaged entries for the same file.

--- a/apps/browser/src/backend/services/git/types.ts
+++ b/apps/browser/src/backend/services/git/types.ts
@@ -1,6 +1,8 @@
 import type { Logger } from '@/services/logger';
 import type { TelemetryService } from '@/services/telemetry';
 import type {
+  MountedWorkspaceGitDiffEntry,
+  MountedWorkspaceGitDiffSummary,
   MountedWorkspaceGitStatusSummary,
   MountedWorkspaceGitSummary,
 } from '@shared/karton-contracts/ui';
@@ -123,20 +125,8 @@ export type GitCreateWorktreeOptions = {
   sourceBranch: string;
 };
 
-export type GitDiffNumstatEntry = {
-  path: string;
-  added: number;
-  deleted: number;
-  changeType: 'modified' | 'added' | 'deleted' | 'renamed' | 'untracked';
-  oldPath?: string;
-  staged: boolean;
-};
-
-export type GitDiffNumstatSummary = {
-  entries: GitDiffNumstatEntry[];
-  totalAdded: number;
-  totalDeleted: number;
-};
+export type GitDiffNumstatEntry = MountedWorkspaceGitDiffEntry;
+export type GitDiffNumstatSummary = MountedWorkspaceGitDiffSummary;
 
 export type GitStatusSummary = MountedWorkspaceGitStatusSummary;
 export type { MountedWorkspaceGitSummary };

--- a/apps/browser/src/backend/services/git/types.ts
+++ b/apps/browser/src/backend/services/git/types.ts
@@ -127,7 +127,7 @@ export type GitDiffNumstatEntry = {
   path: string;
   added: number;
   deleted: number;
-  changeType: 'modified' | 'added' | 'deleted' | 'renamed';
+  changeType: 'modified' | 'added' | 'deleted' | 'renamed' | 'untracked';
   oldPath?: string;
   staged: boolean;
 };

--- a/apps/browser/src/backend/services/git/types.ts
+++ b/apps/browser/src/backend/services/git/types.ts
@@ -123,5 +123,20 @@ export type GitCreateWorktreeOptions = {
   sourceBranch: string;
 };
 
+export type GitDiffNumstatEntry = {
+  path: string;
+  added: number;
+  deleted: number;
+  changeType: 'modified' | 'added' | 'deleted' | 'renamed';
+  oldPath?: string;
+  staged: boolean;
+};
+
+export type GitDiffNumstatSummary = {
+  entries: GitDiffNumstatEntry[];
+  totalAdded: number;
+  totalDeleted: number;
+};
+
 export type GitStatusSummary = MountedWorkspaceGitStatusSummary;
 export type { MountedWorkspaceGitSummary };

--- a/apps/browser/src/backend/services/toolbox/services/mount-manager/index.ts
+++ b/apps/browser/src/backend/services/toolbox/services/mount-manager/index.ts
@@ -1651,6 +1651,9 @@ export class MountManagerService extends DisposableService {
     this.lspReady.clear();
     this.uiKarton.removeServerProcedureHandler('toolbox.mountWorkspace');
     this.uiKarton.removeServerProcedureHandler('toolbox.unmountWorkspace');
+    this.uiKarton.removeServerProcedureHandler(
+      'toolbox.getWorkspaceDiffSummary',
+    );
     this.uiKarton.removeServerProcedureHandler('toolbox.listGitBranchesByPath');
     this.uiKarton.removeServerProcedureHandler(
       'toolbox.listGitWorktreesByPath',

--- a/apps/browser/src/backend/services/toolbox/services/mount-manager/index.ts
+++ b/apps/browser/src/backend/services/toolbox/services/mount-manager/index.ts
@@ -375,6 +375,13 @@ export class MountManagerService extends DisposableService {
     );
 
     this.uiKarton.registerServerProcedureHandler(
+      'toolbox.getWorkspaceDiffSummary',
+      async (_callingClientId: string, workspacePath: string) => {
+        return this.getWorkspaceDiffSummary(workspacePath);
+      },
+    );
+
+    this.uiKarton.registerServerProcedureHandler(
       'toolbox.listGitBranchesByPath',
       async (_callingClientId: string, workspacePath: string) => {
         return this.listGitBranchesByPath(workspacePath);
@@ -660,6 +667,11 @@ export class MountManagerService extends DisposableService {
 
     const resolvedRepoRoot = await safeRealpath(repositoryInfo.repoRoot);
     return resolvedRepoRoot === resolvedMainWorktreePath;
+  }
+
+  private async getWorkspaceDiffSummary(workspacePath: string) {
+    if (!(await this.isTrustedGitPath(workspacePath))) return null;
+    return this.gitService.getDiffNumstat(workspacePath);
   }
 
   private async listGitBranchesByPath(workspacePath: string) {

--- a/apps/browser/src/shared/hotkeys.ts
+++ b/apps/browser/src/shared/hotkeys.ts
@@ -135,6 +135,8 @@ export enum HotkeyActions {
 
   // File tree
   TOGGLE_FILE_TREE = 'toggle_file_tree',
+  TOGGLE_FILE_TREE_FILES = 'toggle_file_tree_files',
+  TOGGLE_FILE_TREE_DIFF = 'toggle_file_tree_diff',
 
   // SVG preview
   TOGGLE_SVG_CODE_MODE = 'toggle_svg_code_mode',
@@ -467,6 +469,14 @@ export const hotkeyDefinitions: Record<HotkeyActions, HotkeyDefinition> = {
   },
   [HotkeyActions.TOGGLE_FILE_TREE]: {
     accelerator: 'Mod+Shift+B',
+    captureDominantly: true,
+  },
+  [HotkeyActions.TOGGLE_FILE_TREE_FILES]: {
+    accelerator: 'Mod+Shift+E',
+    captureDominantly: true,
+  },
+  [HotkeyActions.TOGGLE_FILE_TREE_DIFF]: {
+    accelerator: 'Mod+Shift+G',
     captureDominantly: true,
   },
   [HotkeyActions.TOGGLE_SVG_CODE_MODE]: {

--- a/apps/browser/src/shared/hotkeys.ts
+++ b/apps/browser/src/shared/hotkeys.ts
@@ -477,7 +477,7 @@ export const hotkeyDefinitions: Record<HotkeyActions, HotkeyDefinition> = {
   },
   [HotkeyActions.TOGGLE_FILE_TREE_DIFF]: {
     accelerator: 'Mod+Shift+G',
-    captureDominantly: true,
+    captureDominantly: false,
   },
   [HotkeyActions.TOGGLE_SVG_CODE_MODE]: {
     accelerator: 'Mod+Shift+V',

--- a/apps/browser/src/shared/karton-contracts/ui/index.ts
+++ b/apps/browser/src/shared/karton-contracts/ui/index.ts
@@ -895,7 +895,7 @@ export type MountedWorkspaceGitDiffEntry = {
   path: string;
   added: number;
   deleted: number;
-  changeType: 'modified' | 'added' | 'deleted' | 'renamed';
+  changeType: 'modified' | 'added' | 'deleted' | 'renamed' | 'untracked';
   oldPath?: string;
   staged: boolean;
 };

--- a/apps/browser/src/shared/karton-contracts/ui/index.ts
+++ b/apps/browser/src/shared/karton-contracts/ui/index.ts
@@ -891,6 +891,21 @@ export type MountedWorkspaceGitStatusSummary = NonNullable<
  */
 export type MountedWorkspaceGitSummary = WorkspaceGitSummary;
 
+export type MountedWorkspaceGitDiffEntry = {
+  path: string;
+  added: number;
+  deleted: number;
+  changeType: 'modified' | 'added' | 'deleted' | 'renamed';
+  oldPath?: string;
+  staged: boolean;
+};
+
+export type MountedWorkspaceGitDiffSummary = {
+  entries: MountedWorkspaceGitDiffEntry[];
+  totalAdded: number;
+  totalDeleted: number;
+};
+
 export const EMPTY_MOUNTS: MountEntry[] = [];
 
 export type PendingUserQuestion = {
@@ -1069,6 +1084,7 @@ export type AppState = {
   fileTree: {
     visible: boolean;
     activeWorkspaceKey: string | null;
+    viewMode: 'files' | 'diff';
     expandedDirectoriesByWorkspaceKey: Record<string, string[]>;
     workspaceRevisions: Record<string, number>;
     directoryRevisions: Record<string, Record<string, number>>;
@@ -1278,6 +1294,9 @@ export type KartonContract = {
         agentInstanceId: string,
         mountPrefix: string,
       ) => Promise<void>;
+      getWorkspaceDiffSummary: (
+        workspacePath: string,
+      ) => Promise<MountedWorkspaceGitDiffSummary | null>;
       listGitBranchesByPath: (
         workspacePath: string,
       ) => Promise<WorkspaceGitBranchesResult | null>;
@@ -1822,6 +1841,7 @@ export type KartonContract = {
       ) => Promise<{ success: boolean; error?: string }>;
       setVisible: (visible: boolean) => Promise<void>;
       setActiveWorkspace: (workspaceKey: string | null) => Promise<void>;
+      setViewMode: (mode: 'files' | 'diff') => Promise<void>;
       recreateDeletedFile: (
         workspaceKey: string,
         relativePath: string,
@@ -2054,6 +2074,7 @@ export const defaultState: KartonContract['state'] = {
   fileTree: {
     visible: false,
     activeWorkspaceKey: null,
+    viewMode: 'files',
     expandedDirectoriesByWorkspaceKey: {},
     workspaceRevisions: {},
     directoryRevisions: {},

--- a/apps/browser/src/ui/screens/main/_components/agent-hotkey-bindings.tsx
+++ b/apps/browser/src/ui/screens/main/_components/agent-hotkey-bindings.tsx
@@ -52,6 +52,7 @@ export function AgentHotkeyBindings({
   );
   const fileTreeVisible = useKartonState((s) => s.fileTree.visible);
   const setFileTreeVisible = useKartonProcedure((p) => p.fileTree.setVisible);
+  const setFileTreeViewMode = useKartonProcedure((p) => p.fileTree.setViewMode);
   const { tabUiState, requestTerminalFocus, removeTabUiState } =
     useTabUIState();
 
@@ -295,6 +296,26 @@ export function AgentHotkeyBindings({
       setFileTreeVisible(!fileTreeVisible);
     },
     HotkeyActions.TOGGLE_FILE_TREE,
+    agentHotkeysEnabled,
+  );
+
+  // Mod+Shift+E: open file tree in files view
+  useHotKeyListener(
+    () => {
+      setFileTreeVisible(true);
+      void setFileTreeViewMode('files');
+    },
+    HotkeyActions.TOGGLE_FILE_TREE_FILES,
+    agentHotkeysEnabled,
+  );
+
+  // Mod+Shift+G: open file tree in diff view
+  useHotKeyListener(
+    () => {
+      setFileTreeVisible(true);
+      void setFileTreeViewMode('diff');
+    },
+    HotkeyActions.TOGGLE_FILE_TREE_DIFF,
     agentHotkeysEnabled,
   );
 

--- a/apps/browser/src/ui/screens/main/agent-chat/index.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/index.tsx
@@ -123,7 +123,7 @@ export function AgentChat({
       {topRightActions && (
         <div
           data-tutorial="new-tab-buttons"
-          className="app-no-drag absolute top-1.5 right-2 z-20 flex items-center gap-0 rounded-xl"
+          className="app-no-drag absolute top-1 right-2 z-20 flex items-center gap-0 rounded-xl"
         >
           {topRightActions}
         </div>

--- a/apps/browser/src/ui/screens/main/agent-chat/index.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/index.tsx
@@ -123,7 +123,7 @@ export function AgentChat({
       {topRightActions && (
         <div
           data-tutorial="new-tab-buttons"
-          className="app-no-drag absolute top-1 right-2 z-20 flex items-center gap-0.5 rounded-xl"
+          className="app-no-drag absolute top-1.5 right-2 z-20 flex items-center gap-0 rounded-xl"
         >
           {topRightActions}
         </div>

--- a/apps/browser/src/ui/screens/main/command-center/sources/use-file-command-items.tsx
+++ b/apps/browser/src/ui/screens/main/command-center/sources/use-file-command-items.tsx
@@ -6,6 +6,7 @@ import {
   useKartonState,
 } from '@ui/hooks/use-karton';
 import { FileIcon } from '@ui/components/file-icon';
+import { useOpenAgent } from '@ui/hooks/use-open-chat';
 import { getBaseName } from '@shared/path-utils';
 import {
   getFileTreeWorkspaceKey,
@@ -55,7 +56,7 @@ export function useFileSearchCommandItems(
   isRecent: boolean;
   workspaceOptions: FileSearchWorkspaceOption[];
 } {
-  const openAgent = useKartonState((s) => s.browser?.lastOpenAgentId ?? null);
+  const [openAgent] = useOpenAgent();
   // `useKartonProcedure` returns a fresh function reference on every render
   // (the selector arrow is new each render), so keep it in a ref and exclude
   // it from the search effect deps. Otherwise the effect re-runs on every

--- a/apps/browser/src/ui/screens/main/content/index.tsx
+++ b/apps/browser/src/ui/screens/main/content/index.tsx
@@ -711,11 +711,6 @@ export function MainSection({
       }}
       className="@container overflow-visible! relative flex h-full flex-1 flex-col items-start justify-between"
     >
-      {topRightActions && (
-        <div className="app-no-drag absolute top-1 right-2 z-20 flex items-center gap-0.5">
-          {topRightActions}
-        </div>
-      )}
       {visibleTabIds.length > 0 && <Tutorial tutorialId="content-tabs" />}
       <BrowserTabHotkeys
         onFocusUrlBar={handleFocusUrlBar}
@@ -723,7 +718,7 @@ export function MainSection({
       />
       <div className="flex h-full w-full flex-col">
         {/* Tab bar */}
-        <div className="flex shrink-0 flex-row items-stretch gap-1 border-derived-strong border-b bg-background py-1.5 pr-10 pl-1">
+        <div className="flex shrink-0 flex-row items-stretch gap-1 border-derived-strong border-b bg-background py-1.5 pr-2 pl-3">
           <SortableTabs
             value={effectiveActiveTabId ?? ''}
             onValueChange={(id) => {
@@ -765,6 +760,12 @@ export function MainSection({
               void createTerminal(undefined, openAgent)
             }
           />
+          <div className="flex-1" />
+          {topRightActions && (
+            <div className="flex shrink-0 items-center gap-0">
+              {topRightActions}
+            </div>
+          )}
         </div>
         {/* Content area with per-tab UI */}
         <div className="relative flex size-full flex-col">

--- a/apps/browser/src/ui/screens/main/content/index.tsx
+++ b/apps/browser/src/ui/screens/main/content/index.tsx
@@ -718,7 +718,7 @@ export function MainSection({
       />
       <div className="flex h-full w-full flex-col">
         {/* Tab bar */}
-        <div className="flex shrink-0 flex-row items-stretch gap-1 border-derived-strong border-b bg-background py-1.5 pr-2 pl-3">
+        <div className="flex shrink-0 flex-row items-center gap-1 border-derived-strong border-b bg-background py-1 pr-2 pl-1.5">
           <SortableTabs
             value={effectiveActiveTabId ?? ''}
             onValueChange={(id) => {

--- a/apps/browser/src/ui/screens/main/file-tree/file-tree-diff-view.tsx
+++ b/apps/browser/src/ui/screens/main/file-tree/file-tree-diff-view.tsx
@@ -41,7 +41,9 @@ function DiffRowItem({
   const colorClass = CHANGE_COLORS[row.changeType];
   const fileName = getBaseName(row.path);
   const dirPath =
-    row.path === fileName ? '' : row.path.slice(0, -fileName.length);
+    row.path === fileName
+      ? ''
+      : row.path.slice(0, -fileName.length).replace(/\/$/, '');
 
   return (
     <div
@@ -75,7 +77,9 @@ function DiffRowItem({
         )}
         <span className="min-w-0 flex-1 truncate text-foreground">
           <span>{fileName}</span>
-          {dirPath && <span className="text-muted-foreground">{dirPath}</span>}
+          {dirPath && (
+            <span className="ml-1.5 text-subtle-foreground">{dirPath}</span>
+          )}
           {row.oldPath && (
             <span className="ml-1 text-[10px] text-muted-foreground">
               ← {getBaseName(row.oldPath)}

--- a/apps/browser/src/ui/screens/main/file-tree/file-tree-diff-view.tsx
+++ b/apps/browser/src/ui/screens/main/file-tree/file-tree-diff-view.tsx
@@ -1,4 +1,4 @@
-import { useKartonProcedure } from '@ui/hooks/use-karton';
+import { useKartonProcedure, useKartonState } from '@ui/hooks/use-karton';
 import { useEffect, useState } from 'react';
 import { Virtuoso } from 'react-virtuoso';
 import { cn } from '@ui/utils';
@@ -29,55 +29,64 @@ const CHANGE_COLORS: Record<DiffRow['changeType'], string> = {
 
 function DiffRowItem({
   row,
+  selected,
   onClick,
 }: {
   row: DiffRow;
+  selected: boolean;
   onClick: (row: DiffRow) => void;
 }) {
   const label = CHANGE_LABELS[row.changeType];
   const colorClass = CHANGE_COLORS[row.changeType];
 
   return (
-    <button
-      type="button"
-      className={cn(
-        'flex w-full cursor-pointer items-center gap-1.5 px-2 py-1',
-        'border-derived-weak/40 border-b text-left text-xs transition-colors duration-75 last:border-b-0 hover:bg-surface-1',
-      )}
-      onClick={() => onClick(row)}
-      title={row.oldPath ? `${row.oldPath} → ${row.path}` : row.path}
+    <div
+      className={
+        selected ? 'mx-1 mb-px rounded bg-active-derived' : 'mx-1 mb-px'
+      }
     >
-      <span
+      <button
+        type="button"
         className={cn(
-          'inline-flex w-4 shrink-0 items-center justify-center',
-          'font-mono font-semibold text-[11px] leading-none',
-          colorClass,
+          'flex w-full cursor-pointer items-center gap-1.5 px-2 py-1',
+          'border-derived-weak/40 border-b text-left text-xs transition-colors duration-75 last:border-b-0',
+          selected ? 'hover:bg-foreground/[0.06]' : 'hover:bg-surface-1',
         )}
+        onClick={() => onClick(row)}
+        title={row.oldPath ? `${row.oldPath} → ${row.path}` : row.path}
       >
-        {label}
-      </span>
-      {row.staged && (
-        <span className="shrink-0 rounded bg-surface-2 px-1 font-medium text-[9px] text-muted-foreground leading-none">
-          S
+        <span
+          className={cn(
+            'inline-flex w-4 shrink-0 items-center justify-center',
+            'font-mono font-semibold text-[11px] leading-none',
+            colorClass,
+          )}
+        >
+          {label}
         </span>
-      )}
-      <span className="min-w-0 flex-1 truncate text-foreground/90">
-        <span>{row.path}</span>
-        {row.oldPath && (
-          <span className="ml-1 text-[10px] text-muted-foreground">
-            ← {row.oldPath}
+        {row.staged && (
+          <span className="shrink-0 rounded bg-surface-2 px-1 font-medium text-[9px] text-muted-foreground leading-none">
+            S
           </span>
         )}
-      </span>
-      <span className="flex shrink-0 items-center gap-1.5 font-mono text-[11px] tabular-nums">
-        {row.added > 0 && (
-          <span className="text-success-foreground">+{row.added}</span>
-        )}
-        {row.deleted > 0 && (
-          <span className="text-error-foreground">-{row.deleted}</span>
-        )}
-      </span>
-    </button>
+        <span className="min-w-0 flex-1 truncate text-foreground/90">
+          <span>{row.path}</span>
+          {row.oldPath && (
+            <span className="ml-1 text-[10px] text-muted-foreground">
+              ← {row.oldPath}
+            </span>
+          )}
+        </span>
+        <span className="flex shrink-0 items-center gap-1.5 font-mono text-xs tabular-nums">
+          {row.added > 0 && (
+            <span className="text-success-foreground">+{row.added}</span>
+          )}
+          {row.deleted > 0 && (
+            <span className="text-error-foreground">-{row.deleted}</span>
+          )}
+        </span>
+      </button>
+    </div>
   );
 }
 
@@ -94,6 +103,13 @@ export function FileTreeDiffView({
     (p) => p.toolbox.getWorkspaceDiffSummary,
   );
   const openFileTab = useKartonProcedure((p) => p.fileTree.openFileTab);
+
+  const shownRelativePath = useKartonState((s) => {
+    const activeTabId = s.contentTabs.activeTabId;
+    if (!activeTabId || !workspaceKey) return null;
+    const file = s.contentTabs.tabs[activeTabId]?.file;
+    return file?.workspaceKey === workspaceKey ? file.relativePath : null;
+  });
 
   const [data, setData] = useState<MountedWorkspaceGitDiffSummary | null>(null);
   const [loading, setLoading] = useState(false);
@@ -163,9 +179,16 @@ export function FileTreeDiffView({
     <div className="h-full min-h-0">
       <Virtuoso
         totalCount={rows.length}
-        itemContent={(index) => (
-          <DiffRowItem row={rows[index]!} onClick={handleRowClick} />
-        )}
+        itemContent={(index) => {
+          const row = rows[index]!;
+          return (
+            <DiffRowItem
+              row={row}
+              selected={row.path === shownRelativePath}
+              onClick={handleRowClick}
+            />
+          );
+        }}
         computeItemKey={(index) => {
           const row = rows[index];
           return row ? `${row.staged ? 's:' : ''}${row.path}` : index;

--- a/apps/browser/src/ui/screens/main/file-tree/file-tree-diff-view.tsx
+++ b/apps/browser/src/ui/screens/main/file-tree/file-tree-diff-view.tsx
@@ -1,0 +1,177 @@
+import { useKartonProcedure } from '@ui/hooks/use-karton';
+import { useEffect, useState } from 'react';
+import { Virtuoso } from 'react-virtuoso';
+import { cn } from '@ui/utils';
+import type { MountedWorkspaceGitDiffSummary } from '@shared/karton-contracts/ui';
+
+type DiffRow = {
+  path: string;
+  added: number;
+  deleted: number;
+  changeType: 'modified' | 'added' | 'deleted' | 'renamed';
+  oldPath?: string;
+  staged: boolean;
+};
+
+const CHANGE_LABELS: Record<DiffRow['changeType'], string> = {
+  modified: 'M',
+  added: 'A',
+  deleted: 'D',
+  renamed: 'R',
+};
+
+const CHANGE_COLORS: Record<DiffRow['changeType'], string> = {
+  modified: 'text-primary-foreground',
+  added: 'text-success-foreground',
+  deleted: 'text-error-foreground',
+  renamed: 'text-warning-foreground',
+};
+
+function DiffRowItem({
+  row,
+  onClick,
+}: {
+  row: DiffRow;
+  onClick: (row: DiffRow) => void;
+}) {
+  const label = CHANGE_LABELS[row.changeType];
+  const colorClass = CHANGE_COLORS[row.changeType];
+
+  return (
+    <button
+      type="button"
+      className={cn(
+        'flex w-full cursor-pointer items-center gap-1.5 px-2 py-1',
+        'border-derived-weak/40 border-b text-left text-xs transition-colors duration-75 last:border-b-0 hover:bg-surface-1',
+      )}
+      onClick={() => onClick(row)}
+      title={row.oldPath ? `${row.oldPath} → ${row.path}` : row.path}
+    >
+      <span
+        className={cn(
+          'inline-flex w-4 shrink-0 items-center justify-center',
+          'font-mono font-semibold text-[11px] leading-none',
+          colorClass,
+        )}
+      >
+        {label}
+      </span>
+      {row.staged && (
+        <span className="shrink-0 rounded bg-surface-2 px-1 font-medium text-[9px] text-muted-foreground leading-none">
+          S
+        </span>
+      )}
+      <span className="min-w-0 flex-1 truncate text-foreground/90">
+        <span>{row.path}</span>
+        {row.oldPath && (
+          <span className="ml-1 text-[10px] text-muted-foreground">
+            ← {row.oldPath}
+          </span>
+        )}
+      </span>
+      <span className="flex shrink-0 items-center gap-1.5 font-mono text-[11px] tabular-nums">
+        {row.added > 0 && (
+          <span className="text-success-foreground">+{row.added}</span>
+        )}
+        {row.deleted > 0 && (
+          <span className="text-error-foreground">-{row.deleted}</span>
+        )}
+      </span>
+    </button>
+  );
+}
+
+export function FileTreeDiffView({
+  workspacePath,
+  workspaceKey,
+  openAgent,
+}: {
+  workspacePath: string | null;
+  workspaceKey: string | null;
+  openAgent: string | null;
+}) {
+  const getWorkspaceDiffSummary = useKartonProcedure(
+    (p) => p.toolbox.getWorkspaceDiffSummary,
+  );
+  const openFileTab = useKartonProcedure((p) => p.fileTree.openFileTab);
+
+  const [data, setData] = useState<MountedWorkspaceGitDiffSummary | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    if (!workspacePath) {
+      setData(null);
+      return;
+    }
+    setLoading(true);
+    getWorkspaceDiffSummary(workspacePath)
+      .then((result) => {
+        if (!cancelled) setData(result);
+      })
+      .catch(() => {
+        if (!cancelled) setData(null);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [workspacePath]);
+
+  const rows: DiffRow[] = data?.entries ?? [];
+
+  function handleRowClick(row: DiffRow) {
+    if (!workspaceKey || row.changeType === 'deleted') return;
+    void openFileTab(workspaceKey, row.path, openAgent);
+  }
+
+  if (!workspacePath) {
+    return (
+      <div className="flex h-full items-center justify-center p-4 text-muted-foreground text-xs">
+        No workspace selected
+      </div>
+    );
+  }
+
+  if (loading) {
+    return (
+      <div className="flex h-full items-center justify-center p-4 text-muted-foreground text-xs">
+        Loading diff…
+      </div>
+    );
+  }
+
+  if (data === null) {
+    return (
+      <div className="flex h-full items-center justify-center p-4 text-muted-foreground text-xs">
+        Not a git repository
+      </div>
+    );
+  }
+
+  if (rows.length === 0) {
+    return (
+      <div className="flex h-full items-center justify-center p-4 text-muted-foreground text-xs">
+        Working tree clean
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-full min-h-0">
+      <Virtuoso
+        totalCount={rows.length}
+        itemContent={(index) => (
+          <DiffRowItem row={rows[index]!} onClick={handleRowClick} />
+        )}
+        computeItemKey={(index) => {
+          const row = rows[index];
+          return row ? `${row.staged ? 's:' : ''}${row.path}` : index;
+        }}
+        increaseViewportBy={200}
+      />
+    </div>
+  );
+}

--- a/apps/browser/src/ui/screens/main/file-tree/file-tree-diff-view.tsx
+++ b/apps/browser/src/ui/screens/main/file-tree/file-tree-diff-view.tsx
@@ -2,6 +2,7 @@ import { useKartonProcedure, useKartonState } from '@ui/hooks/use-karton';
 import { useEffect, useState } from 'react';
 import { Virtuoso } from 'react-virtuoso';
 import { cn } from '@ui/utils';
+import { getBaseName } from '@shared/path-utils';
 import type { MountedWorkspaceGitDiffSummary } from '@shared/karton-contracts/ui';
 
 type DiffRow = {
@@ -38,6 +39,9 @@ function DiffRowItem({
 }) {
   const label = CHANGE_LABELS[row.changeType];
   const colorClass = CHANGE_COLORS[row.changeType];
+  const fileName = getBaseName(row.path);
+  const dirPath =
+    row.path === fileName ? '' : row.path.slice(0, -fileName.length);
 
   return (
     <div
@@ -69,11 +73,12 @@ function DiffRowItem({
             S
           </span>
         )}
-        <span className="min-w-0 flex-1 truncate text-foreground/90">
-          <span>{row.path}</span>
+        <span className="min-w-0 flex-1 truncate text-foreground">
+          <span>{fileName}</span>
+          {dirPath && <span className="text-muted-foreground">{dirPath}</span>}
           {row.oldPath && (
             <span className="ml-1 text-[10px] text-muted-foreground">
-              ← {row.oldPath}
+              ← {getBaseName(row.oldPath)}
             </span>
           )}
         </span>

--- a/apps/browser/src/ui/screens/main/file-tree/file-tree-diff-view.tsx
+++ b/apps/browser/src/ui/screens/main/file-tree/file-tree-diff-view.tsx
@@ -7,7 +7,7 @@ type DiffRow = {
   path: string;
   added: number;
   deleted: number;
-  changeType: 'modified' | 'added' | 'deleted' | 'renamed';
+  changeType: 'modified' | 'added' | 'deleted' | 'renamed' | 'untracked';
   oldPath?: string;
   staged: boolean;
 };
@@ -17,6 +17,7 @@ const CHANGE_LABELS: Record<DiffRow['changeType'], string> = {
   added: 'A',
   deleted: 'D',
   renamed: 'R',
+  untracked: 'U',
 };
 
 const CHANGE_COLORS: Record<DiffRow['changeType'], string> = {
@@ -24,6 +25,7 @@ const CHANGE_COLORS: Record<DiffRow['changeType'], string> = {
   added: 'text-success-foreground',
   deleted: 'text-error-foreground',
   renamed: 'text-warning-foreground',
+  untracked: 'text-success-foreground',
 };
 
 function DiffRowItem({

--- a/apps/browser/src/ui/screens/main/file-tree/file-tree-diff-view.tsx
+++ b/apps/browser/src/ui/screens/main/file-tree/file-tree-diff-view.tsx
@@ -1,5 +1,3 @@
-import { useKartonProcedure, useKartonState } from '@ui/hooks/use-karton';
-import { useEffect, useState } from 'react';
 import { Virtuoso } from 'react-virtuoso';
 import { cn } from '@ui/utils';
 import { getBaseName } from '@shared/path-utils';
@@ -100,64 +98,23 @@ function DiffRowItem({
 }
 
 export function FileTreeDiffView({
-  workspacePath,
   workspaceKey,
-  openAgent,
+  data,
+  loading,
+  shownRelativePath,
+  onOpenFile,
 }: {
-  workspacePath: string | null;
   workspaceKey: string | null;
-  openAgent: string | null;
+  data: MountedWorkspaceGitDiffSummary | null;
+  loading: boolean;
+  shownRelativePath: string | null;
+  onOpenFile: (path: string) => void;
 }) {
-  const getWorkspaceDiffSummary = useKartonProcedure(
-    (p) => p.toolbox.getWorkspaceDiffSummary,
-  );
-  const openFileTab = useKartonProcedure((p) => p.fileTree.openFileTab);
-
-  const shownRelativePath = useKartonState((s) => {
-    const activeTabId = s.contentTabs.activeTabId;
-    if (!activeTabId || !workspaceKey) return null;
-    const file = s.contentTabs.tabs[activeTabId]?.file;
-    return file?.workspaceKey === workspaceKey ? file.relativePath : null;
-  });
-
-  const [data, setData] = useState<MountedWorkspaceGitDiffSummary | null>(null);
-  const [loading, setLoading] = useState(false);
-
-  useEffect(() => {
-    let cancelled = false;
-    if (!workspacePath) {
-      setData(null);
-      return;
-    }
-    setLoading(true);
-    getWorkspaceDiffSummary(workspacePath)
-      .then((result) => {
-        if (!cancelled) setData(result);
-      })
-      .catch(() => {
-        if (!cancelled) setData(null);
-      })
-      .finally(() => {
-        if (!cancelled) setLoading(false);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [workspacePath]);
-
   const rows: DiffRow[] = data?.entries ?? [];
 
   function handleRowClick(row: DiffRow) {
     if (!workspaceKey || row.changeType === 'deleted') return;
-    void openFileTab(workspaceKey, row.path, openAgent);
-  }
-
-  if (!workspacePath) {
-    return (
-      <div className="flex h-full items-center justify-center p-4 text-muted-foreground text-xs">
-        No workspace selected
-      </div>
-    );
+    onOpenFile(row.path);
   }
 
   if (loading) {

--- a/apps/browser/src/ui/screens/main/file-tree/file-tree-sidebar.tsx
+++ b/apps/browser/src/ui/screens/main/file-tree/file-tree-sidebar.tsx
@@ -14,6 +14,7 @@ import { useOpenAgent } from '@ui/hooks/use-open-chat';
 import { XIcon, GitBranchIcon } from 'lucide-react';
 import {
   IconFileSearchOutline18,
+  IconFolder5Outline18,
   IconFolderSearchOutline18,
 } from 'nucleo-ui-outline-18';
 import { useCallback, useEffect, useMemo, useState } from 'react';
@@ -234,36 +235,38 @@ export function FileTreeSidebar() {
           className="flex min-h-9 shrink-0 items-center justify-between gap-0.5 border-derived-strong border-b bg-background pr-1.5 pl-2"
         >
           {/* Files / Diff tab toggle */}
-          <div className="flex items-center rounded-md bg-surface-1 p-0.5">
+          <div className="flex h-7 items-center rounded-md bg-surface-1 p-0.5">
             <button
               type="button"
               className={cn(
-                'rounded px-2 py-0.5 font-medium text-[11px] transition-colors duration-100',
+                'flex h-full items-center gap-1 rounded px-2.5 text-xs transition-colors hover:text-foreground',
                 viewMode === 'files'
-                  ? 'bg-background text-foreground shadow-sm'
-                  : 'text-muted-foreground hover:text-foreground',
+                  ? 'bg-background text-foreground ring-1 ring-border-subtle'
+                  : 'text-muted-foreground',
               )}
               onClick={() => setViewMode('files')}
             >
-              Files
+              <IconFolder5Outline18 className="size-3.5" />
+              {viewMode === 'files' && <span>Files</span>}
             </button>
             {isGitRepo && (
               <button
                 type="button"
                 className={cn(
-                  'flex flex-col rounded px-2 py-0.5 leading-tight transition-colors duration-100',
+                  'flex h-full items-center gap-1 rounded pl-2.5 text-xs transition-colors hover:text-foreground',
+                  diffTotals.added > 0 || diffTotals.deleted > 0
+                    ? 'pr-2'
+                    : 'pr-2.5',
                   viewMode === 'diff'
-                    ? 'bg-background text-foreground shadow-sm'
-                    : 'text-muted-foreground hover:text-foreground',
+                    ? 'bg-background text-foreground ring-1 ring-border-subtle'
+                    : 'text-muted-foreground',
                 )}
                 onClick={() => setViewMode('diff')}
               >
-                <span className="flex items-center gap-1 font-medium text-[11px]">
-                  <GitBranchIcon className="size-3" />
-                  Diff
-                </span>
+                <GitBranchIcon className="size-3.5" />
+                {viewMode === 'diff' && <span>Diff</span>}
                 {(diffTotals.added > 0 || diffTotals.deleted > 0) && (
-                  <span className="flex items-center gap-1 font-mono text-[9px] tabular-nums">
+                  <span className="flex flex-col font-mono text-[0.5rem] tabular-nums leading-none">
                     <span className="text-success-foreground">
                       +{diffTotals.added}
                     </span>

--- a/apps/browser/src/ui/screens/main/file-tree/file-tree-sidebar.tsx
+++ b/apps/browser/src/ui/screens/main/file-tree/file-tree-sidebar.tsx
@@ -272,7 +272,13 @@ export function FileTreeSidebar() {
                 </button>
               </TooltipTrigger>
               <TooltipContent>
-                <span>Files</span>
+                <span className="flex items-center gap-1.5">
+                  <span>Files</span>
+                  <HotkeyCombo
+                    action={HotkeyActions.TOGGLE_FILE_TREE_FILES}
+                    size="xs"
+                  />
+                </span>
               </TooltipContent>
             </Tooltip>
             {isGitRepo && (
@@ -306,7 +312,13 @@ export function FileTreeSidebar() {
                   </button>
                 </TooltipTrigger>
                 <TooltipContent>
-                  <span>Changed files</span>
+                  <span className="flex items-center gap-1.5">
+                    <span>Changed files</span>
+                    <HotkeyCombo
+                      action={HotkeyActions.TOGGLE_FILE_TREE_DIFF}
+                      size="xs"
+                    />
+                  </span>
                 </TooltipContent>
               </Tooltip>
             )}

--- a/apps/browser/src/ui/screens/main/file-tree/file-tree-sidebar.tsx
+++ b/apps/browser/src/ui/screens/main/file-tree/file-tree-sidebar.tsx
@@ -255,46 +255,60 @@ export function FileTreeSidebar() {
         >
           {/* Files / Diff tab toggle */}
           <div className="flex h-7 items-center rounded-md bg-surface-1 p-0.5">
-            <button
-              type="button"
-              className={cn(
-                'flex h-full items-center gap-1 rounded px-2.5 text-xs transition-colors hover:text-foreground',
-                viewMode === 'files'
-                  ? 'bg-background text-foreground ring-1 ring-border-subtle'
-                  : 'text-muted-foreground',
-              )}
-              onClick={() => setViewMode('files')}
-            >
-              <IconFolder5Outline18 className="size-3.5" />
-              {viewMode === 'files' && <span>Files</span>}
-            </button>
+            <Tooltip>
+              <TooltipTrigger>
+                <button
+                  type="button"
+                  className={cn(
+                    'flex h-full items-center gap-1 rounded px-2.5 text-xs transition-colors hover:text-foreground',
+                    viewMode === 'files'
+                      ? 'bg-background text-foreground ring-1 ring-border-subtle'
+                      : 'text-muted-foreground',
+                  )}
+                  onClick={() => setViewMode('files')}
+                >
+                  <IconFolder5Outline18 className="size-3.5" />
+                  {viewMode === 'files' && <span>Files</span>}
+                </button>
+              </TooltipTrigger>
+              <TooltipContent>
+                <span>Files</span>
+              </TooltipContent>
+            </Tooltip>
             {isGitRepo && (
-              <button
-                type="button"
-                className={cn(
-                  'flex h-full items-center gap-1 rounded pl-2.5 text-xs transition-colors hover:text-foreground',
-                  diffTotals.added > 0 || diffTotals.deleted > 0
-                    ? 'pr-2'
-                    : 'pr-2.5',
-                  viewMode === 'diff'
-                    ? 'bg-background text-foreground ring-1 ring-border-subtle'
-                    : 'text-muted-foreground',
-                )}
-                onClick={() => setViewMode('diff')}
-              >
-                <GitBranchIcon className="size-3.5" />
-                {viewMode === 'diff' && <span>Diff</span>}
-                {(diffTotals.added > 0 || diffTotals.deleted > 0) && (
-                  <span className="flex flex-col font-mono text-[0.5rem] tabular-nums leading-none">
-                    <span className="text-success-foreground">
-                      +{diffTotals.added}
-                    </span>
-                    <span className="text-error-foreground">
-                      -{diffTotals.deleted}
-                    </span>
-                  </span>
-                )}
-              </button>
+              <Tooltip>
+                <TooltipTrigger>
+                  <button
+                    type="button"
+                    className={cn(
+                      'flex h-full items-center gap-1 rounded pl-2.5 text-xs transition-colors hover:text-foreground',
+                      diffTotals.added > 0 || diffTotals.deleted > 0
+                        ? 'pr-2'
+                        : 'pr-2.5',
+                      viewMode === 'diff'
+                        ? 'bg-background text-foreground ring-1 ring-border-subtle'
+                        : 'text-muted-foreground',
+                    )}
+                    onClick={() => setViewMode('diff')}
+                  >
+                    <GitBranchIcon className="size-3.5" />
+                    {viewMode === 'diff' && <span>Diff</span>}
+                    {(diffTotals.added > 0 || diffTotals.deleted > 0) && (
+                      <span className="flex flex-col font-mono text-[0.5rem] tabular-nums leading-none">
+                        <span className="text-success-foreground">
+                          +{diffTotals.added}
+                        </span>
+                        <span className="text-error-foreground">
+                          -{diffTotals.deleted}
+                        </span>
+                      </span>
+                    )}
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent>
+                  <span>Changed files</span>
+                </TooltipContent>
+              </Tooltip>
             )}
           </div>
           <div className="flex items-center gap-0.5">

--- a/apps/browser/src/ui/screens/main/file-tree/file-tree-sidebar.tsx
+++ b/apps/browser/src/ui/screens/main/file-tree/file-tree-sidebar.tsx
@@ -12,6 +12,7 @@ import {
 } from '@ui/hooks/use-karton';
 import { useOpenAgent } from '@ui/hooks/use-open-chat';
 import { XIcon, GitBranchIcon } from 'lucide-react';
+import type { MountedWorkspaceGitDiffSummary } from '@shared/karton-contracts/ui';
 import {
   IconFileSearchOutline18,
   IconFolder5Outline18,
@@ -72,10 +73,16 @@ export function FileTreeSidebar() {
     null,
   );
   const [isGitRepo, setIsGitRepo] = useState(false);
-  const [diffTotals, setDiffTotals] = useState<{
-    added: number;
-    deleted: number;
-  }>({ added: 0, deleted: 0 });
+  const [diffData, setDiffData] =
+    useState<MountedWorkspaceGitDiffSummary | null>(null);
+  const [diffLoading, setDiffLoading] = useState(false);
+  const diffTotals = useMemo(
+    () => ({
+      added: diffData?.totalAdded ?? 0,
+      deleted: diffData?.totalDeleted ?? 0,
+    }),
+    [diffData],
+  );
 
   const workspaces = useMemo(
     () =>
@@ -101,39 +108,32 @@ export function FileTreeSidebar() {
     }
   }, [activeWorkspaceKey, selectedWorkspaceKey, setActiveWorkspace]);
 
-  // Check if the selected workspace is a git repo
+  // Fetch diff summary when workspace changes
   useEffect(() => {
     let cancelled = false;
     if (!selectedWorkspacePath) {
       setIsGitRepo(false);
+      setDiffData(null);
       return;
     }
-    if (!selectedWorkspacePath) {
-      setIsGitRepo(false);
-      setDiffTotals({ added: 0, deleted: 0 });
-      return;
-    }
+    setDiffLoading(true);
     getWorkspaceDiffSummary(selectedWorkspacePath)
       .then((result) => {
         if (cancelled) return;
         setIsGitRepo(result !== null);
-        if (result) {
-          setDiffTotals({
-            added: result.totalAdded,
-            deleted: result.totalDeleted,
-          });
-        } else {
-          setDiffTotals({ added: 0, deleted: 0 });
-          if (viewMode === 'diff') {
-            void setViewMode('files');
-          }
+        setDiffData(result);
+        if (!result) {
+          void setViewMode('files');
         }
       })
       .catch(() => {
         if (!cancelled) {
           setIsGitRepo(false);
-          setDiffTotals({ added: 0, deleted: 0 });
+          setDiffData(null);
         }
+      })
+      .finally(() => {
+        if (!cancelled) setDiffLoading(false);
       });
     return () => {
       cancelled = true;
@@ -166,6 +166,25 @@ export function FileTreeSidebar() {
       });
     },
     [openCommandCenter, selectedWorkspaceKey],
+  );
+
+  const openFileTab = useKartonProcedure((p) => p.fileTree.openFileTab);
+
+  const shownRelativePath = useKartonState((s) => {
+    const activeTabId = s.contentTabs.activeTabId;
+    if (!activeTabId || !selectedWorkspaceKey) return null;
+    const file = s.contentTabs.tabs[activeTabId]?.file;
+    return file?.workspaceKey === selectedWorkspaceKey
+      ? file.relativePath
+      : null;
+  });
+
+  const handleDiffOpenFile = useCallback(
+    (path: string) => {
+      if (!selectedWorkspaceKey) return;
+      void openFileTab(selectedWorkspaceKey, path, openAgent);
+    },
+    [openFileTab, selectedWorkspaceKey, openAgent],
   );
 
   const previewGroupKey = `file-tree-preview:${openAgent ?? 'global'}`;
@@ -335,12 +354,11 @@ export function FileTreeSidebar() {
       <div className="min-h-0 flex-1 pt-1">
         {viewMode === 'diff' ? (
           <FileTreeDiffView
-            workspacePath={
-              workspaces.find((w) => w.key === selectedWorkspaceKey)?.path ??
-              null
-            }
             workspaceKey={selectedWorkspaceKey}
-            openAgent={openAgent}
+            data={diffData}
+            loading={diffLoading}
+            shownRelativePath={shownRelativePath}
+            onOpenFile={handleDiffOpenFile}
           />
         ) : (
           <FileTreeWorkspaceView

--- a/apps/browser/src/ui/screens/main/file-tree/file-tree-sidebar.tsx
+++ b/apps/browser/src/ui/screens/main/file-tree/file-tree-sidebar.tsx
@@ -71,6 +71,10 @@ export function FileTreeSidebar() {
     null,
   );
   const [isGitRepo, setIsGitRepo] = useState(false);
+  const [diffTotals, setDiffTotals] = useState<{
+    added: number;
+    deleted: number;
+  }>({ added: 0, deleted: 0 });
 
   const workspaces = useMemo(
     () =>
@@ -103,16 +107,32 @@ export function FileTreeSidebar() {
       setIsGitRepo(false);
       return;
     }
+    if (!selectedWorkspacePath) {
+      setIsGitRepo(false);
+      setDiffTotals({ added: 0, deleted: 0 });
+      return;
+    }
     getWorkspaceDiffSummary(selectedWorkspacePath)
       .then((result) => {
         if (cancelled) return;
         setIsGitRepo(result !== null);
-        if (result === null && viewMode === 'diff') {
-          void setViewMode('files');
+        if (result) {
+          setDiffTotals({
+            added: result.totalAdded,
+            deleted: result.totalDeleted,
+          });
+        } else {
+          setDiffTotals({ added: 0, deleted: 0 });
+          if (viewMode === 'diff') {
+            void setViewMode('files');
+          }
         }
       })
       .catch(() => {
-        if (!cancelled) setIsGitRepo(false);
+        if (!cancelled) {
+          setIsGitRepo(false);
+          setDiffTotals({ added: 0, deleted: 0 });
+        }
       });
     return () => {
       cancelled = true;
@@ -211,7 +231,7 @@ export function FileTreeSidebar() {
       {workspaces.length > 0 && (
         <div
           data-tutorial="file-tree-search-bar"
-          className="flex h-9 shrink-0 items-center justify-between gap-0.5 border-derived-strong border-b bg-background pr-1.5 pl-2"
+          className="flex min-h-9 shrink-0 items-center justify-between gap-0.5 border-derived-strong border-b bg-background pr-1.5 pl-2"
         >
           {/* Files / Diff tab toggle */}
           <div className="flex items-center rounded-md bg-surface-1 p-0.5">
@@ -231,15 +251,27 @@ export function FileTreeSidebar() {
               <button
                 type="button"
                 className={cn(
-                  'flex items-center gap-1 rounded px-2 py-0.5 font-medium text-[11px] transition-colors duration-100',
+                  'flex flex-col rounded px-2 py-0.5 leading-tight transition-colors duration-100',
                   viewMode === 'diff'
                     ? 'bg-background text-foreground shadow-sm'
                     : 'text-muted-foreground hover:text-foreground',
                 )}
                 onClick={() => setViewMode('diff')}
               >
-                <GitBranchIcon className="size-3" />
-                Diff
+                <span className="flex items-center gap-1 font-medium text-[11px]">
+                  <GitBranchIcon className="size-3" />
+                  Diff
+                </span>
+                {(diffTotals.added > 0 || diffTotals.deleted > 0) && (
+                  <span className="flex items-center gap-1 font-mono text-[9px] tabular-nums">
+                    <span className="text-success-foreground">
+                      +{diffTotals.added}
+                    </span>
+                    <span className="text-error-foreground">
+                      -{diffTotals.deleted}
+                    </span>
+                  </span>
+                )}
               </button>
             )}
           </div>

--- a/apps/browser/src/ui/screens/main/file-tree/file-tree-sidebar.tsx
+++ b/apps/browser/src/ui/screens/main/file-tree/file-tree-sidebar.tsx
@@ -124,7 +124,9 @@ export function FileTreeSidebar() {
       setDiffData(null);
       return;
     }
-    setDiffLoading(true);
+    // Keep stale data visible during re-fetch to prevent flicker.
+    // Only show loading spinner on the initial fetch.
+    if (!diffData) setDiffLoading(true);
     getWorkspaceDiffSummary(selectedWorkspacePath)
       .then((result) => {
         if (cancelled) return;

--- a/apps/browser/src/ui/screens/main/file-tree/file-tree-sidebar.tsx
+++ b/apps/browser/src/ui/screens/main/file-tree/file-tree-sidebar.tsx
@@ -102,6 +102,14 @@ export function FileTreeSidebar() {
   const selectedWorkspacePath =
     workspaces.find((ws) => ws.key === selectedWorkspaceKey)?.path ?? null;
 
+  // Subscribe to workspace revisions so the diff view re-fetches when
+  // files change (agent edits, external writes, etc.).
+  const workspaceRevision = useKartonState((s) =>
+    selectedWorkspaceKey
+      ? (s.fileTree.workspaceRevisions[selectedWorkspaceKey] ?? 0)
+      : 0,
+  );
+
   useEffect(() => {
     if (selectedWorkspaceKey !== activeWorkspaceKey) {
       void setActiveWorkspace(selectedWorkspaceKey);
@@ -138,7 +146,7 @@ export function FileTreeSidebar() {
     return () => {
       cancelled = true;
     };
-  }, [selectedWorkspacePath]);
+  }, [selectedWorkspacePath, workspaceRevision]);
 
   useEffect(() => {
     setPreviewTargetPath(null);

--- a/apps/browser/src/ui/screens/main/file-tree/file-tree-sidebar.tsx
+++ b/apps/browser/src/ui/screens/main/file-tree/file-tree-sidebar.tsx
@@ -11,7 +11,7 @@ import {
   useKartonState,
 } from '@ui/hooks/use-karton';
 import { useOpenAgent } from '@ui/hooks/use-open-chat';
-import { XIcon } from 'lucide-react';
+import { XIcon, GitBranchIcon } from 'lucide-react';
 import {
   IconFileSearchOutline18,
   IconFolderSearchOutline18,
@@ -22,6 +22,7 @@ import { HotkeyCombo } from '@ui/components/hotkey-combo';
 import { useCommandCenter } from '../command-center';
 import { FileTreePreviewCoordinator } from './file-tree-preview-coordinator';
 import { FileTreeWorkspaceView } from './file-tree-workspace-view';
+import { FileTreeDiffView } from './file-tree-diff-view';
 import {
   getFileTreeWorkspaceKey,
   getFileTreeWorkspaceMountsForAgent,
@@ -56,14 +57,20 @@ export function FileTreeSidebar() {
   const activeWorkspaceKey = useKartonState(
     (s) => s.fileTree.activeWorkspaceKey,
   );
+  const viewMode = useKartonState((s) => s.fileTree.viewMode);
   const setVisible = useKartonProcedure((p) => p.fileTree.setVisible);
   const setActiveWorkspace = useKartonProcedure(
     (p) => p.fileTree.setActiveWorkspace,
+  );
+  const setViewMode = useKartonProcedure((p) => p.fileTree.setViewMode);
+  const getWorkspaceDiffSummary = useKartonProcedure(
+    (p) => p.toolbox.getWorkspaceDiffSummary,
   );
   const { open: openCommandCenter } = useCommandCenter();
   const [previewTargetPath, setPreviewTargetPath] = useState<string | null>(
     null,
   );
+  const [isGitRepo, setIsGitRepo] = useState(false);
 
   const workspaces = useMemo(
     () =>
@@ -80,11 +87,37 @@ export function FileTreeSidebar() {
     ? activeWorkspaceKey
     : (workspaces[0]?.key ?? null);
 
+  const selectedWorkspacePath =
+    workspaces.find((ws) => ws.key === selectedWorkspaceKey)?.path ?? null;
+
   useEffect(() => {
     if (selectedWorkspaceKey !== activeWorkspaceKey) {
       void setActiveWorkspace(selectedWorkspaceKey);
     }
   }, [activeWorkspaceKey, selectedWorkspaceKey, setActiveWorkspace]);
+
+  // Check if the selected workspace is a git repo
+  useEffect(() => {
+    let cancelled = false;
+    if (!selectedWorkspacePath) {
+      setIsGitRepo(false);
+      return;
+    }
+    getWorkspaceDiffSummary(selectedWorkspacePath)
+      .then((result) => {
+        if (cancelled) return;
+        setIsGitRepo(result !== null);
+        if (result === null && viewMode === 'diff') {
+          void setViewMode('files');
+        }
+      })
+      .catch(() => {
+        if (!cancelled) setIsGitRepo(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedWorkspacePath]);
 
   useEffect(() => {
     setPreviewTargetPath(null);
@@ -178,53 +211,84 @@ export function FileTreeSidebar() {
       {workspaces.length > 0 && (
         <div
           data-tutorial="file-tree-search-bar"
-          className="flex h-9 shrink-0 items-center justify-end gap-0.5 border-derived-strong border-b bg-background pr-1.5 pl-2"
+          className="flex h-9 shrink-0 items-center justify-between gap-0.5 border-derived-strong border-b bg-background pr-1.5 pl-2"
         >
-          {/* Files/Git mode switcher hidden until Git Diff view is functional. */}
-          <Tooltip>
-            <TooltipTrigger>
-              <Button
-                className="size-7 shrink-0"
-                variant="ghost"
-                size="icon-sm"
-                aria-label="Search in content"
-                onClick={() => openFileSearch(true)}
+          {/* Files / Diff tab toggle */}
+          <div className="flex items-center rounded-md bg-surface-1 p-0.5">
+            <button
+              type="button"
+              className={cn(
+                'rounded px-2 py-0.5 font-medium text-[11px] transition-colors duration-100',
+                viewMode === 'files'
+                  ? 'bg-background text-foreground shadow-sm'
+                  : 'text-muted-foreground hover:text-foreground',
+              )}
+              onClick={() => setViewMode('files')}
+            >
+              Files
+            </button>
+            {isGitRepo && (
+              <button
+                type="button"
+                className={cn(
+                  'flex items-center gap-1 rounded px-2 py-0.5 font-medium text-[11px] transition-colors duration-100',
+                  viewMode === 'diff'
+                    ? 'bg-background text-foreground shadow-sm'
+                    : 'text-muted-foreground hover:text-foreground',
+                )}
+                onClick={() => setViewMode('diff')}
               >
-                <IconFileSearchOutline18 className="size-4" />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>
-              <span className="flex items-center gap-1.5">
-                <span>Search in content</span>
-                <HotkeyCombo
-                  action={HotkeyActions.OPEN_CONTENT_FILE_SEARCH}
-                  size="xs"
-                />
-              </span>
-            </TooltipContent>
-          </Tooltip>
-          <Tooltip>
-            <TooltipTrigger>
-              <Button
-                className="size-7 shrink-0"
-                variant="ghost"
-                size="icon-sm"
-                aria-label="Search files"
-                onClick={() => openFileSearch(false)}
-              >
-                <IconFolderSearchOutline18 className="size-4" />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>
-              <span className="flex items-center gap-1.5">
-                <span>Search for files</span>
-                <HotkeyCombo
-                  action={HotkeyActions.OPEN_FILE_SEARCH}
-                  size="xs"
-                />
-              </span>
-            </TooltipContent>
-          </Tooltip>
+                <GitBranchIcon className="size-3" />
+                Diff
+              </button>
+            )}
+          </div>
+          <div className="flex items-center gap-0.5">
+            <Tooltip>
+              <TooltipTrigger>
+                <Button
+                  className="size-7 shrink-0"
+                  variant="ghost"
+                  size="icon-sm"
+                  aria-label="Search in content"
+                  onClick={() => openFileSearch(true)}
+                >
+                  <IconFileSearchOutline18 className="size-4" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>
+                <span className="flex items-center gap-1.5">
+                  <span>Search in content</span>
+                  <HotkeyCombo
+                    action={HotkeyActions.OPEN_CONTENT_FILE_SEARCH}
+                    size="xs"
+                  />
+                </span>
+              </TooltipContent>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger>
+                <Button
+                  className="size-7 shrink-0"
+                  variant="ghost"
+                  size="icon-sm"
+                  aria-label="Search files"
+                  onClick={() => openFileSearch(false)}
+                >
+                  <IconFolderSearchOutline18 className="size-4" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>
+                <span className="flex items-center gap-1.5">
+                  <span>Search for files</span>
+                  <HotkeyCombo
+                    action={HotkeyActions.OPEN_FILE_SEARCH}
+                    size="xs"
+                  />
+                </span>
+              </TooltipContent>
+            </Tooltip>
+          </div>
         </div>
       )}
       <FileTreePreviewCoordinator
@@ -234,10 +298,21 @@ export function FileTreeSidebar() {
         onPreviewTargetClose={handlePreviewTargetClose}
       />
       <div className="min-h-0 flex-1 pt-1">
-        <FileTreeWorkspaceView
-          workspaceKey={selectedWorkspaceKey}
-          onPreviewTargetChange={handlePreviewTargetChange}
-        />
+        {viewMode === 'diff' ? (
+          <FileTreeDiffView
+            workspacePath={
+              workspaces.find((w) => w.key === selectedWorkspaceKey)?.path ??
+              null
+            }
+            workspaceKey={selectedWorkspaceKey}
+            openAgent={openAgent}
+          />
+        ) : (
+          <FileTreeWorkspaceView
+            workspaceKey={selectedWorkspaceKey}
+            onPreviewTargetChange={handlePreviewTargetChange}
+          />
+        )}
       </div>
     </aside>
   );

--- a/apps/browser/src/ui/screens/main/file-tree/file-tree-sidebar.tsx
+++ b/apps/browser/src/ui/screens/main/file-tree/file-tree-sidebar.tsx
@@ -26,27 +26,12 @@ import { FileTreePreviewCoordinator } from './file-tree-preview-coordinator';
 import { FileTreeWorkspaceView } from './file-tree-workspace-view';
 import { FileTreeDiffView } from './file-tree-diff-view';
 import {
+  areFileTreeWorkspaceMountsEqual,
   getFileTreeWorkspaceKey,
   getFileTreeWorkspaceMountsForAgent,
   getFileTreeWorkspaceName,
 } from './file-tree-utils';
 import { Tutorial } from '@ui/components/tutorial';
-
-function areFileTreeWorkspaceMountsEqual(
-  a: ReturnType<typeof getFileTreeWorkspaceMountsForAgent>,
-  b: ReturnType<typeof getFileTreeWorkspaceMountsForAgent>,
-): boolean {
-  return (
-    a.length === b.length &&
-    a.every((mount, index) => {
-      const otherMount = b[index];
-      return (
-        otherMount !== undefined &&
-        getFileTreeWorkspaceKey(mount) === getFileTreeWorkspaceKey(otherMount)
-      );
-    })
-  );
-}
 
 export function FileTreeSidebar() {
   const [openAgent] = useOpenAgent();

--- a/apps/browser/src/ui/screens/main/file-tree/file-tree-toggle-button.tsx
+++ b/apps/browser/src/ui/screens/main/file-tree/file-tree-toggle-button.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react';
 import { Button } from '@stagewise/stage-ui/components/button';
 import {
   Tooltip,
@@ -5,34 +6,118 @@ import {
   TooltipTrigger,
 } from '@stagewise/stage-ui/components/tooltip';
 import { FolderIcon, FolderTreeIcon } from 'lucide-react';
-import { useKartonProcedure, useKartonState } from '@ui/hooks/use-karton';
+import {
+  useComparingSelector,
+  useKartonProcedure,
+  useKartonState,
+} from '@ui/hooks/use-karton';
+import { useOpenAgent } from '@ui/hooks/use-open-chat';
 import { HotkeyCombo } from '@ui/components/hotkey-combo';
 import { HotkeyActions } from '@shared/hotkeys';
+import {
+  getFileTreeWorkspaceKey,
+  getFileTreeWorkspaceMountsForAgent,
+} from './file-tree-utils';
+
+function areMountsEqual(
+  a: ReturnType<typeof getFileTreeWorkspaceMountsForAgent>,
+  b: ReturnType<typeof getFileTreeWorkspaceMountsForAgent>,
+): boolean {
+  return (
+    a.length === b.length &&
+    a.every((mount, index) => {
+      const other = b[index];
+      return (
+        other !== undefined &&
+        getFileTreeWorkspaceKey(mount) === getFileTreeWorkspaceKey(other)
+      );
+    })
+  );
+}
 
 export function FileTreeToggleButton() {
   const visible = useKartonState((s) => s.fileTree.visible);
   const setVisible = useKartonProcedure((p) => p.fileTree.setVisible);
+  const [openAgent] = useOpenAgent();
+  const getWorkspaceDiffSummary = useKartonProcedure(
+    (p) => p.toolbox.getWorkspaceDiffSummary,
+  );
   const label = visible ? 'Hide file tree' : 'Show file tree';
   const Icon = visible ? FolderTreeIcon : FolderIcon;
 
+  // Resolve selected workspace path (same logic as sidebar)
+  const workspaceMounts = useKartonState(
+    useComparingSelector(
+      (s) => getFileTreeWorkspaceMountsForAgent(s, openAgent),
+      areMountsEqual,
+    ),
+  );
+  const activeWorkspaceKey = useKartonState(
+    (s) => s.fileTree.activeWorkspaceKey,
+  );
+  const selectedWorkspacePath =
+    workspaceMounts.find(
+      (m) => getFileTreeWorkspaceKey(m) === activeWorkspaceKey,
+    )?.path ??
+    workspaceMounts[0]?.path ??
+    null;
+
+  const [diffTotals, setDiffTotals] = useState({ added: 0, deleted: 0 });
+
+  useEffect(() => {
+    if (visible || !selectedWorkspacePath) {
+      setDiffTotals({ added: 0, deleted: 0 });
+      return;
+    }
+    let cancelled = false;
+    getWorkspaceDiffSummary(selectedWorkspacePath)
+      .then((result) => {
+        if (cancelled) return;
+        if (result) {
+          setDiffTotals({
+            added: result.totalAdded,
+            deleted: result.totalDeleted,
+          });
+        } else {
+          setDiffTotals({ added: 0, deleted: 0 });
+        }
+      })
+      .catch(() => {
+        if (!cancelled) setDiffTotals({ added: 0, deleted: 0 });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [visible, selectedWorkspacePath, getWorkspaceDiffSummary]);
+
+  const showDiff = !visible && (diffTotals.added > 0 || diffTotals.deleted > 0);
+
   return (
-    <Tooltip>
-      <TooltipTrigger>
-        <Button
-          variant="ghost"
-          size="icon-sm"
-          aria-label={label}
-          onClick={() => setVisible(!visible)}
-        >
-          <Icon className="size-4" />
-        </Button>
-      </TooltipTrigger>
-      <TooltipContent>
-        <span className="flex items-center gap-1.5">
-          <span>{label}</span>
-          <HotkeyCombo action={HotkeyActions.TOGGLE_FILE_TREE} size="xs" />
+    <>
+      <Tooltip>
+        <TooltipTrigger>
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            aria-label={label}
+            onClick={() => setVisible(!visible)}
+          >
+            <Icon className="size-4" />
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>
+          <span className="flex items-center gap-1.5">
+            <span>{label}</span>
+            <HotkeyCombo action={HotkeyActions.TOGGLE_FILE_TREE} size="xs" />
+          </span>
+        </TooltipContent>
+      </Tooltip>
+      {showDiff && (
+        <span className="flex min-w-0 shrink-0 flex-col font-mono text-[0.5rem] text-muted-foreground tabular-nums leading-none">
+          <span className="text-success-foreground">+{diffTotals.added}</span>
+          <span className="text-error-foreground">-{diffTotals.deleted}</span>
         </span>
-      </TooltipContent>
-    </Tooltip>
+      )}
+    </>
   );
 }

--- a/apps/browser/src/ui/screens/main/file-tree/file-tree-toggle-button.tsx
+++ b/apps/browser/src/ui/screens/main/file-tree/file-tree-toggle-button.tsx
@@ -15,6 +15,7 @@ import { useOpenAgent } from '@ui/hooks/use-open-chat';
 import { HotkeyCombo } from '@ui/components/hotkey-combo';
 import { HotkeyActions } from '@shared/hotkeys';
 import {
+  areFileTreeWorkspaceMountsEqual,
   getFileTreeWorkspaceKey,
   getFileTreeWorkspaceMountsForAgent,
 } from './file-tree-utils';
@@ -22,22 +23,6 @@ import {
 // Cache diff totals per workspace across mount/unmount cycles to
 // prevent flicker when the toggle button moves between containers.
 const diffTotalsCache = new Map<string, { added: number; deleted: number }>();
-
-function areMountsEqual(
-  a: ReturnType<typeof getFileTreeWorkspaceMountsForAgent>,
-  b: ReturnType<typeof getFileTreeWorkspaceMountsForAgent>,
-): boolean {
-  return (
-    a.length === b.length &&
-    a.every((mount, index) => {
-      const other = b[index];
-      return (
-        other !== undefined &&
-        getFileTreeWorkspaceKey(mount) === getFileTreeWorkspaceKey(other)
-      );
-    })
-  );
-}
 
 export function FileTreeToggleButton() {
   const visible = useKartonState((s) => s.fileTree.visible);
@@ -53,7 +38,7 @@ export function FileTreeToggleButton() {
   const workspaceMounts = useKartonState(
     useComparingSelector(
       (s) => getFileTreeWorkspaceMountsForAgent(s, openAgent),
-      areMountsEqual,
+      areFileTreeWorkspaceMountsEqual,
     ),
   );
   const activeWorkspaceKey = useKartonState(

--- a/apps/browser/src/ui/screens/main/file-tree/file-tree-toggle-button.tsx
+++ b/apps/browser/src/ui/screens/main/file-tree/file-tree-toggle-button.tsx
@@ -59,17 +59,28 @@ export function FileTreeToggleButton() {
   const activeWorkspaceKey = useKartonState(
     (s) => s.fileTree.activeWorkspaceKey,
   );
-  const selectedWorkspacePath =
-    workspaceMounts.find(
-      (m) => getFileTreeWorkspaceKey(m) === activeWorkspaceKey,
-    )?.path ??
-    workspaceMounts[0]?.path ??
-    null;
+
+  // Derive the effective workspace key with fallback — same logic as the
+  // sidebar. When the sidebar is collapsed, activeWorkspaceKey can be stale
+  // or null, but we still need to track revisions for the fallback workspace.
+  const selectedWorkspaceKey = workspaceMounts.some(
+    (m) => getFileTreeWorkspaceKey(m) === activeWorkspaceKey,
+  )
+    ? activeWorkspaceKey
+    : workspaceMounts[0]
+      ? getFileTreeWorkspaceKey(workspaceMounts[0])
+      : null;
+
+  const selectedWorkspacePath = selectedWorkspaceKey
+    ? (workspaceMounts.find(
+        (m) => getFileTreeWorkspaceKey(m) === selectedWorkspaceKey,
+      )?.path ?? null)
+    : null;
 
   // Re-fetch diff totals when the workspace files change.
   const workspaceRevision = useKartonState((s) =>
-    activeWorkspaceKey
-      ? (s.fileTree.workspaceRevisions[activeWorkspaceKey] ?? 0)
+    selectedWorkspaceKey
+      ? (s.fileTree.workspaceRevisions[selectedWorkspaceKey] ?? 0)
       : 0,
   );
 

--- a/apps/browser/src/ui/screens/main/file-tree/file-tree-toggle-button.tsx
+++ b/apps/browser/src/ui/screens/main/file-tree/file-tree-toggle-button.tsx
@@ -19,6 +19,10 @@ import {
   getFileTreeWorkspaceMountsForAgent,
 } from './file-tree-utils';
 
+// Cache diff totals per workspace across mount/unmount cycles to
+// prevent flicker when the toggle button moves between containers.
+const diffTotalsCache = new Map<string, { added: number; deleted: number }>();
+
 function areMountsEqual(
   a: ReturnType<typeof getFileTreeWorkspaceMountsForAgent>,
   b: ReturnType<typeof getFileTreeWorkspaceMountsForAgent>,
@@ -62,25 +66,38 @@ export function FileTreeToggleButton() {
     workspaceMounts[0]?.path ??
     null;
 
-  const [diffTotals, setDiffTotals] = useState({ added: 0, deleted: 0 });
+  // Re-fetch diff totals when the workspace files change.
+  const workspaceRevision = useKartonState((s) =>
+    activeWorkspaceKey
+      ? (s.fileTree.workspaceRevisions[activeWorkspaceKey] ?? 0)
+      : 0,
+  );
+
+  const [diffTotals, setDiffTotals] = useState(() => {
+    if (!selectedWorkspacePath) return { added: 0, deleted: 0 };
+    return (
+      diffTotalsCache.get(selectedWorkspacePath) ?? {
+        added: 0,
+        deleted: 0,
+      }
+    );
+  });
 
   useEffect(() => {
     if (visible || !selectedWorkspacePath) {
       setDiffTotals({ added: 0, deleted: 0 });
       return;
     }
+    const workspacePath = selectedWorkspacePath;
     let cancelled = false;
-    getWorkspaceDiffSummary(selectedWorkspacePath)
+    getWorkspaceDiffSummary(workspacePath)
       .then((result) => {
         if (cancelled) return;
-        if (result) {
-          setDiffTotals({
-            added: result.totalAdded,
-            deleted: result.totalDeleted,
-          });
-        } else {
-          setDiffTotals({ added: 0, deleted: 0 });
-        }
+        const totals = result
+          ? { added: result.totalAdded, deleted: result.totalDeleted }
+          : { added: 0, deleted: 0 };
+        diffTotalsCache.set(workspacePath, totals);
+        setDiffTotals(totals);
       })
       .catch(() => {
         if (!cancelled) setDiffTotals({ added: 0, deleted: 0 });
@@ -88,12 +105,17 @@ export function FileTreeToggleButton() {
     return () => {
       cancelled = true;
     };
-  }, [visible, selectedWorkspacePath, getWorkspaceDiffSummary]);
+  }, [
+    visible,
+    selectedWorkspacePath,
+    workspaceRevision,
+    getWorkspaceDiffSummary,
+  ]);
 
   const showDiff = !visible && (diffTotals.added > 0 || diffTotals.deleted > 0);
 
   return (
-    <>
+    <div className="flex items-center">
       <Tooltip>
         <TooltipTrigger>
           <Button
@@ -118,6 +140,6 @@ export function FileTreeToggleButton() {
           <span className="text-error-foreground">-{diffTotals.deleted}</span>
         </span>
       )}
-    </>
+    </div>
   );
 }

--- a/apps/browser/src/ui/screens/main/file-tree/file-tree-utils.ts
+++ b/apps/browser/src/ui/screens/main/file-tree/file-tree-utils.ts
@@ -46,6 +46,22 @@ export function getFileTreeWorkspaceMountsForAgent(
   return Array.from(mountsByKey.values());
 }
 
+export function areFileTreeWorkspaceMountsEqual(
+  a: MountEntry[],
+  b: MountEntry[],
+): boolean {
+  return (
+    a.length === b.length &&
+    a.every((mount, index) => {
+      const otherMount = b[index];
+      return (
+        otherMount !== undefined &&
+        getFileTreeWorkspaceKey(mount) === getFileTreeWorkspaceKey(otherMount)
+      );
+    })
+  );
+}
+
 export function getAllFileTreeWorkspaceMounts(
   state: FileTreeMountState,
 ): MountEntry[] {

--- a/apps/browser/src/ui/screens/main/file-tree/use-file-tree-entries.ts
+++ b/apps/browser/src/ui/screens/main/file-tree/use-file-tree-entries.ts
@@ -153,9 +153,13 @@ export function useFileTreeEntries(workspaceKey: string | null) {
     [directoryRevisions, listDirectory, workspaceRevision, workspaceKey],
   );
 
+  // Reset state only when the workspace changes, not on every revision
+  // bump. The missingDirectoryPaths computation below already detects
+  // stale cached entries and triggers re-fetches without a flash.
   useEffect(() => {
     setDirectories({});
-  }, [workspaceRevision, workspaceKey]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [workspaceKey]);
 
   const missingDirectoryPaths = useMemo(() => {
     if (!workspaceKey) return [];

--- a/apps/browser/src/ui/screens/main/index.tsx
+++ b/apps/browser/src/ui/screens/main/index.tsx
@@ -74,7 +74,7 @@ function persistPanelSize(key: string, size: number) {
 }
 
 function ActionDivider() {
-  return <div className="mx-px h-5 w-px bg-border-subtle" />;
+  return <div className="h-5 w-px bg-border-subtle" />;
 }
 
 export function DefaultLayout({ show }: { show: boolean }) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Git Diff view in the file tree sidebar with a Files/Diff toggle, hotkeys, badges, and +/− totals. Backend merges staged/unstaged changes, preserves per-side status, detects renames, counts untracked lines, and keeps the UI in sync without flicker.

- **New Features**
  - Diff tab with M/A/D/R/U badges, +/− counts, staged marker; splits filename/dir; compact rename indicator; highlights open file; click to open; virtualized via `react-virtuoso`.
  - Files/Diff toggle with Git gating and tooltips; Mod+Shift+E opens Files, Mod+Shift+G opens Diff (opens the panel if closed). Shows +N/−N totals in the Diff tab and on the collapsed toggle button.
  - Backend/RPCs: `GitService.getDiffNumstat()` (merges staged/unstaged, uses `--find-renames` + `--name-status`, counts untracked, totals); `toolbox.getWorkspaceDiffSummary`; `fileTree.viewMode` and `fileTree.setViewMode`.

- **Bug Fixes**
  - Preserve staged vs. unstaged change types using separate `name-status` maps; promote a merged entry to deleted when either side reports a delete; when a staged delete is recreated as an untracked file at the same path, merge counts and mark as modified.
  - Diff view and toggle button stay in sync with file changes via workspace revision bumps; toggle tracks a fallback workspace key when the sidebar is collapsed.
  - Prevent flicker by keeping stale data during re-fetch and avoiding directory state resets on routine revisions; toggle button caches diff totals and updates smoothly.
  - Command Center file search now uses the active agent from `useOpenAgent`, preventing missing files when opened during agent creation; Mod+Shift+G yields to the find-in-page bar when it is open.
  - Enable rename detection in both `--numstat` and `--name-status`; correctly parse brace-style and full-path renames. Tightened tab bar height and aligned top-right actions; extracted shared mounts comparator to `file-tree-utils`; aliased `GitDiffNumstat` types to `@shared/karton-contracts/ui`; added a null guard when opening files from Diff.

<sup>Written for commit 526bb8d410619a4fe8fea4cc5ab99dae263b460e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1329?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * File tree now supports **Files ↔ Diff** mode with per-file **added/deleted** counts, including **staged** and **untracked** items.
  * Sidebar fetches and displays a workspace Git diff summary in a dedicated diff view, updating on workspace changes.
  * Added hotkeys: **Mod+Shift+E** (Files) and **Mod+Shift+G** (Diff).
* **UI Improvements**
  * Updated file-tree layout/header placement and enhanced the diff empty/loading states and totals indicator.
* **Bug Fixes**
  * Reduced UI flicker by avoiding unnecessary directory resets and refining diff refresh/caching invalidation.
* **Tests**
  * Expanded Git diff numstat parsing/merge/rename/untracked coverage; updated file-tree view-mode test defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->