### PR TITLE
fix(agent-core): fix build dependency

### DIFF
--- a/agent/runtime-node/package.json
+++ b/agent/runtime-node/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@stagewise/agent-runtime-node",
   "version": "0.2.0",
-  "private": true,
+  "author": "stagewise GmbH",
+  "license": "MIT",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -15,6 +16,9 @@
     "dist/**/*.js",
     "dist/**/*.d.ts"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "tsx build.ts && tsc --emitDeclarationOnly",
     "dev": "tsx build.ts --watch",

--- a/packages/agent-core/build.js
+++ b/packages/agent-core/build.js
@@ -57,6 +57,7 @@ await esbuild.build({
   format: 'esm',
   sourcemap: true,
   external: [
+    '@stagewise/agent-runtime-node',
     '@ai-sdk/anthropic',
     '@ai-sdk/google',
     '@ai-sdk/openai',


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `agent-core` build by marking `@stagewise/agent-runtime-node` as external in `esbuild` to avoid bundling/runtime issues. Prepares `@stagewise/agent-runtime-node` for public publishing by removing `private`, adding `author`, `license: MIT`, and `publishConfig.access: public`.

<sup>Written for commit 68f733876f2f1fffceb190554a8c47fc85f6ad05. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1330?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the build output behavior so an additional runtime dependency is preserved as an external module, improving compatibility across runtime environments.
  * Updated the runtime package’s publishing configuration to be publicly publishable, and added standard package metadata (author and license) for clearer identification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->