### PR TITLE
fix(agent-core): surface Z.ai balance errors

### DIFF
--- a/packages/agent-core/src/agents/base-agent.ts
+++ b/packages/agent-core/src/agents/base-agent.ts
@@ -32,6 +32,12 @@ import {
 } from '../host/models';
 import type { AgentCtor, AgentTypeRegistry } from './agents-registry';
 
+type ProviderApiError = {
+  message?: string;
+  statusCode?: number;
+  providerCode?: string;
+};
+
 /**
  * Helper type — extracts the `instanceConfig` field from an agent
  * constructor type registered in `AgentTypeMap`. Wrapped in tuple
@@ -1785,9 +1791,15 @@ export abstract class BaseAgent<
             exceeded_window_count: sortedWindows.length,
           });
         }
-        const parsedOverloadBase = parsedPlanLimit
-          ? null
-          : this.parseUpstreamOverloadError(error);
+        const parsedProviderError = this.parseProviderError(error);
+        const parsedOverloadBase =
+          parsedPlanLimit ||
+          this.isZaiBillingOrQuotaError(
+            parsedProviderError,
+            modelWithOptions.reasoningSignatureSource,
+          )
+            ? null
+            : this.parseUpstreamOverloadError(error);
         const parsedOverload: Extract<
           AgentRuntimeError,
           { kind: 'upstream-overload' }
@@ -1810,7 +1822,7 @@ export abstract class BaseAgent<
         this.state.commands.recordStepError({
           error: parsedPlanLimit ??
             parsedOverload ?? {
-              message: `LLM provider error: ${error.message}`,
+              message: `LLM provider error: ${parsedProviderError?.message ?? error.message}`,
               stack: error.stack,
             },
           markUnread: 'mark-unread',
@@ -3059,11 +3071,65 @@ export abstract class BaseAgent<
     }
   }
 
+  private parseProviderError(error: Error): ProviderApiError | null {
+    const frame = BaseAgent.unwrapApiErrorFrame(error);
+    const statusCode =
+      typeof frame.statusCode === 'number' ? frame.statusCode : undefined;
+
+    let body: Record<string, unknown> | null = null;
+    if (typeof frame.responseBody === 'string') {
+      try {
+        body = JSON.parse(frame.responseBody);
+      } catch {
+        body = null;
+      }
+    }
+
+    const errInBody = (body?.error ?? undefined) as
+      | Record<string, unknown>
+      | undefined;
+    const message =
+      typeof errInBody?.message === 'string'
+        ? (errInBody.message as string)
+        : undefined;
+    const rawCode = errInBody?.code;
+    const providerCode =
+      typeof rawCode === 'string'
+        ? rawCode
+        : typeof rawCode === 'number'
+          ? String(rawCode)
+          : undefined;
+
+    if (!message && statusCode === undefined && !providerCode) return null;
+    return { message, statusCode, providerCode };
+  }
+
+  private isZaiBillingOrQuotaError(
+    providerError: ProviderApiError | null,
+    reasoningSignatureSource?: ReasoningSignatureSource,
+  ): boolean {
+    if (reasoningSignatureSource?.provider !== 'z-ai') return false;
+
+    const message = providerError?.message?.toLowerCase() ?? '';
+    const code = providerError?.providerCode;
+
+    // Keep Z.ai billing/resource-package failures generic so the UI shows
+    // the actionable upstream message instead of "temporarily unavailable".
+    return (
+      // Z.ai: { error: { code: '1113', message: 'Insufficient balance...' } }
+      code === '1113' ||
+      message.includes('insufficient balance') ||
+      message.includes('no resource package') ||
+      message.includes('please recharge')
+    );
+  }
+
   /**
    * Detect upstream-overload errors (429 rate-limits, 502/503 provider-down,
-   * Anthropic `overloaded_error`). Permissive on purpose: any HTTP status in
-   * {429, 502, 503, 529} or a body with matching shape is treated as
-   * temporary unavailability. See docs:
+   * Anthropic `overloaded_error`). 429 is ambiguous, so provider billing or
+   * quota failures are intentionally left as generic provider errors to show
+   * the actionable upstream message instead of "temporarily unavailable".
+   * See docs:
    * https://openrouter.ai/docs/api/reference/errors-and-debugging.mdx
    */
   private parseUpstreamOverloadError(error: Error): AgentRuntimeError | null {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show Z.ai billing/quota errors instead of “temporarily unavailable” by parsing provider API error frames and skipping overload classification for those cases in `agent-core`. This surfaces actionable messages to users.

- **Bug Fixes**
  - Parse provider error frames to read `message`, `statusCode`, and provider code; step errors now show the upstream provider message when available.
  - For `z-ai`, detect billing/quota failures (code `1113` or phrases like “insufficient balance”, “no resource package”, “please recharge”) and skip overload handling so 429 isn’t misclassified as “temporarily unavailable”.

<sup>Written for commit f6d48611ecd4c919fc71016dce8d7d8de3208628. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1334?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling for provider API failures with more detailed, actionable error messages
  * Improved classification of quota and billing-related error scenarios
  * Error messages now include provider-specific details to help users better understand and resolve issues

<!-- end of auto-generated comment: release notes by coderabbit.ai -->