### PR TITLE
Fix battery usage

### DIFF
--- a/apps/browser/src/ui/screens/main/file-tree/file-tree-toggle-button.tsx
+++ b/apps/browser/src/ui/screens/main/file-tree/file-tree-toggle-button.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Button } from '@stagewise/stage-ui/components/button';
 import {
   Tooltip,
@@ -80,6 +80,14 @@ export function FileTreeToggleButton() {
     );
   });
 
+  // Use a ref for the procedure to keep it out of the effect deps.
+  // useKartonProcedure takes an inline selector (new function identity each
+  // render), so even though the underlying proxy is cached, the useMemo
+  // inside the hook recomputes. Including the result in deps is fragile —
+  // a ref avoids the issue entirely, matching the sidebar's pattern.
+  const getWorkspaceDiffSummaryRef = useRef(getWorkspaceDiffSummary);
+  getWorkspaceDiffSummaryRef.current = getWorkspaceDiffSummary;
+
   useEffect(() => {
     if (visible || !selectedWorkspacePath) {
       setDiffTotals({ added: 0, deleted: 0 });
@@ -87,7 +95,8 @@ export function FileTreeToggleButton() {
     }
     const workspacePath = selectedWorkspacePath;
     let cancelled = false;
-    getWorkspaceDiffSummary(workspacePath)
+    getWorkspaceDiffSummaryRef
+      .current(workspacePath)
       .then((result) => {
         if (cancelled) return;
         const totals = result
@@ -102,12 +111,7 @@ export function FileTreeToggleButton() {
     return () => {
       cancelled = true;
     };
-  }, [
-    visible,
-    selectedWorkspacePath,
-    workspaceRevision,
-    getWorkspaceDiffSummary,
-  ]);
+  }, [visible, selectedWorkspacePath, workspaceRevision]);
 
   const showDiff = !visible && (diffTotals.added > 0 || diffTotals.deleted > 0);
 

--- a/packages/karton/src/shared/procedure-proxy.ts
+++ b/packages/karton/src/shared/procedure-proxy.ts
@@ -12,6 +12,13 @@ export function createProcedureProxy(
   path?: string,
   options?: RPCCallOptions,
 ): any {
+  // Cache child proxies by property name so that repeated property
+  // accesses return the same reference. Without this, every render
+  // that calls a selector like `(p) => p.toolbox.getWorkspaceDiffSummary`
+  // produces a brand-new Proxy, breaking useMemo/useEffect dependency
+  // checks and causing infinite render loops.
+  const childCache = new Map<string | symbol, any>();
+
   return new Proxy(() => {}, {
     get(_target, prop) {
       // Handle special properties
@@ -23,16 +30,24 @@ export function createProcedureProxy(
         return undefined;
       }
 
+      const cached = childCache.get(prop);
+      if (cached !== undefined) return cached;
+
+      let child: any;
+
       // .fire returns a proxy variant that uses fire-and-forget
       if (prop === 'fire') {
-        return createProcedureProxy(call, path, {
+        child = createProcedureProxy(call, path, {
           ...options,
           fireAndForget: true,
         });
+      } else {
+        const newPath = path ? `${path}.${String(prop)}` : String(prop);
+        child = createProcedureProxy(call, newPath, options);
       }
 
-      const newPath = path ? `${path}.${String(prop)}` : String(prop);
-      return createProcedureProxy(call, newPath, options);
+      childCache.set(prop, child);
+      return child;
     },
 
     apply(_target, _thisArg, args) {

--- a/packages/karton/test/shared/procedure-proxy.test.ts
+++ b/packages/karton/test/shared/procedure-proxy.test.ts
@@ -84,6 +84,32 @@ describe('Procedure Proxy', () => {
       expect(proxy.test.valueOf()).toBe('[Proxy: test]');
       expect(mockCall).not.toHaveBeenCalled();
     });
+
+    it('should return the same reference for repeated property accesses', () => {
+      const mockCall = vi.fn();
+      
+      const proxy = createProcedureProxy(mockCall);
+      
+      // Same property accessed twice must return the same proxy
+      const a = proxy.toolbox.getWorkspaceDiffSummary;
+      const b = proxy.toolbox.getWorkspaceDiffSummary;
+      expect(a).toBe(b);
+      
+      // Intermediate proxies are also cached
+      const c = proxy.toolbox;
+      const d = proxy.toolbox;
+      expect(c).toBe(d);
+    });
+
+    it('should return different references for different paths', () => {
+      const mockCall = vi.fn();
+      
+      const proxy = createProcedureProxy(mockCall);
+      
+      const a = proxy.api.v1;
+      const b = proxy.api.v2;
+      expect(a).not.toBe(b);
+    });
   });
 
   describe('extractProceduresFromTree', () => {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a runaway RPC/effect loop that kept the renderer ~47Hz, letting the GPU idle and cutting idle battery drain. Caches `karton` proxy children and removes an unstable effect dep in the file tree toggle.

- **Bug Fixes**
  - `karton`: cache child proxies in `createProcedureProxy` so repeated property reads return the same instance; restores referential stability and stops infinite re-renders.
  - Browser: use a ref to call `getWorkspaceDiffSummary` in `FileTreeToggleButton`; effect deps are now `[visible, selectedWorkspacePath, workspaceRevision]`.
  - Tests: add checks that same paths yield the same proxy and different paths yield different proxies.

<sup>Written for commit 1358e6c6e5b8247f1e00b28f3a62157e3ecd42b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1350?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stabilized file tree diff summary fetching behavior to avoid unintended re-fetches caused by internal procedure identity changes.
* **Performance**
  * Improved repeated access performance for procedure proxies by caching child proxies for the same property paths.
* **Tests**
  * Added coverage to verify cached proxy references for repeated nested property access, and to confirm different paths return different proxies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->