### PR TITLE
fix(agent-core): stop wrapping link protocol examples in backticks in system prompt

### DIFF
--- a/packages/agent-core/src/agents/chat/system-prompt-builder/output-style-defaults.ts
+++ b/packages/agent-core/src/agents/chat/system-prompt-builder/output-style-defaults.ts
@@ -15,7 +15,7 @@ export const BASELINE_OUTPUT_PROTOCOLS: readonly OutputProtocol[] = [
   {
     name: 'path',
     syntax: '[](path:{PATH})',
-    rule: 'Every reference to files, folders, workspaces, or attachments. Append `?display=expanded` (e.g. `[](path:./README.md?display=expanded)`) for inline preview.',
+    rule: 'Every reference to files, folders, workspaces, or attachments. Append `?display=expanded` (e.g. [](path:./README.md?display=expanded)) for inline preview.',
   },
 ];
 

--- a/packages/agent-core/src/agents/chat/system-prompt-builder/system-prompt-builder.ts
+++ b/packages/agent-core/src/agents/chat/system-prompt-builder/system-prompt-builder.ts
@@ -103,7 +103,7 @@ export function buildChatSystemPrompt(args: BuildChatSystemPromptArgs): string {
 function renderProtocolsTable(protocols: readonly OutputProtocol[]): string {
   if (protocols.length === 0) return '';
   const rows = protocols.map(
-    (p) => `| \`${p.name}\` | \`${p.syntax}\` | ${p.rule} |`,
+    (p) => `| \`${p.name}\` | ${p.syntax} | ${p.rule} |`,
   );
   return [
     '### Protocols',
@@ -120,7 +120,7 @@ function renderAliasesTable(aliases: readonly OutputAlias[]): string {
   return [
     '### Aliases',
     '',
-    'Markdown links with descriptive labels and these alias hrefs render as host-resolved URLs (e.g. `[Report an issue](report-agent-issue)`).',
+    'Markdown links with descriptive labels and these alias hrefs render as host-resolved URLs (e.g. [Report an issue](report-agent-issue)).',
     '',
     '| Alias | Use Case |',
     '|-------|----------|',


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Stop wrapping link protocol examples in backticks in the `agent-core` chat system prompt so examples render as clickable Markdown links, not code. Updates the Protocols and Aliases tables and the `path` rule example to show bare link syntax.

<sup>Written for commit 901c0d45d7b0f4491681e7ad367fcf7e15c3ca56. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1346?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated markdown formatting in system prompts to improve display consistency across protocol documentation and aliases descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->