### PR TITLE
Add diff rendering tabs

### DIFF
--- a/apps/browser/src/backend/services/file-tree/index.ts
+++ b/apps/browser/src/backend/services/file-tree/index.ts
@@ -387,6 +387,8 @@ export class FileTreeService extends DisposableService {
         mimeType: preview.mimeType,
         size: preview.size,
         readOnly: preview.readOnly,
+        showDiff: options?.showDiff,
+        diffStaged: options?.diffStaged,
       },
       agentInstanceId,
       options,

--- a/apps/browser/src/backend/services/file-tree/index.ts
+++ b/apps/browser/src/backend/services/file-tree/index.ts
@@ -389,6 +389,7 @@ export class FileTreeService extends DisposableService {
         readOnly: preview.readOnly,
         showDiff: options?.showDiff,
         diffStaged: options?.diffStaged,
+        diffOldPath: options?.diffOldPath,
       },
       agentInstanceId,
       options,

--- a/apps/browser/src/backend/services/git/index.ts
+++ b/apps/browser/src/backend/services/git/index.ts
@@ -1303,22 +1303,25 @@ export class GitService extends DisposableService {
   }
 
   /**
-   * Fetch the committed (HEAD) content and the current working-tree content
-   * of a file that appears in the git diff. Used by the file-tree diff view
-   * to open a side-by-side Monaco diff editor.
+   * Fetch the original/modified content of a file that appears in the git
+   * diff. Used by the file-tree diff view to open a side-by-side Monaco diff
+   * editor.
    *
-   * The diff always compares `HEAD` against the file on disk — never the
-   * staged index snapshot — so the view reflects the file's latest state
-   * regardless of what is staged. The returned `mtimeMs` is the working-tree
-   * file's modification time, used as the save concurrency baseline.
+   * The comparison depends on `staged`:
+   * - `staged: true`  → HEAD (committed) vs. the staged index snapshot
+   *   (`git show :path`). The modified side is the index blob, which has no
+   *   working-tree file to save edits back to, so `mtimeMs` is `null` and the
+   *   caller keeps the view read-only.
+   * - `staged: false` → HEAD (committed) vs. the working-tree file on disk.
+   *   The modified side is the live file, so `mtimeMs` is its modification
+   *   time, used as the save concurrency baseline, and the view is editable.
    *
-   * The `staged` flag is accepted for call-site compatibility but does not
-   * affect which versions are compared.
+   * For renamed files the HEAD blob lives at the old path.
    */
   public async getFileDiffContent(
     workspacePath: string,
     filePath: string,
-    _staged: boolean,
+    staged: boolean,
     oldPath?: string,
   ): Promise<{
     original: string;
@@ -1328,9 +1331,26 @@ export class GitService extends DisposableService {
     const repositoryInfo = await this.getRepositoryInfo(workspacePath);
     if (!repositoryInfo) return null;
 
-    // HEAD (committed) vs. the working-tree file on disk. For renamed files
-    // the HEAD blob lives at the old path.
+    // For renamed files the HEAD blob lives at the old path.
     const headPath = oldPath ?? filePath;
+
+    if (staged) {
+      // HEAD vs. the staged index snapshot. `git show :path` reads the blob
+      // currently recorded in the index. There is no on-disk file backing the
+      // modified side, so report a null mtime baseline and let the UI treat
+      // the view as read-only.
+      const [headVersion, indexVersion] = await Promise.all([
+        this.runGitRaw(workspacePath, ['show', `HEAD:${headPath}`]),
+        this.runGitRaw(workspacePath, ['show', `:${filePath}`]),
+      ]);
+      return {
+        original: headVersion ?? '',
+        modified: indexVersion ?? '',
+        mtimeMs: null,
+      };
+    }
+
+    // HEAD (committed) vs. the working-tree file on disk (editable).
     const absPath = path.join(workspacePath, filePath);
     const [headVersion, diskVersion, stat] = await Promise.all([
       this.runGitRaw(workspacePath, ['show', `HEAD:${headPath}`]),

--- a/apps/browser/src/backend/services/git/index.ts
+++ b/apps/browser/src/backend/services/git/index.ts
@@ -1279,16 +1279,14 @@ export class GitService extends DisposableService {
     };
   }
 
-  private async runGit(cwd: string, args: string[]): Promise<string | null> {
+  private async runGitRaw(cwd: string, args: string[]): Promise<string | null> {
     this.assertNotDisposed();
     try {
       const resolvedEnv = await this.getResolvedEnv();
-      const result = await this.runGitCommand(
-        cwd,
-        args,
-        resolvedEnv ?? process.env,
+      return (
+        (await this.runGitCommand(cwd, args, resolvedEnv ?? process.env)) ??
+        null
       );
-      return result?.replace(/\r?\n$/, '') ?? null;
     } catch (error) {
       this.logger.debug('[GitService] Git command failed', {
         cwd,
@@ -1297,6 +1295,53 @@ export class GitService extends DisposableService {
       });
       return null;
     }
+  }
+
+  private async runGit(cwd: string, args: string[]): Promise<string | null> {
+    const result = await this.runGitRaw(cwd, args);
+    return result?.replace(/\r?\n$/, '') ?? null;
+  }
+
+  /**
+   * Fetch the committed (HEAD) content and the current working-tree content
+   * of a file that appears in the git diff. Used by the file-tree diff view
+   * to open a side-by-side Monaco diff editor.
+   *
+   * The diff always compares `HEAD` against the file on disk — never the
+   * staged index snapshot — so the view reflects the file's latest state
+   * regardless of what is staged. The returned `mtimeMs` is the working-tree
+   * file's modification time, used as the save concurrency baseline.
+   *
+   * The `staged` flag is accepted for call-site compatibility but does not
+   * affect which versions are compared.
+   */
+  public async getFileDiffContent(
+    workspacePath: string,
+    filePath: string,
+    _staged: boolean,
+    oldPath?: string,
+  ): Promise<{
+    original: string;
+    modified: string;
+    mtimeMs: number | null;
+  } | null> {
+    const repositoryInfo = await this.getRepositoryInfo(workspacePath);
+    if (!repositoryInfo) return null;
+
+    // HEAD (committed) vs. the working-tree file on disk. For renamed files
+    // the HEAD blob lives at the old path.
+    const headPath = oldPath ?? filePath;
+    const absPath = path.join(workspacePath, filePath);
+    const [headVersion, diskVersion, stat] = await Promise.all([
+      this.runGitRaw(workspacePath, ['show', `HEAD:${headPath}`]),
+      fs.readFile(absPath, 'utf8').catch(() => null),
+      fs.stat(absPath).catch(() => null),
+    ]);
+    return {
+      original: headVersion ?? '',
+      modified: diskVersion ?? '',
+      mtimeMs: stat?.mtimeMs ?? null,
+    };
   }
 
   private async runGitStrict(

--- a/apps/browser/src/backend/services/git/index.ts
+++ b/apps/browser/src/backend/services/git/index.ts
@@ -1195,6 +1195,14 @@ export class GitService extends DisposableService {
     try {
       const buf = await fs.readFile(absPath);
       if (buf.length === 0) return 0;
+      // Skip binary files. Git's numstat reports binaries as `-/-` (uncounted)
+      // rather than counting newline bytes, so an untracked image/font/build
+      // artifact must not be reported as thousands of "added" lines. Mirror
+      // git's heuristic: a NUL byte within the first 8000 bytes means binary.
+      const sniffLen = Math.min(buf.length, 8000);
+      for (let i = 0; i < sniffLen; i++) {
+        if (buf[i] === 0x00) return 0;
+      }
       // Count \n bytes.
       let count = 0;
       for (const byte of buf) {

--- a/apps/browser/src/backend/services/toolbox/services/mount-manager/index.ts
+++ b/apps/browser/src/backend/services/toolbox/services/mount-manager/index.ts
@@ -382,6 +382,24 @@ export class MountManagerService extends DisposableService {
     );
 
     this.uiKarton.registerServerProcedureHandler(
+      'toolbox.getFileDiffContent',
+      async (
+        _callingClientId: string,
+        workspacePath: string,
+        filePath: string,
+        staged: boolean,
+        oldPath?: string,
+      ) => {
+        return this.getFileDiffContent(
+          workspacePath,
+          filePath,
+          staged,
+          oldPath,
+        );
+      },
+    );
+
+    this.uiKarton.registerServerProcedureHandler(
       'toolbox.listGitBranchesByPath',
       async (_callingClientId: string, workspacePath: string) => {
         return this.listGitBranchesByPath(workspacePath);
@@ -672,6 +690,21 @@ export class MountManagerService extends DisposableService {
   private async getWorkspaceDiffSummary(workspacePath: string) {
     if (!(await this.isTrustedGitPath(workspacePath))) return null;
     return this.gitService.getDiffNumstat(workspacePath);
+  }
+
+  private async getFileDiffContent(
+    workspacePath: string,
+    filePath: string,
+    staged: boolean,
+    oldPath?: string,
+  ) {
+    if (!(await this.isTrustedGitPath(workspacePath))) return null;
+    return this.gitService.getFileDiffContent(
+      workspacePath,
+      filePath,
+      staged,
+      oldPath,
+    );
   }
 
   private async listGitBranchesByPath(workspacePath: string) {
@@ -1654,6 +1687,7 @@ export class MountManagerService extends DisposableService {
     this.uiKarton.removeServerProcedureHandler(
       'toolbox.getWorkspaceDiffSummary',
     );
+    this.uiKarton.removeServerProcedureHandler('toolbox.getFileDiffContent');
     this.uiKarton.removeServerProcedureHandler('toolbox.listGitBranchesByPath');
     this.uiKarton.removeServerProcedureHandler(
       'toolbox.listGitWorktreesByPath',

--- a/apps/browser/src/backend/services/toolbox/services/mount-manager/index.ts
+++ b/apps/browser/src/backend/services/toolbox/services/mount-manager/index.ts
@@ -699,12 +699,47 @@ export class MountManagerService extends DisposableService {
     oldPath?: string,
   ) {
     if (!(await this.isTrustedGitPath(workspacePath))) return null;
-    return this.gitService.getFileDiffContent(
+
+    // `filePath`/`oldPath` arrive from the renderer and are interpolated into
+    // `fs.readFile`/`git show` against the workspace root. Reject anything
+    // that resolves outside the workspace (e.g. `../../etc/passwd`) and pass
+    // the normalized, workspace-relative paths downstream.
+    const sanitizedFilePath = this.sanitizeWorkspaceRelativePath(
       workspacePath,
       filePath,
-      staged,
-      oldPath,
     );
+    if (sanitizedFilePath === null) return null;
+    let sanitizedOldPath: string | undefined;
+    if (oldPath !== undefined) {
+      const sanitized = this.sanitizeWorkspaceRelativePath(
+        workspacePath,
+        oldPath,
+      );
+      if (sanitized === null) return null;
+      sanitizedOldPath = sanitized;
+    }
+
+    return this.gitService.getFileDiffContent(
+      workspacePath,
+      sanitizedFilePath,
+      staged,
+      sanitizedOldPath,
+    );
+  }
+
+  /**
+   * Resolve a renderer-supplied relative path against the workspace root and
+   * return its normalized, workspace-relative form. Returns `null` when the
+   * input is absolute or escapes the workspace via `..` segments.
+   */
+  private sanitizeWorkspaceRelativePath(
+    workspacePath: string,
+    relativePath: string,
+  ): string | null {
+    if (path.isAbsolute(relativePath)) return null;
+    const resolved = path.resolve(workspacePath, relativePath);
+    if (!this.isPathInside(workspacePath, resolved)) return null;
+    return path.relative(workspacePath, resolved);
   }
 
   private async listGitBranchesByPath(workspacePath: string) {

--- a/apps/browser/src/backend/services/toolbox/services/mount-manager/index.ts
+++ b/apps/browser/src/backend/services/toolbox/services/mount-manager/index.ts
@@ -704,14 +704,14 @@ export class MountManagerService extends DisposableService {
     // `fs.readFile`/`git show` against the workspace root. Reject anything
     // that resolves outside the workspace (e.g. `../../etc/passwd`) and pass
     // the normalized, workspace-relative paths downstream.
-    const sanitizedFilePath = this.sanitizeWorkspaceRelativePath(
+    const sanitizedFilePath = await this.sanitizeWorkspaceRelativePath(
       workspacePath,
       filePath,
     );
     if (sanitizedFilePath === null) return null;
     let sanitizedOldPath: string | undefined;
     if (oldPath !== undefined) {
-      const sanitized = this.sanitizeWorkspaceRelativePath(
+      const sanitized = await this.sanitizeWorkspaceRelativePath(
         workspacePath,
         oldPath,
       );
@@ -729,17 +729,40 @@ export class MountManagerService extends DisposableService {
 
   /**
    * Resolve a renderer-supplied relative path against the workspace root and
-   * return its normalized, workspace-relative form. Returns `null` when the
-   * input is absolute or escapes the workspace via `..` segments.
+   * return its normalized, workspace-relative form using POSIX separators.
+   * Returns `null` when the input is absolute, escapes the workspace via `..`
+   * segments, or resolves (through symlinks) to a target outside the
+   * workspace.
    */
-  private sanitizeWorkspaceRelativePath(
+  private async sanitizeWorkspaceRelativePath(
     workspacePath: string,
     relativePath: string,
-  ): string | null {
+  ): Promise<string | null> {
     if (path.isAbsolute(relativePath)) return null;
     const resolved = path.resolve(workspacePath, relativePath);
+    // Lexical containment first: reject `..` escapes before touching the FS.
     if (!this.isPathInside(workspacePath, resolved)) return null;
-    return path.relative(workspacePath, resolved);
+    // Symlink containment: a workspace-internal path can still be (or live
+    // under) a symlink that points outside the workspace, which a purely
+    // lexical check would let through. Resolve real paths and re-verify
+    // containment. When the target does not exist yet, realpath returns null
+    // — fall back to the lexical result, since a missing file cannot leak
+    // data (the downstream read simply yields nothing).
+    const [realWorkspace, realResolved] = await Promise.all([
+      safeRealpath(workspacePath),
+      safeRealpath(resolved),
+    ]);
+    if (
+      realWorkspace &&
+      realResolved &&
+      !this.isPathInside(realWorkspace, realResolved)
+    ) {
+      return null;
+    }
+    // git's `show HEAD:<path>` / `show :<path>` and the downstream blob
+    // lookups expect POSIX separators; `path.relative` yields backslashes on
+    // Windows, which would break nested-file lookups. Normalize to `/`.
+    return path.relative(workspacePath, resolved).split(path.sep).join('/');
   }
 
   private async listGitBranchesByPath(workspacePath: string) {

--- a/apps/browser/src/backend/services/window-layout/index.ts
+++ b/apps/browser/src/backend/services/window-layout/index.ts
@@ -76,6 +76,7 @@ const fileTabMetadataSchema = z.object({
   readOnly: z.boolean().optional(),
   showDiff: z.boolean().optional(),
   diffStaged: z.boolean().optional(),
+  diffOldPath: z.string().optional(),
 });
 
 const tabEntrySchema = z.discriminatedUnion('type', [

--- a/apps/browser/src/backend/services/window-layout/index.ts
+++ b/apps/browser/src/backend/services/window-layout/index.ts
@@ -74,6 +74,8 @@ const fileTabMetadataSchema = z.object({
   size: z.number(),
   displayName: z.string().optional(),
   readOnly: z.boolean().optional(),
+  showDiff: z.boolean().optional(),
+  diffStaged: z.boolean().optional(),
 });
 
 const tabEntrySchema = z.discriminatedUnion('type', [
@@ -834,7 +836,12 @@ export class WindowLayoutService extends DisposableService {
         tab.type === 'file' &&
         tab.file?.workspaceKey === file.workspaceKey &&
         tab.file.relativePath === file.relativePath &&
-        tab.agentInstanceId === (agentInstanceId ?? null),
+        tab.agentInstanceId === (agentInstanceId ?? null) &&
+        // A diff tab and a regular file tab for the same path are distinct
+        // surfaces — opening the file while its diff is open must create a
+        // separate plain-editor tab instead of switching to the diff.
+        Boolean(tab.file.showDiff) === Boolean(file.showDiff) &&
+        Boolean(tab.file.diffStaged) === Boolean(file.diffStaged),
     );
     if (existing) {
       if (!options?.preview) this.promoteFileTab(existing[0]);
@@ -854,8 +861,9 @@ export class WindowLayoutService extends DisposableService {
             tab.agentInstanceId === (agentInstanceId ?? null),
         )
       : undefined;
-    const title =
+    const baseTitle =
       file.displayName?.trim() || path.basename(file.relativePath) || 'File';
+    const title = file.showDiff ? `Diff: ${baseTitle}` : baseTitle;
 
     if (reusablePreview) {
       const [id] = reusablePreview;

--- a/apps/browser/src/shared/karton-contracts/ui/index.ts
+++ b/apps/browser/src/shared/karton-contracts/ui/index.ts
@@ -679,6 +679,12 @@ export type FileTabMetadata = {
    * working tree). Only meaningful when showDiff is true.
    */
   diffStaged?: boolean;
+  /**
+   * For renamed files, the pre-rename path where the committed (HEAD) blob
+   * lives. Used by the diff view to load the original side. Only meaningful
+   * when showDiff is true.
+   */
+  diffOldPath?: string;
 };
 
 export type TabLifecycle =
@@ -692,6 +698,8 @@ export type OpenFileTabOptions = {
   showDiff?: boolean;
   /** Staged (HEAD vs index) or unstaged (index vs working tree). */
   diffStaged?: boolean;
+  /** For renamed files, the pre-rename path of the committed (HEAD) blob. */
+  diffOldPath?: string;
 };
 
 export type FileTreeClipboardOperation = 'copy' | 'cut';

--- a/apps/browser/src/shared/karton-contracts/ui/index.ts
+++ b/apps/browser/src/shared/karton-contracts/ui/index.ts
@@ -643,6 +643,17 @@ export type FileTabNotice =
   | { kind: 'moved'; fromRelativePath: string }
   | { kind: 'deleted' };
 
+export type FileDiffContent = {
+  original: string;
+  modified: string;
+  /**
+   * mtime (ms) of the working-tree file the `modified` side was read from.
+   * Used as the optimistic-concurrency baseline when saving edits made in
+   * the diff view. `null` when the file does not exist on disk.
+   */
+  mtimeMs: number | null;
+};
+
 export type FileTabMetadata = {
   workspaceKey: FileTreeWorkspaceKey;
   relativePath: string;
@@ -658,6 +669,16 @@ export type FileTabMetadata = {
   displayName?: string;
   /** When true, the tab content is read-only (e.g. attachment blobs). */
   readOnly?: boolean;
+  /**
+   * When true, the tab opens a git diff editor (Monaco DiffEditor)
+   * showing the changes for this file instead of the regular editor.
+   */
+  showDiff?: boolean;
+  /**
+   * Whether the diff is staged (HEAD vs index) or unstaged (index vs
+   * working tree). Only meaningful when showDiff is true.
+   */
+  diffStaged?: boolean;
 };
 
 export type TabLifecycle =
@@ -667,6 +688,10 @@ export type TabLifecycle =
 export type OpenFileTabOptions = {
   preview?: boolean;
   temporaryGroupKey?: string;
+  /** Open the tab as a git diff editor (Monaco DiffEditor). */
+  showDiff?: boolean;
+  /** Staged (HEAD vs index) or unstaged (index vs working tree). */
+  diffStaged?: boolean;
 };
 
 export type FileTreeClipboardOperation = 'copy' | 'cut';
@@ -1303,6 +1328,16 @@ export type KartonContract = {
       getWorkspaceDiffSummary: (
         workspacePath: string,
       ) => Promise<MountedWorkspaceGitDiffSummary | null>;
+      /**
+       * Fetch the original and modified content for a file that appears
+       * in the git diff, so the file-tree can open a Monaco DiffEditor.
+       */
+      getFileDiffContent: (
+        workspacePath: string,
+        filePath: string,
+        staged: boolean,
+        oldPath?: string,
+      ) => Promise<FileDiffContent | null>;
       listGitBranchesByPath: (
         workspacePath: string,
       ) => Promise<WorkspaceGitBranchesResult | null>;

--- a/apps/browser/src/ui/screens/main/content/_components/tab-favicon.tsx
+++ b/apps/browser/src/ui/screens/main/content/_components/tab-favicon.tsx
@@ -1,5 +1,6 @@
 import type { TabState } from '@shared/karton-contracts/ui';
 import {
+  IconArrowsOppositeDirectionXOutline18,
   IconBoxSparkleOutline18,
   IconEarthOutline18,
   IconSquareTerminalOutline18,
@@ -47,6 +48,8 @@ export function TabFavicon({ tabState }: { tabState: TabState }) {
         <div className="flex size-4 items-center justify-center p-[1px]">
           <Logo color="current" className="size-full text-primary-solid" />
         </div>
+      ) : tabState?.type === 'file' && tabState.file?.showDiff ? (
+        <IconArrowsOppositeDirectionXOutline18 className="size-4 text-muted-foreground" />
       ) : tabState?.type === 'file' && tabState.file ? (
         <FileIcon filePath={tabState.file.relativePath} className="size-4" />
       ) : tabState?.isLoading ? (

--- a/apps/browser/src/ui/screens/main/content/index.tsx
+++ b/apps/browser/src/ui/screens/main/content/index.tsx
@@ -503,13 +503,22 @@ export function MainSection({
       .map((id): SortableTabItem | null => {
         const tab = tabs[id];
         if (!tab) return null;
+        // Diff tabs are prefixed with "Diff: " in the strip. Done in the UI
+        // (idempotently) so the prefix is guaranteed even for tabs persisted
+        // before the backend title logic, and never double-applied.
+        const displayTitle =
+          tab.type === 'file' && tab.file?.showDiff
+            ? tab.title.startsWith('Diff: ')
+              ? tab.title
+              : `Diff: ${tab.title}`
+            : tab.title;
         return {
           id,
           label:
             tab.type === 'file' && tab.lifecycle.kind === 'temporary' ? (
-              <span className="italic">{tab.title}</span>
+              <span className="italic">{displayTitle}</span>
             ) : (
-              tab.title
+              displayTitle
             ),
           icon: <TabPinIcon tab={tab} openAgent={openAgent} />,
           onClose: () => closeTabWithUnsavedCheck(id),

--- a/apps/browser/src/ui/screens/main/content/index.tsx
+++ b/apps/browser/src/ui/screens/main/content/index.tsx
@@ -735,7 +735,7 @@ export function MainSection({
             }}
             ref={tabBarScrollRef}
             style={maskStyle}
-            className="min-w-0 flex-1 items-center gap-1 overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+            className="w-auto min-w-0 max-w-full shrink items-center gap-1 overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
           >
             {/* Global (pinned) tabs — shrinks independently, inner scroll handles overflow */}
             {globalTabItems.length > 0 && (
@@ -762,6 +762,10 @@ export function MainSection({
               />
             )}
           </SortableTabs>
+          {/* New-tab buttons hug the right edge of the tab list: they stay
+              outside the scrollable section and follow the list's end until
+              the flexible spacer collapses, at which point they sit next to
+              the fixed close/expand controls and the list scrolls instead. */}
           <div className="app-no-drag flex shrink-0 items-center gap-0.5">
             <NewTabButtons
               buttonClassName="size-7"
@@ -770,6 +774,9 @@ export function MainSection({
                 void createTerminal(undefined, openAgent)
               }
             />
+          </div>
+          <div className="min-w-0 flex-1" />
+          <div className="app-no-drag flex shrink-0 items-center gap-0.5">
             {topRightActions}
           </div>
         </div>

--- a/apps/browser/src/ui/screens/main/file-tree/file-preview-tab-content.tsx
+++ b/apps/browser/src/ui/screens/main/file-tree/file-preview-tab-content.tsx
@@ -204,6 +204,11 @@ const SOURCE_LANGUAGE_ITEMS: Array<{
 const previewCache = new Map<string, CachedPreview>();
 const previewRequests = new Map<string, Promise<FilePreviewResult | null>>();
 const textDraftCache = new Map<string, string>();
+// Unsaved modified-side edits for diff tabs, keyed by tab id (stable across
+// unmount/remount within a session). Lets the editable diff editor restore a
+// user's in-progress edits when its tab is hidden and shown again, mirroring
+// the plain editor's `textDraftCache`.
+const diffDraftCache = new Map<string, string>();
 function getPreviewCacheKey(workspaceKey: string, relativePath: string) {
   return `${workspaceKey}:${relativePath}`;
 }
@@ -1064,6 +1069,11 @@ function DiffEditorPreview({
     return stored === 'inline' || stored === 'split' ? stored : 'inline';
   });
   const [diffContent, setDiffContent] = useState<FileDiffContent | null>(null);
+  // The value rendered into the editable (modified/right) pane. Held separately
+  // from `diffContent.modified` (the on-disk baseline) so it can be seeded from
+  // `diffDraftCache` on mount and only reset on an explicit reload/adopt — never
+  // mid-edit — which would otherwise clobber the model's content + undo stack.
+  const [modifiedValue, setModifiedValue] = useState<string | null>(null);
   const [diffError, setDiffError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const language = languageFromPath(tab.relativePath);
@@ -1125,6 +1135,10 @@ function DiffEditorPreview({
           setDiffError('Unable to load diff content.');
           return null;
         }
+        // Explicit reload discards any in-progress draft and loads the fresh
+        // on-disk content into the modified pane.
+        diffDraftCache.delete(tabId);
+        setModifiedValue(content.modified);
         return { text: content.modified, mtimeMs: content.mtimeMs };
       } catch (err) {
         setDiffError(
@@ -1138,6 +1152,12 @@ function DiffEditorPreview({
     unsavedTitle: tab.relativePath.split('/').pop() || tab.relativePath,
     onSaved: (result) => {
       diskMtimeRef.current = result?.mtimeMs ?? null;
+      // Saved content now matches disk; drop the draft so a later remount
+      // reloads the clean on-disk version.
+      diffDraftCache.delete(tabId);
+    },
+    onDiscard: () => {
+      diffDraftCache.delete(tabId);
     },
     onSaveError: (err) => {
       setDiffError(err instanceof Error ? err.message : 'Failed to save');
@@ -1173,6 +1193,9 @@ function DiffEditorPreview({
       const modified = editor.getModifiedEditor();
       modified.onDidFocusEditorWidget(markFocused);
       modified.onDidChangeModelContent(() => {
+        // Persist the in-progress edit so it survives an unmount/remount of
+        // this tab (mirrors the plain editor's `textDraftCache`).
+        diffDraftCache.set(tabId, modified.getValue());
         notifyContentChanged();
       });
       refreshState();
@@ -1204,6 +1227,11 @@ function DiffEditorPreview({
           content?.modified ?? '',
           content?.mtimeMs ?? null,
         );
+        // Seed the modified pane from any cached draft (in-progress edits from
+        // a prior mount of this tab) falling back to the on-disk content. The
+        // baseline stays the on-disk content above, so a restored draft is
+        // correctly reported as dirty.
+        setModifiedValue(diffDraftCache.get(tabId) ?? content?.modified ?? '');
         if (!content) setDiffError('Unable to load diff content.');
       })
       .catch((err) => {
@@ -1268,7 +1296,13 @@ function DiffEditorPreview({
       if (cancelled || !content) return;
       diskMtimeRef.current = content.mtimeMs ?? stat.mtimeMs;
       const outcome = reconcileDisk(content.modified, content.mtimeMs);
-      if (outcome === 'adopted') setDiffContent(content);
+      // 'adopted' means the user had no local edits, so the fresh on-disk
+      // content can replace both the baseline and the visible modified pane.
+      if (outcome === 'adopted') {
+        setDiffContent(content);
+        diffDraftCache.delete(tabId);
+        setModifiedValue(content.modified);
+      }
     })();
     return () => {
       cancelled = true;
@@ -1351,7 +1385,7 @@ function DiffEditorPreview({
             width="100%"
             language={language === 'plaintext' ? undefined : language}
             original={diffContent.original}
-            modified={diffContent.modified}
+            modified={modifiedValue ?? diffContent.modified}
             theme={MONACO_THEME_NAME}
             beforeMount={configureMonacoTheme}
             onMount={handleDiffMount}

--- a/apps/browser/src/ui/screens/main/file-tree/file-preview-tab-content.tsx
+++ b/apps/browser/src/ui/screens/main/file-tree/file-preview-tab-content.tsx
@@ -31,11 +31,9 @@ import {
 import { IconDatabaseFillDuo18 } from 'nucleo-ui-fill-duo-18';
 import type { FileDiffContent } from '@shared/karton-contracts/ui';
 import {
-  Columns3Icon,
   Loader2Icon,
   MinusIcon,
   PlusIcon,
-  PanelTopIcon,
   TriangleAlertIcon,
   XIcon,
 } from 'lucide-react';
@@ -47,7 +45,9 @@ import {
   IconEye2Outline18,
   IconOpenExternalOutline18,
   IconRedoOutline18,
+  IconSplitViewOutline18,
   IconSquareCodeOutline18,
+  IconTextAlignLeft2Outline18,
   IconTextBgColorOutline18,
   IconTextColorOutline18,
   IconUndoOutline18,
@@ -1306,7 +1306,7 @@ function DiffEditorPreview({
               aria-pressed={diffMode === 'inline'}
               onClick={() => persistMode('inline')}
             >
-              <PanelTopIcon className="size-3.5" />
+              <IconTextAlignLeft2Outline18 className="size-3.5" />
               {diffMode === 'inline' ? <span>Inline</span> : null}
             </button>
             <button
@@ -1320,7 +1320,7 @@ function DiffEditorPreview({
               aria-pressed={diffMode === 'split'}
               onClick={() => persistMode('split')}
             >
-              <Columns3Icon className="size-3.5" />
+              <IconSplitViewOutline18 className="size-3.5" />
               {diffMode === 'split' ? <span>Split</span> : null}
             </button>
           </div>

--- a/apps/browser/src/ui/screens/main/file-tree/file-preview-tab-content.tsx
+++ b/apps/browser/src/ui/screens/main/file-tree/file-preview-tab-content.tsx
@@ -1280,7 +1280,7 @@ function DiffEditorPreview({
       clearTimeout(safetyTimer);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [workspacePath, tab.relativePath, tab.diffStaged]);
+  }, [workspacePath, tab.relativePath, tab.diffStaged, tab.diffOldPath]);
 
   // Live external-change detection. The file-tree watcher bumps the backing
   // directory's revision whenever its contents change on disk; on each bump we
@@ -1347,6 +1347,7 @@ function DiffEditorPreview({
     tab.workspaceKey,
     tab.relativePath,
     tab.diffStaged,
+    tab.diffOldPath,
     reconcileDisk,
   ]);
 

--- a/apps/browser/src/ui/screens/main/file-tree/file-preview-tab-content.tsx
+++ b/apps/browser/src/ui/screens/main/file-tree/file-preview-tab-content.tsx
@@ -484,7 +484,7 @@ const MONACO_SHARED_OPTIONS: Monaco.editor.IStandaloneEditorConstructionOptions 
   {
     minimap: { enabled: false },
     scrollBeyondLastLine: false,
-    wordWrap: 'on',
+    wordWrap: 'off',
     automaticLayout: true,
     renderLineHighlight: 'line',
     scrollbar: {
@@ -1366,12 +1366,11 @@ function DiffEditorPreview({
               readOnly: !editable,
               originalEditable: false,
               renderIndicators: true,
-              // The base `wordWrap` only reliably reaches the modified pane.
-              // The diff editor's own wrap control defaults to 'inherit',
-              // which Monaco applies inconsistently, leaving the original
-              // (left) pane unwrapped and horizontally scrollable. Force wrap
-              // on so both panes wrap identically and stay aligned.
-              diffWordWrap: 'on',
+              // Disable word wrap in both panes; lines scroll horizontally
+              // instead. The diff editor's own wrap control defaults to
+              // 'inherit', which Monaco applies inconsistently across panes,
+              // so set it explicitly to keep both sides identical.
+              diffWordWrap: 'off',
               enableSplitViewResizing: diffMode === 'split',
               // The diff editor renders both its own vertical scrollbar and a
               // wider diff overview ruler (the colored add/remove map). That

--- a/apps/browser/src/ui/screens/main/file-tree/file-preview-tab-content.tsx
+++ b/apps/browser/src/ui/screens/main/file-tree/file-preview-tab-content.tsx
@@ -1366,6 +1366,12 @@ function DiffEditorPreview({
               readOnly: !editable,
               originalEditable: false,
               renderIndicators: true,
+              // The base `wordWrap` only reliably reaches the modified pane.
+              // The diff editor's own wrap control defaults to 'inherit',
+              // which Monaco applies inconsistently, leaving the original
+              // (left) pane unwrapped and horizontally scrollable. Force wrap
+              // on so both panes wrap identically and stay aligned.
+              diffWordWrap: 'on',
               enableSplitViewResizing: diffMode === 'split',
               // The diff editor renders both its own vertical scrollbar and a
               // wider diff overview ruler (the colored add/remove map). That

--- a/apps/browser/src/ui/screens/main/file-tree/file-preview-tab-content.tsx
+++ b/apps/browser/src/ui/screens/main/file-tree/file-preview-tab-content.tsx
@@ -1371,12 +1371,15 @@ function DiffEditorPreview({
               // 'inherit', which Monaco applies inconsistently across panes,
               // so set it explicitly to keep both sides identical.
               diffWordWrap: 'off',
-              // Inline mode renders two line-number columns (original +
-              // modified). Trim the default gutter padding (glyph margin,
-              // line-decoration band, and minimum number width) so the line
-              // numbers don't sit behind a wide empty left margin.
+              // Monaco reserves a left margin in the modified editor for the
+              // revert-change arrow icons. In split mode that margin shows up
+              // as empty space between the two panes; in inline mode it pads
+              // the left of the gutter. Disable it to reclaim that space.
+              renderMarginRevertIcon: false,
+              // Trim the remaining gutter chrome: drop the glyph margin and
+              // code folding controls, and keep a tight line-number column.
               glyphMargin: false,
-              lineDecorationsWidth: 0,
+              lineDecorationsWidth: 1,
               lineNumbersMinChars: 3,
               folding: false,
               enableSplitViewResizing: diffMode === 'split',

--- a/apps/browser/src/ui/screens/main/file-tree/file-preview-tab-content.tsx
+++ b/apps/browser/src/ui/screens/main/file-tree/file-preview-tab-content.tsx
@@ -1084,13 +1084,27 @@ function DiffEditorPreview({
 
   // The diff always renders the committed (HEAD) version against the current
   // working-tree file, so the modified/right side is the live file on disk
-  // and is editable unless the tab is explicitly read-only.
-  const editable = !(tab.readOnly ?? false);
+  // and is editable unless the tab is explicitly read-only. Staged diffs are
+  // the exception: they render the index snapshot (mtimeMs: null) with no
+  // editable on-disk backing, so saving could overwrite unrelated unstaged
+  // edits in the working tree — keep them read-only.
+  const editable = !(tab.readOnly ?? false) && !(tab.diffStaged ?? false);
 
   // Last on-disk mtime we have reconciled to. Lets the live-detection effect
   // skip a git-diff fetch when an unrelated change bumps the directory
   // revision, and avoids treating our own writes as external edits.
   const diskMtimeRef = useRef<number | null>(null);
+
+  // In-progress modified-side edits are cached by file identity — workspace +
+  // path + staged flag — not by tab id. A tab id can be reused for a different
+  // file or diff mode, and keying drafts by it would restore the wrong content
+  // into the editable pane. A ref keeps the key current for the mount-time
+  // content listener without forcing it to re-register on every render.
+  const diffDraftKey = `${tab.workspaceKey}:${tab.relativePath}:${
+    tab.diffStaged ? 'staged' : 'working'
+  }`;
+  const diffDraftKeyRef = useRef(diffDraftKey);
+  diffDraftKeyRef.current = diffDraftKey;
 
   const persistMode = useCallback(
     (next: DiffMode) => {
@@ -1128,6 +1142,7 @@ function DiffEditorPreview({
           workspacePath,
           tab.relativePath,
           tab.diffStaged ?? false,
+          tab.diffOldPath,
         );
         setDiffContent(content);
         diskMtimeRef.current = content?.mtimeMs ?? null;
@@ -1137,7 +1152,7 @@ function DiffEditorPreview({
         }
         // Explicit reload discards any in-progress draft and loads the fresh
         // on-disk content into the modified pane.
-        diffDraftCache.delete(tabId);
+        diffDraftCache.delete(diffDraftKeyRef.current);
         setModifiedValue(content.modified);
         return { text: content.modified, mtimeMs: content.mtimeMs };
       } catch (err) {
@@ -1154,10 +1169,10 @@ function DiffEditorPreview({
       diskMtimeRef.current = result?.mtimeMs ?? null;
       // Saved content now matches disk; drop the draft so a later remount
       // reloads the clean on-disk version.
-      diffDraftCache.delete(tabId);
+      diffDraftCache.delete(diffDraftKeyRef.current);
     },
     onDiscard: () => {
-      diffDraftCache.delete(tabId);
+      diffDraftCache.delete(diffDraftKeyRef.current);
     },
     onSaveError: (err) => {
       setDiffError(err instanceof Error ? err.message : 'Failed to save');
@@ -1173,8 +1188,11 @@ function DiffEditorPreview({
   // built-in automaticLayout does not reliably recover, so we force a
   // layout on mount and observe the container for size changes.
   const handleDiffMount = useCallback(
-    (editor: Monaco.editor.IStandaloneDiffEditor) => {
+    (editor: Monaco.editor.IStandaloneDiffEditor, monaco: MonacoApi) => {
       diffEditorRef.current = editor;
+      // Keep diff tabs on the live OS color scheme, matching the plain editor
+      // mount; otherwise a theme flip leaves the diff on a stale Monaco theme.
+      registerMonacoThemeSync(monaco);
       const container = editor.getContainerDomNode();
       const relayout = () => editor.layout();
       // Force an initial layout once the browser has painted the container.
@@ -1195,7 +1213,7 @@ function DiffEditorPreview({
       modified.onDidChangeModelContent(() => {
         // Persist the in-progress edit so it survives an unmount/remount of
         // this tab (mirrors the plain editor's `textDraftCache`).
-        diffDraftCache.set(tabId, modified.getValue());
+        diffDraftCache.set(diffDraftKeyRef.current, modified.getValue());
         notifyContentChanged();
       });
       refreshState();
@@ -1218,9 +1236,18 @@ function DiffEditorPreview({
     }, 15_000);
 
     getFileDiffContentRef
-      .current(workspacePath, tab.relativePath, tab.diffStaged ?? false)
+      .current(
+        workspacePath,
+        tab.relativePath,
+        tab.diffStaged ?? false,
+        tab.diffOldPath,
+      )
       .then((content) => {
         if (cancelled) return;
+        // A success that lands after the safety timeout already fired must
+        // clear the stale timeout error, otherwise the error pane stays up
+        // despite valid content now being available.
+        setDiffError(null);
         setDiffContent(content);
         diskMtimeRef.current = content?.mtimeMs ?? null;
         controller.setBaseline(
@@ -1231,7 +1258,11 @@ function DiffEditorPreview({
         // a prior mount of this tab) falling back to the on-disk content. The
         // baseline stays the on-disk content above, so a restored draft is
         // correctly reported as dirty.
-        setModifiedValue(diffDraftCache.get(tabId) ?? content?.modified ?? '');
+        setModifiedValue(
+          diffDraftCache.get(diffDraftKeyRef.current) ??
+            content?.modified ??
+            '',
+        );
         if (!content) setDiffError('Unable to load diff content.');
       })
       .catch((err) => {
@@ -1289,6 +1320,7 @@ function DiffEditorPreview({
           workspacePath,
           tab.relativePath,
           tab.diffStaged ?? false,
+          tab.diffOldPath,
         );
       } catch {
         return;
@@ -1300,7 +1332,7 @@ function DiffEditorPreview({
       // content can replace both the baseline and the visible modified pane.
       if (outcome === 'adopted') {
         setDiffContent(content);
-        diffDraftCache.delete(tabId);
+        diffDraftCache.delete(diffDraftKeyRef.current);
         setModifiedValue(content.modified);
       }
     })();
@@ -2699,6 +2731,11 @@ export function FilePreviewTabContent({ tab }: FilePreviewTabContentProps) {
   const [isRecreating, setIsRecreating] = useState(false);
   const workspaceKey = tab.file?.workspaceKey;
   const relativePath = tab.file?.relativePath;
+  // Git diff tabs render via DiffEditorPreview, which loads its own content.
+  // Skip the regular file-preview fetch/revalidate pipeline entirely so a
+  // diff tab doesn't trigger redundant getFilePreview calls on every watcher
+  // revision bump.
+  const isDiffTab = tab.file?.showDiff ?? false;
   const cacheKey =
     workspaceKey && relativePath
       ? getPreviewCacheKey(workspaceKey, relativePath)
@@ -2749,6 +2786,7 @@ export function FilePreviewTabContent({ tab }: FilePreviewTabContentProps) {
   // mount) and live external-edit detection (run on directory-revision bumps).
   // Read-only blobs (attachments) never change, so they are skipped entirely.
   const revalidate = useCallback(async () => {
+    if (isDiffTab) return;
     if (!workspaceKey || !relativePath || !cacheKey) return;
     const current = previewCache.get(cacheKey);
     // Nothing loaded yet — the initial-load effect owns the first fetch.
@@ -2792,9 +2830,17 @@ export function FilePreviewTabContent({ tab }: FilePreviewTabContentProps) {
     previewCache.set(cacheKey, { preview: result, error: nextError });
     setPreview(result);
     setError(nextError);
-  }, [workspaceKey, relativePath, cacheKey, getFileStat, getFilePreview]);
+  }, [
+    isDiffTab,
+    workspaceKey,
+    relativePath,
+    cacheKey,
+    getFileStat,
+    getFilePreview,
+  ]);
 
   useEffect(() => {
+    if (isDiffTab) return;
     if (!workspaceKey || !relativePath || !cacheKey) return;
     const cachedPreview = previewCache.get(cacheKey);
     if (cachedPreview) {
@@ -2843,7 +2889,7 @@ export function FilePreviewTabContent({ tab }: FilePreviewTabContentProps) {
     return () => {
       cancelled = true;
     };
-  }, [workspaceKey, relativePath, cacheKey, getFilePreview]);
+  }, [isDiffTab, workspaceKey, relativePath, cacheKey, getFilePreview]);
 
   // Revalidate when the tab (re)mounts and whenever the backing directory
   // changes on disk. On mount this ensures a re-opened tab shows the latest

--- a/apps/browser/src/ui/screens/main/file-tree/file-preview-tab-content.tsx
+++ b/apps/browser/src/ui/screens/main/file-tree/file-preview-tab-content.tsx
@@ -1371,6 +1371,14 @@ function DiffEditorPreview({
               // 'inherit', which Monaco applies inconsistently across panes,
               // so set it explicitly to keep both sides identical.
               diffWordWrap: 'off',
+              // Inline mode renders two line-number columns (original +
+              // modified). Trim the default gutter padding (glyph margin,
+              // line-decoration band, and minimum number width) so the line
+              // numbers don't sit behind a wide empty left margin.
+              glyphMargin: false,
+              lineDecorationsWidth: 0,
+              lineNumbersMinChars: 3,
+              folding: false,
               enableSplitViewResizing: diffMode === 'split',
               // The diff editor renders both its own vertical scrollbar and a
               // wider diff overview ruler (the colored add/remove map). That

--- a/apps/browser/src/ui/screens/main/file-tree/file-preview-tab-content.tsx
+++ b/apps/browser/src/ui/screens/main/file-tree/file-preview-tab-content.tsx
@@ -1377,10 +1377,13 @@ function DiffEditorPreview({
               // the left of the gutter. Disable it to reclaim that space.
               renderMarginRevertIcon: false,
               // Trim the remaining gutter chrome: drop the glyph margin and
-              // code folding controls, and keep a tight line-number column.
+              // code folding controls. lineNumbersMinChars keeps the (right-
+              // aligned) number column from reserving extra blank space to
+              // the left of the digits, while lineDecorationsWidth restores a
+              // readable gap between the numbers and the code.
               glyphMargin: false,
-              lineDecorationsWidth: 1,
-              lineNumbersMinChars: 3,
+              lineNumbersMinChars: 2,
+              lineDecorationsWidth: 10,
               folding: false,
               enableSplitViewResizing: diffMode === 'split',
               // The diff editor renders both its own vertical scrollbar and a

--- a/apps/browser/src/ui/screens/main/file-tree/file-preview-tab-content.tsx
+++ b/apps/browser/src/ui/screens/main/file-tree/file-preview-tab-content.tsx
@@ -1067,7 +1067,7 @@ function DiffEditorPreview({
   const [diffError, setDiffError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const language = languageFromPath(tab.relativePath);
-  const { markFocused } = useFileCodeZoom(tabId);
+  const { fontSize, markFocused } = useFileCodeZoom(tabId);
   const diffEditorRef = useRef<Monaco.editor.IStandaloneDiffEditor | null>(
     null,
   );
@@ -1377,6 +1377,13 @@ function DiffEditorPreview({
                 vertical: 'hidden',
                 verticalScrollbarSize: 0,
               },
+              // Apply the shared file-code zoom level. IDiffEditorOptions
+              // extends the base editor options, so this propagates to both
+              // the original and modified panes. The @monaco-editor/react
+              // DiffEditor re-applies options on change, so updating the zoom
+              // store re-renders this component and rescales the diff.
+              fontSize,
+              lineHeight: fontSize * 1.5,
             }}
           />
         )}

--- a/apps/browser/src/ui/screens/main/file-tree/file-preview-tab-content.tsx
+++ b/apps/browser/src/ui/screens/main/file-tree/file-preview-tab-content.tsx
@@ -1061,7 +1061,7 @@ function DiffEditorPreview({
   const getFileStat = useKartonProcedure((p) => p.fileTree.getFileStat);
   const [diffMode, setDiffMode] = useState<DiffMode>(() => {
     const stored = diffModeStore.get(tabId);
-    return stored === 'inline' || stored === 'split' ? stored : 'split';
+    return stored === 'inline' || stored === 'split' ? stored : 'inline';
   });
   const [diffContent, setDiffContent] = useState<FileDiffContent | null>(null);
   const [diffError, setDiffError] = useState<string | null>(null);

--- a/apps/browser/src/ui/screens/main/file-tree/file-preview-tab-content.tsx
+++ b/apps/browser/src/ui/screens/main/file-tree/file-preview-tab-content.tsx
@@ -20,7 +20,6 @@ import type {
   FileStatResult,
   TabState,
 } from '@shared/karton-contracts/ui';
-import { FILE_SAVE_CONFLICT_CODE } from '@shared/karton-contracts/ui';
 import {
   useCallback,
   useEffect,
@@ -30,10 +29,13 @@ import {
   type ReactElement,
 } from 'react';
 import { IconDatabaseFillDuo18 } from 'nucleo-ui-fill-duo-18';
+import type { FileDiffContent } from '@shared/karton-contracts/ui';
 import {
+  Columns3Icon,
   Loader2Icon,
   MinusIcon,
   PlusIcon,
+  PanelTopIcon,
   TriangleAlertIcon,
   XIcon,
 } from 'lucide-react';
@@ -51,7 +53,7 @@ import {
   IconUndoOutline18,
 } from 'nucleo-ui-outline-18';
 import { Menu as MenuBase } from '@base-ui/react/menu';
-import MonacoEditor from '@monaco-editor/react';
+import MonacoEditor, { DiffEditor } from '@monaco-editor/react';
 import type * as Monaco from 'monaco-editor';
 import { HotkeyActions } from '@shared/hotkeys';
 import { useHotKeyListener } from '@ui/hooks/use-hotkey-listener';
@@ -64,11 +66,11 @@ import {
   nativeFileManagerLabel,
 } from '@shared/ide-url';
 import type { OpenFilesInIde } from '@shared/karton-contracts/ui/shared-types';
-import {
-  clearFileTabUnsavedEditEntry,
-  setFileTabUnsavedEditEntry,
-} from './file-tab-unsaved-edits';
 import { Streamdown } from '@ui/components/streamdown';
+import {
+  type EditorActions,
+  useFileEditorController,
+} from './use-file-editor-controller';
 
 const MONACO_THEME_NAME = 'stagewise-file-preview';
 
@@ -93,27 +95,8 @@ const scrollStateStore = new Map<
 /** Persists markdown preview/source mode across tab switches. */
 const markdownModeStore = new Map<string, 'preview' | 'source'>();
 
-type EditorActions = {
-  save: () => void;
-  /** Overwrite the on-disk file, ignoring a detected external modification. */
-  forceSave: () => void;
-  /** Discard local edits and load the latest on-disk content. */
-  reload: () => void;
-  undo: () => void;
-  redo: () => void;
-  canUndo: boolean;
-  canRedo: boolean;
-  isDirty: boolean;
-  isSaving: boolean;
-  /** When true, the file is read-only (e.g. attachment blob) — no saving. */
-  readOnly: boolean;
-  /**
-   * True when the on-disk file changed while the user has unsaved local
-   * edits. The UI surfaces a conflict warning with reload/overwrite options
-   * instead of silently losing or overwriting either side.
-   */
-  externalChange: boolean;
-};
+/** Persists diff editor mode (inline/split) across tab switches. */
+const diffModeStore = new Map<string, 'inline' | 'split'>();
 
 type ImagePreviewBackground = SvgPreviewBackground;
 
@@ -564,28 +547,13 @@ function useSourceCursorPosition(editor: MonacoEditorInstance | null): {
   return cursorPosition;
 }
 
-function createEditorActionState(editor: MonacoEditorInstance | null) {
-  const model = editor?.getModel();
-  if (!model) {
-    return {
-      canUndo: false,
-      canRedo: false,
-    };
-  }
-
-  return {
-    canUndo: model.canUndo(),
-    canRedo: model.canRedo(),
-  };
-}
-
 function useEditorActions(
   tabId: string,
   editor: MonacoEditorInstance | null,
   preview: FilePreviewResult,
   text: string,
   setText: (value: string) => void,
-) {
+): EditorActions {
   const saveFile = useKartonProcedure((p) => p.fileTree.saveFile);
   const getFilePreview = useKartonProcedure((p) => p.fileTree.getFilePreview);
   const readOnly = preview.readOnly ?? false;
@@ -593,243 +561,96 @@ function useEditorActions(
     preview.workspaceKey,
     preview.relativePath,
   );
-  const [isDirty, setIsDirty] = useState(false);
-  const [isSaving, setIsSaving] = useState(false);
-  const [canUndo, setCanUndo] = useState(false);
-  const [canRedo, setCanRedo] = useState(false);
-  const [externalChange, setExternalChange] = useState(false);
 
-  // The on-disk content + mtime the editor is currently based on. These form
-  // the baseline for dirty detection, live external-edit adoption, and the
-  // save-time conflict guard.
-  const savedTextRef = useRef(preview.text ?? '');
-  const baselineMtimeRef = useRef<number | undefined>(preview.mtimeMs);
-  const lastDiskTextRef = useRef(preview.text ?? '');
+  // Track the editor + current draft text in refs so the controller's stable
+  // callbacks always observe live values without being re-created.
+  const editorRef = useRef(editor);
+  editorRef.current = editor;
+  const textRef = useRef(text);
+  textRef.current = text;
 
-  const refreshActionState = useCallback(() => {
-    const state = createEditorActionState(editor);
-    const currentText = editor?.getValue() ?? text;
-    setCanUndo(state.canUndo);
-    setCanRedo(state.canRedo);
-    setIsDirty(currentText !== savedTextRef.current);
-  }, [editor, text]);
+  const controller = useFileEditorController({
+    tabId,
+    workspaceKey: preview.workspaceKey,
+    relativePath: preview.relativePath,
+    readOnly,
+    saveFile,
+    initialText: preview.text ?? '',
+    initialMtimeMs: preview.mtimeMs,
+    getModel: () => editorRef.current?.getModel(),
+    // Fall back to the draft text when the editor is unmounted (e.g. SVG /
+    // markdown preview mode) so dirty detection keeps working.
+    getValue: () => editorRef.current?.getValue() ?? textRef.current,
+    reload: async () => {
+      const result = await getFilePreview(
+        preview.workspaceKey,
+        preview.relativePath,
+      );
+      if (!result) return null;
+      const diskText = result.text ?? '';
+      const key = getPreviewCacheKey(result.workspaceKey, result.relativePath);
+      previewCache.set(key, { preview: result, error: null });
+      textDraftCache.set(key, diskText);
+      setText(diskText);
+      return { text: diskText, mtimeMs: result.mtimeMs };
+    },
+    unsavedTitle: preview.relativePath.split('/').pop() || preview.relativePath,
+    onDiscard: () => {
+      textDraftCache.delete(cacheKey);
+    },
+    onSaved: (result, nextText) => {
+      if (!result) return;
+      const key = getPreviewCacheKey(result.workspaceKey, result.relativePath);
+      previewCache.set(key, { preview: result, error: null });
+      textDraftCache.set(key, nextText);
+    },
+  });
+
+  const { reconcileDisk, refreshState, notifyContentChanged } = controller;
 
   // React to fresh on-disk content arriving from the parent's revalidation
   // (driven by the file-tree watcher bumping the backing directory's
-  // revision). With no local edits we adopt the new content live; with
-  // unsaved edits we keep them and raise a conflict so the user is warned.
+  // revision). With no local edits the new content is adopted live; with
+  // unsaved edits a conflict is raised so the user is warned.
   useEffect(() => {
     if (readOnly) return;
-    const diskText = preview.text ?? '';
-    if (diskText === lastDiskTextRef.current) {
-      // Content unchanged (e.g. a metadata-only touch) — just refresh the
-      // mtime baseline so the next save isn't flagged as a false conflict.
-      baselineMtimeRef.current = preview.mtimeMs;
-      return;
+    const outcome = reconcileDisk(preview.text ?? '', preview.mtimeMs);
+    if (outcome === 'adopted') {
+      textDraftCache.set(cacheKey, preview.text ?? '');
+      setText(preview.text ?? '');
     }
-    lastDiskTextRef.current = diskText;
-    const editorText = editor?.getValue() ?? savedTextRef.current;
-    const userHasEdits = editorText !== savedTextRef.current;
-    if (userHasEdits) {
-      setExternalChange(true);
-      return;
-    }
-    savedTextRef.current = diskText;
-    baselineMtimeRef.current = preview.mtimeMs;
-    setExternalChange(false);
-    setIsDirty(false);
-    textDraftCache.set(cacheKey, diskText);
-    setText(diskText);
-    clearFileTabUnsavedEditEntry(tabId);
   }, [
     preview.text,
     preview.mtimeMs,
     readOnly,
-    editor,
     cacheKey,
-    tabId,
     setText,
+    reconcileDisk,
   ]);
 
-  useEffect(() => {
-    return () => clearFileTabUnsavedEditEntry(tabId);
-  }, [tabId]);
-
-  const save = useCallback(
-    async (force = false): Promise<boolean> => {
-      if (readOnly || !editor || isSaving) return false;
-
-      const nextText = editor.getValue();
-      setIsSaving(true);
-      try {
-        const result = await saveFile(
-          preview.workspaceKey,
-          preview.relativePath,
-          nextText,
-          force ? null : baselineMtimeRef.current,
-        );
-        savedTextRef.current = nextText;
-        lastDiskTextRef.current = nextText;
-        baselineMtimeRef.current = result?.mtimeMs;
-        setIsDirty(false);
-        setExternalChange(false);
-        clearFileTabUnsavedEditEntry(tabId);
-        if (result) {
-          const key = getPreviewCacheKey(
-            result.workspaceKey,
-            result.relativePath,
-          );
-          previewCache.set(key, { preview: result, error: null });
-          textDraftCache.set(key, nextText);
-        }
-        return true;
-      } catch (err) {
-        // The backend rejected the save because the file was modified
-        // externally. Surface the conflict instead of throwing so the user
-        // can reload or explicitly overwrite.
-        if (
-          err instanceof Error &&
-          err.message.includes(FILE_SAVE_CONFLICT_CODE)
-        ) {
-          setExternalChange(true);
-          return false;
-        }
-        throw err;
-      } finally {
-        setIsSaving(false);
-        refreshActionState();
-      }
-    },
-    [editor, isSaving, preview, readOnly, refreshActionState, saveFile, tabId],
-  );
-
-  const handleSave = useCallback(() => {
-    // While an external-change conflict is surfaced, the regular save is
-    // blocked — the user must explicitly Reload or Overwrite from the banner.
-    if (externalChange) return;
-    void save(false);
-  }, [save, externalChange]);
-
-  const forceSave = useCallback(() => {
-    void save(true);
-  }, [save]);
-
-  // Discard local edits and load the latest on-disk content.
-  const reload = useCallback(async () => {
-    const result = await getFilePreview(
-      preview.workspaceKey,
-      preview.relativePath,
-    );
-    if (!result) return;
-    const diskText = result.text ?? '';
-    savedTextRef.current = diskText;
-    lastDiskTextRef.current = diskText;
-    baselineMtimeRef.current = result.mtimeMs;
-    const key = getPreviewCacheKey(result.workspaceKey, result.relativePath);
-    previewCache.set(key, { preview: result, error: null });
-    textDraftCache.set(key, diskText);
-    setText(diskText);
-    setExternalChange(false);
-    setIsDirty(false);
-    clearFileTabUnsavedEditEntry(tabId);
-  }, [
-    getFilePreview,
-    preview.workspaceKey,
-    preview.relativePath,
-    setText,
-    tabId,
-  ]);
-
-  const handleReload = useCallback(() => {
-    void reload();
-  }, [reload]);
-
-  const undo = useCallback(() => {
-    const model = editor?.getModel();
-    if (!model?.canUndo()) return false;
-    void model.undo();
-    window.setTimeout(refreshActionState, 0);
-  }, [editor, refreshActionState]);
-
-  const redo = useCallback(() => {
-    const model = editor?.getModel();
-    if (!model?.canRedo()) return false;
-    void model.redo();
-    window.setTimeout(refreshActionState, 0);
-  }, [editor, refreshActionState]);
-
-  useHotKeyListener(handleSave, HotkeyActions.SAVE_FILE);
-  useHotKeyListener(undo, HotkeyActions.UNDO_FILE_EDIT);
-  useHotKeyListener(redo, HotkeyActions.REDO_FILE_EDIT);
-
-  // Keep dirty state in sync with the text value regardless of editor
+  // Keep dirty/undo/redo in sync with the text value regardless of editor
   // mount state. When the editor is unmounted (e.g. SVG preview mode),
   // onDidChangeModelContent doesn't fire, so we rely on this effect.
   useEffect(() => {
-    refreshActionState();
-  }, [text, refreshActionState]);
+    refreshState();
+  }, [text, refreshState]);
 
   useEffect(() => {
     if (!editor) return;
-
-    refreshActionState();
-
+    refreshState();
     const contentDisposable = editor.onDidChangeModelContent(() => {
-      const nextText = editor.getValue();
-      const isNextDirty = nextText !== savedTextRef.current;
-      setIsDirty(isNextDirty);
-      // Read-only files (e.g. attachment blobs) can never be saved, so don't
-      // surface an unsaved-edit prompt for them.
-      if (isNextDirty && !readOnly) {
-        setFileTabUnsavedEditEntry({
-          tabId,
-          title: preview.relativePath.split('/').pop() || preview.relativePath,
-          workspaceKey: preview.workspaceKey,
-          relativePath: preview.relativePath,
-          save: () => save(false),
-          discard: () => {
-            textDraftCache.delete(
-              getPreviewCacheKey(preview.workspaceKey, preview.relativePath),
-            );
-            clearFileTabUnsavedEditEntry(tabId);
-          },
-        });
-      } else {
-        clearFileTabUnsavedEditEntry(tabId);
-      }
-      window.setTimeout(refreshActionState, 0);
+      notifyContentChanged();
     });
     const cursorDisposable = editor.onDidChangeCursorSelection(() => {
-      window.setTimeout(refreshActionState, 0);
+      window.setTimeout(refreshState, 0);
     });
-
     return () => {
       contentDisposable.dispose();
       cursorDisposable.dispose();
     };
-  }, [
-    editor,
-    readOnly,
-    refreshActionState,
-    save,
-    tabId,
-    preview.relativePath,
-    preview.workspaceKey,
-  ]);
+  }, [editor, refreshState, notifyContentChanged]);
 
-  return {
-    save: handleSave,
-    forceSave,
-    reload: handleReload,
-    undo,
-    redo,
-    canUndo,
-    canRedo,
-    isDirty,
-    isSaving,
-    readOnly,
-    externalChange,
-  } satisfies EditorActions;
+  return controller.actions;
 }
 
 function ToolbarTooltip({
@@ -1218,6 +1039,350 @@ function useFileCodeZoom(tabId: string, enabled = true) {
     zoomPercentage,
     zoomPercentageRef,
   };
+}
+
+type DiffMode = 'inline' | 'split';
+
+function DiffEditorPreview({
+  tab,
+  tabId,
+}: {
+  tab: NonNullable<TabState['file']>;
+  tabId: string;
+}) {
+  const getFileDiffContent = useKartonProcedure(
+    (p) => p.toolbox.getFileDiffContent,
+  );
+  // Karton procedure identities are not guaranteed stable across renders;
+  // keep this one in a ref so the load effect/reload don't re-run every render.
+  const getFileDiffContentRef = useRef(getFileDiffContent);
+  getFileDiffContentRef.current = getFileDiffContent;
+  const saveFile = useKartonProcedure((p) => p.fileTree.saveFile);
+  const getFileStat = useKartonProcedure((p) => p.fileTree.getFileStat);
+  const [diffMode, setDiffMode] = useState<DiffMode>(() => {
+    const stored = diffModeStore.get(tabId);
+    return stored === 'inline' || stored === 'split' ? stored : 'split';
+  });
+  const [diffContent, setDiffContent] = useState<FileDiffContent | null>(null);
+  const [diffError, setDiffError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const language = languageFromPath(tab.relativePath);
+  const { markFocused } = useFileCodeZoom(tabId);
+  const diffEditorRef = useRef<Monaco.editor.IStandaloneDiffEditor | null>(
+    null,
+  );
+
+  // The diff always renders the committed (HEAD) version against the current
+  // working-tree file, so the modified/right side is the live file on disk
+  // and is editable unless the tab is explicitly read-only.
+  const editable = !(tab.readOnly ?? false);
+
+  // Last on-disk mtime we have reconciled to. Lets the live-detection effect
+  // skip a git-diff fetch when an unrelated change bumps the directory
+  // revision, and avoids treating our own writes as external edits.
+  const diskMtimeRef = useRef<number | null>(null);
+
+  const persistMode = useCallback(
+    (next: DiffMode) => {
+      diffModeStore.set(tabId, next);
+      setDiffMode(next);
+    },
+    [tabId],
+  );
+
+  // Extract the workspace path from the workspace key for the git diff
+  // procedure (it expects a filesystem path, not a composite key).
+  const workspacePath = useMemo(() => {
+    const colonIdx = tab.workspaceKey.indexOf(':');
+    return colonIdx < 0
+      ? tab.workspaceKey
+      : tab.workspaceKey.slice(colonIdx + 1);
+  }, [tab.workspaceKey]);
+
+  // All save / dirty / undo-redo / conflict / unsaved-prompt / hotkey behavior
+  // is shared with the plain source editor via this controller. The diff
+  // editor only supplies the editable (modified) model + a diff-aware reload.
+  const controller = useFileEditorController({
+    tabId,
+    workspaceKey: tab.workspaceKey,
+    relativePath: tab.relativePath,
+    readOnly: !editable,
+    saveFile,
+    getModel: () => diffEditorRef.current?.getModifiedEditor().getModel(),
+    getValue: () => diffEditorRef.current?.getModifiedEditor().getValue(),
+    reload: async () => {
+      setIsLoading(true);
+      setDiffError(null);
+      try {
+        const content = await getFileDiffContentRef.current(
+          workspacePath,
+          tab.relativePath,
+          tab.diffStaged ?? false,
+        );
+        setDiffContent(content);
+        diskMtimeRef.current = content?.mtimeMs ?? null;
+        if (!content) {
+          setDiffError('Unable to load diff content.');
+          return null;
+        }
+        return { text: content.modified, mtimeMs: content.mtimeMs };
+      } catch (err) {
+        setDiffError(
+          err instanceof Error ? err.message : 'Failed to load diff',
+        );
+        return null;
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    unsavedTitle: tab.relativePath.split('/').pop() || tab.relativePath,
+    onSaved: (result) => {
+      diskMtimeRef.current = result?.mtimeMs ?? null;
+    },
+    onSaveError: (err) => {
+      setDiffError(err instanceof Error ? err.message : 'Failed to save');
+    },
+  });
+
+  const { actions, reconcileDisk, refreshState, notifyContentChanged } =
+    controller;
+
+  // The @monaco-editor/react DiffEditor frequently mounts before its flex
+  // container has a measured width, collapsing both panes to zero width
+  // (only the right-edge overview ruler + scrollbar stay visible). Its
+  // built-in automaticLayout does not reliably recover, so we force a
+  // layout on mount and observe the container for size changes.
+  const handleDiffMount = useCallback(
+    (editor: Monaco.editor.IStandaloneDiffEditor) => {
+      diffEditorRef.current = editor;
+      const container = editor.getContainerDomNode();
+      const relayout = () => editor.layout();
+      // Force an initial layout once the browser has painted the container.
+      requestAnimationFrame(relayout);
+      setTimeout(relayout, 0);
+      setTimeout(relayout, 100);
+      const target = container?.parentElement ?? container;
+      if (target && typeof ResizeObserver !== 'undefined') {
+        const observer = new ResizeObserver(() => editor.layout());
+        observer.observe(target);
+        editor.onDidDispose(() => observer.disconnect());
+      }
+
+      // Wire dirty tracking on the modified (right) editor. Save/undo/redo
+      // hotkeys are handled globally by the controller.
+      const modified = editor.getModifiedEditor();
+      modified.onDidFocusEditorWidget(markFocused);
+      modified.onDidChangeModelContent(() => {
+        notifyContentChanged();
+      });
+      refreshState();
+    },
+    [markFocused, notifyContentChanged, refreshState],
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+    setIsLoading(true);
+    setDiffError(null);
+
+    // Safety timeout — surface an error if the backend doesn't respond
+    // within a reasonable window instead of spinning forever.
+    const safetyTimer = setTimeout(() => {
+      if (!cancelled) {
+        setDiffError('Diff load timed out.');
+        setIsLoading(false);
+      }
+    }, 15_000);
+
+    getFileDiffContentRef
+      .current(workspacePath, tab.relativePath, tab.diffStaged ?? false)
+      .then((content) => {
+        if (cancelled) return;
+        setDiffContent(content);
+        diskMtimeRef.current = content?.mtimeMs ?? null;
+        controller.setBaseline(
+          content?.modified ?? '',
+          content?.mtimeMs ?? null,
+        );
+        if (!content) setDiffError('Unable to load diff content.');
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setDiffError(
+          err instanceof Error ? err.message : 'Failed to load diff',
+        );
+      })
+      .finally(() => {
+        clearTimeout(safetyTimer);
+        if (!cancelled) setIsLoading(false);
+      });
+    return () => {
+      cancelled = true;
+      clearTimeout(safetyTimer);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [workspacePath, tab.relativePath, tab.diffStaged]);
+
+  // Live external-change detection. The file-tree watcher bumps the backing
+  // directory's revision whenever its contents change on disk; on each bump we
+  // cheaply stat the file and, if it actually changed, re-fetch the diff and
+  // reconcile (adopt the new content when clean, raise a conflict otherwise).
+  const directoryRevision = useKartonState((s) => {
+    const slash = tab.relativePath.lastIndexOf('/');
+    const directoryPath = slash === -1 ? '' : tab.relativePath.slice(0, slash);
+    return (
+      s.fileTree.directoryRevisions?.[tab.workspaceKey]?.[directoryPath] ??
+      s.fileTree.workspaceRevisions?.[tab.workspaceKey] ??
+      0
+    );
+  });
+  const prevRevisionRef = useRef(directoryRevision);
+
+  useEffect(() => {
+    // Skip the initial run — the load effect owns the first fetch/baseline.
+    if (prevRevisionRef.current === directoryRevision) return;
+    prevRevisionRef.current = directoryRevision;
+    if (!editable) return;
+
+    let cancelled = false;
+    void (async () => {
+      let stat: Awaited<ReturnType<typeof getFileStat>> = null;
+      try {
+        stat = await getFileStat(tab.workspaceKey, tab.relativePath);
+      } catch {
+        return; // Transient failure — keep showing the current diff.
+      }
+      if (cancelled || !stat) return;
+      if (stat.mtimeMs === diskMtimeRef.current) return; // Unchanged on disk.
+
+      let content: FileDiffContent | null;
+      try {
+        content = await getFileDiffContentRef.current(
+          workspacePath,
+          tab.relativePath,
+          tab.diffStaged ?? false,
+        );
+      } catch {
+        return;
+      }
+      if (cancelled || !content) return;
+      diskMtimeRef.current = content.mtimeMs ?? stat.mtimeMs;
+      const outcome = reconcileDisk(content.modified, content.mtimeMs);
+      if (outcome === 'adopted') setDiffContent(content);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    directoryRevision,
+    editable,
+    getFileStat,
+    workspacePath,
+    tab.workspaceKey,
+    tab.relativePath,
+    tab.diffStaged,
+    reconcileDisk,
+  ]);
+
+  return (
+    <div className="flex size-full flex-col bg-background">
+      <FileTabToolbar
+        actions={actions}
+        openExternalPath={getPreviewAbsolutePath({
+          workspaceKey: tab.workspaceKey,
+          relativePath: tab.relativePath,
+        } as FilePreviewResult)}
+        onInteract={markFocused}
+        right={
+          <div className="flex h-7 items-center gap-1 rounded-md bg-surface-1 p-0.5">
+            <button
+              type="button"
+              className={cn(
+                'flex h-full cursor-pointer items-center gap-1 rounded px-2.5 text-muted-foreground text-xs transition-colors hover:text-foreground',
+                diffMode === 'inline' &&
+                  'bg-background text-foreground ring-1 ring-border-subtle',
+              )}
+              aria-label="Inline diff"
+              aria-pressed={diffMode === 'inline'}
+              onClick={() => persistMode('inline')}
+            >
+              <PanelTopIcon className="size-3.5" />
+              {diffMode === 'inline' ? <span>Inline</span> : null}
+            </button>
+            <button
+              type="button"
+              className={cn(
+                'flex h-full cursor-pointer items-center gap-1 rounded px-2.5 text-muted-foreground text-xs transition-colors hover:text-foreground',
+                diffMode === 'split' &&
+                  'bg-background text-foreground ring-1 ring-border-subtle',
+              )}
+              aria-label="Split diff"
+              aria-pressed={diffMode === 'split'}
+              onClick={() => persistMode('split')}
+            >
+              <Columns3Icon className="size-3.5" />
+              {diffMode === 'split' ? <span>Split</span> : null}
+            </button>
+          </div>
+        }
+      />
+      {actions.externalChange ? (
+        <ExternalChangeBanner actions={actions} />
+      ) : null}
+      <div
+        className="min-h-0 flex-1"
+        onFocusCapture={markFocused}
+        onPointerDownCapture={markFocused}
+      >
+        {isLoading ? (
+          <div className="flex size-full items-center justify-center text-muted-foreground text-xs">
+            <div className="flex items-center gap-2">
+              <Loader2Icon className="size-3.5 animate-spin" />
+              <span>Loading diff…</span>
+            </div>
+          </div>
+        ) : diffError || !diffContent ? (
+          <div className="flex size-full items-center justify-center text-error-foreground text-sm">
+            {diffError ?? 'Unable to load diff'}
+          </div>
+        ) : (
+          <DiffEditor
+            height="100%"
+            width="100%"
+            language={language === 'plaintext' ? undefined : language}
+            original={diffContent.original}
+            modified={diffContent.modified}
+            theme={MONACO_THEME_NAME}
+            beforeMount={configureMonacoTheme}
+            onMount={handleDiffMount}
+            options={{
+              ...MONACO_SHARED_OPTIONS,
+              renderSideBySide: diffMode === 'split',
+              // Monaco otherwise auto-collapses side-by-side to inline
+              // whenever the editor is narrower than
+              // renderSideBySideInlineBreakpoint (900px). The file panel is
+              // usually narrower than that, so force the chosen mode.
+              useInlineViewWhenSpaceIsLimited: false,
+              readOnly: !editable,
+              originalEditable: false,
+              renderIndicators: true,
+              enableSplitViewResizing: diffMode === 'split',
+              // The diff editor renders both its own vertical scrollbar and a
+              // wider diff overview ruler (the colored add/remove map). That
+              // looks like two stacked scrollbars. Hide the plain scrollbar
+              // and keep the highlighted overview ruler as the sole scroll
+              // affordance (it supports click/drag-to-scroll).
+              scrollbar: {
+                ...MONACO_SHARED_OPTIONS.scrollbar,
+                vertical: 'hidden',
+                verticalScrollbarSize: 0,
+              },
+            }}
+          />
+        )}
+      </div>
+    </div>
+  );
 }
 
 function TextEditorPreview({
@@ -2707,6 +2872,16 @@ export function FilePreviewTabContent({ tab }: FilePreviewTabContentProps) {
             </div>
           )}
         </div>
+      </div>
+    );
+  }
+
+  // Git diff view: bypass the regular file preview pipeline entirely.
+  // The DiffEditorPreview loads its own content and is read-only.
+  if (tab.file?.showDiff) {
+    return (
+      <div className="absolute inset-0 z-10 flex flex-col bg-background">
+        <DiffEditorPreview tab={tab.file} tabId={tab.id} />
       </div>
     );
   }

--- a/apps/browser/src/ui/screens/main/file-tree/file-tree-diff-view.tsx
+++ b/apps/browser/src/ui/screens/main/file-tree/file-tree-diff-view.tsx
@@ -110,13 +110,13 @@ export function FileTreeDiffView({
   data: MountedWorkspaceGitDiffSummary | null;
   loading: boolean;
   shownRelativePath: string | null;
-  onOpenFile: (path: string) => void;
+  onOpenFile: (path: string, staged: boolean) => void;
 }) {
   const rows: DiffRow[] = data?.entries ?? [];
 
   function handleRowClick(row: DiffRow) {
     if (!workspaceKey || row.changeType === 'deleted') return;
-    onOpenFile(row.path);
+    onOpenFile(row.path, row.staged);
   }
 
   if (loading) {

--- a/apps/browser/src/ui/screens/main/file-tree/file-tree-diff-view.tsx
+++ b/apps/browser/src/ui/screens/main/file-tree/file-tree-diff-view.tsx
@@ -2,6 +2,7 @@ import { Virtuoso } from 'react-virtuoso';
 import { cn } from '@ui/utils';
 import { getBaseName } from '@shared/path-utils';
 import type { MountedWorkspaceGitDiffSummary } from '@shared/karton-contracts/ui';
+import { formatDiffCount } from './format-diff-count';
 
 type DiffRow = {
   path: string;
@@ -88,10 +89,14 @@ function DiffRowItem({
         </span>
         <span className="flex shrink-0 items-center gap-1.5 font-mono text-xs tabular-nums">
           {row.added > 0 && (
-            <span className="text-success-foreground">+{row.added}</span>
+            <span className="text-success-foreground">
+              +{formatDiffCount(row.added)}
+            </span>
           )}
           {row.deleted > 0 && (
-            <span className="text-error-foreground">-{row.deleted}</span>
+            <span className="text-error-foreground">
+              -{formatDiffCount(row.deleted)}
+            </span>
           )}
         </span>
       </button>

--- a/apps/browser/src/ui/screens/main/file-tree/file-tree-diff-view.tsx
+++ b/apps/browser/src/ui/screens/main/file-tree/file-tree-diff-view.tsx
@@ -110,13 +110,15 @@ export function FileTreeDiffView({
   data: MountedWorkspaceGitDiffSummary | null;
   loading: boolean;
   shownRelativePath: string | null;
-  onOpenFile: (path: string, staged: boolean) => void;
+  onOpenFile: (path: string, staged: boolean, oldPath?: string) => void;
 }) {
   const rows: DiffRow[] = data?.entries ?? [];
 
   function handleRowClick(row: DiffRow) {
     if (!workspaceKey || row.changeType === 'deleted') return;
-    onOpenFile(row.path, row.staged);
+    // Renamed files keep their committed (HEAD) blob at the old path, so the
+    // diff view needs it to load the original side.
+    onOpenFile(row.path, row.staged, row.oldPath);
   }
 
   if (loading) {

--- a/apps/browser/src/ui/screens/main/file-tree/file-tree-sidebar.tsx
+++ b/apps/browser/src/ui/screens/main/file-tree/file-tree-sidebar.tsx
@@ -174,10 +174,19 @@ export function FileTreeSidebar() {
       : null;
   });
 
+  const _getFileDiffContent = useKartonProcedure(
+    (p) => p.toolbox.getFileDiffContent,
+  );
+
   const handleDiffOpenFile = useCallback(
-    (path: string) => {
+    (path: string, staged: boolean) => {
       if (!selectedWorkspaceKey) return;
-      void openFileTab(selectedWorkspaceKey, path, openAgent);
+      // Open the file as a diff tab — the content will be fetched inside
+      // the DiffEditorPreview component.
+      void openFileTab(selectedWorkspaceKey, path, openAgent, {
+        showDiff: true,
+        diffStaged: staged,
+      });
     },
     [openFileTab, selectedWorkspaceKey, openAgent],
   );

--- a/apps/browser/src/ui/screens/main/file-tree/file-tree-sidebar.tsx
+++ b/apps/browser/src/ui/screens/main/file-tree/file-tree-sidebar.tsx
@@ -25,6 +25,7 @@ import { useCommandCenter } from '../command-center';
 import { FileTreePreviewCoordinator } from './file-tree-preview-coordinator';
 import { FileTreeWorkspaceView } from './file-tree-workspace-view';
 import { FileTreeDiffView } from './file-tree-diff-view';
+import { formatDiffCount } from './format-diff-count';
 import {
   areFileTreeWorkspaceMountsEqual,
   getFileTreeWorkspaceKey,
@@ -308,10 +309,10 @@ export function FileTreeSidebar() {
                     {(diffTotals.added > 0 || diffTotals.deleted > 0) && (
                       <span className="flex flex-col font-mono text-[0.5rem] tabular-nums leading-none">
                         <span className="text-success-foreground">
-                          +{diffTotals.added}
+                          +{formatDiffCount(diffTotals.added)}
                         </span>
                         <span className="text-error-foreground">
-                          -{diffTotals.deleted}
+                          -{formatDiffCount(diffTotals.deleted)}
                         </span>
                       </span>
                     )}

--- a/apps/browser/src/ui/screens/main/file-tree/file-tree-sidebar.tsx
+++ b/apps/browser/src/ui/screens/main/file-tree/file-tree-sidebar.tsx
@@ -179,13 +179,15 @@ export function FileTreeSidebar() {
   );
 
   const handleDiffOpenFile = useCallback(
-    (path: string, staged: boolean) => {
+    (path: string, staged: boolean, oldPath?: string) => {
       if (!selectedWorkspaceKey) return;
       // Open the file as a diff tab — the content will be fetched inside
-      // the DiffEditorPreview component.
+      // the DiffEditorPreview component. `oldPath` is threaded through for
+      // renamed files so the original (HEAD) side can be located.
       void openFileTab(selectedWorkspaceKey, path, openAgent, {
         showDiff: true,
         diffStaged: staged,
+        diffOldPath: oldPath,
       });
     },
     [openFileTab, selectedWorkspaceKey, openAgent],

--- a/apps/browser/src/ui/screens/main/file-tree/file-tree-toggle-button.tsx
+++ b/apps/browser/src/ui/screens/main/file-tree/file-tree-toggle-button.tsx
@@ -19,6 +19,7 @@ import {
   getFileTreeWorkspaceKey,
   getFileTreeWorkspaceMountsForAgent,
 } from './file-tree-utils';
+import { formatDiffCount } from './format-diff-count';
 
 // Cache diff totals per workspace across mount/unmount cycles to
 // prevent flicker when the toggle button moves between containers.
@@ -111,31 +112,34 @@ export function FileTreeToggleButton() {
   const showDiff = !visible && (diffTotals.added > 0 || diffTotals.deleted > 0);
 
   return (
-    <div className="flex items-center">
-      <Tooltip>
-        <TooltipTrigger>
-          <Button
-            variant="ghost"
-            size="icon-sm"
-            aria-label={label}
-            onClick={() => setVisible(!visible)}
-          >
-            <Icon className="size-4" />
-          </Button>
-        </TooltipTrigger>
-        <TooltipContent>
-          <span className="flex items-center gap-1.5">
-            <span>{label}</span>
-            <HotkeyCombo action={HotkeyActions.TOGGLE_FILE_TREE} size="xs" />
-          </span>
-        </TooltipContent>
-      </Tooltip>
-      {showDiff && (
-        <span className="flex min-w-0 shrink-0 flex-col font-mono text-[0.5rem] text-muted-foreground tabular-nums leading-none">
-          <span className="text-success-foreground">+{diffTotals.added}</span>
-          <span className="text-error-foreground">-{diffTotals.deleted}</span>
+    <Tooltip>
+      <TooltipTrigger>
+        <Button
+          variant="ghost"
+          size={showDiff ? 'sm' : 'icon-sm'}
+          aria-label={label}
+          onClick={() => setVisible(!visible)}
+          className={showDiff ? 'gap-1 rounded-full px-2' : undefined}
+        >
+          <Icon className="size-4 shrink-0" />
+          {showDiff && (
+            <span className="flex min-w-0 shrink-0 flex-col font-mono text-[0.5rem] tabular-nums leading-none">
+              <span className="text-success-foreground">
+                +{formatDiffCount(diffTotals.added)}
+              </span>
+              <span className="text-error-foreground">
+                -{formatDiffCount(diffTotals.deleted)}
+              </span>
+            </span>
+          )}
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent>
+        <span className="flex items-center gap-1.5">
+          <span>{label}</span>
+          <HotkeyCombo action={HotkeyActions.TOGGLE_FILE_TREE} size="xs" />
         </span>
-      )}
-    </div>
+      </TooltipContent>
+    </Tooltip>
   );
 }

--- a/apps/browser/src/ui/screens/main/file-tree/format-diff-count.ts
+++ b/apps/browser/src/ui/screens/main/file-tree/format-diff-count.ts
@@ -1,0 +1,17 @@
+/**
+ * Maximum diff line delta rendered as an exact number. Anything strictly
+ * greater is collapsed to `MANY` so the compact diff badges (file-tree toggle
+ * button, diff tab control, per-file rows) don't blow up to six-digit counts
+ * that overflow their containers and carry no useful signal at that scale.
+ */
+export const DIFF_COUNT_MANY_THRESHOLD = 10_000;
+
+/**
+ * Format a diff line count for the compact +/- badges. Returns the raw number
+ * as a string, or `MANY` once it exceeds {@link DIFF_COUNT_MANY_THRESHOLD}.
+ * The sign prefix (`+` / `-`) is rendered by the caller, so `+1034848`
+ * becomes `+MANY`.
+ */
+export function formatDiffCount(value: number): string {
+  return value > DIFF_COUNT_MANY_THRESHOLD ? 'MANY' : String(value);
+}

--- a/apps/browser/src/ui/screens/main/file-tree/use-file-editor-controller.ts
+++ b/apps/browser/src/ui/screens/main/file-tree/use-file-editor-controller.ts
@@ -1,0 +1,342 @@
+import type * as Monaco from 'monaco-editor';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { FilePreviewResult } from '@shared/karton-contracts/ui';
+import { FILE_SAVE_CONFLICT_CODE } from '@shared/karton-contracts/ui';
+import { HotkeyActions } from '@shared/hotkeys';
+import { useHotKeyListener } from '@ui/hooks/use-hotkey-listener';
+import {
+  clearFileTabUnsavedEditEntry,
+  setFileTabUnsavedEditEntry,
+} from './file-tab-unsaved-edits';
+
+/**
+ * The save / undo / redo / conflict surface a file-editing tab exposes to the
+ * toolbar and the external-change banner. Implemented identically by the plain
+ * source editor and the diff editor via {@link useFileEditorController}.
+ */
+export type EditorActions = {
+  save: () => void;
+  forceSave: () => void;
+  reload: () => void;
+  undo: () => void;
+  redo: () => void;
+  canUndo: boolean;
+  canRedo: boolean;
+  isDirty: boolean;
+  isSaving: boolean;
+  readOnly: boolean;
+  externalChange: boolean;
+};
+
+/** Signature of `fileTree.saveFile`, threaded in so the hook stays UI-only. */
+type SaveFileProcedure = (
+  workspaceKey: string,
+  relativePath: string,
+  text: string,
+  expectedMtimeMs?: number | null,
+) => Promise<FilePreviewResult | null>;
+
+/** Outcome of reconciling the editor against fresh on-disk content. */
+export type DiskReconcileOutcome = 'unchanged' | 'adopted' | 'conflict';
+
+/** Fresh on-disk baseline (text + mtime) after a reload/fetch. */
+export type DiskBaseline = { text: string; mtimeMs: number | null };
+
+export interface FileEditorControllerOptions {
+  tabId: string;
+  workspaceKey: string;
+  relativePath: string;
+  readOnly: boolean;
+  saveFile: SaveFileProcedure;
+  /**
+   * On-disk baseline the editor is first loaded with. Seeded once into the
+   * baseline refs so the initial reconcile/save isn't treated as a conflict.
+   * Omit when the content loads asynchronously and call {@link setBaseline}
+   * once it arrives instead.
+   */
+  initialText?: string;
+  initialMtimeMs?: number | null;
+  /** The editable text model (modified side for diffs) for undo/redo state. */
+  getModel: () => Monaco.editor.ITextModel | null | undefined;
+  /** Current editor text to persist / diff against the baseline. */
+  getValue: () => string | null | undefined;
+  /**
+   * Discard local edits and load the freshest on-disk content into the editor.
+   * Implementations apply the content themselves and return the new baseline;
+   * the controller resets dirty/conflict state and updates its baseline refs.
+   */
+  reload: () => Promise<DiskBaseline | null>;
+  /** Title shown in the unsaved-edits close prompt. */
+  unsavedTitle: string;
+  /** Discard handler invoked from the unsaved-edits close prompt. */
+  onDiscard?: () => void;
+  /** Invoked after a successful save (e.g. to update caches). */
+  onSaved?: (result: FilePreviewResult | null, nextText: string) => void;
+  /**
+   * Invoked on a non-conflict save failure. When omitted the error is
+   * re-thrown (matching the plain editor's original behavior); when provided
+   * (the diff editor) the error is surfaced inline instead.
+   */
+  onSaveError?: (error: unknown) => void;
+}
+
+/**
+ * Shared editing controller for file tabs. Centralizes the dirty/undo/redo
+ * tracking, optimistic-concurrency save (with {@link FILE_SAVE_CONFLICT_CODE}
+ * handling), live external-change reconciliation, unsaved-edit close prompt,
+ * and the Save/Undo/Redo hotkeys — so the plain source editor and the diff
+ * editor behave identically without duplicating the logic.
+ */
+export function useFileEditorController(options: FileEditorControllerOptions) {
+  const optionsRef = useRef(options);
+  optionsRef.current = options;
+  const { readOnly } = options;
+
+  const [isDirty, setIsDirty] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+  const [canUndo, setCanUndo] = useState(false);
+  const [canRedo, setCanRedo] = useState(false);
+  const [externalChange, setExternalChange] = useState(false);
+
+  // Mirror save/conflict flags into refs so the stable callbacks below can read
+  // the latest value without being re-created (which would re-bind hotkeys).
+  const isSavingRef = useRef(false);
+  const externalChangeRef = useRef(false);
+  externalChangeRef.current = externalChange;
+
+  // Baseline the editor content is measured against. `savedText` drives dirty
+  // detection; `baselineMtime` is the optimistic-concurrency token for saves;
+  // `lastDiskText` is the most recent on-disk content the controller has seen
+  // (used to ignore metadata-only touches and our own writes).
+  const savedTextRef = useRef(options.initialText ?? '');
+  const baselineMtimeRef = useRef<number | null | undefined>(
+    options.initialMtimeMs,
+  );
+  const lastDiskTextRef = useRef(options.initialText ?? '');
+
+  const setBaseline = useCallback((text: string, mtimeMs: number | null) => {
+    savedTextRef.current = text;
+    lastDiskTextRef.current = text;
+    baselineMtimeRef.current = mtimeMs;
+  }, []);
+
+  const refreshState = useCallback(() => {
+    const { getModel, getValue } = optionsRef.current;
+    const model = getModel();
+    setCanUndo(Boolean(model?.canUndo()));
+    setCanRedo(Boolean(model?.canRedo()));
+    const value = getValue();
+    if (value != null) setIsDirty(value !== savedTextRef.current);
+  }, []);
+
+  const save = useCallback(
+    async (force = false): Promise<boolean> => {
+      const {
+        readOnly: ro,
+        getValue,
+        saveFile,
+        workspaceKey,
+        relativePath,
+        tabId,
+        onSaved,
+        onSaveError,
+      } = optionsRef.current;
+      const nextText = getValue();
+      if (ro || nextText == null || isSavingRef.current) return false;
+      isSavingRef.current = true;
+      setIsSaving(true);
+      try {
+        const result = await saveFile(
+          workspaceKey,
+          relativePath,
+          nextText,
+          force ? null : baselineMtimeRef.current,
+        );
+        // Record the just-written content as the new baseline so the directory
+        // revision bump our own write triggers isn't seen as an external edit.
+        savedTextRef.current = nextText;
+        lastDiskTextRef.current = nextText;
+        baselineMtimeRef.current = result?.mtimeMs ?? null;
+        setIsDirty(false);
+        setExternalChange(false);
+        clearFileTabUnsavedEditEntry(tabId);
+        onSaved?.(result, nextText);
+        return true;
+      } catch (err) {
+        // The backend rejected the save because the file changed on disk since
+        // it was loaded — surface the conflict instead of overwriting blindly.
+        if (
+          err instanceof Error &&
+          err.message.includes(FILE_SAVE_CONFLICT_CODE)
+        ) {
+          setExternalChange(true);
+          return false;
+        }
+        if (onSaveError) {
+          onSaveError(err);
+          return false;
+        }
+        throw err;
+      } finally {
+        isSavingRef.current = false;
+        setIsSaving(false);
+        refreshState();
+      }
+    },
+    [refreshState],
+  );
+
+  // While an external-change conflict is surfaced the plain save is blocked;
+  // the user must explicitly Reload or Overwrite from the banner.
+  const handleSave = useCallback(() => {
+    if (externalChangeRef.current) return;
+    void save(false);
+  }, [save]);
+
+  const forceSave = useCallback(() => {
+    void save(true);
+  }, [save]);
+
+  const reload = useCallback(async () => {
+    const baseline = await optionsRef.current.reload();
+    if (baseline) setBaseline(baseline.text, baseline.mtimeMs);
+    setExternalChange(false);
+    setIsDirty(false);
+    clearFileTabUnsavedEditEntry(optionsRef.current.tabId);
+    window.setTimeout(refreshState, 0);
+  }, [refreshState, setBaseline]);
+
+  const undo = useCallback(() => {
+    const model = optionsRef.current.getModel();
+    if (!model?.canUndo()) return;
+    void model.undo();
+    window.setTimeout(refreshState, 0);
+  }, [refreshState]);
+
+  const redo = useCallback(() => {
+    const model = optionsRef.current.getModel();
+    if (!model?.canRedo()) return;
+    void model.redo();
+    window.setTimeout(refreshState, 0);
+  }, [refreshState]);
+
+  /**
+   * Reconcile the editor against freshly-read on-disk content. With no local
+   * edits the new content is adopted as the baseline (caller pushes it into the
+   * editor on `'adopted'`); with unsaved edits a conflict is raised so the user
+   * is warned before losing work.
+   */
+  const reconcileDisk = useCallback(
+    (diskText: string, mtimeMs: number | null): DiskReconcileOutcome => {
+      if (optionsRef.current.readOnly) return 'unchanged';
+      if (diskText === lastDiskTextRef.current) {
+        // Content unchanged (e.g. a metadata-only touch) — refresh the mtime
+        // baseline so the next save isn't flagged as a false conflict.
+        baselineMtimeRef.current = mtimeMs;
+        return 'unchanged';
+      }
+      lastDiskTextRef.current = diskText;
+      const value = optionsRef.current.getValue() ?? savedTextRef.current;
+      const userHasEdits = value !== savedTextRef.current;
+      if (userHasEdits) {
+        setExternalChange(true);
+        return 'conflict';
+      }
+      savedTextRef.current = diskText;
+      baselineMtimeRef.current = mtimeMs;
+      setExternalChange(false);
+      setIsDirty(false);
+      clearFileTabUnsavedEditEntry(optionsRef.current.tabId);
+      return 'adopted';
+    },
+    [],
+  );
+
+  /**
+   * Recompute dirty/undo/redo state after an editor content change and
+   * register (or clear) the unsaved-edits close prompt accordingly.
+   */
+  const notifyContentChanged = useCallback(() => {
+    const {
+      getValue,
+      readOnly: ro,
+      tabId,
+      unsavedTitle,
+      workspaceKey,
+      relativePath,
+      onDiscard,
+    } = optionsRef.current;
+    const value = getValue();
+    const nextDirty = value != null && value !== savedTextRef.current;
+    setIsDirty(nextDirty);
+    if (nextDirty && !ro) {
+      setFileTabUnsavedEditEntry({
+        tabId,
+        title: unsavedTitle,
+        workspaceKey,
+        relativePath,
+        save: () => save(false),
+        discard: () => {
+          onDiscard?.();
+          clearFileTabUnsavedEditEntry(tabId);
+        },
+      });
+    } else {
+      clearFileTabUnsavedEditEntry(tabId);
+    }
+    window.setTimeout(refreshState, 0);
+  }, [save, refreshState]);
+
+  // Clear any lingering unsaved-edit prompt when the tab unmounts.
+  useEffect(() => {
+    const { tabId } = optionsRef.current;
+    return () => clearFileTabUnsavedEditEntry(tabId);
+  }, []);
+
+  useHotKeyListener(handleSave, HotkeyActions.SAVE_FILE);
+  useHotKeyListener(undo, HotkeyActions.UNDO_FILE_EDIT);
+  useHotKeyListener(redo, HotkeyActions.REDO_FILE_EDIT);
+
+  const actions = useMemo<EditorActions>(
+    () => ({
+      save: () => handleSave(),
+      forceSave,
+      reload: () => void reload(),
+      undo,
+      redo,
+      canUndo,
+      canRedo,
+      isDirty,
+      isSaving,
+      readOnly,
+      externalChange,
+    }),
+    [
+      handleSave,
+      forceSave,
+      reload,
+      undo,
+      redo,
+      canUndo,
+      canRedo,
+      isDirty,
+      isSaving,
+      readOnly,
+      externalChange,
+    ],
+  );
+
+  return {
+    actions,
+    save,
+    handleSave,
+    forceSave,
+    reload,
+    undo,
+    redo,
+    refreshState,
+    reconcileDisk,
+    notifyContentChanged,
+    setBaseline,
+  };
+}

--- a/apps/browser/src/ui/screens/main/file-tree/use-file-editor-controller.ts
+++ b/apps/browser/src/ui/screens/main/file-tree/use-file-editor-controller.ts
@@ -199,7 +199,14 @@ export function useFileEditorController(options: FileEditorControllerOptions) {
 
   const reload = useCallback(async () => {
     const baseline = await optionsRef.current.reload();
-    if (baseline) setBaseline(baseline.text, baseline.mtimeMs);
+    if (!baseline) {
+      // Reload failed (e.g. a transient fetch error). Keep the current edits,
+      // dirty/conflict flags and the unsaved-edits close prompt intact so the
+      // user's work isn't silently discarded — they can retry the reload.
+      window.setTimeout(refreshState, 0);
+      return;
+    }
+    setBaseline(baseline.text, baseline.mtimeMs);
     setExternalChange(false);
     setIsDirty(false);
     clearFileTabUnsavedEditEntry(optionsRef.current.tabId);


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a built-in Git diff editor in file tabs with inline/split modes (default inline), editable for unstaged changes with shared save/undo and conflict protection. Diff tabs show a "Diff:" title and icon; large diff counts are capped; tab bar and file‑tree toggle badges are refined.

- **New Features**
  - Open files as diff tabs with an inline/split toggle (persisted per tab) and a "Diff:" title + diff icon.
  - Unstaged diffs are editable with save/undo/redo and conflict protection via shared `useFileEditorController`; drafts persist across remounts; staged diffs are read‑only.
  - Backend/contracts: `GitService.getFileDiffContent` and `toolbox.getFileDiffContent` load HEAD vs index/working tree (include `mtimeMs`), support renames via `diffOldPath`; tabs store `showDiff`/`diffStaged`/`diffOldPath`; window layout treats diff tabs separately; diff tabs bypass the regular file‑preview fetch path.
  - Diff counts cap to +MANY/‑MANY above 10k and show on the file‑tree toggle and per‑file rows; the badge is part of the clickable toggle; new‑tab buttons sit outside the tab strip scroll area.

- **Bug Fixes**
  - Exclude binary files from untracked line counts (NUL‑byte heuristic).
  - Diff editor polish and parity: apply file‑code zoom, disable word wrap in all modes, trim gutters/remove revert‑icon margin, balance line‑number spacing, hide the plain scrollbar in favor of the diff overview ruler, and persist view mode; theme sync on mount.
  - Hardened persistence and security: sanitize paths to block traversal/symlink escapes and normalize POSIX separators; accurate staged snapshot handling and rename support; skip file‑preview revalidation for diff tabs to avoid redundant fetches.

<sup>Written for commit a4c6c35ac2bdabfc4765aec80c7cc403fd916da9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1332?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

**New Features**
- Added Git diff editing in the file editor, including staged vs unstaged views and rename-aware originals.
- Diff tabs can open directly in Monaco diff mode, with saved baseline support for safer diff saves.
- File tree diff UI now shows staged indicators and diff totals with compact formatting.

**Bug Fixes**
- Prevents reusing mismatched tabs between diff and non-diff modes for the same file/scope.
- Avoids redundant preview reloads when opening diff tabs.

**UI Improvements**
- Updated diff tab labeling, icons, and improved tab bar spacing/scroll behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->