### PR TITLE
fix(stagewise): use platform-correct worktree-setup script in git-pat…

### DIFF
--- a/apps/browser/src/backend/services/toolbox/services/mount-manager/git-path-actions.test.ts
+++ b/apps/browser/src/backend/services/toolbox/services/mount-manager/git-path-actions.test.ts
@@ -20,6 +20,10 @@ import type { Logger } from '@/services/logger';
 import type { TelemetryService } from '@/services/telemetry';
 import type { UserExperienceService } from '@/services/experience';
 import { getWorktreesDir } from '@/utils/paths';
+import {
+  WORKTREE_SETUP_SCRIPT_RELATIVE_PATHS,
+  variantForPlatform,
+} from '@shared/worktree-setup';
 import type { WorkspaceGitSetupRun } from '@shared/karton-contracts/ui';
 import {
   AgentStore,
@@ -212,6 +216,25 @@ function setAgentMount(
   agentMounts.set(agentId, mounts);
 }
 
+/**
+ * Writes a worktree-setup script in the variant the `WorktreeSetupRunner`
+ * actually selects for the current platform. The runner uses
+ * `variantForPlatform(process.platform)` to decide whether to look for
+ * `.sh` (POSIX) or `.ps1` (PowerShell); writing the wrong variant causes
+ * the runner to silently skip setup, which makes the test time out on
+ * Windows.
+ */
+async function writePlatformSetupScript(
+  worktreePath: string,
+  content: string,
+): Promise<void> {
+  const relativePath =
+    WORKTREE_SETUP_SCRIPT_RELATIVE_PATHS[variantForPlatform(process.platform)];
+  const scriptPath = path.join(worktreePath, relativePath);
+  await fs.mkdir(path.dirname(scriptPath), { recursive: true });
+  await fs.writeFile(scriptPath, content);
+}
+
 function detachWorkspacePathFromAgents(
   service: MountManagerService,
   workspacePath: string,
@@ -380,13 +403,7 @@ describe('MountManagerService path-based Git actions', () => {
     const mainPath = linkedPath.replace('linked-worktree', 'main-worktree');
     await fs.mkdir(mainPath, { recursive: true });
     const createdPath = path.join(mainPath, '..', 'created-worktree');
-    const scriptPath = path.join(
-      createdPath,
-      '.stagewise',
-      'worktree-setup.sh',
-    );
-    await fs.mkdir(path.dirname(scriptPath), { recursive: true });
-    await fs.writeFile(scriptPath, 'exit 0');
+    await writePlatformSetupScript(createdPath, 'exit 0');
     const { service, procedureHandlers, gitService, state } = createHarness({
       recentPaths: [linkedPath],
     });
@@ -457,13 +474,7 @@ describe('MountManagerService path-based Git actions', () => {
   it('starts pending setup only after mounting the created worktree', async () => {
     const recentPath = await fs.mkdtemp(path.join(os.tmpdir(), 'recent-repo-'));
     const createdPath = path.join(recentPath, '..', 'created-worktree');
-    const scriptPath = path.join(
-      createdPath,
-      '.stagewise',
-      'worktree-setup.sh',
-    );
-    await fs.mkdir(path.dirname(scriptPath), { recursive: true });
-    await fs.writeFile(scriptPath, 'exit 0');
+    await writePlatformSetupScript(createdPath, 'exit 0');
     const { service, procedureHandlers, state } = createHarness({
       recentPaths: [recentPath],
     });
@@ -524,13 +535,12 @@ describe('MountManagerService path-based Git actions', () => {
   it('keeps failed setup worktrees mounted', async () => {
     const recentPath = await fs.mkdtemp(path.join(os.tmpdir(), 'recent-repo-'));
     const createdPath = path.join(recentPath, '..', 'created-worktree');
-    const scriptPath = path.join(
+    // PowerShell exits with `exit 1` just like POSIX shells; the stderr
+    // redirection syntax differs but the test only asserts `status`.
+    await writePlatformSetupScript(
       createdPath,
-      '.stagewise',
-      'worktree-setup.sh',
+      process.platform === 'win32' ? 'exit 1' : 'echo failed >&2\nexit 1',
     );
-    await fs.mkdir(path.dirname(scriptPath), { recursive: true });
-    await fs.writeFile(scriptPath, 'echo failed >&2\nexit 1');
     const { service, procedureHandlers, state } = createHarness({
       recentPaths: [recentPath],
     });

--- a/packages/agent-core/vitest.config.ts
+++ b/packages/agent-core/vitest.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  ssr: {
+    // web-tree-sitter ships WASM and uses CJS patterns — let Node
+    // resolve it natively instead of Vite trying to transform it.
+    external: ['web-tree-sitter'],
+  },
+  test: {
+    globals: true,
+    environment: 'node',
+    passWithNoTests: true,
+    testTimeout: 60000, // 60s — accommodates heavy SQLite tests on slow CI runners
+    hookTimeout: 60000,
+    fileParallelism: false, // Sequential execution — avoids I/O contention from concurrent SQLite temp DBs
+    include: ['src/**/*.test.ts'],
+  },
+});

--- a/packages/agent-shell/vitest.config.ts
+++ b/packages/agent-shell/vitest.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  ssr: {
+    // node-pty ships native .node binaries — let Node resolve it
+    // natively instead of Vite trying to transform it.
+    external: ['node-pty'],
+  },
+  test: {
+    globals: true,
+    environment: 'node',
+    passWithNoTests: true,
+    testTimeout: 60000, // 60s — PTY integration tests need to spawn shells and wait for command execution
+    hookTimeout: 60000,
+    fileParallelism: false, // Sequential execution — PTY tests are resource-intensive and shouldn't contend
+    include: ['src/**/*.test.ts'],
+  },
+});


### PR DESCRIPTION
…h-actions tests

Three tests in git-path-actions.test.ts hardcoded the POSIX worktree-setup.sh as the setup script path. On Windows, WorktreeSetupRunner uses variantForPlatform(process.platform) which selects the powershell variant and looks for worktree-setup.ps1 instead. The missing script caused the runner to silently skip setup, leaving state empty and vi.waitFor to time out, making the Windows CI job appear flaky.

Added a writePlatformSetupScript helper that writes the variant matching the host platform, and updated the three affected tests to use it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Windows CI flakiness by generating the platform-correct worktree-setup script in git-path-actions tests and by running `agent-core` and `agent-shell` tests sequentially with 60s timeouts. This prevents skipped setup and avoids Vitest timeouts on slow runners.

- **Bug Fixes**
  - Added `writePlatformSetupScript` to create the `.sh` or `.ps1` at `WORKTREE_SETUP_SCRIPT_RELATIVE_PATHS` from `@shared/worktree-setup`; updated three tests to use it, including platform-correct failure script content.
  - Added Vitest config in `agent-core`: sequential test files, 60s test/hook timeouts, externalized `web-tree-sitter` for SSR.
  - Added Vitest config in `agent-shell`: sequential tests, 60s test/hook timeouts, externalized `node-pty` for SSR to prevent PTY init timeouts.

<sup>Written for commit 97b14736a1a3a94356b91af53d7de93b7ed5c120. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1341?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved platform-specific worktree setup in the mount manager test suite by generating the correct setup script for the current OS and using platform-appropriate failure script content.
* **Tests & Tooling**
  * Updated agent-core and agent-shell Vitest configuration to run in a Node environment with global test APIs, extended test/hook timeouts, sequential execution, and safe handling when no tests are found.
  * Added SSR externalization for key native/WASM dependencies to prevent unwanted bundling/transforms during tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->