### PR TITLE
fix(stagewise): focus chat input on agent switch over web/terminal tabs

### DIFF
--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/panel-footer.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/panel-footer.tsx
@@ -232,6 +232,9 @@ export const ChatPanelFooter = memo(function ChatPanelFooter() {
   const setChatInputState = useKartonProcedure(
     (p) => p.agents.updateInputState,
   );
+  const togglePanelKeyboardFocus = useKartonProcedure(
+    (p) => p.browser.layout.togglePanelKeyboardFocus,
+  );
 
   const [localInputState, setLocalInputState] = useState<Content | null>(() => {
     const initial = chatInputStateRef.current;
@@ -283,18 +286,51 @@ export const ChatPanelFooter = memo(function ChatPanelFooter() {
 
   const { activeEditMessageId, setMainDropHandler } = useMessageEditState();
 
-  // Focus input and recalculate send-button state when agent changes.
-  // ChatInput has key={openAgent} so it fully re-mounts on switch —
-  // the initial render with restored content doesn't fire onChange,
-  // leaving canSendMessage stale.  Recalculate after the new mount.
+  // Mirror the panel-focus procedure into a ref so the agent-switch effect
+  // below can call it without listing it as a dependency. The procedure
+  // comes from useKartonProcedure with an inline selector, so its identity
+  // is not stable across renders. Depending on it directly would make the
+  // effect run on every render and continuously reclaim UI keyboard focus,
+  // locking focus onto the chat input and making nothing else interactive.
+  const togglePanelKeyboardFocusRef = useRef(togglePanelKeyboardFocus);
+  togglePanelKeyboardFocusRef.current = togglePanelKeyboardFocus;
+
+  // Focus the chat input whenever the active agent changes, regardless of
+  // whether a browser tab or terminal is currently showing.
+  //
+  // ChatInput has key={openAgent} so it fully re-mounts on switch — the
+  // initial render with restored content doesn't fire onChange, leaving
+  // canSendMessage stale. Recalculate after the new mount.
+  //
+  // Browser-tab case: the active tab's webContents holds native OS keyboard
+  // focus, so a bare DOM .focus() on the chat input would not receive
+  // keystrokes (document.hasFocus() === false — typing goes to the page).
+  // togglePanelKeyboardFocus('stagewise-ui') reclaims native focus to the UI
+  // view first. On macOS/Linux this does NOT change z-order (see
+  // focus-handling.md, Invariant #2), so the web content stays
+  // mouse-interactive. The terminal case is handled separately by gating the
+  // terminal's own auto-focus (see per-terminal-content.tsx).
+  //
+  // Runs exactly once per agent switch (deps: [openAgent] only).
   useEffect(() => {
-    if (openAgent)
-      requestAnimationFrame(() => {
-        chatInputRef.current?.focus();
-        const textLength =
-          chatInputRef.current?.getTextContent()?.trim().length ?? 0;
-        setCanSendMessage(textLength > 0);
-      });
+    if (!openAgent) return;
+    let cancelled = false;
+    const frame = requestAnimationFrame(async () => {
+      try {
+        await togglePanelKeyboardFocusRef.current('stagewise-ui');
+      } catch {
+        // Still focus the chat input if the panel-focus handoff fails.
+      }
+      if (cancelled) return;
+      chatInputRef.current?.focus();
+      const textLength =
+        chatInputRef.current?.getTextContent()?.trim().length ?? 0;
+      setCanSendMessage(textLength > 0);
+    });
+    return () => {
+      cancelled = true;
+      cancelAnimationFrame(frame);
+    };
   }, [openAgent]);
 
   const activeTabUrl = useKartonState((s) => {
@@ -332,9 +368,6 @@ export const ChatPanelFooter = memo(function ChatPanelFooter() {
   }, [selectionModeActive, activeEditMessageId]);
 
   // Karton procedures
-  const togglePanelKeyboardFocus = useKartonProcedure(
-    (p) => p.browser.layout.togglePanelKeyboardFocus,
-  );
   const sendUserMessage = useKartonProcedure((p) => p.agents.sendUserMessage);
   const stopAgent = useKartonProcedure((p) => p.agents.stop);
   const createWorkspaceGitWorktree = useKartonProcedure(

--- a/apps/browser/src/ui/screens/main/terminal-panel/_components/per-terminal-content.tsx
+++ b/apps/browser/src/ui/screens/main/terminal-panel/_components/per-terminal-content.tsx
@@ -317,12 +317,16 @@ export function PerTerminalContent({
         try {
           fitAddon.fit();
           sendResize(true);
-          if (isActiveRef.current) {
-            if (terminalFocusRequestIdRef.current !== undefined) {
-              focusTerminalIfReady();
-            } else {
-              term.focus();
-            }
+          // Only claim keyboard focus on an explicit focus request
+          // (hotkey/command center). Becoming active merely because the
+          // user switched agents/tabs must NOT steal focus — the chat
+          // input owns focus on agent switch. The user can click the
+          // terminal to focus it (handled by xterm + onPointerDown).
+          if (
+            isActiveRef.current &&
+            terminalFocusRequestIdRef.current !== undefined
+          ) {
+            focusTerminalIfReady();
           }
         } catch {
           // May fail during layout transitions.
@@ -385,6 +389,12 @@ export function PerTerminalContent({
   }, [outputBuffer, baseOffset, endOffset]);
 
   // Re-fit when terminal zoom or active state changes.
+  //
+  // Deliberately does NOT call term.focus(). Re-fitting on activation or
+  // zoom must not grab keyboard focus, otherwise it competes with the chat
+  // input on agent switch and refocuses the terminal on every zoom change.
+  // Explicit focus requests are handled by the terminalFocusRequestId
+  // effect above; user clicks are handled by xterm itself.
   useEffect(() => {
     if (!isActive) return;
     const term = terminalRef.current;
@@ -399,7 +409,6 @@ export function PerTerminalContent({
         try {
           fit.fit();
           sendResize(true);
-          term.focus();
         } catch {
           // ignore
         }


### PR DESCRIPTION
Reclaim native UI keyboard focus on agent switch so the chat input receives keystrokes even when a browser tab holds OS focus, and gate the terminal's unconditional auto-focus so re-fit/activation no longer steals focus from the chat input.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure the chat input gets keyboard focus on agent switch, even if a web or terminal tab held OS focus. Also prevent the terminal from stealing focus during activation or re-fit.

- **Bug Fixes**
  - Reclaim native UI focus via `browser.layout.togglePanelKeyboardFocus('stagewise-ui')`, then focus the chat input and recalc the send button state after agent switch.
  - Gate terminal focus to explicit requests only; no auto-focus on activation, zoom, or re-fit.
  - Avoid continuous focus grabs by storing the focus procedure in a ref and running the effect only on agent changes.

<sup>Written for commit 850674f3d5eceb921f88cb52b2f690638d6fcb53. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1337?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved keyboard focus handling when switching between agents in the chat panel.
  * Fixed terminal panel to no longer steal focus from the chat input during state changes.
  * Enhanced focus restoration for better user experience during multi-component interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->