### PR TITLE
feat(stagewise): add model alias presets with fixed thinking

### DIFF
--- a/apps/browser/src/backend/agents/chat/chat.test.ts
+++ b/apps/browser/src/backend/agents/chat/chat.test.ts
@@ -26,6 +26,10 @@ const HOST_TOOL_IDS = [
 ] as const;
 
 describe('BrowserChatAgent', () => {
+  it('defaults new browser chat agents to the Default alias', () => {
+    expect(BrowserChatAgent.config.defaultModelId).toBe('default');
+  });
+
   it('getAdditionalTools requests every browser host tool from the toolbox', async () => {
     const getTool = vi.fn().mockResolvedValue({ kind: 'host-tool' });
     const instance = Object.create(BrowserChatAgent.prototype) as {

--- a/apps/browser/src/backend/agents/chat/chat.ts
+++ b/apps/browser/src/backend/agents/chat/chat.ts
@@ -1,4 +1,4 @@
-import { ChatAgent } from '@stagewise/agent-core/agents';
+import { ChatAgent, type BaseAgentConfig } from '@stagewise/agent-core/agents';
 
 /**
  * Browser-host chat agent.
@@ -10,6 +10,11 @@ import { ChatAgent } from '@stagewise/agent-core/agents';
  * `AgentTypes.CHAT` in the browser's {@link AgentTypeRegistry}.
  */
 export class BrowserChatAgent extends ChatAgent {
+  public static readonly config = {
+    ...ChatAgent.config,
+    defaultModelId: 'default',
+  } satisfies BaseAgentConfig<never>;
+
   // Return type uses `any` to bridge the `Tool` shape divergence between the
   // copy of `@ai-sdk/provider-utils` that `'ai'` resolves to at the host's
   // compile site and the copy `@stagewise/agent-core`'s `.d.ts` references

--- a/apps/browser/src/backend/agents/model-provider.test.ts
+++ b/apps/browser/src/backend/agents/model-provider.test.ts
@@ -56,6 +56,115 @@ const agentStepMetadata = {
   [MODEL_REQUEST_PURPOSE_METADATA_KEY]: 'agent-step',
 };
 
+describe('model alias routing', () => {
+  it('accepts alias IDs as built-in models', () => {
+    const service = createTestModelProviderService();
+
+    expect(service.modelExists('default')).toBe(true);
+    expect(service.modelExists('quick')).toBe(true);
+    expect(service.modelExists('smart')).toBe(true);
+  });
+
+  it.each([
+    ['default', 'deepseek', 'deepseek-v4-pro'],
+    ['quick', 'google', 'gemini-3.5-flash'],
+    ['smart', 'z-ai', 'glm-5.2'],
+  ] as const)('routes %s through the target built-in model', (aliasId, provider, targetModelId) => {
+    const service = createTestModelProviderService();
+
+    const result = service.getModelWithOptions(aliasId, 'trace-1');
+
+    expect(result.contextWindowSize).toBeGreaterThan(0);
+    expect(result.reasoningSignatureSource).toMatchObject({
+      providerMode: 'stagewise',
+      provider,
+      modelId: `${provider}/${targetModelId}`,
+    });
+  });
+
+  it('uses fixed preset reasoning for alias requests', () => {
+    const service = createTestModelProviderService();
+
+    const defaultResult = service.getModelWithOptions(
+      'default',
+      'trace-1',
+      agentStepMetadata,
+    );
+    const quickResult = service.getModelWithOptions(
+      'quick',
+      'trace-1',
+      agentStepMetadata,
+    );
+    const smartResult = service.getModelWithOptions(
+      'smart',
+      'trace-1',
+      agentStepMetadata,
+    );
+
+    expect(defaultResult.providerOptions).toMatchObject({
+      openai: { reasoningEffort: 'medium' },
+      stagewise: {
+        reasoning: { enabled: true, effort: 'medium' },
+        provider: { require_parameters: true },
+      },
+    });
+    expect(quickResult.providerOptions).toMatchObject({
+      google: {
+        thinkingConfig: { includeThoughts: true, thinkingLevel: 'low' },
+      },
+      stagewise: { reasoning: { enabled: true, effort: 'medium' } },
+    });
+    expect(smartResult.providerOptions).toMatchObject({
+      openai: { reasoningEffort: 'xhigh' },
+      stagewise: { reasoning: { enabled: true, effort: 'xhigh' } },
+    });
+  });
+
+  it('ignores target model thinking overrides for alias requests', () => {
+    const service = createTestModelProviderService({
+      modelThinkingOverrides: {
+        'deepseek-v4-pro': { value: 'high' },
+      },
+    });
+
+    const result = service.getModelWithOptions(
+      'default',
+      'trace-1',
+      agentStepMetadata,
+    );
+
+    expect(result.providerOptions).toMatchObject({
+      openai: { reasoningEffort: 'medium' },
+      stagewise: {
+        reasoning: { enabled: true, effort: 'medium' },
+        provider: { require_parameters: true },
+      },
+    });
+  });
+
+  it('keeps target model thinking overrides for concrete requests', () => {
+    const service = createTestModelProviderService({
+      modelThinkingOverrides: {
+        'deepseek-v4-pro': { value: 'high' },
+      },
+    });
+
+    const result = service.getModelWithOptions(
+      'deepseek-v4-pro',
+      'trace-1',
+      agentStepMetadata,
+    );
+
+    expect(result.providerOptions).toMatchObject({
+      openai: { reasoningEffort: 'high' },
+      stagewise: {
+        reasoning: { enabled: true, effort: 'medium' },
+        provider: { require_parameters: true },
+      },
+    });
+  });
+});
+
 describe('thinking override provider option resolution', () => {
   it('returns base provider options unchanged when no override exists', () => {
     const service = createTestModelProviderService();

--- a/apps/browser/src/backend/agents/model-provider.ts
+++ b/apps/browser/src/backend/agents/model-provider.ts
@@ -1,5 +1,5 @@
 import type { TelemetryService } from '@/services/telemetry';
-import type { ModelId } from '@shared/available-models';
+import type { ModelAlias, ModelId } from '@shared/available-models';
 import type {
   ModelProvider,
   ApiSpec,
@@ -14,7 +14,11 @@ import {
   type ProviderMode,
 } from './reasoning-signatures';
 import type { LanguageModelV3 } from '@ai-sdk/provider';
-import { availableModels } from '@shared/available-models';
+import {
+  type availableModels,
+  getAvailableModel,
+  getModelAlias,
+} from '@shared/available-models';
 import { createAnthropic } from '@ai-sdk/anthropic';
 import { createOpenAI } from '@ai-sdk/openai';
 import { createGoogleGenerativeAI } from '@ai-sdk/google';
@@ -281,7 +285,7 @@ export class ModelProviderService {
    * Check whether a model ID exists (built-in or custom).
    */
   public modelExists(modelId: ModelId): boolean {
-    if (availableModels.some((m) => m.modelId === modelId)) return true;
+    if (getAvailableModel(modelId)) return true;
     return this.preferencesService
       .get()
       .customModels.some((m) => m.modelId === modelId);
@@ -316,12 +320,19 @@ export class ModelProviderService {
     traceId: string,
     otherPostHogProperties?: Record<string, unknown>,
   ): ModelWithOptions {
-    const builtIn = availableModels.find((m) => m.modelId === modelId);
+    const builtIn = getAvailableModel(modelId);
     if (builtIn) {
+      const alias = getModelAlias(modelId);
       return this.createBuiltInModelWithOptions(
         builtIn,
         traceId,
-        otherPostHogProperties,
+        alias,
+        alias
+          ? {
+              ...otherPostHogProperties,
+              requestedModelId: alias.modelId,
+            }
+          : otherPostHogProperties,
       );
     }
 
@@ -342,6 +353,7 @@ export class ModelProviderService {
   private createBuiltInModelWithOptions(
     modelSettings: BuiltInModelSettings,
     traceId: string,
+    alias?: ModelAlias,
     otherPostHogProperties?: Record<string, unknown>,
   ): ModelWithOptions {
     const officialProvider = modelSettings.officialProvider as
@@ -357,6 +369,11 @@ export class ModelProviderService {
       unknown
     >;
     const posthogProperties = omitModelRequestMetadata(otherPostHogProperties);
+    const thinkingOverride =
+      alias?.thinkingPreset ??
+      this.preferencesService.get().agent.modelThinkingOverrides[
+        modelSettings.modelId
+      ];
 
     const posthogConfig = {
       posthogTraceId: traceId,
@@ -398,10 +415,7 @@ export class ModelProviderService {
         providerOptions: resolveThinkingProviderOptions({
           baseProviderOptions,
           modelSettings,
-          override:
-            this.preferencesService.get().agent.modelThinkingOverrides[
-              modelSettings.modelId
-            ],
+          override: thinkingOverride,
           providerMode: 'stagewise',
           semanticProvider: officialProvider,
           requestMetadata: otherPostHogProperties,
@@ -445,10 +459,7 @@ export class ModelProviderService {
           resolveThinkingProviderOptions({
             baseProviderOptions,
             modelSettings,
-            override:
-              this.preferencesService.get().agent.modelThinkingOverrides[
-                modelSettings.modelId
-              ],
+            override: thinkingOverride,
             providerMode: 'custom',
             semanticProvider: getSemanticProviderForApiSpec(
               resolved.customEndpoint.apiSpec,
@@ -480,10 +491,7 @@ export class ModelProviderService {
         resolveThinkingProviderOptions({
           baseProviderOptions,
           modelSettings,
-          override:
-            this.preferencesService.get().agent.modelThinkingOverrides[
-              modelSettings.modelId
-            ],
+          override: thinkingOverride,
           providerMode: 'official',
           semanticProvider: officialProvider,
           requestMetadata: otherPostHogProperties,

--- a/apps/browser/src/shared/available-models.test.ts
+++ b/apps/browser/src/shared/available-models.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+import {
+  availableModels,
+  getModelCapabilities,
+  getSelectableBuiltInModels,
+  availableModelAliases,
+  resolveModelAlias,
+} from './available-models';
+
+describe('model aliases', () => {
+  it('resolves aliases to their target model IDs', () => {
+    expect(resolveModelAlias('default')).toBe('deepseek-v4-pro');
+    expect(resolveModelAlias('smart')).toBe('glm-5.2');
+    expect(resolveModelAlias('quick')).toBe('gemini-3.5-flash');
+    expect(resolveModelAlias('gpt-5.5')).toBe('gpt-5.5');
+  });
+
+  it('keeps aliases first in the selectable built-in model list', () => {
+    const selectableModels = getSelectableBuiltInModels();
+
+    expect(
+      selectableModels
+        .slice(0, availableModelAliases.length)
+        .map((model) => model.modelId),
+    ).toEqual(availableModelAliases.map((alias) => alias.modelId));
+  });
+
+  it('keeps aliases visible even when their target models are disabled', () => {
+    const selectableModelIds = getSelectableBuiltInModels({
+      disabledModelIds: ['deepseek-v4-pro'],
+    }).map((model) => model.modelId);
+
+    // Aliases are always available regardless of target model disabled state
+    expect(selectableModelIds).toContain('default');
+    expect(selectableModelIds).toContain('quick');
+    expect(selectableModelIds).toContain('smart');
+    // The disabled target model itself is still hidden
+    expect(selectableModelIds).not.toContain('deepseek-v4-pro');
+  });
+
+  it('returns target model capabilities for alias IDs', () => {
+    for (const alias of availableModelAliases) {
+      expect(getModelCapabilities(alias.modelId)).toEqual(
+        getModelCapabilities(alias.targetModelId),
+      );
+    }
+  });
+
+  it('defines fixed thinking presets for aliases', () => {
+    expect(
+      Object.fromEntries(
+        availableModelAliases.map((alias) => [
+          alias.modelId,
+          alias.thinkingPreset,
+        ]),
+      ),
+    ).toEqual({
+      default: { enabled: true, value: 'medium' },
+      quick: { enabled: true, value: 'low' },
+      smart: { enabled: true, value: 'xhigh' },
+    });
+  });
+
+  it('defines aliases for existing built-in target models', () => {
+    const availableModelIds = new Set(
+      availableModels.map((model) => model.modelId),
+    );
+
+    for (const alias of availableModelAliases) {
+      expect(availableModelIds.has(alias.targetModelId)).toBe(true);
+    }
+  });
+});

--- a/apps/browser/src/shared/available-models.ts
+++ b/apps/browser/src/shared/available-models.ts
@@ -1,4 +1,7 @@
-import type { ModelSettings } from '@shared/karton-contracts/ui/shared-types';
+import type {
+  ModelSettings,
+  ModelThinkingOverride,
+} from '@shared/karton-contracts/ui/shared-types';
 
 const anthropicHeaders = {
   'anthropic-beta':
@@ -1318,8 +1321,123 @@ export const availableModels = [
   },
 ] as const satisfies ModelSettings[];
 
-export type BuiltInModelId = (typeof availableModels)[number]['modelId'];
-export type ModelId = BuiltInModelId | (string & {});
+export type BuiltInModel = (typeof availableModels)[number];
+export type BuiltInModelId = BuiltInModel['modelId'];
+
+export const availableModelAliases = [
+  {
+    modelId: 'default',
+    targetModelId: 'deepseek-v4-pro',
+    modelDisplayName: 'Default',
+    modelDescription:
+      'Recommended balanced model for everyday agent work, powered by DeepSeek V4 Pro.',
+    thinkingPreset: { enabled: true, value: 'medium' },
+  },
+  {
+    modelId: 'quick',
+    targetModelId: 'gemini-3.5-flash',
+    modelDisplayName: 'Quick',
+    modelDescription:
+      'Recommended fast model for quick iterations and lightweight changes, powered by Gemini 3.5 Flash.',
+    thinkingPreset: { enabled: true, value: 'low' },
+  },
+  {
+    modelId: 'smart',
+    targetModelId: 'glm-5.2',
+    modelDisplayName: 'Smart',
+    modelDescription:
+      'Recommended high-reasoning model for complex coding and planning, powered by GLM 5.2.',
+    thinkingPreset: { enabled: true, value: 'xhigh' },
+  },
+] as const satisfies readonly {
+  modelId: string;
+  targetModelId: BuiltInModelId;
+  modelDisplayName: string;
+  modelDescription: string;
+  thinkingPreset: ModelThinkingOverride;
+}[];
+
+export type ModelAlias = (typeof availableModelAliases)[number];
+export type ModelAliasId = ModelAlias['modelId'];
+export type ModelId = BuiltInModelId | ModelAliasId | (string & {});
+
+type SelectableBuiltInConcreteModel = BuiltInModel & {
+  kind: 'model';
+  targetModelId: BuiltInModelId;
+  targetModel: BuiltInModel;
+};
+
+type SelectableBuiltInAliasModel = Omit<
+  BuiltInModel,
+  'modelId' | 'modelDisplayName' | 'modelDescription'
+> & {
+  kind: 'alias';
+  modelId: ModelAliasId;
+  modelDisplayName: string;
+  modelDescription: string;
+  targetModelId: BuiltInModelId;
+  targetModel: BuiltInModel;
+  alias: ModelAlias;
+};
+
+export type SelectableBuiltInModel =
+  | SelectableBuiltInConcreteModel
+  | SelectableBuiltInAliasModel;
+
+export function getModelAlias(modelId: string): ModelAlias | undefined {
+  return availableModelAliases.find((alias) => alias.modelId === modelId);
+}
+
+export function resolveModelAlias(modelId: string): string {
+  return getModelAlias(modelId)?.targetModelId ?? modelId;
+}
+
+export function getAvailableModel(modelId: string): BuiltInModel | undefined {
+  const resolvedModelId = resolveModelAlias(modelId);
+  return availableModels.find((model) => model.modelId === resolvedModelId);
+}
+
+export function getSelectableBuiltInModels({
+  disabledModelIds,
+}: {
+  disabledModelIds?: Iterable<string>;
+} = {}): SelectableBuiltInModel[] {
+  const disabled = new Set(disabledModelIds);
+  const aliases = availableModelAliases.flatMap((alias) => {
+    const targetModel = getAvailableModel(alias.targetModelId);
+    if (!targetModel) return [];
+    // Aliases are always available in the selector regardless of whether
+    // their target model is disabled. "Disabling" a model only hides it
+    // from the selector — it does not block backend routing.
+    if (disabled.has(alias.modelId)) {
+      return [];
+    }
+
+    return [
+      {
+        ...targetModel,
+        kind: 'alias' as const,
+        modelId: alias.modelId,
+        modelDisplayName: alias.modelDisplayName,
+        modelDescription: alias.modelDescription,
+        targetModelId: alias.targetModelId,
+        targetModel,
+        alias,
+      },
+    ];
+  });
+
+  const concreteModels = availableModels
+    .filter((model) => !disabled.has(model.modelId))
+    .map((model) => ({
+      ...model,
+      kind: 'model' as const,
+      targetModelId: model.modelId,
+      targetModel: model,
+    }));
+
+  return [...aliases, ...concreteModels];
+}
 
 /**
  * Look up a model's capabilities by ID.
@@ -1329,7 +1447,7 @@ export type ModelId = BuiltInModelId | (string & {});
 export function getModelCapabilities(
   modelId: ModelId,
 ): ModelSettings['capabilities'] {
-  const model = availableModels.find((m) => m.modelId === modelId);
+  const model = getAvailableModel(modelId);
   if (model) return model.capabilities;
 
   return {

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/message-runtime-error.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/message-runtime-error.tsx
@@ -17,7 +17,7 @@ import {
 import { ChevronDownIcon } from 'lucide-react';
 import { useKartonState, useKartonProcedure } from '@ui/hooks/use-karton';
 import { useOpenAgent } from '@ui/hooks/use-open-chat';
-import { availableModels } from '@shared/available-models';
+import { getAvailableModel } from '@shared/available-models';
 import type { ModelProvider } from '@shared/karton-contracts/ui/shared-types';
 import type { AgentRuntimeError } from '@shared/karton-contracts/ui/agent';
 
@@ -226,7 +226,7 @@ function UpstreamOverloadError({
   // the active model while the card is visible does not mislabel the heading.
   const modelName = useMemo(() => {
     if (!error.modelId) return null;
-    const m = availableModels.find((m) => m.modelId === error.modelId);
+    const m = getAvailableModel(error.modelId);
     return m?.modelDisplayName ?? null;
   }, [error.modelId]);
   const heading = modelName
@@ -317,9 +317,7 @@ function GenericError({
     if (!isAuthorizationError(error)) return false;
     if (!activeModelId || !providerConfigs) return false;
 
-    const builtInModel = availableModels.find(
-      (m) => m.modelId === activeModelId,
-    );
+    const builtInModel = getAvailableModel(activeModelId);
     if (!builtInModel) return false;
 
     const provider = builtInModel.officialProvider as ModelProvider | undefined;

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/model-select.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/model-select.tsx
@@ -1,10 +1,5 @@
 import { Combobox as ComboboxBase } from '@base-ui/react/combobox';
-import {
-  IconArrowUpOutline18,
-  IconArrowDownOutline18,
-  IconXmarkOutline18,
-  IconBrainOutline18,
-} from 'nucleo-ui-outline-18';
+import { IconXmarkOutline18, IconBrainOutline18 } from 'nucleo-ui-outline-18';
 import { Button } from '@stagewise/stage-ui/components/button';
 import {
   Combobox,
@@ -20,9 +15,13 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from '@stagewise/stage-ui/components/tooltip';
-import type { ModelId } from '@shared/available-models';
+import type { BuiltInModel, ModelId } from '@shared/available-models';
 import { IconChevronDownFill18 } from 'nucleo-ui-fill-18';
-import { availableModels } from '@shared/available-models';
+import {
+  getAvailableModel,
+  getModelAlias,
+  getSelectableBuiltInModels,
+} from '@shared/available-models';
 import { HotkeyActions } from '@shared/hotkeys';
 import { useKartonProcedure, useKartonState } from '@ui/hooks/use-karton';
 import { useOpenAgent } from '@ui/hooks/use-open-chat';
@@ -58,9 +57,11 @@ interface ModelOption {
   context: string;
   thinkingEnabled: boolean;
   thinkingLabel?: string;
-  catalogModel?: (typeof availableModels)[number];
+  isAlias?: boolean;
+  catalogModel?: BuiltInModel;
+  targetModelId?: string;
   pricingMultiplier?: number;
-  group?: string;
+  group: 'Recommended' | 'Custom';
 }
 
 function ModelTooltipContent({
@@ -99,7 +100,7 @@ interface ModelSelectProps {
 }
 
 function getThinkingDefaultOptionsForModel(
-  model: (typeof availableModels)[number],
+  model: BuiltInModel,
   preferences: UserPreferences,
 ): Parameters<typeof getModelThinkingDisplayState>[2] {
   const provider = model.officialProvider;
@@ -155,26 +156,31 @@ export const ModelSelect = memo(function ModelSelect({
   // Build flat model options list
   const modelOptions = useMemo<ModelOption[]>(() => {
     const disabled = new Set(disabledModelIds);
-    const builtIn: ModelOption[] = availableModels
-      .filter((m) => !disabled.has(m.modelId))
-      .map((model) => {
-        const thinkingDisplay = getModelThinkingDisplayState(
-          model,
-          modelThinkingOverrides[model.modelId],
-          getThinkingDefaultOptionsForModel(model, preferences),
-        );
+    const builtIn: ModelOption[] = getSelectableBuiltInModels({
+      disabledModelIds,
+    }).map((model) => {
+      const thinkingDisplay = getModelThinkingDisplayState(
+        model.targetModel,
+        model.kind === 'alias'
+          ? model.alias.thinkingPreset
+          : modelThinkingOverrides[model.targetModelId],
+        getThinkingDefaultOptionsForModel(model.targetModel, preferences),
+      );
 
-        return {
-          modelId: model.modelId,
-          displayName: model.modelDisplayName,
-          description: model.modelDescription,
-          context: model.modelContext,
-          thinkingEnabled: thinkingDisplay !== null,
-          thinkingLabel: thinkingDisplay?.label,
-          catalogModel: model,
-          pricingMultiplier: model.pricing?.relativeMultiplier,
-        };
-      });
+      return {
+        modelId: model.modelId,
+        displayName: model.modelDisplayName,
+        description: model.modelDescription,
+        context: model.modelContext,
+        thinkingEnabled: thinkingDisplay !== null,
+        thinkingLabel: thinkingDisplay?.label,
+        isAlias: model.kind === 'alias',
+        catalogModel: model.kind === 'alias' ? undefined : model.targetModel,
+        targetModelId: model.targetModelId,
+        pricingMultiplier: model.pricing?.relativeMultiplier,
+        group: model.kind === 'alias' ? 'Recommended' : 'Custom',
+      };
+    });
 
     const custom: ModelOption[] = customModels
       .filter((m) => !disabled.has(m.modelId))
@@ -200,25 +206,23 @@ export const ModelSelect = memo(function ModelSelect({
     return map;
   }, [modelOptions]);
 
-  // Group models for rendering (ungrouped built-in + custom group)
+  // Group models for rendering (recommended aliases first, then the rest).
   const groupedModels = useMemo(() => {
-    const groups: { label: string | null; models: ModelOption[] }[] = [];
-    const ungrouped: ModelOption[] = [];
-    const customGroup: ModelOption[] = [];
+    const recommended: ModelOption[] = [];
+    const custom: ModelOption[] = [];
 
     for (const model of modelOptions) {
-      if (model.group === 'Custom') {
-        customGroup.push(model);
+      if (model.group === 'Recommended') {
+        recommended.push(model);
       } else {
-        ungrouped.push(model);
+        custom.push(model);
       }
     }
 
-    if (ungrouped.length > 0) groups.push({ label: null, models: ungrouped });
-    if (customGroup.length > 0)
-      groups.push({ label: 'Custom', models: customGroup });
-
-    return groups;
+    return [
+      { label: 'Recommended', models: recommended },
+      { label: 'Custom', models: custom },
+    ].filter(({ models }) => models.length > 0);
   }, [modelOptions]);
 
   const [open, setOpen] = useState(false);
@@ -271,15 +275,16 @@ export const ModelSelect = memo(function ModelSelect({
   const hasFilteredResults = filteredModelIds.length > 0;
 
   // Display labels for the trigger
-  const selectedDisplayName = useMemo(() => {
-    if (!selectedModel) return 'Select model';
-    return modelMap.get(selectedModel)?.displayName ?? selectedModel;
-  }, [modelMap, selectedModel]);
+  const selectedModelOption = selectedModel
+    ? modelMap.get(selectedModel)
+    : undefined;
 
-  const selectedThinkingLabel = useMemo(() => {
-    if (!selectedModel) return undefined;
-    return modelMap.get(selectedModel)?.thinkingLabel;
-  }, [modelMap, selectedModel]);
+  const selectedDisplayName =
+    selectedModelOption?.displayName ?? selectedModel ?? 'Select model';
+
+  const selectedThinkingLabel = selectedModelOption?.isAlias
+    ? undefined
+    : selectedModelOption?.thinkingLabel;
 
   const inputRef = useRef<HTMLInputElement>(null);
 
@@ -320,7 +325,9 @@ export const ModelSelect = memo(function ModelSelect({
 
   const editingThinkingModel = useMemo(
     () =>
-      availableModels.find((model) => model.modelId === editingThinkingModelId),
+      editingThinkingModelId
+        ? getAvailableModel(editingThinkingModelId)
+        : undefined,
     [editingThinkingModelId],
   );
 
@@ -401,24 +408,26 @@ export const ModelSelect = memo(function ModelSelect({
 
   const handleSetThinkingEnabled = useCallback(
     async (modelId: string, enabled: boolean) => {
-      const model = availableModels.find((item) => item.modelId === modelId);
+      const model = getAvailableModel(modelId);
       if (!model) return;
+      const targetModelId = model.modelId;
 
       const route = getThinkingDefaultOptionsForModel(model, preferences);
       const option = enabled
         ? getEnabledModelThinkingOption(
             model,
-            modelThinkingOverrides[modelId]?.value,
+            modelThinkingOverrides[targetModelId]?.value,
             route,
           )
         : (getModelThinkingOptions(model, route).find(
-            (item) => item.value === modelThinkingOverrides[modelId]?.value,
+            (item) =>
+              item.value === modelThinkingOverrides[targetModelId]?.value,
           ) ?? getModelThinkingOptions(model, route)[0]);
       if (!option) return;
 
       const [, patches] = produceWithPatches(preferences, (draft) => {
-        draft.agent.modelThinkingOverrides[modelId] = {
-          ...draft.agent.modelThinkingOverrides[modelId],
+        draft.agent.modelThinkingOverrides[targetModelId] = {
+          ...draft.agent.modelThinkingOverrides[targetModelId],
           enabled,
           provider: option.provider,
           value: option.value,
@@ -431,8 +440,9 @@ export const ModelSelect = memo(function ModelSelect({
 
   const handleSetThinkingValue = useCallback(
     async (modelId: string, value: string) => {
-      const model = availableModels.find((item) => item.modelId === modelId);
+      const model = getAvailableModel(modelId);
       if (!model) return;
+      const targetModelId = model.modelId;
 
       const route = getThinkingDefaultOptionsForModel(model, preferences);
       const option = getModelThinkingOptions(model, route).find(
@@ -441,7 +451,7 @@ export const ModelSelect = memo(function ModelSelect({
       if (!option) return;
 
       const [, patches] = produceWithPatches(preferences, (draft) => {
-        draft.agent.modelThinkingOverrides[modelId] = {
+        draft.agent.modelThinkingOverrides[targetModelId] = {
           enabled: true,
           provider: option.provider,
           value: option.value,
@@ -454,8 +464,9 @@ export const ModelSelect = memo(function ModelSelect({
 
   const handleResetThinkingOverride = useCallback(
     async (modelId: string) => {
+      const targetModelId = getAvailableModel(modelId)?.modelId ?? modelId;
       const [, patches] = produceWithPatches(preferences, (draft) => {
-        delete draft.agent.modelThinkingOverrides[modelId];
+        delete draft.agent.modelThinkingOverrides[targetModelId];
       });
       await updatePreferences(patches);
     },
@@ -465,14 +476,16 @@ export const ModelSelect = memo(function ModelSelect({
   const handleCycleThinkingEffort = useCallback(() => {
     if (!selectedModel) return false;
 
-    const model = availableModels.find(
-      (item) => item.modelId === selectedModel,
-    );
+    // Aliases use fixed thinking presets — cycling is disabled for them.
+    if (getModelAlias(selectedModel)) return false;
+
+    const model = getAvailableModel(selectedModel);
     if (!model) return false;
+    const targetModelId = model.modelId;
 
     const display = getModelThinkingDisplayState(
       model,
-      modelThinkingOverrides[model.modelId],
+      modelThinkingOverrides[targetModelId],
       getThinkingDefaultOptionsForModel(model, preferences),
     );
     if (!display) return false;
@@ -480,7 +493,7 @@ export const ModelSelect = memo(function ModelSelect({
     const route = getThinkingDefaultOptionsForModel(model, preferences);
     const nextOption = getNextModelThinkingOption(model, display.value, route);
     const [, patches] = produceWithPatches(preferences, (draft) => {
-      draft.agent.modelThinkingOverrides[model.modelId] = {
+      draft.agent.modelThinkingOverrides[targetModelId] = {
         enabled: true,
         provider: nextOption.provider,
         value: nextOption.value,
@@ -590,30 +603,21 @@ export const ModelSelect = memo(function ModelSelect({
                   className="mask-alpha scrollbar-subtle max-h-48 overflow-y-auto"
                   style={listMaskStyle}
                 >
-                  {filteredGroupedModels.map(({ label, models }) =>
-                    label ? (
-                      <ComboboxGroup key={label}>
-                        <ComboboxGroupLabel>{label}</ComboboxGroupLabel>
-                        {models.map((model) => (
-                          <ModelItem
-                            key={model.modelId}
-                            model={model}
-                            onHighlight={handleItemHover}
-                            onEditThinking={handleEditThinking}
-                          />
-                        ))}
-                      </ComboboxGroup>
-                    ) : (
-                      models.map((model) => (
+                  {filteredGroupedModels.map(({ label, models }) => (
+                    <ComboboxGroup key={label}>
+                      <ComboboxGroupLabel className="px-1.5 pt-2 pb-1 font-normal text-sidebar-foreground text-xs first:pt-0">
+                        {label}
+                      </ComboboxGroupLabel>
+                      {models.map((model) => (
                         <ModelItem
                           key={model.modelId}
                           model={model}
                           onHighlight={handleItemHover}
                           onEditThinking={handleEditThinking}
                         />
-                      ))
-                    ),
-                  )}
+                      ))}
+                    </ComboboxGroup>
+                  ))}
                 </div>
 
                 {!hasFilteredResults && (
@@ -697,15 +701,6 @@ const ModelItem = memo(function ModelItem({
     event: React.MouseEvent<HTMLElement>,
   ) => void;
 }) {
-  const PriceIcon =
-    model.pricingMultiplier != null
-      ? model.pricingMultiplier < 0.5
-        ? IconArrowDownOutline18
-        : model.pricingMultiplier > 2.0
-          ? IconArrowUpOutline18
-          : null
-      : null;
-
   const itemRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -730,18 +725,22 @@ const ModelItem = memo(function ModelItem({
       <span className="col-start-2 flex min-w-0 flex-row items-center justify-between gap-4 text-xs">
         <div className="flex flex-row items-center gap-1.5">
           <span className="truncate">{model.displayName}</span>
-          {PriceIcon && (
-            <span className="inline-flex items-center text-subtle-foreground">
-              $
-              <PriceIcon className="size-2.75" />
-            </span>
-          )}
         </div>
         {model.thinkingLabel && (
-          <span className="relative flex h-4 min-w-14 shrink-0 items-center justify-end text-[10px]">
-            <span className="inline-flex items-center gap-1 text-subtle-foreground group-data-[highlighted]/item:opacity-0">
+          <span
+            className={cn(
+              'relative flex h-4 shrink-0 items-center justify-end text-[10px]',
+              model.isAlias ? 'min-w-3' : 'min-w-14',
+            )}
+          >
+            <span
+              className={cn(
+                'inline-flex items-center gap-1 text-subtle-foreground',
+                !model.isAlias && 'group-data-[highlighted]/item:opacity-0',
+              )}
+            >
               <IconBrainOutline18 className="size-2.75" />
-              {model.thinkingLabel}
+              {!model.isAlias && model.thinkingLabel}
             </span>
             {model.catalogModel && (
               <Button
@@ -749,7 +748,9 @@ const ModelItem = memo(function ModelItem({
                 variant="ghost"
                 size="xs"
                 className="absolute right-0 h-auto px-0 py-0 text-[10px] opacity-0 group-data-[highlighted]/item:opacity-100"
-                onClick={(event) => onEditThinking(model.modelId, event)}
+                onClick={(event) =>
+                  onEditThinking(model.targetModelId ?? model.modelId, event)
+                }
               >
                 Edit
               </Button>

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/panel-footer.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/panel-footer.tsx
@@ -66,7 +66,7 @@ import type { AgentMessage } from '@shared/karton-contracts/ui/agent';
 import { EMPTY_MOUNTS, type MountEntry } from '@shared/karton-contracts/ui';
 import { useOpenAgent } from '@ui/hooks/use-open-chat';
 import { useContentCollapsed } from '../../../_components/content-collapsed-context';
-import { availableModels } from '@shared/available-models';
+import { getAvailableModel } from '@shared/available-models';
 import { useChatDraft } from '@ui/hooks/use-chat-draft';
 import type { Content } from '@tiptap/core';
 import {
@@ -1105,7 +1105,7 @@ export const ChatPanelFooter = memo(function ChatPanelFooter() {
   const customModels = useKartonState((s) => s.preferences.customModels);
   const maxTokens = useMemo(() => {
     if (!activeModelId) return 200000;
-    const builtIn = availableModels.find((m) => m.modelId === activeModelId);
+    const builtIn = getAvailableModel(activeModelId);
     if (builtIn) return builtIn.modelContextRaw;
     const custom = customModels.find((m) => m.modelId === activeModelId);
     if (custom) return custom.contextWindowSize;

--- a/apps/browser/src/ui/screens/settings/sections/models-providers-section.tsx
+++ b/apps/browser/src/ui/screens/settings/sections/models-providers-section.tsx
@@ -18,7 +18,15 @@ import {
   PROVIDER_DISPLAY_INFO,
   PROVIDER_OFFICIAL_URLS,
 } from '@shared/karton-contracts/ui/shared-types';
-import { availableModels } from '@shared/available-models';
+import type {
+  BuiltInModel,
+  SelectableBuiltInModel,
+} from '@shared/available-models';
+import {
+  availableModelAliases,
+  getAvailableModel,
+  getSelectableBuiltInModels,
+} from '@shared/available-models';
 import {
   getEnabledModelThinkingOption,
   getModelThinkingDisplayState,
@@ -65,8 +73,6 @@ import {
   IconPlusOutline18,
   IconPenOutline18,
   IconTrashOutline18,
-  IconArrowUpOutline18,
-  IconArrowDownOutline18,
 } from 'nucleo-ui-outline-18';
 
 enablePatches();
@@ -75,6 +81,9 @@ const EMPTY_CUSTOM_MODELS: UserPreferences['customModels'] = [];
 const EMPTY_CUSTOM_ENDPOINTS: UserPreferences['customEndpoints'] = [];
 const EMPTY_MODEL_THINKING_OVERRIDES: UserPreferences['agent']['modelThinkingOverrides'] =
   {};
+const RECOMMENDED_MODEL_IDS = availableModelAliases.map(
+  (alias) => alias.modelId,
+);
 
 // =============================================================================
 // Model Provider Configuration
@@ -92,7 +101,7 @@ const PROVIDERS: ModelProvider[] = [
 ];
 
 function getThinkingDefaultOptionsForModel(
-  model: (typeof availableModels)[number],
+  model: BuiltInModel,
   preferences: UserPreferences,
 ): Parameters<typeof getModelThinkingDisplayState>[2] {
   const provider = model.officialProvider;
@@ -479,7 +488,7 @@ function ModelProvidersSection() {
 // =============================================================================
 
 const BUILT_IN_MODEL_IDS = new Set(
-  availableModels.map((m) => m.modelId),
+  getSelectableBuiltInModels().map((m) => m.modelId),
 ) as Set<string>;
 
 function CustomModelDialog({
@@ -969,7 +978,7 @@ function BuiltInModelCard({
   onToggle,
   onEditThinking,
 }: {
-  model: (typeof availableModels)[number];
+  model: SelectableBuiltInModel;
   isEnabled: boolean;
   thinkingDisplay: ModelThinkingDisplayState | null;
   onToggle: () => void;
@@ -1000,21 +1009,6 @@ function BuiltInModelCard({
               ? PROVIDER_DISPLAY_INFO[model.officialProvider].name
               : 'Unknown'}{' '}
             &middot; {model.modelContext}
-            {model.pricing &&
-              (model.pricing.relativeMultiplier < 0.5 ||
-                model.pricing.relativeMultiplier > 2.0) && (
-                <>
-                  {' · '}
-                  <span className="inline-flex items-center">
-                    $
-                    {model.pricing.relativeMultiplier < 0.5 ? (
-                      <IconArrowDownOutline18 className="size-2.5" />
-                    ) : (
-                      <IconArrowUpOutline18 className="size-2.5" />
-                    )}
-                  </span>
-                </>
-              )}
           </p>
         </div>
         <div
@@ -1159,9 +1153,12 @@ function CustomModelsSection() {
   const [searchQuery, setSearchQuery] = useState('');
 
   const filteredBuiltIn = useMemo(() => {
-    if (!searchQuery.trim()) return availableModels;
+    const selectableModels = getSelectableBuiltInModels({
+      disabledModelIds: RECOMMENDED_MODEL_IDS,
+    });
+    if (!searchQuery.trim()) return selectableModels;
     const q = searchQuery.toLowerCase();
-    return availableModels.filter(
+    return selectableModels.filter(
       (m) =>
         m.modelId.toLowerCase().includes(q) ||
         m.modelDisplayName.toLowerCase().includes(q) ||
@@ -1206,7 +1203,10 @@ function CustomModelsSection() {
   );
 
   const thinkingPanelModel = useMemo(
-    () => availableModels.find((m) => m.modelId === thinkingPanelModelId),
+    () =>
+      thinkingPanelModelId
+        ? getAvailableModel(thinkingPanelModelId)
+        : undefined,
     [thinkingPanelModelId],
   );
 
@@ -1358,24 +1358,25 @@ function CustomModelsSection() {
 
   const handleSetThinkingEnabled = useCallback(
     async (modelId: string, enabled: boolean) => {
-      const model = availableModels.find((item) => item.modelId === modelId);
+      const model = getAvailableModel(modelId);
       if (!model) return;
+      const targetModelId = model.modelId;
 
       const route = getThinkingDefaultOptionsForModel(model, preferences);
       const option = enabled
         ? getEnabledModelThinkingOption(
             model,
-            thinkingOverrides[modelId]?.value,
+            thinkingOverrides[targetModelId]?.value,
             route,
           )
         : (getModelThinkingOptions(model, route).find(
-            (item) => item.value === thinkingOverrides[modelId]?.value,
+            (item) => item.value === thinkingOverrides[targetModelId]?.value,
           ) ?? getModelThinkingOptions(model, route)[0]);
       if (!option) return;
 
       const [, patches] = produceWithPatches(preferences, (draft) => {
-        draft.agent.modelThinkingOverrides[modelId] = {
-          ...draft.agent.modelThinkingOverrides[modelId],
+        draft.agent.modelThinkingOverrides[targetModelId] = {
+          ...draft.agent.modelThinkingOverrides[targetModelId],
           enabled,
           provider: option.provider,
           value: option.value,
@@ -1388,8 +1389,9 @@ function CustomModelsSection() {
 
   const handleSetThinkingValue = useCallback(
     async (modelId: string, value: string) => {
-      const model = availableModels.find((item) => item.modelId === modelId);
+      const model = getAvailableModel(modelId);
       if (!model) return;
+      const targetModelId = model.modelId;
 
       const route = getThinkingDefaultOptionsForModel(model, preferences);
       const option = getModelThinkingOptions(model, route).find(
@@ -1398,7 +1400,7 @@ function CustomModelsSection() {
       if (!option) return;
 
       const [, patches] = produceWithPatches(preferences, (draft) => {
-        draft.agent.modelThinkingOverrides[modelId] = {
+        draft.agent.modelThinkingOverrides[targetModelId] = {
           enabled: true,
           provider: option.provider,
           value: option.value,
@@ -1411,8 +1413,9 @@ function CustomModelsSection() {
 
   const handleResetThinkingOverride = useCallback(
     async (modelId: string) => {
+      const targetModelId = getAvailableModel(modelId)?.modelId ?? modelId;
       const [, patches] = produceWithPatches(preferences, (draft) => {
-        delete draft.agent.modelThinkingOverrides[modelId];
+        delete draft.agent.modelThinkingOverrides[targetModelId];
       });
       await updatePreferences(patches);
     },
@@ -1508,9 +1511,12 @@ function CustomModelsSection() {
               model={model}
               isEnabled={!disabledModelIds.has(model.modelId)}
               thinkingDisplay={getModelThinkingDisplayState(
-                model,
+                model.targetModel,
                 thinkingOverrides[model.modelId],
-                getThinkingDefaultOptionsForModel(model, preferences),
+                getThinkingDefaultOptionsForModel(
+                  model.targetModel,
+                  preferences,
+                ),
               )}
               onToggle={() => handleToggleModel(model.modelId)}
               onEditThinking={(event) =>


### PR DESCRIPTION
Add Default, Quick, and Smart alias models that route to existing built-in models (deepseek-v4-pro, gemini-3.5-flash, glm-5.2) with fixed thinking presets (medium, low, xhigh).

- Define availableModelAliases and SelectableBuiltInModel union type in available-models.ts with resolve/getSelectable helpers
- Route aliases through target models in ModelProviderService, using preset thinking overrides instead of user-configurable ones
- Set Default alias as the default model for new browser chat agents
- Show aliases in chat model selector under a Recommended group with brain icon; hide thinking labels and edit buttons for aliases
- Hide aliases from settings page entirely
- Guard thinking-effort hotkey cycling to skip alias models
- Remove dead alias-specific code from settings BuiltInModelCard
- Add test coverage for alias resolution, routing, presets, and default model selection

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds model aliases—Default, Quick, and Smart—that map to built-in models with fixed reasoning presets, and makes Default the browser chat default. The picker and backend resolve through aliases; thinking overrides are locked for aliases and still apply to concrete models.

- **New Features**
  - Aliases:
    - Default → deepseek-v4-pro (thinking: medium)
    - Quick → gemini-3.5-flash (thinking: low)
    - Smart → glm-5.2 (thinking: xhigh)
  - Backend accepts alias IDs, routes to target models, and applies fixed presets; user thinking overrides are ignored for aliases and respected for concrete models. Capability lookups and model existence checks resolve through aliases.
  - New browser chat agents default to the Default alias.
  - Model selector shows aliases first under a “Recommended” group with a brain icon; hides thinking labels and “Edit” for aliases. Hotkey thinking-effort cycling skips aliases. Aliases stay visible even if their target model is disabled.
  - Aliases are hidden on the settings page.
  - Helpers added for alias resolution and selection (`availableModelAliases`, `getModelAlias`, `resolveModelAlias`, `getAvailableModel`, `getSelectableBuiltInModels`). Tests cover alias routing, fixed presets, override behavior, capability resolution, visibility, and default model selection.

<sup>Written for commit a298e5310e646f9bf95ab611fa886be2717f6398. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1340?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added built-in model aliases (`default`, `quick`, `smart`) with recommended selection options.

* **Improvements**
  * Model selection, capability lookups, provider routing, and displayed model metadata now resolve alias IDs to their target built-in models.
  * Alias requests use fixed thinking presets, and thinking overrides are applied consistently to alias targets.

* **Bug Fixes**
  * Chat UI max token context and error-stage prompting are now alias-aware.

* **Tests**
  * Added unit tests covering alias routing, selectable alias behavior, and default chat model configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->