### PR TITLE
fix(website): center pricing and enterprise pages on wide screens

### DIFF
--- a/apps/website/src/app/(home)/enterprise/page.tsx
+++ b/apps/website/src/app/(home)/enterprise/page.tsx
@@ -24,7 +24,7 @@ export const metadata: Metadata = {
 export default function EnterprisePage() {
   return (
     <section className="relative z-10 mt-12 w-full pb-4 md:pb-6">
-      <div className="flex justify-start">
+      <div className="flex justify-center">
         <div className="w-full max-w-7xl">
           <ScrollReveal>
             <div className="mb-6 flex flex-col items-start px-4 text-left md:mb-8">

--- a/apps/website/src/app/(home)/pricing/page.tsx
+++ b/apps/website/src/app/(home)/pricing/page.tsx
@@ -90,7 +90,7 @@ export default function PricingPage() {
 
   return (
     <section className="relative z-10 mt-12 w-full pb-4 md:pb-6">
-      <div className="flex justify-start">
+      <div className="flex justify-center">
         <div className="w-full max-w-7xl">
           <ScrollReveal>
             <div className="mt-0 mb-6 flex flex-col items-start px-4 text-left md:mt-2 md:mb-8">


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Center the Pricing and Enterprise pages on wide screens by switching the outer flex container from `justify-start` to `justify-center`. This fixes the off-center layout and keeps content aligned within the `max-w-7xl` container.

<sup>Written for commit 4ecedc4daf5094b55147d147c9af938245e1f6eb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1344?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Centered content layout on the Enterprise page.
  * Centered content layout on the Pricing page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->