### PR TITLE
fix(stagewise): new worktrees sort to top, cap visible at 5, preserve manual order

### DIFF
--- a/apps/browser/src/backend/services/git/index.test.ts
+++ b/apps/browser/src/backend/services/git/index.test.ts
@@ -245,6 +245,7 @@ describe('GitService', () => {
         headSha: 'abc123',
         isDetached: false,
         isMainWorktree: true,
+        createdAt: null,
       },
       {
         worktreeId: repoLinkedPath,
@@ -253,8 +254,57 @@ describe('GitService', () => {
         headSha: 'def456',
         isDetached: false,
         isMainWorktree: false,
+        createdAt: null,
       },
     ]);
+  });
+
+  it('drops prunable worktrees whose working tree is gone', async () => {
+    const { service } = await createGitService({
+      'worktree list --porcelain': [
+        'worktree /repo',
+        'HEAD abc123',
+        'branch refs/heads/main',
+        '',
+        'worktree /repo-linked',
+        'HEAD def456',
+        'branch refs/heads/feature/test',
+        'prunable gitdir file points to non-existent location',
+      ].join('\n'),
+    });
+
+    await expect(service.listWorktrees('/repo')).resolves.toEqual([
+      {
+        worktreeId: repoPath,
+        path: repoPath,
+        branch: 'main',
+        headSha: 'abc123',
+        isDetached: false,
+        isMainWorktree: true,
+        createdAt: null,
+      },
+    ]);
+  });
+
+  it('populates createdAt from the worktree .git birthtime', async () => {
+    const liveRepo = await fs.mkdtemp(path.join(os.tmpdir(), 'git-wt-live-'));
+    await fs.mkdir(path.join(liveRepo, '.git'));
+    try {
+      const { service } = await createGitService({
+        'worktree list --porcelain': [
+          `worktree ${liveRepo}`,
+          'HEAD abc123',
+          'branch refs/heads/main',
+        ].join('\n'),
+      });
+
+      const worktrees = await service.listWorktrees(liveRepo);
+      expect(worktrees).toHaveLength(1);
+      expect(typeof worktrees[0].createdAt).toBe('number');
+      expect(worktrees[0].createdAt).toBeGreaterThan(0);
+    } finally {
+      await fs.rm(liveRepo, { recursive: true, force: true });
+    }
   });
 
   it('returns null mounted workspace summary for a repo subdirectory', async () => {

--- a/apps/browser/src/backend/services/git/index.ts
+++ b/apps/browser/src/backend/services/git/index.ts
@@ -366,6 +366,7 @@ export class GitService extends DisposableService {
       headSha: headShaRaw,
       isDetached: branch === null,
       isMainWorktree: true,
+      createdAt: await this.getWorktreeCreatedAt(worktreePath),
     };
   }
 
@@ -614,10 +615,45 @@ export class GitService extends DisposableService {
       .trim()
       .split(/\n\s*\n/g)
       .filter(Boolean);
-    return entries.flatMap((entry, index) => {
+    const parsed = entries.flatMap((entry, index) => {
       const info = this.parseWorktreeEntry(entry, index === 0);
       return info ? [info] : [];
     });
+    const enriched = await Promise.all(
+      parsed.map(async ({ prunable, ...info }) => ({
+        info: {
+          ...info,
+          createdAt: await this.getWorktreeCreatedAt(info.path),
+        },
+        prunable,
+      })),
+    );
+    // Drop stale worktrees whose working tree was deleted on disk but not yet
+    // pruned: git keeps reporting them (flagged `prunable`) until
+    // `git worktree prune` runs, which otherwise leaves ghost entries in the
+    // sidebar. The main worktree is always kept.
+    return enriched
+      .filter(({ info, prunable }) => info.isMainWorktree || !prunable)
+      .map(({ info }) => info);
+  }
+
+  /**
+   * Best-effort worktree creation time (epoch ms). The `.git` entry inside a
+   * worktree (a gitdir pointer file for linked worktrees, a directory for the
+   * main worktree) is written once at creation and effectively never rewritten,
+   * so its birthtime is a stable age signal. Falls back to ctime/mtime when the
+   * filesystem reports no birthtime, and to `null` when the worktree is gone.
+   */
+  private async getWorktreeCreatedAt(
+    worktreePath: string,
+  ): Promise<number | null> {
+    try {
+      const stat = await fs.stat(path.join(worktreePath, '.git'));
+      const ms = stat.birthtimeMs || stat.ctimeMs || stat.mtimeMs;
+      return Number.isFinite(ms) && ms > 0 ? Math.floor(ms) : null;
+    } catch {
+      return null;
+    }
   }
 
   public async getWorktreeStatus(
@@ -1205,11 +1241,12 @@ export class GitService extends DisposableService {
   private parseWorktreeEntry(
     entry: string,
     isMainWorktree: boolean,
-  ): GitWorktreeInfo | null {
+  ): (GitWorktreeInfo & { prunable: boolean }) | null {
     let worktreePath: string | null = null;
     let headSha: string | null = null;
     let branch: string | null = null;
     let isDetached = false;
+    let prunable = false;
 
     for (const line of entry.split('\n')) {
       if (line.startsWith('worktree ')) {
@@ -1223,6 +1260,8 @@ export class GitService extends DisposableService {
           : raw || null;
       } else if (line === 'detached') {
         isDetached = true;
+      } else if (line === 'prunable' || line.startsWith('prunable ')) {
+        prunable = true;
       }
     }
 
@@ -1235,6 +1274,8 @@ export class GitService extends DisposableService {
       headSha,
       isDetached: isDetached || branch === null,
       isMainWorktree,
+      createdAt: null,
+      prunable,
     };
   }
 

--- a/apps/browser/src/backend/services/git/types.ts
+++ b/apps/browser/src/backend/services/git/types.ts
@@ -51,6 +51,14 @@ export type GitWorktreeInfo = {
   headSha: string | null;
   isDetached: boolean;
   isMainWorktree: boolean;
+  /**
+   * Worktree creation time in epoch ms, derived from the birthtime of the
+   * worktree's `.git` entry. `null` when the worktree is gone from disk or the
+   * filesystem reports no usable timestamp. Used by the sidebar to order
+   * worktrees newest-first; `git worktree list` order is filesystem/alphabetical
+   * and not a reliable age signal.
+   */
+  createdAt: number | null;
 };
 
 export type GitBranchKind = 'local' | 'remote';

--- a/apps/browser/src/shared/karton-contracts/ui/index.ts
+++ b/apps/browser/src/shared/karton-contracts/ui/index.ts
@@ -98,6 +98,12 @@ export type WorkspaceGitWorktreeInfo = {
   isDetached: boolean;
   isMainWorktree: boolean;
   current: boolean;
+  /**
+   * Worktree creation time in epoch ms (birthtime of the worktree's `.git`
+   * entry), or `null` when unavailable. The sidebar orders worktrees
+   * newest-first by this value; `git worktree list` order is not age-based.
+   */
+  createdAt: number | null;
 };
 
 export type WorkspaceGitWorktreesResult = {

--- a/apps/browser/src/ui/screens/main/_lib/agent-list-model.test.ts
+++ b/apps/browser/src/ui/screens/main/_lib/agent-list-model.test.ts
@@ -129,6 +129,102 @@ describe('agent list workspace model', () => {
     expect(groups[0]?.severity).toBe('warning');
   });
 
+  it('orders worktrees root-first then newest-by-age from the git list', () => {
+    // `git worktree list` order is filesystem/alphabetical, not age-based, so
+    // the sidebar relies on the per-worktree `createdAt` timestamp instead.
+    // It must show root first, then the remaining worktrees newest-first
+    // regardless of git-list position or whether they have agents attached.
+    const mkGit = (id: string, isMain: boolean) => ({
+      repositoryId: '/repo/.git',
+      worktreeId: id,
+      repoRoot: id,
+      mainWorktreePath: '/repo',
+      commonGitDir: '/repo/.git',
+      isWorktree: !isMain,
+      branch: null,
+      headSha: 'sha',
+      status: {
+        dirty: false,
+        stagedCount: 0,
+        unstagedCount: 0,
+        untrackedCount: 0,
+      },
+    });
+    const groups = buildWorkspaceAgentGroups({
+      entries: [
+        // Only the oldest non-root worktree has an agent. Age must still win.
+        agent('old', {
+          mountedWorkspaces: [
+            { path: '/wt/old', git: mkGit('/wt/old', false) },
+          ],
+        }),
+        agent('root', {
+          mountedWorkspaces: [{ path: '/repo', git: mkGit('/repo', true) }],
+        }),
+      ],
+      pinnedIds: new Set(),
+      worktreeLists: new Map([
+        [
+          '/repo/.git',
+          {
+            currentPath: '/repo',
+            worktrees: [
+              // Arbitrary git-list order; createdAt (not position) drives sort.
+              {
+                worktreeId: '/repo',
+                path: '/repo',
+                branch: 'main',
+                headSha: 'sha',
+                isDetached: false,
+                isMainWorktree: true,
+                current: true,
+                createdAt: 50,
+              },
+              {
+                worktreeId: '/wt/old',
+                path: '/wt/old',
+                branch: 'old',
+                headSha: 'sha',
+                isDetached: false,
+                isMainWorktree: false,
+                current: false,
+                createdAt: 100,
+              },
+              {
+                worktreeId: '/wt/new',
+                path: '/wt/new',
+                branch: 'new',
+                headSha: 'sha',
+                isDetached: false,
+                isMainWorktree: false,
+                current: false,
+                createdAt: 300,
+              },
+              {
+                worktreeId: '/wt/mid',
+                path: '/wt/mid',
+                branch: 'mid',
+                headSha: 'sha',
+                isDetached: false,
+                isMainWorktree: false,
+                current: false,
+                createdAt: 200,
+              },
+            ],
+          },
+        ],
+      ]),
+      groupOrder: { repoKeys: [], worktreeKeysByRepo: {} },
+    });
+
+    expect(groups[0]?.worktrees.map((group) => group.path)).toEqual([
+      '/repo',
+      '/wt/new',
+      '/wt/mid',
+      '/wt/old',
+    ]);
+  });
+
   it('overlays the freshly fetched worktree branch onto agent-derived groups', () => {
     // The agent mount captured `branch: 'feature'` at mount time. After an
     // external `git switch`, the HEAD watcher bumps the repo revision and the
@@ -175,6 +271,7 @@ describe('agent list workspace model', () => {
                 isDetached: false,
                 isMainWorktree: false,
                 current: true,
+                createdAt: 1000,
               },
             ],
           },

--- a/apps/browser/src/ui/screens/main/_lib/agent-list-model.ts
+++ b/apps/browser/src/ui/screens/main/_lib/agent-list-model.ts
@@ -289,20 +289,27 @@ function isStagewiseOwnedWorktreePath(worktreePath: string): boolean {
 function orderByStableKeys<T extends { key: string }>(
   values: T[],
   orderedKeys: string[] | undefined,
+  newItemSort?: (a: T, b: T) => number,
 ): T[] {
-  if (!orderedKeys || orderedKeys.length === 0) return values;
+  if (!orderedKeys || orderedKeys.length === 0) {
+    if (newItemSort) return [...values].sort(newItemSort);
+    return values;
+  }
   const byKey = new Map(values.map((value) => [value.key, value]));
   const used = new Set<string>();
   const ordered: T[] = [];
-  orderedKeys.forEach((key) => {
+  for (const key of orderedKeys) {
     const value = byKey.get(key);
-    if (!value) return;
+    if (!value) continue;
     ordered.push(value);
     used.add(key);
-  });
-  values.forEach((value) => {
-    if (!used.has(value.key)) ordered.push(value);
-  });
+  }
+  const newItems: T[] = [];
+  for (const value of values) {
+    if (!used.has(value.key)) newItems.push(value);
+  }
+  if (newItemSort) newItems.sort(newItemSort);
+  ordered.push(...newItems);
   return ordered;
 }
 
@@ -402,12 +409,13 @@ export function buildWorkspaceAgentGroups({
     repo.worktrees = orderByStableKeys<WorkspaceWorktreeGroup>(
       repo.worktrees,
       groupOrder.worktreeKeysByRepo[repo.key],
-    ).sort((a, b) => {
-      if (a.isRoot !== b.isRoot) return Number(b.isRoot) - Number(a.isRoot);
-      const aStagewise = isStagewiseOwnedWorktreePath(a.path);
-      const bStagewise = isStagewiseOwnedWorktreePath(b.path);
-      return Number(bStagewise) - Number(aStagewise);
-    });
+      (a, b) => {
+        if (a.isRoot !== b.isRoot) return Number(b.isRoot) - Number(a.isRoot);
+        const aStagewise = isStagewiseOwnedWorktreePath(a.path);
+        const bStagewise = isStagewiseOwnedWorktreePath(b.path);
+        return Number(bStagewise) - Number(aStagewise);
+      },
+    );
 
     repo.worktrees.forEach((worktree) => {
       worktree.severity = maxSeverity(

--- a/apps/browser/src/ui/screens/main/_lib/agent-list-model.ts
+++ b/apps/browser/src/ui/screens/main/_lib/agent-list-model.ts
@@ -48,6 +48,11 @@ export type WorkspaceWorktreeGroup = {
   path: string;
   branch: string | null;
   isRoot: boolean;
+  /**
+   * Worktree creation time in epoch ms (from git), or `null` until the
+   * worktree list resolves. Drives newest-first ordering in the sidebar.
+   */
+  createdAt: number | null;
   severity: AgentStateSeverity | null;
   agents: WorkspaceAgentRow[];
 };
@@ -282,8 +287,22 @@ function getRepoPath(workspace: AgentWorkspaceEntry): string {
   );
 }
 
-function isStagewiseOwnedWorktreePath(worktreePath: string): boolean {
-  return normalizePath(worktreePath).includes('/.stagewise/worktrees/');
+/**
+ * Orders worktree groups for the sidebar: the root worktree is always pinned
+ * to the top, then the rest sort strictly by age, newest first, using the
+ * git-provided `createdAt` timestamp. Worktrees without a timestamp (not yet
+ * resolved from the worktree list) sink to the bottom. Ties fall back to the
+ * stable group key so the order stays deterministic across renders.
+ */
+function compareWorktreesByAge(
+  a: WorkspaceWorktreeGroup,
+  b: WorkspaceWorktreeGroup,
+): number {
+  if (a.isRoot !== b.isRoot) return Number(b.isRoot) - Number(a.isRoot);
+  const aCreated = a.createdAt ?? -1;
+  const bCreated = b.createdAt ?? -1;
+  if (aCreated !== bCreated) return bCreated - aCreated;
+  return a.key < b.key ? -1 : a.key > b.key ? 1 : 0;
 }
 
 function orderByStableKeys<T extends { key: string }>(
@@ -363,6 +382,7 @@ export function buildWorkspaceAgentGroups({
           path: workspace.path,
           branch: workspace.git.branch,
           isRoot: !workspace.git.isWorktree,
+          createdAt: null,
           severity: null,
           agents: [],
         };
@@ -383,15 +403,10 @@ export function buildWorkspaceAgentGroups({
           : `worktree:${item.worktreeId}`;
         const existing = repo.worktrees.find((group) => group.key === key);
         if (existing) {
-          // Worktree groups created from agent mounts carry the branch that was
-          // captured in Karton state at mount time, which goes stale when the
-          // branch is switched outside the app. The worktree list is refetched
-          // whenever the HEAD watcher bumps the repo revision, so it is the
-          // authoritative source for the *current* branch — overlay it onto the
-          // existing group so the label tracks external `git switch`es.
           existing.branch = item.branch;
           existing.label = formatWorktreeLabel(item);
           existing.isRoot = item.isMainWorktree;
+          existing.createdAt = item.createdAt;
           return;
         }
         repo.worktrees.push({
@@ -400,6 +415,7 @@ export function buildWorkspaceAgentGroups({
           path: item.path,
           branch: item.branch,
           isRoot: item.isMainWorktree,
+          createdAt: item.createdAt,
           severity: null,
           agents: [],
         });
@@ -409,12 +425,7 @@ export function buildWorkspaceAgentGroups({
     repo.worktrees = orderByStableKeys<WorkspaceWorktreeGroup>(
       repo.worktrees,
       groupOrder.worktreeKeysByRepo[repo.key],
-      (a, b) => {
-        if (a.isRoot !== b.isRoot) return Number(b.isRoot) - Number(a.isRoot);
-        const aStagewise = isStagewiseOwnedWorktreePath(a.path);
-        const bStagewise = isStagewiseOwnedWorktreePath(b.path);
-        return Number(bStagewise) - Number(aStagewise);
-      },
+      compareWorktreesByAge,
     );
 
     repo.worktrees.forEach((worktree) => {

--- a/apps/browser/src/ui/screens/main/sidebar/agents-list/index.tsx
+++ b/apps/browser/src/ui/screens/main/sidebar/agents-list/index.tsx
@@ -1622,9 +1622,14 @@ export function AgentsList() {
         }
       }
       if (newKeys.length > 0) {
-        order.worktreeKeysByRepo[group.key] = Array.from(
-          new Set([...newKeys, ...worktreeOrder]),
-        );
+        const combined = Array.from(new Set([...newKeys, ...worktreeOrder]));
+        // Root must always be first, even when new keys are prepended.
+        const rootIdx = combined.indexOf('root');
+        if (rootIdx > 0) {
+          combined.splice(rootIdx, 1);
+          combined.unshift('root');
+        }
+        order.worktreeKeysByRepo[group.key] = combined;
       }
     }
 

--- a/apps/browser/src/ui/screens/main/sidebar/agents-list/index.tsx
+++ b/apps/browser/src/ui/screens/main/sidebar/agents-list/index.tsx
@@ -1610,26 +1610,15 @@ export function AgentsList() {
     const nextKeys = new Set(nextGroups.map((group) => group.key));
     const newRepoKeys: string[] = [];
 
+    // Worktree order is intentionally NOT persisted per-repo: there is no
+    // worktree-level drag-and-drop, so there is no manual order to preserve.
+    // Leaving `worktreeKeysByRepo` empty lets the model sort worktrees
+    // deterministically on every render (root first, then newest-by-age).
+    // Persisting a discovery-time order here previously froze worktrees in
+    // whatever arbitrary order they were first seen, overriding the age sort.
     for (const group of nextGroups) {
       if (!order.repoKeys.includes(group.key)) {
         newRepoKeys.push(group.key);
-      }
-      const worktreeOrder = order.worktreeKeysByRepo[group.key] ?? [];
-      const newKeys: string[] = [];
-      for (const worktree of group.worktrees) {
-        if (!worktreeOrder.includes(worktree.key)) {
-          newKeys.push(worktree.key);
-        }
-      }
-      if (newKeys.length > 0) {
-        const combined = Array.from(new Set([...newKeys, ...worktreeOrder]));
-        // Root must always be first, even when new keys are prepended.
-        const rootIdx = combined.indexOf('root');
-        if (rootIdx > 0) {
-          combined.splice(rootIdx, 1);
-          combined.unshift('root');
-        }
-        order.worktreeKeysByRepo[group.key] = combined;
       }
     }
 

--- a/apps/browser/src/ui/screens/main/sidebar/agents-list/index.tsx
+++ b/apps/browser/src/ui/screens/main/sidebar/agents-list/index.tsx
@@ -1615,12 +1615,17 @@ export function AgentsList() {
         newRepoKeys.push(group.key);
       }
       const worktreeOrder = order.worktreeKeysByRepo[group.key] ?? [];
+      const newKeys: string[] = [];
       for (const worktree of group.worktrees) {
         if (!worktreeOrder.includes(worktree.key)) {
-          worktreeOrder.unshift(worktree.key);
+          newKeys.push(worktree.key);
         }
       }
-      order.worktreeKeysByRepo[group.key] = Array.from(new Set(worktreeOrder));
+      if (newKeys.length > 0) {
+        order.worktreeKeysByRepo[group.key] = Array.from(
+          new Set([...newKeys, ...worktreeOrder]),
+        );
+      }
     }
 
     order.repoKeys = [

--- a/apps/browser/src/ui/screens/main/sidebar/agents-list/index.tsx
+++ b/apps/browser/src/ui/screens/main/sidebar/agents-list/index.tsx
@@ -222,7 +222,7 @@ function deriveActivityText(
 const DEFAULT_VISIBLE = 10;
 const SHOW_MORE_INCREMENT = 20;
 const INITIAL_HISTORY_FETCH = DEFAULT_VISIBLE + SHOW_MORE_INCREMENT; // 30
-const DEFAULT_VISIBLE_WORKTREES_PER_REPO = 6;
+const DEFAULT_VISIBLE_WORKTREES_PER_REPO = 5;
 const SHOW_MORE_WORKTREES_INCREMENT = 10;
 const NO_WORKSPACE_GROUP_KEY = '__no-workspace__';
 
@@ -1617,8 +1617,7 @@ export function AgentsList() {
       const worktreeOrder = order.worktreeKeysByRepo[group.key] ?? [];
       for (const worktree of group.worktrees) {
         if (!worktreeOrder.includes(worktree.key)) {
-          if (worktree.isRoot) worktreeOrder.unshift(worktree.key);
-          else worktreeOrder.push(worktree.key);
+          worktreeOrder.unshift(worktree.key);
         }
       }
       order.worktreeKeysByRepo[group.key] = Array.from(new Set(worktreeOrder));


### PR DESCRIPTION
- New worktrees (including freshly created ones) now unshift to front of order so they appear at top, regardless of root/non-root status
- Default visible worktrees per repo capped at 5 (was 6)
- orderByStableKeys now accepts newItemSort callback so manual drag-and-drop order is preserved — only newly discovered items get the isRoot/stagewise sort, not all items

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improve worktree ordering and cleanup. Root stays first, remaining worktrees sort newest-first by actual creation time, each repo shows up to 5 by default, and stale prunable worktrees are hidden.

- **Bug Fixes**
  - Populate `createdAt` from the worktree’s `.git` birthtime and include it in `WorkspaceGitWorktreeInfo`.
  - Filter out `prunable` worktrees (except the main) to remove ghost entries.
  - Sort per-repo worktrees by age using `createdAt` (root first) and stop persisting worktree order for deterministic renders.
  - Batch-prepend new worktree keys without reversing and re-promote root to index 0.

<sup>Written for commit bd389cd776087015c49ebb249ca2feb8d7c75f3e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1331?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Updated the workspace worktree display to show **5 items per repository** instead of 6.
  * Refined sidebar ordering for workspace worktrees, placing the **repo root first** and sorting remaining worktrees by **newest creation time** when available.
* **Behavior Changes**
  * Improved deterministic ordering when explicit worktree preferences are missing, ensuring consistent results across renders.
* **Bug Fixes**
  * Worktrees that are flagged as **prunable** (stale/missing) are now omitted from listings, while the main worktree remains.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->