### PR TITLE
fix(stagewise): project browser env snapshot from contentTabs with ag…

### DIFF
--- a/apps/browser/src/backend/env-domains/browser-domain-adapter.test.ts
+++ b/apps/browser/src/backend/env-domains/browser-domain-adapter.test.ts
@@ -4,26 +4,28 @@ import {
   createBrowserDomainAdapter,
 } from './browser-domain-adapter';
 import type { KartonService } from '../services/karton';
+import type { TabState } from '@shared/karton-contracts/ui';
 
 function makeKarton(state: {
   tabs: Record<
     string,
-    {
+    Partial<TabState> & {
       id: string;
       url: string;
       title: string;
       lastFocusedAt: number;
-      consoleErrorCount?: number;
-      consoleLogCount?: number;
-      faviconUrls?: string[];
-      error?: { code: number; message?: string | null } | null;
     }
   >;
   activeTabId: string | null;
 }): KartonService {
   return {
     state: {
-      browser: state,
+      contentTabs: {
+        tabs: state.tabs,
+        globalOrder: [],
+        agentOrders: {},
+        activeTabId: state.activeTabId,
+      },
     },
   } as unknown as KartonService;
 }
@@ -38,6 +40,7 @@ describe('createBrowserDomainAdapter', () => {
             url: 'https://example.com',
             title: 'Example',
             lastFocusedAt: 1,
+            agentInstanceId: null,
           },
         },
         activeTabId: 'a',
@@ -106,6 +109,53 @@ describe('createBrowserDomainAdapter', () => {
     expect(diff).toContain('browser-restarted');
   });
 
+  it('emits active-tab-changed with from-only when active tab becomes hidden', () => {
+    const adapter = createBrowserDomainAdapter({
+      karton: makeKarton({
+        tabs: {
+          mine: {
+            id: 'mine',
+            url: 'https://mine.com',
+            title: 'Mine',
+            lastFocusedAt: 1,
+            agentInstanceId: 'agent-1',
+          },
+          other: {
+            id: 'other',
+            url: 'https://other.com',
+            title: 'Other',
+            lastFocusedAt: 2,
+            agentInstanceId: 'agent-2',
+          },
+        },
+        // Focus moved to another agent's tab — invisible to agent-1
+        activeTabId: 'other',
+      }),
+      getBrowserSessionId: () => 'session-1',
+    });
+
+    const curr = adapter.getState('agent-1') as never;
+    const prev = {
+      browserSessionId: 'session-1',
+      browser: {
+        tabs: [
+          {
+            id: 'mine',
+            url: 'https://mine.com',
+            title: 'Mine',
+            lastFocusedAt: 1,
+          },
+        ],
+        activeTabId: 'mine',
+      },
+    } as never;
+
+    const diff = adapter.renderState(prev, curr);
+    expect(diff).toContain('active-tab-changed');
+    expect(diff).toContain('from="mine"');
+    expect(diff).not.toContain('to=');
+  });
+
   it('exposes a non-empty promptSection covering CDP/browser keywords', () => {
     const adapter = createBrowserDomainAdapter({
       karton: makeKarton({ tabs: {}, activeTabId: null }),
@@ -115,5 +165,120 @@ describe('createBrowserDomainAdapter', () => {
     const section = adapter.promptSection ?? '';
     expect(section).toContain('CDP');
     expect(section).toContain('Browser Access');
+  });
+
+  it('filters tabs by agentInstanceId — only global + same-agent tabs', () => {
+    const adapter = createBrowserDomainAdapter({
+      karton: makeKarton({
+        tabs: {
+          global: {
+            id: 'global',
+            url: 'https://global.com',
+            title: 'Global',
+            lastFocusedAt: 1,
+            agentInstanceId: null,
+          },
+          mine: {
+            id: 'mine',
+            url: 'https://mine.com',
+            title: 'Mine',
+            lastFocusedAt: 2,
+            agentInstanceId: 'agent-1',
+          },
+          other: {
+            id: 'other',
+            url: 'https://other.com',
+            title: 'Other',
+            lastFocusedAt: 3,
+            agentInstanceId: 'agent-2',
+          },
+        },
+        activeTabId: 'mine',
+      }),
+      getBrowserSessionId: () => 'session-1',
+    });
+
+    const state = adapter.getState('agent-1') as {
+      browser: { tabs: { id: string }[]; activeTabId: string | null };
+    };
+    const tabIds = state.browser.tabs.map((t) => t.id);
+    expect(tabIds).toContain('global');
+    expect(tabIds).toContain('mine');
+    expect(tabIds).not.toContain('other');
+    expect(state.browser.activeTabId).toBe('mine');
+  });
+
+  it('hides activeTabId when the active tab belongs to another agent', () => {
+    const adapter = createBrowserDomainAdapter({
+      karton: makeKarton({
+        tabs: {
+          mine: {
+            id: 'mine',
+            url: 'https://mine.com',
+            title: 'Mine',
+            lastFocusedAt: 1,
+            agentInstanceId: 'agent-1',
+          },
+          other: {
+            id: 'other',
+            url: 'https://other.com',
+            title: 'Other',
+            lastFocusedAt: 2,
+            agentInstanceId: 'agent-2',
+          },
+        },
+        activeTabId: 'other',
+      }),
+      getBrowserSessionId: () => 'session-1',
+    });
+
+    const state = adapter.getState('agent-1') as {
+      browser: { tabs: { id: string }[]; activeTabId: string | null };
+    };
+    expect(state.browser.activeTabId).toBeNull();
+    const tabIds = state.browser.tabs.map((t) => t.id);
+    expect(tabIds).toContain('mine');
+    expect(tabIds).not.toContain('other');
+  });
+
+  it('excludes terminal and file tabs from the snapshot', () => {
+    const adapter = createBrowserDomainAdapter({
+      karton: makeKarton({
+        tabs: {
+          browser: {
+            id: 'browser',
+            url: 'https://browser.com',
+            title: 'Browser',
+            lastFocusedAt: 1,
+            agentInstanceId: null,
+            type: 'browser',
+          },
+          terminal: {
+            id: 'terminal',
+            url: '',
+            title: 'Terminal',
+            lastFocusedAt: 2,
+            agentInstanceId: null,
+            type: 'terminal',
+          },
+          file: {
+            id: 'file',
+            url: '',
+            title: 'file.ts',
+            lastFocusedAt: 3,
+            agentInstanceId: null,
+            type: 'file',
+          },
+        },
+        activeTabId: 'browser',
+      }),
+      getBrowserSessionId: () => 'session-1',
+    });
+
+    const state = adapter.getState('agent-1') as {
+      browser: { tabs: { id: string }[]; activeTabId: string | null };
+    };
+    const tabIds = state.browser.tabs.map((t) => t.id);
+    expect(tabIds).toEqual(['browser']);
   });
 });

--- a/apps/browser/src/backend/env-domains/browser-domain-adapter.ts
+++ b/apps/browser/src/backend/env-domains/browser-domain-adapter.ts
@@ -30,9 +30,30 @@ export interface BrowserDomainAdapterDeps {
   getBrowserSessionId?: () => string;
 }
 
-function projectBrowserSnapshot(karton: KartonService): BrowserSnapshot {
-  const browser = karton.state.browser;
-  const tabs = Object.values(browser.tabs)
+/**
+ * Project a per-agent browser snapshot from `contentTabs`.
+ *
+ * Tab entries live in `contentTabs.tabs` (not `browser.tabs`, which is
+ * a legacy/unused slice). Only browser-type tabs that are either global
+ * (agentInstanceId === null) or assigned to the requesting agent are
+ * included. The active tab is only reported if it is visible to this
+ * agent.
+ */
+function projectBrowserSnapshot(
+  karton: KartonService,
+  agentInstanceId: string,
+): BrowserSnapshot {
+  const contentTabs = karton.state.contentTabs;
+
+  const isTabVisible = (tab: { agentInstanceId: string | null }) =>
+    tab.agentInstanceId == null || tab.agentInstanceId === agentInstanceId;
+
+  const isBrowserTab = (tab: { type?: string }) =>
+    tab.type === undefined || tab.type === 'browser';
+
+  const tabs = Object.values(contentTabs.tabs)
+    .filter(isBrowserTab)
+    .filter(isTabVisible)
     .sort((a, b) => b.lastFocusedAt - a.lastFocusedAt)
     .map((tab) => ({
       id: tab.id,
@@ -49,7 +70,16 @@ function projectBrowserSnapshot(karton: KartonService): BrowserSnapshot {
         : null,
       lastFocusedAt: tab.lastFocusedAt,
     }));
-  return { tabs, activeTabId: browser.activeTabId ?? null };
+
+  // Only report an active tab if it is a browser tab visible to this agent.
+  const activeTabId = contentTabs.activeTabId;
+  const activeTab = activeTabId ? contentTabs.tabs[activeTabId] : undefined;
+  const activeTabIdVisible =
+    activeTab && isBrowserTab(activeTab) && isTabVisible(activeTab)
+      ? activeTabId
+      : null;
+
+  return { tabs, activeTabId: activeTabIdVisible };
 }
 
 function formatTimestamp(epochMs: number): string {
@@ -161,13 +191,12 @@ function computeBrowserChanges(
     }
   }
 
-  if (
-    previous.browser.activeTabId !== current.browser.activeTabId &&
-    current.browser.activeTabId !== null
-  ) {
-    const attrs: Record<string, string> = { to: current.browser.activeTabId };
+  if (previous.browser.activeTabId !== current.browser.activeTabId) {
+    const attrs: Record<string, string> = {};
     if (previous.browser.activeTabId !== null)
       attrs.from = previous.browser.activeTabId;
+    if (current.browser.activeTabId !== null)
+      attrs.to = current.browser.activeTabId;
     changes.push({ type: 'active-tab-changed', attributes: attrs });
   }
 
@@ -186,9 +215,9 @@ export function createBrowserDomainAdapter(
     renderOrder: 0,
     schemaVersion: BROWSER_DOMAIN_SCHEMA_VERSION,
     promptSection: BrowserDomainPromptSection,
-    getState() {
+    getState(agentInstanceId: string) {
       return {
-        browser: projectBrowserSnapshot(deps.karton),
+        browser: projectBrowserSnapshot(deps.karton, agentInstanceId),
         browserSessionId: resolveSessionId(),
       };
     },

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/rich-text/mentions/providers/tab-provider.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/rich-text/mentions/providers/tab-provider.tsx
@@ -19,9 +19,18 @@ export const tabProvider: MentionProvider = {
     <GlobeIcon className={cn('size-2.5 shrink-0', className)} />
   ),
   query: (_input: string, ctx: MentionContext): TabMentionItem[] => {
-    const entries = Object.entries(ctx.tabs).sort(([a], [b]) =>
-      a.localeCompare(b),
-    );
+    const entries = Object.entries(ctx.tabs)
+      .filter(([, tab]) => {
+        // Only browser-type tabs (exclude terminal/file tabs)
+        const isBrowserTab = tab.type === undefined || tab.type === 'browser';
+        if (!isBrowserTab) return false;
+        // Only global tabs (null) and tabs assigned to the active agent
+        return (
+          tab.agentInstanceId == null ||
+          tab.agentInstanceId === ctx.agentInstanceId
+        );
+      })
+      .sort(([a], [b]) => a.localeCompare(b));
     return entries.map(([tabId, tab]) => ({
       id: tabId,
       label: safeHost(tab.url),


### PR DESCRIPTION
…ent filtering

The browser domain adapter read from karton.state.browser.tabs and browser.activeTabId — both dead state initialized to {} / null at boot and never written to. All tab lifecycle code writes to contentTabs.tabs and contentTabs.activeTabId instead, so the adapter always projected an empty snapshot, producing 'No tabs open.' in the agent environment.

Additionally, the adapter ignored the agentInstanceId parameter from DomainAdapter.getState(), and the @-mention tab provider iterated all contentTabs.tabs without filtering by agent.

Changes:
- browser-domain-adapter: projectBrowserSnapshot now reads from contentTabs, filters by agentInstanceId (global + same-agent only), excludes terminal/file tabs, and only reports activeTabId if the active tab is visible to the requesting agent
- tab-provider: filter @-mention list by ctx.agentInstanceId and exclude non-browser tabs
- Update tests to use contentTabs mock shape; add 3 new tests covering agent filtering, active-tab visibility, and terminal/file exclusion

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the browser environment snapshot with per‑agent filtering and correct active‑tab change events. Also fixes @‑mention tab suggestions and hides the active tab when it isn’t visible.

- **Bug Fixes**
  - Snapshot now reads from `contentTabs`, filters to global + same‑agent browser tabs, excludes terminal/file tabs, only reports `activeTabId` if visible, and emits `active-tab-changed` with from‑only when focus moves to an invisible tab.
  - `getState(agentInstanceId)` is respected; tab-provider filters by `ctx.agentInstanceId` and excludes non‑browser tabs.
  - Tests updated to use `contentTabs` shape; added cases for agent filtering, active‑tab visibility, non‑browser exclusion, and from‑only `active-tab-changed`.

<sup>Written for commit 036e1e6b255453b35f6b8efef685076f191f32a7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1349?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced multi-agent tab management with per-agent visibility filtering—each agent now sees only global tabs and those assigned to them.
  * Active tab handling is more robust when switching agents, including clearer active-tab change updates.
  * Tab suggestions in chat are now limited to relevant browser/global tabs for the current agent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->