### PR TITLE
Performance improvements

### DIFF
--- a/apps/browser/src/backend/services/log-ingest/index.ts
+++ b/apps/browser/src/backend/services/log-ingest/index.ts
@@ -268,6 +268,9 @@ export class LogIngestService {
     this.flushTimer = setInterval(() => {
       void this.flushAll();
     }, FLUSH_INTERVAL_MS);
+    // Allow Node to enter deeper idle states when no other work is active.
+    // The timer still fires on its 500ms cadence when buffers have data.
+    this.flushTimer.unref?.();
   }
 
   private async flushAll(): Promise<void> {

--- a/apps/browser/src/backend/services/macos-closed-lid-sleep.ts
+++ b/apps/browser/src/backend/services/macos-closed-lid-sleep.ts
@@ -12,7 +12,7 @@ const OSASCRIPT_PATH = '/usr/bin/osascript';
 const SUDO_PATH = '/usr/bin/sudo';
 const SUDOERS_RULE_PATH = '/etc/sudoers.d/stagewise-closed-lid-sleep';
 const SUDOERS_TEMP_RULE_PATH = '/tmp/stagewise-closed-lid-sleep-sudoers';
-const STATUS_REFRESH_INTERVAL_MS = 5_000;
+const STATUS_REFRESH_INTERVAL_MS = 30_000;
 
 type ClosedLidSleepState = {
   isSupported: boolean;
@@ -130,6 +130,10 @@ export class MacOSClosedLidSleepService extends DisposableService {
     });
 
     this.statusInterval = setInterval(() => {
+      // Only poll when the feature is actively in use or transitioning.
+      // When closed-lid sleep is off and stable, skip the expensive pmset
+      // fork/exec to save energy.
+      if (!this.ownedByStagewise && !this.isChanging) return;
       this.syncState().catch((error) => {
         this.logger.debug(
           '[MacOSClosedLidSleepService] Failed to refresh state',

--- a/apps/browser/src/backend/services/window-layout/browsing-tab-controller.ts
+++ b/apps/browser/src/backend/services/window-layout/browsing-tab-controller.ts
@@ -1750,6 +1750,11 @@ export class BrowsingTabController extends EventEmitter<TabControllerEventMap> {
     // Schedule screenshot capture after debounce period
     this.screenshotOnResizeTimeout = setTimeout(() => {
       this.screenshotOnResizeTimeout = null;
+      // Energy-saving: mirror the interval guards. Skip resize-driven captures
+      // while the tab is hidden or the app window is unfocused. A fresh capture
+      // is triggered automatically on visibility/focus restore (see setVisible /
+      // setAppFocused), so the screenshot is never left stale once visible.
+      if (!this.isTabVisible || !this.isAppFocused) return;
       this.captureScreenshot().catch((err) => {
         this.logger.debug(
           `[TabController] Failed to capture screenshot on resize: ${err}`,

--- a/apps/browser/src/backend/services/window-layout/browsing-tab-controller.ts
+++ b/apps/browser/src/backend/services/window-layout/browsing-tab-controller.ts
@@ -211,6 +211,11 @@ export class BrowsingTabController extends EventEmitter<TabControllerEventMap> {
   private screenshotOnResizeTimeout: NodeJS.Timeout | null = null;
   private readonly SCREENSHOT_RESIZE_DEBOUNCE_MS = 200; // 200ms debounce
 
+  // Energy-saving: track whether this tab is visible and the app window is focused.
+  // Screenshot and viewport intervals are skipped when either is false.
+  private isTabVisible = false;
+  private isAppFocused = true;
+
   // DevTools debugger tracking
   private devToolsDebugger: Electron.Debugger | null = null;
   private devToolsPlaceholderObjectId: string | null = null;
@@ -428,9 +433,42 @@ export class BrowsingTabController extends EventEmitter<TabControllerEventMap> {
 
   public setVisible(visible: boolean) {
     this.webContentsView.setVisible(visible);
+    const wasVisible = this.isTabVisible;
+    this.isTabVisible = visible;
+
     // Update audio state when tab becomes visible to ensure it's current
     if (visible) {
       this.updateAudioState();
+    }
+
+    // Trigger an immediate screenshot when the tab transitions from hidden to
+    // visible while the app is focused — the previous screenshot may be stale.
+    if (visible && !wasVisible && this.isAppFocused) {
+      this.captureScreenshot().catch((err) => {
+        this.logger.debug(
+          `[TabController] Failed to capture screenshot on visibility restore: ${err}`,
+        );
+      });
+    }
+  }
+
+  /**
+   * Updates the app focus state for this tab.
+   * When the app regains focus and the tab is visible, an immediate screenshot
+   * is triggered to refresh potentially stale state.
+   */
+  public setAppFocused(focused: boolean) {
+    const wasFocused = this.isAppFocused;
+    this.isAppFocused = focused;
+
+    // Trigger an immediate screenshot when the app regains focus and the tab
+    // is visible — the previous screenshot may be stale.
+    if (focused && !wasFocused && this.isTabVisible) {
+      this.captureScreenshot().catch((err) => {
+        this.logger.debug(
+          `[TabController] Failed to capture screenshot on focus restore: ${err}`,
+        );
+      });
     }
   }
 
@@ -1633,8 +1671,10 @@ export class BrowsingTabController extends EventEmitter<TabControllerEventMap> {
       return;
     }
 
-    // Only poll viewport when context selection is active OR DevTools are open
+    // Only poll viewport when context selection is active OR DevTools are open,
+    // and only when the tab is visible and the app window is focused.
     this.viewportTrackingInterval = setInterval(() => {
+      if (!this.isTabVisible || !this.isAppFocused) return;
       // Only poll if context selection is active or DevTools are open
       if (
         this.isContextSelectionActive ||
@@ -1668,8 +1708,10 @@ export class BrowsingTabController extends EventEmitter<TabControllerEventMap> {
       return;
     }
 
-    // Capture screenshot every 15 seconds
+    // Capture screenshot every 15 seconds, but only when the tab is visible
+    // and the app window is focused. This prevents per-tab GPU work while idle.
     this.screenshotInterval = setInterval(() => {
+      if (!this.isTabVisible || !this.isAppFocused) return;
       this.captureScreenshot().catch((err) => {
         this.logger.debug(
           `[TabController] Failed to capture screenshot: ${err}`,

--- a/apps/browser/src/backend/services/window-layout/index.ts
+++ b/apps/browser/src/backend/services/window-layout/index.ts
@@ -159,6 +159,10 @@ export class WindowLayoutService extends DisposableService {
   private activeTabId: string | null = null;
   private chatStateController: ChatStateController | null = null;
 
+  /** Tracks whether the app window is currently focused. Propagated to all
+   *  BrowsingTabControllers to gate energy-consuming intervals. */
+  private appFocused = true;
+
   private currentWebContentBounds: Electron.Rectangle | null = null;
   private isWebContentInteractive = false;
 
@@ -608,6 +612,21 @@ export class WindowLayoutService extends DisposableService {
     this.baseWindow.on('close', () => {
       this.saveWindowState();
       this.saveTabState();
+    });
+
+    // Track app focus state and propagate to all tab controllers so they can
+    // gate energy-consuming intervals (screenshots, viewport polling).
+    this.baseWindow.on('focus', () => {
+      if (!this.appFocused) {
+        this.appFocused = true;
+        this.propagateAppFocusToTabs(true);
+      }
+    });
+    this.baseWindow.on('blur', () => {
+      if (this.appFocused) {
+        this.appFocused = false;
+        this.propagateAppFocusToTabs(false);
+      }
     });
 
     // Listen for OS theme changes and update window colors accordingly
@@ -1329,6 +1348,13 @@ export class WindowLayoutService extends DisposableService {
     return this.tabs[this.activeTabId];
   }
 
+  /** Propagates the app focus state to all existing tab controllers. */
+  private propagateAppFocusToTabs(focused: boolean) {
+    for (const tab of Object.values(this.tabs)) {
+      tab.setAppFocused(focused);
+    }
+  }
+
   /**
    * Get a tab by ID, or the active tab if no ID is provided.
    * Used by services like DevToolAPIService to access tabs.
@@ -1440,6 +1466,9 @@ export class WindowLayoutService extends DisposableService {
       },
       this.telemetryService ?? undefined,
     );
+
+    // Initialize the tab's focus state to match the current app focus state.
+    tab.setAppFocused(this.appFocused);
 
     // Subscribe to state updates
     tab.on('stateUpdated', (updates) => {

--- a/apps/browser/src/backend/wiring/pages-state-sync.ts
+++ b/apps/browser/src/backend/wiring/pages-state-sync.ts
@@ -3,6 +3,7 @@ import type { KartonService } from '../services/karton';
 import type { PagesService } from '../services/pages';
 import type { GlobalConfigService } from '../services/global-config';
 import type { Logger } from '../services/logger';
+import type { FileDiff } from '@stagewise/agent-core/types/diff-history';
 
 export async function wirePagesStateSync(deps: {
   uiKarton: KartonService;
@@ -13,36 +14,49 @@ export async function wirePagesStateSync(deps: {
   const { uiKarton, pagesService, globalConfigService, logger } = deps;
 
   // --- Pending edits sync (uiKarton -> pages) ---
-  const previousPendingEditsSnapshots = new Map<string, string>();
-
+  // Uses syncDerivedState with a lightweight custom snapshot function that
+  // mirrors the original hash-based comparison, avoiding JSON.stringify on
+  // potentially large file-diff contents. The selector derives a per-agent
+  // map of pending diffs; the consumer only fires when the snapshot changes.
   const hashContent = (s: string | null | undefined): string => {
     if (!s) return '0';
     const mid = Math.floor(s.length / 2);
     return `${s.length}:${s.slice(0, 8)}:${s.slice(-8)}:${s[mid] ?? ''}`;
   };
 
-  uiKarton.registerStateChangeCallback((state) => {
-    const activeAgentInstanceIds = Object.keys(state.agents.instances);
+  const pendingEditsSnapshot = (diffs: Record<string, FileDiff[]>): string =>
+    Object.keys(diffs)
+      .sort()
+      .map((agentId) => {
+        const entries = diffs[agentId];
+        const key = entries
+          .map(
+            (e) =>
+              `${e.path}|${e.isExternal ? `${e.baselineOid}|${e.currentOid}` : `${hashContent(e.baseline)}|${hashContent(e.current)}`}`,
+          )
+          .join('||');
+        return `${agentId}:${key}`;
+      })
+      .join('\n');
 
-    for (const agentInstanceId of activeAgentInstanceIds) {
-      const pendingEdits =
-        state.toolbox[agentInstanceId]?.pendingFileDiffs ?? [];
-
-      const snapshotKey = `${pendingEdits
-        .map(
-          (e) =>
-            `${e.path}|${e.isExternal ? `${e.baselineOid}|${e.currentOid}` : `${hashContent(e.baseline)}|${hashContent(e.current)}`}`,
-        )
-        .join('||')}`;
-
-      const previousSnapshot =
-        previousPendingEditsSnapshots.get(agentInstanceId) ?? '';
-      if (snapshotKey !== previousSnapshot) {
-        previousPendingEditsSnapshots.set(agentInstanceId, snapshotKey);
+  syncDerivedState(
+    uiKarton,
+    (state) => {
+      const result: Record<string, FileDiff[]> = {};
+      for (const agentInstanceId of Object.keys(state.agents.instances)) {
+        const pendingEdits =
+          state.toolbox[agentInstanceId]?.pendingFileDiffs ?? [];
+        result[agentInstanceId] = pendingEdits;
+      }
+      return result;
+    },
+    (diffs) => {
+      for (const [agentInstanceId, pendingEdits] of Object.entries(diffs)) {
         pagesService.updatePendingEditsState(agentInstanceId, pendingEdits);
       }
-    }
-  });
+    },
+    { snapshotFn: pendingEditsSnapshot },
+  );
 
   // --- Pending app message sync (uiKarton -> pages) ---
   syncDerivedState(

--- a/apps/browser/src/ui/components/context-providers.tsx
+++ b/apps/browser/src/ui/components/context-providers.tsx
@@ -7,8 +7,10 @@ import { TabStateUIProvider } from '../hooks/use-tab-ui-state';
 import { ErrorBoundary } from './error-boundary';
 import { TutorialProvider } from '@ui/contexts/tutorial';
 import { PersonalizationThemeSyncer } from './personalization-theme-syncer';
+import { useAnimationIdleGate } from '@ui/hooks/use-animation-idle-gate';
 
 export function ContextProviders({ children }: { children?: ReactNode }) {
+  useAnimationIdleGate();
   return (
     <TooltipProvider>
       <KartonProvider>

--- a/apps/browser/src/ui/hooks/use-animation-idle-gate.ts
+++ b/apps/browser/src/ui/hooks/use-animation-idle-gate.ts
@@ -1,0 +1,33 @@
+import { useEffect } from 'react';
+
+/**
+ * Toggles the `app-idle` class on `<html>` when the window loses focus or the
+ * page becomes hidden. The CSS rule `.app-idle * { animation-play-state: paused
+ * !important }` pauses all infinite CSS animations, allowing the GPU/compositor
+ * to enter low-power states while the app is not visible.
+ *
+ * Animations resume from their current frame when focus is restored.
+ */
+export function useAnimationIdleGate(): void {
+  useEffect(() => {
+    const root = document.documentElement;
+
+    const update = () => {
+      const isIdle =
+        !document.hasFocus() || document.visibilityState !== 'visible';
+      root.classList.toggle('app-idle', isIdle);
+    };
+
+    window.addEventListener('focus', update);
+    window.addEventListener('blur', update);
+    document.addEventListener('visibilitychange', update);
+    update();
+
+    return () => {
+      window.removeEventListener('focus', update);
+      window.removeEventListener('blur', update);
+      document.removeEventListener('visibilitychange', update);
+      root.classList.remove('app-idle');
+    };
+  }, []);
+}

--- a/apps/browser/src/ui/hooks/use-posthog.tsx
+++ b/apps/browser/src/ui/hooks/use-posthog.tsx
@@ -49,18 +49,13 @@ export function PostHogProvider({ children }: PostHogProviderProps) {
           if (containsResizeObserverLoopError(event)) return null;
           return event;
         },
-        disable_session_recording: telemetryLevel !== 'full',
+        disable_session_recording: true,
         autocapture: true,
         api_host: apiHost,
         ui_host: 'https://eu.posthog.com',
         capture_pageview: false, // We capture pageviews manually
         capture_pageleave: true, // Enable pageleave capture
         debug: import.meta.env.NODE_ENV === 'development',
-        session_recording: {
-          compress_events: true,
-          recordCrossOriginIframes: false,
-          recordHeaders: false,
-        },
       });
       const initKey = `${apiKey}::${apiHost ?? ''}`;
       if (registeredSuperPropsInitKey !== initKey) {

--- a/packages/stage-ui/src/styles/animations.css
+++ b/packages/stage-ui/src/styles/animations.css
@@ -203,3 +203,12 @@
 @utility shimmer-to-* {
   --shimmer-color-2: --value(--color-*);
 }
+
+/* When the app window is not focused or the page is hidden, pause all
+   infinite CSS animations to let the browser compositor and GPU enter
+   low-power states. Paused animations resume from their current frame
+   when focus is restored — no visible jump. */
+:root.app-idle *,
+.app-idle * {
+  animation-play-state: paused !important;
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cuts idle CPU/GPU by gating screenshot/viewport work and resize-driven captures on tab visibility and app focus, pausing infinite CSS animations when idle, throttling background polls, disabling session recording, and trimming pending-edits sync churn.

- **Refactors**
  - Focus/visibility: track app focus in window layout, propagate to tabs; skip screenshot/viewport intervals when hidden or unfocused; trigger an immediate screenshot on visibility/focus restore; gate resize-driven captures too.
  - macOS closed‑lid sleep: poll every 30s and skip `pmset` when the feature is off and stable.
  - Logging: `unref` the log‑ingest flush timer so Node can idle.
  - UI: add `useAnimationIdleGate` and `.app-idle` to pause infinite CSS animations when hidden/unfocused.
  - Telemetry: force `disable_session_recording: true` for PostHog.
  - State sync: use `syncDerivedState` with a lightweight snapshot for pending file diffs (`FileDiff` from `@stagewise/agent-core`) to avoid heavy JSON and redundant updates.

<sup>Written for commit 3f2738cbc2a6ea6ab7d28253cf7566ab8358503e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1345?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added idle detection that pauses infinite animations when the app isn’t focused or the page is hidden.

* **Performance & Optimization**
  * Improved background efficiency by deepening Node.js idle behavior during flush cycles.
  * Reduced CPU/battery usage by pausing tab screenshot/viewport work when the tab isn’t visible or the app isn’t focused.
  * Decreased unnecessary macOS lid-sleep polling by increasing the interval and skipping expensive checks during stable inactive periods.

* **Bug Fixes / Reliability**
  * Kept pending edits syncing aligned using centralized derived-state updates.

* **Analytics**
  * Disabled session recording by default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->