### PR TITLE
Clocked shader

### DIFF
--- a/apps/website/content/career/growth-hacker-intern-bielefeld.mdx
+++ b/apps/website/content/career/growth-hacker-intern-bielefeld.mdx
@@ -1,7 +1,8 @@
 ---
-title: Growth Hacker Intern (Mandatory Internship / Pflichtpraktikum)
+title: Growth Hacker Intern (Mandatory Internship)
 location: Bielefeld, Germany (in-office)
 type: Full-time
+section: Marketing
 ---
 
 ## Help build the future of AI agents

--- a/apps/website/content/career/growth-hacker-intern-bielefeld.mdx
+++ b/apps/website/content/career/growth-hacker-intern-bielefeld.mdx
@@ -28,7 +28,7 @@ Your ultimate goal: **Make developers and development teams all around the world
 - Basic German skills
 - Highly autonomous and execution-oriented
 - Interested in startups, AI, and growth
-- Some experience with marketing related tools and metrics
+- Some experience with marketing-related tools and metrics
 - Willing to message the founders about your next great idea, even on a Saturday night
 - Excited to **take ownership and make a visible impact**
 
@@ -55,4 +55,4 @@ Send us your application at [**career@stagewise.io**](mailto:career@stagewise.io
 
 Tell us your story, a brand that positively stands out to you (and why), why you're the perfect fit, and what makes you unique. We want our team to consist of extraordinary people, and your application should reflect that.
 
-Afterwards, we're kicking off with a short 15-minute video call and then do a 30-minute meeting in our office. After a trial day where you can meet the team and learn about our product, we can get started with the role if everything fits!
+Afterwards, we kick off with a short 15-minute video call and then do a 30-minute meeting in our office. After a trial day where you can meet the team and learn about our product, we can get started with the role if everything fits!

--- a/apps/website/content/career/growth-hacker-intern-bielefeld.mdx
+++ b/apps/website/content/career/growth-hacker-intern-bielefeld.mdx
@@ -1,0 +1,57 @@
+---
+title: Growth Hacker Intern (Mandatory Internship / Pflichtpraktikum)
+location: Bielefeld, Germany (in-office)
+type: Full-time
+---
+
+## Help build the future of AI agents
+
+**stagewise** is building the open-source infrastructure layer for sovereign AI agents. We enable organizations to create, orchestrate, and operate AI agents across their entire business while maintaining full control over their models, data, and workflows.
+
+Backed by **Y Combinator**, we're building the foundation for a future where AI agents become a core part of how companies build software, automate operations, and get work done.
+
+## What You'll Do
+
+We're looking for a hyper-ambitious student with a growth hacker mindset.
+
+You'll work directly with the founders to grow **stagewise** through a mix of SEO, GEO, content, outbound initiatives, community building, and creative growth experiments. You'll have significant freedom to develop ideas, drag our team in front of the camera, test strategies, and execute them independently.
+
+Your ultimate goal: **Make developers and development teams all around the world fall in love with our product**.
+
+## Who We're Looking For
+
+- Bachelor's or Master's student looking for a **mandatory internship (Pflichtpraktikum)**
+- Available **full-time for at least 3 months**
+- Able to regularly work in our office in Bielefeld
+- Excellent English skills
+- Basic German skills
+- Highly autonomous and execution-oriented
+- Interested in startups, AI, and growth
+- Some experience with marketing related tools and metrics
+- Willing to message the founders about your next great idea, even on a Saturday night
+- Excited to **take ownership and make a visible impact**
+
+## Why stagewise?
+
+We believe the best people do their best work when they're trusted with real responsibility. You'll work directly with the founders, help shape our growth strategy, and have the freedom to pursue ideas you believe will move the company forward.
+
+We're looking for people who are excited about what we're building and want to contribute to something very ambitious. If you want to help revolutionize the world with AI, you'll fit right in.
+
+## What We Offer
+
+- 3-month or more full-time Pflichtpraktikum
+- **€650/month** (Bachelor) or **€850/month** (Master)
+- Direct collaboration with the founders
+- High ownership and autonomy from day one
+- **Opportunity for long-term employment after the internship**
+- Office directly at Bielefeld Hauptbahnhof (ecos office center)
+- MacBook, high-quality monitor, air-conditioned office
+- Unlimited coffee and flexible working hours
+
+## Hiring Process
+
+Send us your application at [**career@stagewise.io**](mailto:career@stagewise.io) – and please be creative!
+
+Tell us your story, a brand that positively stands out to you (and why), why you're the perfect fit, and what makes you unique. We want our team to consist of extraordinary people, and your application should reflect that.
+
+Afterwards, we're kicking off with a short 15-minute video call and then do a 30-minute meeting in our office. After a trial day where you can meet the team and learn about our product, we can get started with the role if everything fits!

--- a/apps/website/content/career/working-student-product-engineer-bielefeld.mdx
+++ b/apps/website/content/career/working-student-product-engineer-bielefeld.mdx
@@ -1,0 +1,75 @@
+---
+title: Product Engineer (Working Student)
+location: Bielefeld, Germany (in-office)
+type: Part-time
+---
+
+## Build the future of AI agents
+
+**stagewise** is building the open-source infrastructure layer for sovereign AI agents. We enable organizations to create, orchestrate, and operate AI agents across their entire business while maintaining full control over their models, data, and workflows.
+
+Backed by **Y Combinator**, we're building the foundation for a future where AI agents become a core part of how companies build software, automate operations, and get work done.
+
+## What You'll Do
+
+You'll work on the **stagewise IDE**, our open-source platform for managing coding agents in the age of agentic software development. Your mission is simple: build the go-to agentic IDE developers will reach for when working with AI.
+
+You'll:
+
+- Ship features end-to-end across our React, TypeScript, and Node.js stack
+- Own GitHub issues from backlog to production
+- Review, improve, and approve agent-generated pull requests
+- Build stagewise with stagewise
+- Continuously benchmark competing products and identify where we should win
+- Improve performance, reliability, and developer experience
+- Create reusable UX patterns that scale across the product
+
+If you enjoy eliminating unnecessary re-renders, squeezing out performance gains, refining interactions, and turning rough ideas into polished products, you'll probably enjoy this role.
+
+## Who We're Looking For
+
+- Strong TypeScript & React experience
+- Solid Node.js experience
+- Daily user of agentic coding tools
+- Comfortable taking ownership and driving projects independently
+- Understands what makes products feel great
+- Excellent English skills
+- Basic German skills
+
+**React and TypeScript expertise are not optional.** You should be comfortable building and maintaining production-grade applications.
+
+**If your GitHub profile doesn't represent some of your proudest work, this role is probably not for you.**
+
+Bonus points if you:
+
+- Contribute to open source
+- Have built developer tools before
+- Have strong opinions about AI-assisted software development
+- Compare products and tools for fun
+
+## Why stagewise?
+
+We believe the best people do their best work when they're trusted with real responsibility. You'll work directly with the founders, help shape our product roadmap, and have the freedom to pursue ideas you believe will move the company forward.
+
+We're looking for people who are excited about what we're building and want to contribute to something very ambitious. If you want to help revolutionize the world with AI, you'll fit right in.
+
+Also, the **stagewise IDE** is open source, and all of your contributions will be visible to the community.
+
+## What We Offer
+
+- 20 hours/week during the semester
+- 40 hours/week during semester breaks
+- High ownership and autonomy from day one
+- Direct collaboration with the founders
+- Opportunity for long-term employment
+- Office directly at **Bielefeld Hauptbahnhof**
+- MacBook, high-quality monitor, air-conditioned office
+- Unlimited coffee and flexible working hours
+
+## Hiring Process
+
+Send us your application at [**career@stagewise.io**](mailto:career@stagewise.io) – and please be creative!
+
+Tell us your story, a product you genuinely enjoy using (and why), why you're the perfect fit, and what makes you unique. We want our team to consist of extraordinary people, and your application should reflect that.
+
+Afterward, we'll kick things off with a short 15-minute video call, followed by a 30-minute meeting at our office. After a trial day where you can meet the team and learn more about the product, we'll get started if both sides feel it's a great fit.

--- a/apps/website/content/career/working-student-product-engineer-bielefeld.mdx
+++ b/apps/website/content/career/working-student-product-engineer-bielefeld.mdx
@@ -2,6 +2,7 @@
 title: Product Engineer (Working Student)
 location: Bielefeld, Germany (in-office)
 type: Part-time
+section: Engineering
 ---
 
 ## Build the future of AI agents

--- a/apps/website/src/app/(home)/(legal)/legal-notice/page.tsx
+++ b/apps/website/src/app/(home)/(legal)/legal-notice/page.tsx
@@ -28,7 +28,9 @@ export default async function LegalNoticePage() {
 
   const { content } = await compileMDX({
     source: page.source,
-    options: { development: true } as never,
+    options: {
+      mdxOptions: { development: process.env.NODE_ENV !== 'production' },
+    },
   });
 
   return (

--- a/apps/website/src/app/(home)/(legal)/privacy/page.tsx
+++ b/apps/website/src/app/(home)/(legal)/privacy/page.tsx
@@ -28,7 +28,9 @@ export default async function PrivacyPolicyPage() {
 
   const { content } = await compileMDX({
     source: page.source,
-    options: { development: true } as never,
+    options: {
+      mdxOptions: { development: process.env.NODE_ENV !== 'production' },
+    },
   });
 
   return (

--- a/apps/website/src/app/(home)/(legal)/terms/page.tsx
+++ b/apps/website/src/app/(home)/(legal)/terms/page.tsx
@@ -28,7 +28,9 @@ export default async function TermsPage() {
 
   const { content } = await compileMDX({
     source: page.source,
-    options: { development: true } as never,
+    options: {
+      mdxOptions: { development: process.env.NODE_ENV !== 'production' },
+    },
   });
 
   return (

--- a/apps/website/src/app/(home)/(legal)/trademark-policy/page.tsx
+++ b/apps/website/src/app/(home)/(legal)/trademark-policy/page.tsx
@@ -28,7 +28,9 @@ export default async function TrademarkPolicyPage() {
 
   const { content } = await compileMDX({
     source: page.source,
-    options: { development: true } as never,
+    options: {
+      mdxOptions: { development: process.env.NODE_ENV !== 'production' },
+    },
   });
 
   return (

--- a/apps/website/src/app/(home)/careers/[slug]/opengraph-image.tsx
+++ b/apps/website/src/app/(home)/careers/[slug]/opengraph-image.tsx
@@ -1,0 +1,27 @@
+import {
+  OG_SIZE,
+  OG_CONTENT_TYPE,
+  generateJobOgImage,
+  loadGeistMedium,
+} from '@/lib/og-image';
+import { getJob } from '@/lib/source';
+import { notFound } from 'next/navigation';
+
+export const runtime = 'nodejs';
+export const size = OG_SIZE;
+export const contentType = OG_CONTENT_TYPE;
+
+export default async function Image(props: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await props.params;
+  const job = getJob(slug);
+  if (!job) notFound();
+
+  const geistMedium = loadGeistMedium();
+  return generateJobOgImage({
+    jobTitle: job.title,
+    jobLocation: job.location,
+    geistFont: geistMedium,
+  });
+}

--- a/apps/website/src/app/(home)/careers/[slug]/page.tsx
+++ b/apps/website/src/app/(home)/careers/[slug]/page.tsx
@@ -50,6 +50,9 @@ export default async function JobDetailPage(props: {
           </h1>
           <div className="flex flex-wrap gap-2">
             <span className="inline-flex items-center rounded-full border border-derived-subtle bg-surface-tinted px-3 py-1 font-medium text-[11px] text-primary-foreground">
+              {job.section}
+            </span>
+            <span className="inline-flex items-center rounded-full border border-derived-subtle bg-surface-tinted px-3 py-1 font-medium text-[11px] text-primary-foreground">
               {job.type}
             </span>
             <span className="inline-flex items-center rounded-full border border-derived-subtle bg-surface-tinted px-3 py-1 font-medium text-[11px] text-primary-foreground">

--- a/apps/website/src/app/(home)/careers/[slug]/page.tsx
+++ b/apps/website/src/app/(home)/careers/[slug]/page.tsx
@@ -1,0 +1,101 @@
+import { ScrollReveal } from '@/components/landing/scroll-reveal';
+import { getAllJobParams, getJob } from '@/lib/source';
+import { getMDXComponents } from '@/mdx-components';
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import { compileMDX } from 'next-mdx-remote/rsc';
+
+export default async function JobDetailPage(props: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await props.params;
+  const job = getJob(slug);
+  if (!job) notFound();
+
+  const { content } = await compileMDX({
+    source: job.source,
+    options: {
+      mdxOptions: { development: process.env.NODE_ENV !== 'production' },
+    },
+    components: getMDXComponents(),
+  });
+
+  return (
+    <div className="mx-auto mt-12 w-full max-w-3xl px-4">
+      <ScrollReveal>
+        <Link
+          href="/careers"
+          className="inline-flex items-center gap-1 text-muted-foreground text-sm transition-colors hover:text-foreground"
+        >
+          <svg
+            className="size-4"
+            viewBox="0 0 16 16"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <path d="M10 3L5 8l5 5" />
+          </svg>
+          All positions
+        </Link>
+      </ScrollReveal>
+
+      <ScrollReveal delay={50}>
+        <div className="mt-8 flex flex-col items-start gap-4 text-left">
+          <h1 className="font-medium text-3xl text-foreground tracking-tight md:text-5xl">
+            {job.title}
+          </h1>
+          <div className="flex flex-wrap gap-2">
+            <span className="inline-flex items-center rounded-full border border-derived-subtle bg-surface-tinted px-3 py-1 font-medium text-[11px] text-primary-foreground">
+              {job.type}
+            </span>
+            <span className="inline-flex items-center rounded-full border border-derived-subtle bg-surface-tinted px-3 py-1 font-medium text-[11px] text-primary-foreground">
+              {job.location}
+            </span>
+          </div>
+        </div>
+      </ScrollReveal>
+
+      <ScrollReveal delay={100}>
+        <div className="news-prose prose prose-zinc dark:prose-invert mt-12 max-w-none">
+          {content}
+        </div>
+      </ScrollReveal>
+    </div>
+  );
+}
+
+export async function generateStaticParams() {
+  return getAllJobParams().map(({ slug }) => ({ slug: slug[0] }));
+}
+
+export async function generateMetadata(props: {
+  params: Promise<{ slug: string }>;
+}): Promise<Metadata> {
+  const { slug } = await props.params;
+  const job = getJob(slug);
+  if (!job) notFound();
+
+  const description = `${job.title} — ${job.type}, ${job.location}. Join stagewise and help build the future of AI-driven development.`;
+
+  return {
+    title: `${job.title} · stagewise Careers`,
+    description,
+    openGraph: {
+      title: `${job.title} · stagewise Careers`,
+      description,
+      locale: 'en_US',
+    },
+    twitter: {
+      title: `${job.title} · stagewise Careers`,
+      description,
+      creator: '@stagewise_io',
+    },
+    category: 'Jobs',
+    applicationName: 'stagewise',
+    publisher: 'stagewise',
+  };
+}

--- a/apps/website/src/app/(home)/careers/[slug]/page.tsx
+++ b/apps/website/src/app/(home)/careers/[slug]/page.tsx
@@ -72,7 +72,7 @@ export default async function JobDetailPage(props: {
 }
 
 export async function generateStaticParams() {
-  return getAllJobParams().map(({ slug }) => ({ slug: slug[0] }));
+  return getAllJobParams();
 }
 
 export async function generateMetadata(props: {

--- a/apps/website/src/app/(home)/careers/layout.tsx
+++ b/apps/website/src/app/(home)/careers/layout.tsx
@@ -1,0 +1,25 @@
+import type { Metadata } from 'next';
+import type { ReactNode } from 'react';
+
+export const metadata: Metadata = {
+  title: 'Career · stagewise',
+  description:
+    'Join stagewise and help build the future of AI-driven development. We are hiring in-person in San Francisco and Bielefeld.',
+  openGraph: {
+    title: 'Career · stagewise',
+    description:
+      'Join stagewise and help build the future of AI-driven development. We are hiring in-person in San Francisco and Bielefeld.',
+    type: 'website',
+  },
+  twitter: {
+    title: 'Career · stagewise',
+    description:
+      'Join stagewise and help build the future of AI-driven development. We are hiring in-person in San Francisco and Bielefeld.',
+    creator: '@stagewise_io',
+  },
+  category: 'technology',
+};
+
+export default function CareerLayout({ children }: { children: ReactNode }) {
+  return <>{children}</>;
+}

--- a/apps/website/src/app/(home)/careers/opengraph-image.tsx
+++ b/apps/website/src/app/(home)/careers/opengraph-image.tsx
@@ -14,7 +14,7 @@ export default function Image() {
   const geistMedium = loadGeistMedium();
   return generateOgImage({
     pageName: 'Career',
-    pageSlug: 'career',
+    pageSlug: 'careers',
     geistFont: geistMedium,
   });
 }

--- a/apps/website/src/app/(home)/careers/opengraph-image.tsx
+++ b/apps/website/src/app/(home)/careers/opengraph-image.tsx
@@ -1,0 +1,20 @@
+import {
+  OG_SIZE,
+  OG_CONTENT_TYPE,
+  generateOgImage,
+  loadGeistMedium,
+} from '@/lib/og-image';
+
+export const runtime = 'nodejs';
+export const alt = 'stagewise - Career';
+export const size = OG_SIZE;
+export const contentType = OG_CONTENT_TYPE;
+
+export default function Image() {
+  const geistMedium = loadGeistMedium();
+  return generateOgImage({
+    pageName: 'Career',
+    pageSlug: 'career',
+    geistFont: geistMedium,
+  });
+}

--- a/apps/website/src/app/(home)/careers/page.tsx
+++ b/apps/website/src/app/(home)/careers/page.tsx
@@ -1,0 +1,178 @@
+import { ScrollReveal } from '@/components/landing/scroll-reveal';
+import { getAllJobs } from '@/lib/source';
+import type { Metadata } from 'next';
+import Link from 'next/link';
+
+export const metadata: Metadata = {
+  title: 'Careers · stagewise',
+  description:
+    'Join stagewise and help build the future of AI-driven development. We are hiring in-person in San Francisco and Bielefeld.',
+  openGraph: {
+    title: 'Careers · stagewise',
+    description:
+      'Join stagewise and help build the future of AI-driven development. We are hiring in-person in San Francisco and Bielefeld.',
+    type: 'website',
+  },
+  twitter: {
+    title: 'Careers · stagewise',
+    description:
+      'Join stagewise and help build the future of AI-driven development. We are hiring in-person in San Francisco and Bielefeld.',
+    creator: '@stagewise_io',
+  },
+  category: 'technology',
+};
+
+export default function CareerPage() {
+  const jobs = getAllJobs();
+
+  return (
+    <div className="relative mx-auto mt-12 w-full max-w-3xl px-4">
+      <ScrollReveal>
+        <div className="flex flex-col items-start gap-3 text-left">
+          <h1 className="font-medium text-3xl text-foreground tracking-tight md:text-5xl">
+            Careers
+          </h1>
+          <p className="text-lg text-muted-foreground">
+            Build the future of AI-driven development
+          </p>
+        </div>
+      </ScrollReveal>
+
+      {/* Job listings */}
+      <section className="mt-10">
+        <ScrollReveal>
+          <h2 className="mb-4 font-medium text-2xl tracking-tight md:text-3xl">
+            Open positions
+          </h2>
+        </ScrollReveal>
+
+        {jobs.length === 0 ? (
+          <ScrollReveal delay={100}>
+            <div className="rounded-lg bg-surface-1 p-8">
+              <p className="text-muted-foreground">
+                No open positions right now. Check back soon or reach out to{' '}
+                <a
+                  href="mailto:career@stagewise.io"
+                  className="text-primary-foreground transition-colors hover:text-hover-derived"
+                >
+                  career@stagewise.io
+                </a>{' '}
+                to introduce yourself.
+              </p>
+            </div>
+          </ScrollReveal>
+        ) : (
+          <ScrollReveal>
+            <div className="flex flex-col gap-px overflow-hidden rounded-lg bg-surface-2">
+              {jobs.map((job, index) => (
+                <div key={job.slug} className="bg-surface-1">
+                  <ScrollReveal delay={100 + index * 100}>
+                    <Link
+                      href={job.url}
+                      className="group flex items-center justify-between gap-6 p-6 transition-[padding-left] hover:pl-7 active:pl-7"
+                    >
+                      <div className="flex flex-col gap-1">
+                        <h3 className="font-medium text-foreground text-lg">
+                          {job.title}
+                        </h3>
+                        <p className="text-muted-foreground text-sm">
+                          {job.type} &middot; {job.location}
+                        </p>
+                      </div>
+                      <svg
+                        className="pointer-events-none size-4 text-muted-foreground/50 opacity-0 transition-opacity group-hover:opacity-100"
+                        viewBox="0 0 16 16"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth="2"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                      >
+                        <path d="M6 3l5 5-5 5" />
+                      </svg>
+                    </Link>
+                  </ScrollReveal>
+                </div>
+              ))}
+            </div>
+          </ScrollReveal>
+        )}
+      </section>
+
+      {/* Our principles */}
+      <section className="mt-16">
+        <ScrollReveal>
+          <h2 className="mb-4 font-medium text-2xl tracking-tight md:text-3xl">
+            Our principles
+          </h2>
+        </ScrollReveal>
+        <ScrollReveal delay={100}>
+          <ul className="flex flex-col gap-4">
+            <li className="text-base text-muted-foreground">
+              <span className="font-medium text-foreground">Be yourself</span>:{' '}
+              We're searching for extraordinary people that bring in their own
+              human touch into our team.
+            </li>
+            <li className="text-base text-muted-foreground">
+              <span className="font-medium text-foreground">Be ambitious</span>:{' '}
+              We're here to win, and this requires hard work from all of us.
+            </li>
+            <li className="text-base text-muted-foreground">
+              <span className="font-medium text-foreground">Be humble</span>:{' '}
+              The world is changing rapidly, we recognize this and are willing
+              to learn continuously.
+            </li>
+            <li className="text-base text-muted-foreground">
+              <span className="font-medium text-foreground">Be honest</span>:{' '}
+              Nobody wins if we can't speak the truth. We need to be efficient
+              with our time and words.
+            </li>
+            <li className="text-base text-muted-foreground">
+              <span className="font-medium text-foreground">Be nice</span>:{' '}
+              Being honest does <em>NOT</em> equal being mean. We're a team. We
+              win and lose together.
+            </li>
+            <li className="text-base text-muted-foreground">
+              <span className="font-medium text-foreground">Be visionary</span>:{' '}
+              We want to make a big dent in the fabric of the universe. Standard
+              solutions are not enough for this.
+            </li>
+          </ul>
+        </ScrollReveal>
+      </section>
+
+      {/* General application CTA */}
+      <section className="mt-16">
+        <ScrollReveal>
+          <div>
+            <h2 className="mb-4 font-medium text-2xl tracking-tight md:text-3xl">
+              Don't see the right fit?
+            </h2>
+            <p className="mb-6 text-base text-muted-foreground">
+              We are always looking for exceptional people. Send us your
+              background and tell us how you would contribute to stagewise.
+            </p>
+            <a
+              href="mailto:career@stagewise.io"
+              className="inline-flex items-center gap-2 text-primary-foreground transition-colors hover:text-hover-derived active:text-active-derived"
+            >
+              <svg
+                className="size-4"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <rect width="20" height="16" x="2" y="4" rx="2" />
+                <path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7" />
+              </svg>
+              career@stagewise.io
+            </a>
+          </div>
+        </ScrollReveal>
+      </section>
+    </div>
+  );
+}

--- a/apps/website/src/app/(home)/careers/page.tsx
+++ b/apps/website/src/app/(home)/careers/page.tsx
@@ -76,7 +76,8 @@ export default function CareerPage() {
                           {job.title}
                         </h3>
                         <p className="text-muted-foreground text-sm">
-                          {job.type} &middot; {job.location}
+                          {job.section} &middot; {job.type} &middot;{' '}
+                          {job.location}
                         </p>
                       </div>
                       <svg

--- a/apps/website/src/app/(home)/careers/page.tsx
+++ b/apps/website/src/app/(home)/careers/page.tsx
@@ -81,6 +81,8 @@ export default function CareerPage() {
                         </p>
                       </div>
                       <svg
+                        aria-hidden="true"
+                        focusable="false"
                         className="pointer-events-none size-4 text-muted-foreground/50 opacity-0 transition-opacity group-hover:opacity-100"
                         viewBox="0 0 16 16"
                         fill="none"
@@ -158,6 +160,8 @@ export default function CareerPage() {
               className="inline-flex items-center gap-2 text-primary-foreground transition-colors hover:text-hover-derived active:text-active-derived"
             >
               <svg
+                aria-hidden="true"
+                focusable="false"
                 className="size-4"
                 viewBox="0 0 24 24"
                 fill="none"

--- a/apps/website/src/app/(home)/company/page.tsx
+++ b/apps/website/src/app/(home)/company/page.tsx
@@ -420,7 +420,8 @@ export default function CompanyPage() {
                         {job.title}
                       </span>
                       <span className="truncate text-muted-foreground text-xs">
-                        {job.type} &middot; {job.location}
+                        {job.section} &middot; {job.type} &middot;{' '}
+                        {job.location}
                       </span>
                     </Link>
                   </li>

--- a/apps/website/src/app/(home)/company/page.tsx
+++ b/apps/website/src/app/(home)/company/page.tsx
@@ -1,7 +1,9 @@
 import { ScrollReveal } from '@/components/landing/scroll-reveal';
 import { IconGithub } from 'nucleo-social-media';
-import { IconEnvelopePenOutline18 } from 'nucleo-ui-outline-18';
+import { IconArrowRightFill18 } from 'nucleo-ui-fill-18';
+import { getAllJobs } from '@/lib/source';
 import Image from 'next/image';
+import Link from 'next/link';
 import bgDark from '../_components/feature-images/bg-dark.jpg';
 import bgLight from '../_components/feature-images/bg-light.jpg';
 import githubRepoIssuesDark from '../_components/feature-images/github-repo-issues-dark.webp';
@@ -153,6 +155,8 @@ function BackerCell({ backer, index }: { backer: Backer; index: number }) {
 }
 
 export default function CompanyPage() {
+  const jobs = getAllJobs();
+
   return (
     <div className="relative mx-auto mt-12 w-full max-w-5xl px-4">
       <ScrollReveal>
@@ -406,34 +410,19 @@ export default function CompanyPage() {
                 We're hiring in-person in San Francisco and Bielefeld.
               </p>
               <ul className="mb-10 divide-y divide-border/50">
-                {[
-                  {
-                    title: 'Senior Software Engineer',
-                    location: 'San Francisco, USA',
-                  },
-                  {
-                    title: 'Growth & Marketing Engineer',
-                    location: 'San Francisco, USA',
-                  },
-                  {
-                    title: 'Senior Software Engineer',
-                    location: 'Bielefeld, Germany',
-                  },
-                  {
-                    title: 'Growth & Marketing Engineer',
-                    location: 'Bielefeld, Germany',
-                  },
-                ].map((job) => (
-                  <li
-                    key={`${job.title}-${job.location}`}
-                    className="flex items-center justify-between gap-4 py-4 first:pt-0 last:pb-0"
-                  >
-                    <p className="font-medium text-foreground text-sm">
-                      {job.title}
-                    </p>
-                    <p className="text-muted-foreground text-xs">
-                      In-Person &middot; {job.location}
-                    </p>
+                {jobs.map((job) => (
+                  <li key={job.slug} className="py-4 first:pt-0 last:pb-0">
+                    <Link
+                      href={job.url}
+                      className="group flex flex-col gap-1 transition-colors hover:text-hover-derived"
+                    >
+                      <span className="truncate font-medium text-foreground text-sm">
+                        {job.title}
+                      </span>
+                      <span className="truncate text-muted-foreground text-xs">
+                        {job.type} &middot; {job.location}
+                      </span>
+                    </Link>
                   </li>
                 ))}
               </ul>
@@ -441,13 +430,13 @@ export default function CompanyPage() {
                 We expect applicants to be sophisticated users of AI-driven
                 development tooling and workflows.
               </p>
-              <a
-                href="mailto:career@stagewise.io"
+              <Link
+                href="/careers"
                 className="inline-flex w-fit items-center gap-2 text-primary-foreground transition-colors hover:text-hover-derived active:text-active-derived"
               >
-                <IconEnvelopePenOutline18 className="size-4" />
-                Apply via mail
-              </a>
+                View all positions
+                <IconArrowRightFill18 className="inline size-4" />
+              </Link>
             </div>
           </ScrollReveal>
           <ScrollReveal className="h-full" delay={75}>

--- a/apps/website/src/app/(home)/navbar.tsx
+++ b/apps/website/src/app/(home)/navbar.tsx
@@ -282,7 +282,7 @@ export function Navbar() {
                     Company
                   </NavLink>
                   <NavLink href="/careers" onClick={() => setIsOpen(false)}>
-                    Career
+                    Careers
                   </NavLink>
                 </div>
               )}

--- a/apps/website/src/app/(home)/navbar.tsx
+++ b/apps/website/src/app/(home)/navbar.tsx
@@ -119,8 +119,8 @@ function ResourcesDropdown() {
   }, []);
 
   const pathname = usePathname();
-  const isResourcesActive = ['/docs', '/news', '/company'].some((p) =>
-    p.startsWith('/') ? pathname.startsWith(p) : false,
+  const isResourcesActive = ['/docs', '/news', '/company', '/careers'].some(
+    (p) => (p.startsWith('/') ? pathname.startsWith(p) : false),
   );
 
   return (
@@ -154,6 +154,7 @@ function ResourcesDropdown() {
           <NavLink href="https://docs.stagewise.io">Docs</NavLink>
           <NavLink href="/news">News</NavLink>
           <NavLink href="/company">Company</NavLink>
+          <NavLink href="/careers">Careers</NavLink>
         </div>
       )}
     </div>
@@ -279,6 +280,9 @@ export function Navbar() {
                   </NavLink>
                   <NavLink href="/company" onClick={() => setIsOpen(false)}>
                     Company
+                  </NavLink>
+                  <NavLink href="/careers" onClick={() => setIsOpen(false)}>
+                    Career
                   </NavLink>
                 </div>
               )}

--- a/apps/website/src/app/(home)/news/[slug]/page.tsx
+++ b/apps/website/src/app/(home)/news/[slug]/page.tsx
@@ -15,7 +15,9 @@ export default async function PostPage(props: {
 
   const { content } = await compileMDX({
     source: post.source,
-    options: { development: true } as never,
+    options: {
+      mdxOptions: { development: process.env.NODE_ENV !== 'production' },
+    },
     components: getMDXComponents(),
   });
 

--- a/apps/website/src/app/global.css
+++ b/apps/website/src/app/global.css
@@ -153,3 +153,22 @@
 .news-prose p {
   text-align: left;
 }
+
+.prose h1,
+.prose h2,
+.prose h3,
+.prose h4,
+.prose h5,
+.prose h6 {
+  font-weight: 500;
+  letter-spacing: -0.025em;
+}
+
+.prose blockquote {
+  font-weight: 400;
+  font-style: italic;
+}
+
+.prose em {
+  font-style: oblique 5deg;
+}

--- a/apps/website/src/app/sitemap.ts
+++ b/apps/website/src/app/sitemap.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { getAllNewsPosts } from '@/lib/source';
+import { getAllJobs, getAllNewsPosts } from '@/lib/source';
 import type { MetadataRoute } from 'next';
 
 const siteUrl = 'https://stagewise.io';
@@ -71,7 +71,9 @@ export default function sitemap(): MetadataRoute.Sitemap {
     createSitemapEntry(post.url, post.date),
   );
 
-  const entries = [...staticPageEntries, ...newsEntries];
+  const jobEntries = getAllJobs().map((job) => createSitemapEntry(job.url));
+
+  const entries = [...staticPageEntries, ...newsEntries, ...jobEntries];
   const dedupedEntries = new Map(entries.map((entry) => [entry.url, entry]));
 
   return [...dedupedEntries.values()].sort((a, b) =>

--- a/apps/website/src/lib/og-image.tsx
+++ b/apps/website/src/lib/og-image.tsx
@@ -166,6 +166,124 @@ export function generateNewsPostOgImage({
   );
 }
 
+export function generateJobOgImage({
+  jobTitle,
+  jobLocation,
+  geistFont,
+}: {
+  jobTitle: string;
+  jobLocation?: string;
+  geistFont: Buffer;
+}): ImageResponse {
+  const logoSize = 40;
+  const padding = 56;
+
+  return new ImageResponse(
+    <div
+      style={{
+        width: '100%',
+        height: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'flex-start',
+        justifyContent: 'center',
+        background: '#fdfcfc',
+        padding: `0 0 0 ${padding}px`,
+        position: 'relative',
+      }}
+    >
+      {/* Logo mark + "Career" label */}
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: `${logoSize * 0.4}px`,
+        }}
+      >
+        <svg
+          width={logoSize}
+          height={logoSize}
+          viewBox="0 0 100 100"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path fill="#2559fe" d={LOGO_MARK_PATH} />
+          <circle fill="#2559fe" cx="50" cy="50" r="28" />
+        </svg>
+        <div
+          style={{
+            fontSize: `${logoSize * 0.9}px`,
+            fontWeight: 500,
+            color: '#161515',
+            letterSpacing: '-0.025em',
+            fontFamily: 'Geist',
+          }}
+        >
+          Career
+        </div>
+      </div>
+      {/* Job title */}
+      <div
+        style={{
+          marginTop: '20px',
+          fontSize: '72px',
+          fontWeight: 500,
+          color: '#161515',
+          letterSpacing: '-0.025em',
+          fontFamily: 'Geist',
+          maxWidth: `${OG_SIZE.width - padding * 2}px`,
+          lineHeight: 1.1,
+          whiteSpace: 'pre-wrap',
+          wordBreak: 'break-word',
+        }}
+      >
+        {jobTitle}
+      </div>
+      {/* Location */}
+      {jobLocation && (
+        <div
+          style={{
+            marginTop: '20px',
+            fontSize: '32px',
+            fontWeight: 500,
+            color: '#595855',
+            letterSpacing: '-0.01em',
+            fontFamily: 'Geist',
+          }}
+        >
+          {jobLocation}
+        </div>
+      )}
+      {/* Bottom-right URL */}
+      <div
+        style={{
+          position: 'absolute',
+          bottom: `${padding}px`,
+          right: `${padding}px`,
+          fontSize: '28px',
+          fontWeight: 500,
+          color: '#595855',
+          letterSpacing: '-0.01em',
+          fontFamily: 'Geist',
+        }}
+      >
+        stagewise.io/careers
+      </div>
+    </div>,
+    {
+      ...OG_SIZE,
+      fonts: [
+        {
+          name: 'Geist',
+          data: geistFont,
+          style: 'normal',
+          weight: 500,
+        },
+      ],
+    },
+  );
+}
+
 export function generateOgImage({
   pageName,
   pageSlug,

--- a/apps/website/src/lib/og-image.tsx
+++ b/apps/website/src/lib/og-image.tsx
@@ -44,13 +44,17 @@ function LogoCombo({ size }: { size: number }) {
   );
 }
 
-export function generateNewsPostOgImage({
-  postTitle,
-  postDate,
+function generateContentOgImage({
+  label,
+  title,
+  subtitle,
+  bottomUrl,
   geistFont,
 }: {
-  postTitle: string;
-  postDate?: Date;
+  label: string;
+  title: string;
+  subtitle?: string;
+  bottomUrl: string;
   geistFont: Buffer;
 }): ImageResponse {
   const logoSize = 40;
@@ -70,7 +74,7 @@ export function generateNewsPostOgImage({
         position: 'relative',
       }}
     >
-      {/* Logo mark + "Newsroom" label */}
+      {/* Logo mark + label */}
       <div
         style={{
           display: 'flex',
@@ -97,10 +101,10 @@ export function generateNewsPostOgImage({
             fontFamily: 'Geist',
           }}
         >
-          Newsroom
+          {label}
         </div>
       </div>
-      {/* Post title */}
+      {/* Title */}
       <div
         style={{
           marginTop: '20px',
@@ -115,10 +119,10 @@ export function generateNewsPostOgImage({
           wordBreak: 'break-word',
         }}
       >
-        {postTitle}
+        {title}
       </div>
-      {/* Date */}
-      {postDate && (
+      {/* Subtitle */}
+      {subtitle && (
         <div
           style={{
             marginTop: '20px',
@@ -129,11 +133,7 @@ export function generateNewsPostOgImage({
             fontFamily: 'Geist',
           }}
         >
-          {postDate.toLocaleString('en-US', {
-            year: 'numeric',
-            month: 'short',
-            day: 'numeric',
-          })}
+          {subtitle}
         </div>
       )}
       {/* Bottom-right URL */}
@@ -149,7 +149,7 @@ export function generateNewsPostOgImage({
           fontFamily: 'Geist',
         }}
       >
-        stagewise.io/news
+        {bottomUrl}
       </div>
     </div>,
     {
@@ -166,6 +166,32 @@ export function generateNewsPostOgImage({
   );
 }
 
+export function generateNewsPostOgImage({
+  postTitle,
+  postDate,
+  geistFont,
+}: {
+  postTitle: string;
+  postDate?: Date;
+  geistFont: Buffer;
+}): ImageResponse {
+  const subtitle = postDate
+    ? postDate.toLocaleString('en-US', {
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric',
+      })
+    : undefined;
+
+  return generateContentOgImage({
+    label: 'Newsroom',
+    title: postTitle,
+    subtitle,
+    bottomUrl: 'stagewise.io/news',
+    geistFont,
+  });
+}
+
 export function generateJobOgImage({
   jobTitle,
   jobLocation,
@@ -175,113 +201,13 @@ export function generateJobOgImage({
   jobLocation?: string;
   geistFont: Buffer;
 }): ImageResponse {
-  const logoSize = 40;
-  const padding = 56;
-
-  return new ImageResponse(
-    <div
-      style={{
-        width: '100%',
-        height: '100%',
-        display: 'flex',
-        flexDirection: 'column',
-        alignItems: 'flex-start',
-        justifyContent: 'center',
-        background: '#fdfcfc',
-        padding: `0 0 0 ${padding}px`,
-        position: 'relative',
-      }}
-    >
-      {/* Logo mark + "Career" label */}
-      <div
-        style={{
-          display: 'flex',
-          alignItems: 'center',
-          gap: `${logoSize * 0.4}px`,
-        }}
-      >
-        <svg
-          width={logoSize}
-          height={logoSize}
-          viewBox="0 0 100 100"
-          fill="none"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path fill="#2559fe" d={LOGO_MARK_PATH} />
-          <circle fill="#2559fe" cx="50" cy="50" r="28" />
-        </svg>
-        <div
-          style={{
-            fontSize: `${logoSize * 0.9}px`,
-            fontWeight: 500,
-            color: '#161515',
-            letterSpacing: '-0.025em',
-            fontFamily: 'Geist',
-          }}
-        >
-          Career
-        </div>
-      </div>
-      {/* Job title */}
-      <div
-        style={{
-          marginTop: '20px',
-          fontSize: '72px',
-          fontWeight: 500,
-          color: '#161515',
-          letterSpacing: '-0.025em',
-          fontFamily: 'Geist',
-          maxWidth: `${OG_SIZE.width - padding * 2}px`,
-          lineHeight: 1.1,
-          whiteSpace: 'pre-wrap',
-          wordBreak: 'break-word',
-        }}
-      >
-        {jobTitle}
-      </div>
-      {/* Location */}
-      {jobLocation && (
-        <div
-          style={{
-            marginTop: '20px',
-            fontSize: '32px',
-            fontWeight: 500,
-            color: '#595855',
-            letterSpacing: '-0.01em',
-            fontFamily: 'Geist',
-          }}
-        >
-          {jobLocation}
-        </div>
-      )}
-      {/* Bottom-right URL */}
-      <div
-        style={{
-          position: 'absolute',
-          bottom: `${padding}px`,
-          right: `${padding}px`,
-          fontSize: '28px',
-          fontWeight: 500,
-          color: '#595855',
-          letterSpacing: '-0.01em',
-          fontFamily: 'Geist',
-        }}
-      >
-        stagewise.io/careers
-      </div>
-    </div>,
-    {
-      ...OG_SIZE,
-      fonts: [
-        {
-          name: 'Geist',
-          data: geistFont,
-          style: 'normal',
-          weight: 500,
-        },
-      ],
-    },
-  );
+  return generateContentOgImage({
+    label: 'Career',
+    title: jobTitle,
+    subtitle: jobLocation,
+    bottomUrl: 'stagewise.io/careers',
+    geistFont,
+  });
 }
 
 export function generateOgImage({

--- a/apps/website/src/lib/source.ts
+++ b/apps/website/src/lib/source.ts
@@ -101,16 +101,31 @@ export interface JobPosting {
   source: string;
 }
 
+function sanitizeSlugSegment(input: string): string | null {
+  const normalized = input
+    .trim()
+    .toLowerCase()
+    .replace(/[\s_]+/g, '-')
+    .replace(/[^a-z0-9-]/g, '')
+    .replace(/-+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  return normalized.length > 0 ? normalized : null;
+}
+
 function loadJobPosting(filename: string): JobPosting {
   const filepath = path.join(contentRoot, 'career', filename);
   const raw = fs.readFileSync(filepath, 'utf-8');
   const { data, content } = matter(raw);
 
-  const slug = filename.replace(/\.mdx?$/, '');
+  const rawSlug = filename.replace(/\.mdx?$/, '');
+  const slug = sanitizeSlugSegment(rawSlug);
+  if (!slug) {
+    throw new Error(`Invalid job filename slug: ${filename}`);
+  }
 
   return {
     slug,
-    url: `/careers/${slug}`,
+    url: `/careers/${encodeURIComponent(slug)}`,
     title: data.title as string,
     location: data.location as string,
     type: data.type as string,
@@ -125,7 +140,16 @@ export function getAllJobs(): JobPosting[] {
   const files = fs
     .readdirSync(dir)
     .filter((f) => f.endsWith('.mdx') || f.endsWith('.md'));
-  return files.map(loadJobPosting);
+  return files
+    .map((file) => {
+      try {
+        return loadJobPosting(file);
+      } catch {
+        return null;
+      }
+    })
+    .filter((job): job is JobPosting => job !== null)
+    .sort((a, b) => a.title.localeCompare(b.title));
 }
 
 export function getJob(slug: string): JobPosting | null {
@@ -139,8 +163,8 @@ export function getJob(slug: string): JobPosting | null {
   return loadJobPosting(filename);
 }
 
-export function getAllJobParams(): { slug: string[] }[] {
-  return getAllJobs().map((j) => ({ slug: [j.slug] }));
+export function getAllJobParams(): { slug: string }[] {
+  return getAllJobs().map((j) => ({ slug: j.slug }));
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/website/src/lib/source.ts
+++ b/apps/website/src/lib/source.ts
@@ -95,6 +95,8 @@ export interface JobPosting {
   location: string;
   /** Employment type, e.g. "Full-time", "Part-time", "Contract" */
   type: string;
+  /** Department section, e.g. "Engineering", "Marketing", "Operations", "Sales" */
+  section: string;
   /** Raw MDX source string */
   source: string;
 }
@@ -112,6 +114,7 @@ function loadJobPosting(filename: string): JobPosting {
     title: data.title as string,
     location: data.location as string,
     type: data.type as string,
+    section: data.section as string,
     source: content,
   };
 }

--- a/apps/website/src/lib/source.ts
+++ b/apps/website/src/lib/source.ts
@@ -85,6 +85,62 @@ export function getAllNewsParams(): { slug: string[] }[] {
 export { getNewsTypeLabel };
 
 // ---------------------------------------------------------------------------
+// Jobs / Career
+// ---------------------------------------------------------------------------
+
+export interface JobPosting {
+  slug: string;
+  url: string;
+  title: string;
+  location: string;
+  /** Employment type, e.g. "Full-time", "Part-time", "Contract" */
+  type: string;
+  /** Raw MDX source string */
+  source: string;
+}
+
+function loadJobPosting(filename: string): JobPosting {
+  const filepath = path.join(contentRoot, 'career', filename);
+  const raw = fs.readFileSync(filepath, 'utf-8');
+  const { data, content } = matter(raw);
+
+  const slug = filename.replace(/\.mdx?$/, '');
+
+  return {
+    slug,
+    url: `/careers/${slug}`,
+    title: data.title as string,
+    location: data.location as string,
+    type: data.type as string,
+    source: content,
+  };
+}
+
+export function getAllJobs(): JobPosting[] {
+  const dir = path.join(contentRoot, 'career');
+  if (!fs.existsSync(dir)) return [];
+  const files = fs
+    .readdirSync(dir)
+    .filter((f) => f.endsWith('.mdx') || f.endsWith('.md'));
+  return files.map(loadJobPosting);
+}
+
+export function getJob(slug: string): JobPosting | null {
+  const dir = path.join(contentRoot, 'career');
+  if (!fs.existsSync(dir)) return null;
+  const files = fs
+    .readdirSync(dir)
+    .filter((f) => f.endsWith('.mdx') || f.endsWith('.md'));
+  const filename = files.find((f) => f.replace(/\.mdx?$/, '') === slug);
+  if (!filename) return null;
+  return loadJobPosting(filename);
+}
+
+export function getAllJobParams(): { slug: string[] }[] {
+  return getAllJobs().map((j) => ({ slug: [j.slug] }));
+}
+
+// ---------------------------------------------------------------------------
 // Legal
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Launches a new careers section with MDX-driven listings and job detail pages at `/careers`, complete with OG images and sitemap entries. Also updates company navigation and styling, refactors OG image generation, and fixes static params and accessibility issues.

- **New Features**
  - Add `/careers` index with dynamic listings from MDX via `getAllJobs` and an “Our principles” section.
  - Add `/careers/[slug]` job detail pages with badges and per-job OG images using `generateJobOgImage`.
  - Add careers OG image route and prose styling updates for headings, quotes, and emphasis.
  - Integrate jobs into `sitemap.ts`; introduce `section` field in job model and parser.
  - Update company page to show live jobs and CTA to `/careers`; add “Careers” link to navbar; migrate from `/career` to `/careers`.

- **Bug Fixes**
  - MDX compilation now respects `NODE_ENV` across legal, news, and careers; fixed job static params shape in `getAllJobParams`; added a11y attrs to decorative SVGs; deduplicated OG image generator; minor copy fix in internship posting.

<sup>Written for commit 8655500f36f6d7d51fe85d3e543fa50542291b0b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1348?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated careers section with open positions, principles, and application CTAs.
  * Added individual career detail pages for each role, including job-specific metadata and Open Graph images.
  * Updated the sitemap and Open Graph image generation to include careers/jobs.
  * Added new career postings (Growth Hacker Intern—Bielefeld; Product Engineer (Working Student)—Bielefeld).
* **Bug Fixes**
  * Updated MDX compilation to use environment-based “development” settings across legal/privacy/terms/trademark/news and job detail pages.
* **Style**
  * Improved `.prose` typography (headings, blockquotes, emphasized text).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->