### PR TITLE
fix(agent-shell): prevent host env vars from leaking into child processes

### DIFF
--- a/apps/browser/src/backend/services/git/index.ts
+++ b/apps/browser/src/backend/services/git/index.ts
@@ -1327,14 +1327,14 @@ export class GitService extends DisposableService {
   private async runGitRaw(cwd: string, args: string[]): Promise<string | null> {
     this.assertNotDisposed();
     try {
+      // Always pass resolvedEnv through sanitizeEnv. When resolvedEnv is
+      // available (from the user's login shell), sanitizeEnv preserves
+      // user-set BLOCKLIST vars (NODE_ENV, etc.) but still strips
+      // ELECTRON_*, sensitive keys, and the shell-integration guard.
+      // When resolvedEnv is null, sanitizeEnv falls back to a sanitized
+      // process.env with BLOCKLIST vars removed.
       const resolvedEnv = await this.getResolvedEnv();
-      // Sanitize the fallback env to strip host-process contamination
-      // vars (NODE_ENV, BUILD_MODE, app config keys/URLs). When
-      // resolvedEnv is available it comes from the user's login shell
-      // and is used as-is; the fallback to process.env is the path that
-      // would leak app-internal vars into git child processes.
-      const env =
-        resolvedEnv ?? sanitizeEnv(undefined, undefined, { forAgent: false });
+      const env = sanitizeEnv(resolvedEnv, undefined, { forAgent: false });
       return (await this.runGitCommand(cwd, args, env)) ?? null;
     } catch (error) {
       this.logger.debug('[GitService] Git command failed', {
@@ -1419,8 +1419,7 @@ export class GitService extends DisposableService {
   ): Promise<GitStrictCommandResult> {
     this.assertNotDisposed();
     const resolvedEnv = await this.getResolvedEnv();
-    const env =
-      resolvedEnv ?? sanitizeEnv(undefined, undefined, { forAgent: false });
+    const env = sanitizeEnv(resolvedEnv, undefined, { forAgent: false });
     const result = await this.runGitMutationCommand(cwd, args, env);
     this.logger.debug('[GitService] Git mutation finished', {
       cwd,

--- a/apps/browser/src/backend/services/git/index.ts
+++ b/apps/browser/src/backend/services/git/index.ts
@@ -5,6 +5,7 @@ import path from 'node:path';
 import { promisify } from 'node:util';
 import { DisposableService } from '@/services/disposable';
 import { getWorktreesDir } from '@/utils/paths';
+import { sanitizeEnv } from '@stagewise/agent-shell';
 import type {
   GitActionFailure,
   GitActionFailureReason,
@@ -1327,10 +1328,14 @@ export class GitService extends DisposableService {
     this.assertNotDisposed();
     try {
       const resolvedEnv = await this.getResolvedEnv();
-      return (
-        (await this.runGitCommand(cwd, args, resolvedEnv ?? process.env)) ??
-        null
-      );
+      // Sanitize the fallback env to strip host-process contamination
+      // vars (NODE_ENV, BUILD_MODE, app config keys/URLs). When
+      // resolvedEnv is available it comes from the user's login shell
+      // and is used as-is; the fallback to process.env is the path that
+      // would leak app-internal vars into git child processes.
+      const env =
+        resolvedEnv ?? sanitizeEnv(undefined, undefined, { forAgent: false });
+      return (await this.runGitCommand(cwd, args, env)) ?? null;
     } catch (error) {
       this.logger.debug('[GitService] Git command failed', {
         cwd,
@@ -1414,11 +1419,9 @@ export class GitService extends DisposableService {
   ): Promise<GitStrictCommandResult> {
     this.assertNotDisposed();
     const resolvedEnv = await this.getResolvedEnv();
-    const result = await this.runGitMutationCommand(
-      cwd,
-      args,
-      resolvedEnv ?? process.env,
-    );
+    const env =
+      resolvedEnv ?? sanitizeEnv(undefined, undefined, { forAgent: false });
+    const result = await this.runGitMutationCommand(cwd, args, env);
     this.logger.debug('[GitService] Git mutation finished', {
       cwd,
       args,

--- a/apps/browser/src/backend/services/terminal/index.ts
+++ b/apps/browser/src/backend/services/terminal/index.ts
@@ -22,6 +22,7 @@ import type { Logger } from '@/services/logger';
 import type { KartonService } from '@/services/karton';
 import {
   OscParser,
+  sanitizeEnv,
   DEFAULT_TERMINAL_COLS,
   DEFAULT_TERMINAL_ROWS,
 } from '@stagewise/agent-shell';
@@ -370,14 +371,15 @@ export class TerminalService extends DisposableService {
     this.logger = logger;
     this.uiKarton = uiKarton;
     this.shell = shell;
-    this.resolvedEnv = Object.fromEntries(
-      Object.entries(process.env).filter(
-        (entry): entry is [string, string] => typeof entry[1] === 'string',
-      ),
-    );
-    if (resolvedEnv) {
-      Object.assign(this.resolvedEnv, resolvedEnv);
-    }
+    // Sanitize the environment before passing it to user terminal PTYs.
+    // This strips host-process contamination vars (NODE_ENV, BUILD_MODE,
+    // app config keys/URLs) that would otherwise leak from the stagewise
+    // app process into every terminal session. Uses the same sanitizeEnv
+    // as agent terminals, but with forAgent: false so user terminals
+    // keep normal shell history and don't carry the STAGEWISE_SHELL marker.
+    this.resolvedEnv = sanitizeEnv(resolvedEnv, shell.type, {
+      forAgent: false,
+    });
   }
 
   // ─── Initialisation ──────────────────────────────────────────

--- a/apps/browser/src/backend/services/toolbox/index.ts
+++ b/apps/browser/src/backend/services/toolbox/index.ts
@@ -1442,19 +1442,18 @@ export class ToolboxService
     // Create TerminalService for user-controllable terminal tabs.
     // Requires a detected shell — if no shell is available, terminal
     // creation will silently fail (procedure handler not registered).
-    const terminalEnv =
-      resolvedEnv ??
-      Object.fromEntries(
-        Object.entries(process.env).filter(
-          (entry): entry is [string, string] => typeof entry[1] === 'string',
-        ),
-      );
+    // When resolvedEnv is null (shell-env resolution failed), pass null
+    // directly — sanitizeEnv will fall back to process.env internally
+    // and apply the BLOCKLIST to strip host-process contamination vars
+    // (NODE_ENV, BUILD_MODE, etc.). Constructing a process.env copy here
+    // would bypass the blocklist since sanitizeEnv treats any non-null
+    // value as a resolved shell env.
     if (this.detectedShell) {
       this.terminalService = new TerminalService(
         this.logger,
         this.uiKarton,
         this.detectedShell,
-        terminalEnv,
+        resolvedEnv,
       );
       this.terminalService.initialize();
       // Restore PTYs for terminal tabs persisted in loadTabState.

--- a/apps/browser/src/backend/services/toolbox/services/mount-manager/worktree-setup-runner.ts
+++ b/apps/browser/src/backend/services/toolbox/services/mount-manager/worktree-setup-runner.ts
@@ -295,9 +295,11 @@ export class WorktreeSetupRunner {
     // (on fallback) BLOCKLIST vars. User-set BLOCKLIST vars from
     // resolvedEnv are preserved. STAGEWISE_*_WORKTREE_PATH vars are
     // merged on top after sanitization.
-    const sanitizedBase = sanitizeEnv(resolvedEnv, undefined, {
-      forAgent: false,
-    });
+    const sanitizedBase = sanitizeEnv(
+      resolvedEnv,
+      variant === 'powershell' ? 'powershell' : 'sh',
+      { forAgent: false },
+    );
     const env: NodeJS.ProcessEnv = mergeEnv(sanitizedBase, {
       STAGEWISE_SOURCE_WORKTREE_PATH: metadata.sourceWorktreePath,
       STAGEWISE_TARGET_WORKTREE_PATH: metadata.workspacePath,

--- a/apps/browser/src/backend/services/toolbox/services/mount-manager/worktree-setup-runner.ts
+++ b/apps/browser/src/backend/services/toolbox/services/mount-manager/worktree-setup-runner.ts
@@ -290,15 +290,15 @@ export class WorktreeSetupRunner {
     }
     if (activeRun.settled) return;
 
-    // Use sanitized process.env as the base to prevent host-process
-    // contamination vars (NODE_ENV, BUILD_MODE, app config keys/URLs)
-    // from leaking into the worktree setup script and its children.
-    // resolvedEnv (from the user's login shell) overrides on top.
-    const sanitizedBase = sanitizeEnv(undefined, undefined, {
+    // Sanitize resolvedEnv (or process.env fallback) to strip
+    // ELECTRON_*, sensitive keys, the shell-integration guard, and
+    // (on fallback) BLOCKLIST vars. User-set BLOCKLIST vars from
+    // resolvedEnv are preserved. STAGEWISE_*_WORKTREE_PATH vars are
+    // merged on top after sanitization.
+    const sanitizedBase = sanitizeEnv(resolvedEnv, undefined, {
       forAgent: false,
     });
     const env: NodeJS.ProcessEnv = mergeEnv(sanitizedBase, {
-      ...(resolvedEnv ?? {}),
       STAGEWISE_SOURCE_WORKTREE_PATH: metadata.sourceWorktreePath,
       STAGEWISE_TARGET_WORKTREE_PATH: metadata.workspacePath,
       STAGEWISE_MAIN_WORKTREE_PATH: metadata.mainWorktreePath,

--- a/apps/browser/src/backend/services/toolbox/services/mount-manager/worktree-setup-runner.ts
+++ b/apps/browser/src/backend/services/toolbox/services/mount-manager/worktree-setup-runner.ts
@@ -8,6 +8,7 @@ import {
   WORKTREE_SETUP_SCRIPT_RELATIVE_PATHS,
   variantForPlatform,
 } from '@shared/worktree-setup';
+import { sanitizeEnv } from '@stagewise/agent-shell';
 import type { KartonService } from '@/services/karton';
 import type { Logger } from '@/services/logger';
 import type { TelemetryService } from '@/services/telemetry';
@@ -289,7 +290,14 @@ export class WorktreeSetupRunner {
     }
     if (activeRun.settled) return;
 
-    const env: NodeJS.ProcessEnv = mergeEnv(process.env, {
+    // Use sanitized process.env as the base to prevent host-process
+    // contamination vars (NODE_ENV, BUILD_MODE, app config keys/URLs)
+    // from leaking into the worktree setup script and its children.
+    // resolvedEnv (from the user's login shell) overrides on top.
+    const sanitizedBase = sanitizeEnv(undefined, undefined, {
+      forAgent: false,
+    });
+    const env: NodeJS.ProcessEnv = mergeEnv(sanitizedBase, {
       ...(resolvedEnv ?? {}),
       STAGEWISE_SOURCE_WORKTREE_PATH: metadata.sourceWorktreePath,
       STAGEWISE_TARGET_WORKTREE_PATH: metadata.workspacePath,

--- a/packages/agent-shell/src/engine/index.ts
+++ b/packages/agent-shell/src/engine/index.ts
@@ -5,7 +5,7 @@ export { DisposableService } from './disposable';
 export { SessionManager } from './session-manager';
 export { OscParser, wrapWithSentinel } from './osc-parser';
 export { SessionLogger } from './session-logger';
-export { sanitizeEnv } from './sanitize-env';
+export { sanitizeEnv, BLOCKLIST } from './sanitize-env';
 export {
   detectShell,
   resolveShellEnv,

--- a/packages/agent-shell/src/engine/index.ts
+++ b/packages/agent-shell/src/engine/index.ts
@@ -5,7 +5,7 @@ export { DisposableService } from './disposable';
 export { SessionManager } from './session-manager';
 export { OscParser, wrapWithSentinel } from './osc-parser';
 export { SessionLogger } from './session-logger';
-export { sanitizeEnv, BLOCKLIST } from './sanitize-env';
+export { sanitizeEnv } from './sanitize-env';
 export {
   detectShell,
   resolveShellEnv,

--- a/packages/agent-shell/src/engine/sanitize-env.test.ts
+++ b/packages/agent-shell/src/engine/sanitize-env.test.ts
@@ -135,6 +135,16 @@ describe('sanitizeEnv', () => {
 
       expect(env.BUILD_MODE).toBeUndefined();
     });
+
+    it('strips blocklisted vars case-insensitively', () => {
+      process.env.node_env = 'production';
+      process.env.Build_Mode = 'production';
+
+      const env = sanitizeEnv();
+
+      expect(env.node_env).toBeUndefined();
+      expect(env.Build_Mode).toBeUndefined();
+    });
   });
 
   it('strips the inherited shell-integration guard so each PTY can re-source', () => {

--- a/packages/agent-shell/src/engine/sanitize-env.test.ts
+++ b/packages/agent-shell/src/engine/sanitize-env.test.ts
@@ -253,5 +253,38 @@ describe('sanitizeEnv', () => {
 
       expect(env.NODE_ENV).toBeUndefined();
     });
+
+    it('preserves credential vars for user terminals (forAgent: false)', () => {
+      // User terminals and worktree setup scripts need credentials like
+      // NPM_TOKEN, GITHUB_TOKEN to authenticate — same as a regular
+      // terminal. Sensitive-var stripping is agent-only.
+      const env = sanitizeEnv(
+        {
+          NPM_TOKEN: 'abc123',
+          GITHUB_TOKEN: 'ghp_xyz',
+          DB_PASSWORD: 'secret',
+          PRIVATE_KEY: 'key',
+          SSH_AUTH_SOCK: '/tmp/ssh-agent',
+        },
+        undefined,
+        { forAgent: false },
+      );
+
+      expect(env.NPM_TOKEN).toBe('abc123');
+      expect(env.GITHUB_TOKEN).toBe('ghp_xyz');
+      expect(env.DB_PASSWORD).toBe('secret');
+      expect(env.PRIVATE_KEY).toBe('key');
+      expect(env.SSH_AUTH_SOCK).toBe('/tmp/ssh-agent');
+    });
+
+    it('strips credential vars for agent terminals (default)', () => {
+      const env = sanitizeEnv({
+        NPM_TOKEN: 'abc123',
+        GITHUB_TOKEN: 'ghp_xyz',
+      });
+
+      expect(env.NPM_TOKEN).toBeUndefined();
+      expect(env.GITHUB_TOKEN).toBeUndefined();
+    });
   });
 });

--- a/packages/agent-shell/src/engine/sanitize-env.test.ts
+++ b/packages/agent-shell/src/engine/sanitize-env.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { sanitizeEnv } from './sanitize-env';
+import { sanitizeEnv, BLOCKLIST } from './sanitize-env';
 
 describe('sanitizeEnv', () => {
   let originalEnv: NodeJS.ProcessEnv;
@@ -68,6 +68,75 @@ describe('sanitizeEnv', () => {
     expect(env.SOME_NORMAL_VAR).toBe('hello');
   });
 
+  describe('host-process contamination blocklist', () => {
+    // BLOCKLIST only applies when falling back to process.env (no
+    // resolved shell env). When a resolved env is available, values
+    // come from the user's own shell profile and should pass through.
+
+    it('strips NODE_ENV from process.env fallback', () => {
+      process.env.NODE_ENV = 'production';
+
+      const env = sanitizeEnv();
+
+      expect(env.NODE_ENV).toBeUndefined();
+    });
+
+    it('preserves NODE_ENV from resolvedEnv (user-set in .zshrc)', () => {
+      const env = sanitizeEnv({
+        PATH: '/usr/bin',
+        NODE_ENV: 'development',
+      });
+
+      expect(env.NODE_ENV).toBe('development');
+    });
+
+    it('strips all blocklisted vars from process.env fallback', () => {
+      for (const key of BLOCKLIST) {
+        process.env[key] = 'should-be-stripped';
+      }
+
+      const env = sanitizeEnv();
+
+      for (const key of BLOCKLIST) {
+        expect(env[key]).toBeUndefined();
+      }
+    });
+
+    it('preserves non-sensitive blocklisted vars from resolvedEnv', () => {
+      // Only non-sensitive blocklisted vars should pass through from
+      // resolved env. Keys like POSTHOG_API_KEY still get stripped by
+      // the sensitive-pattern filter even from resolved env.
+      const nonSensitive = [
+        'NODE_ENV',
+        'BUILD_MODE',
+        'POSTHOG_HOST',
+        'STAGEWISE_CONSOLE_URL',
+        'API_URL',
+        'LLM_PROXY_URL',
+        'UPDATE_SERVER_ORIGIN',
+        'SUPABASE_URL',
+      ];
+      const resolved: Record<string, string> = {};
+      for (const key of nonSensitive) {
+        resolved[key] = 'user-set';
+      }
+
+      const env = sanitizeEnv(resolved);
+
+      for (const key of nonSensitive) {
+        expect(env[key]).toBe('user-set');
+      }
+    });
+
+    it('strips BUILD_MODE from process.env even though it is not sensitive', () => {
+      process.env.BUILD_MODE = 'production';
+
+      const env = sanitizeEnv();
+
+      expect(env.BUILD_MODE).toBeUndefined();
+    });
+  });
+
   it('strips the inherited shell-integration guard so each PTY can re-source', () => {
     // If this leaks into the spawn env, the integration script's first-line
     // guard short-circuits before registering OSC 133 hooks and every session
@@ -134,5 +203,45 @@ describe('sanitizeEnv', () => {
     expect(env.MY_SECRET_TOKEN).toBeUndefined();
     expect(env.ELECTRON_RUN_AS_NODE).toBeUndefined();
     expect(env.STAGEWISE_SHELL).toBe('1');
+  });
+
+  describe('forAgent option', () => {
+    it('applies agent-specific env by default (STAGEWISE_SHELL, HISTFILE)', () => {
+      const env = sanitizeEnv();
+
+      expect(env.STAGEWISE_SHELL).toBe('1');
+      expect(env.HISTFILE).toBe('/dev/null');
+      expect(env.HISTSIZE).toBe('0');
+      expect(env.SAVEHIST).toBe('0');
+    });
+
+    it('omits agent-specific env when forAgent is false', () => {
+      const env = sanitizeEnv(undefined, undefined, { forAgent: false });
+
+      expect(env.STAGEWISE_SHELL).toBeUndefined();
+      expect(env.HISTFILE).toBeUndefined();
+      expect(env.HISTSIZE).toBeUndefined();
+      expect(env.SAVEHIST).toBeUndefined();
+    });
+
+    it('preserves user-set vars from resolved env for user terminals', () => {
+      const env = sanitizeEnv(
+        { NODE_ENV: 'development', PATH: '/usr/bin' },
+        undefined,
+        { forAgent: false },
+      );
+
+      // Resolved env values come from the user's shell profile — pass through.
+      expect(env.NODE_ENV).toBe('development');
+      expect(env.PATH).toBe('/usr/bin');
+    });
+
+    it('strips blocklisted vars from process.env fallback for user terminals', () => {
+      process.env.NODE_ENV = 'production';
+
+      const env = sanitizeEnv(undefined, undefined, { forAgent: false });
+
+      expect(env.NODE_ENV).toBeUndefined();
+    });
   });
 });

--- a/packages/agent-shell/src/engine/sanitize-env.ts
+++ b/packages/agent-shell/src/engine/sanitize-env.ts
@@ -166,7 +166,13 @@ export function sanitizeEnv(
     // sanitization while still affecting tools that check case-insensitively.
     if (!hasResolvedEnv && BLOCKLIST.has(key.toUpperCase())) continue;
 
-    if (!isWhitelisted(key) && isSensitive(key)) continue;
+    // Strip credential-like vars (SECRET, TOKEN, KEY, PASSWORD, etc.)
+    // only for agent terminals — to keep them out of LLM context. User
+    // terminals and worktree setup scripts need these (NPM_TOKEN,
+    // GITHUB_TOKEN, etc.) to authenticate against private registries
+    // and services, just like a regular terminal session would.
+    if (options?.forAgent !== false && !isWhitelisted(key) && isSensitive(key))
+      continue;
 
     env[key] = value;
   }

--- a/packages/agent-shell/src/engine/sanitize-env.ts
+++ b/packages/agent-shell/src/engine/sanitize-env.ts
@@ -20,8 +20,35 @@ const WHITELIST = new Set([
   'XDG_CONFIG_HOME',
   'XDG_DATA_HOME',
   'XDG_CACHE_HOME',
-  'NODE_ENV',
   'npm_config_registry',
+]);
+
+/**
+ * Environment variables injected by the stagewise host process (via Vite
+ * `define` or the Electron main process) that must never propagate to
+ * user or agent terminals. These are app-level configuration values, not
+ * part of the user's shell environment.
+ *
+ * `NODE_ENV` is the primary offender: the IDE sets it to `production` in
+ * bundled builds, and it silently changes the behavior of every Node.js
+ * tool the user runs in the terminal (Next.js, Express, etc.).
+ *
+ * The blocklist takes priority over the whitelist — even if a var is
+ * whitelisted or set by the user's shell profile, the app's value must
+ * not leak through. The user's shell rc files can still export these
+ * vars themselves; we only strip the inherited app-process values.
+ */
+export const BLOCKLIST = new Set([
+  'NODE_ENV',
+  'BUILD_MODE',
+  'POSTHOG_API_KEY',
+  'POSTHOG_HOST',
+  'STAGEWISE_CONSOLE_URL',
+  'API_URL',
+  'LLM_PROXY_URL',
+  'UPDATE_SERVER_ORIGIN',
+  'SUPABASE_URL',
+  'SUPABASE_PUBLISHABLE_KEY',
 ]);
 
 /**
@@ -104,8 +131,10 @@ function isWhitelisted(key: string): boolean {
 export function sanitizeEnv(
   resolvedEnv?: Record<string, string> | null,
   shellType?: ShellType,
+  options?: { forAgent?: boolean },
 ): Record<string, string> {
   const env: Record<string, string> = {};
+  const hasResolvedEnv = resolvedEnv != null;
   const base: Record<string, string | undefined> =
     resolvedEnv ?? (process.env as Record<string, string | undefined>);
 
@@ -122,6 +151,15 @@ export function sanitizeEnv(
     // every session falls back to sentinel mode. Each fresh PTY must start with
     // a clean slate so its own sourcing can register the hooks.
     if (key === '__STAGEWISE_SHELL_INTEGRATION') continue;
+
+    // Strip host-process contamination vars (NODE_ENV, BUILD_MODE, app
+    // config URLs/keys) — but ONLY when falling back to process.env.
+    // When a resolved shell env is available (from resolveShellEnv, which
+    // spawns a login shell and captures its env), the values are the
+    // user's own — if they export NODE_ENV in .zshrc, that should pass
+    // through. resolveShellEnv already strips BLOCKLIST vars from its
+    // seed env, so the login shell never sees the app's contamination.
+    if (!hasResolvedEnv && BLOCKLIST.has(key)) continue;
 
     if (!isWhitelisted(key) && isSensitive(key)) continue;
 
@@ -149,16 +187,30 @@ export function sanitizeEnv(
     }
   }
 
-  // Defense-in-depth: disable persistent shell history for agent PTYs.
-  // The integration scripts also do this (and override anything rc files
-  // set), but env-level values cover the `sh` branch and the rare fallback
-  // where integration sourcing fails. User rc files that unconditionally
-  // export HISTFILE will beat this — that case is handled by the scripts.
-  env.HISTFILE = '/dev/null';
-  env.HISTSIZE = '0';
-  env.SAVEHIST = '0';
+  // Agent-specific env modifications. Applied only for agent PTYs
+  // (forAgent !== false). User terminals retain normal shell history
+  // behavior and do not carry the STAGEWISE_SHELL marker.
+  if (options?.forAgent !== false) {
+    // Defense-in-depth: disable persistent shell history for agent PTYs.
+    // The integration scripts also do this (and override anything rc files
+    // set), but env-level values cover the `sh` branch and the rare fallback
+    // where integration sourcing fails. User rc files that unconditionally
+    // export HISTFILE will beat this — that case is handled by the scripts.
+    env.HISTFILE = '/dev/null';
+    env.HISTSIZE = '0';
+    env.SAVEHIST = '0';
 
-  env.STAGEWISE_SHELL = '1';
+    env.STAGEWISE_SHELL = '1';
+  } else {
+    // User terminals: actively remove agent-specific vars that may have
+    // leaked from the host process env (e.g. when tests run inside a
+    // stagewise shell, or the app was launched from a terminal that had
+    // STAGEWISE_SHELL set). Without this, they'd pass through unchanged.
+    delete env.HISTFILE;
+    delete env.HISTSIZE;
+    delete env.SAVEHIST;
+    delete env.STAGEWISE_SHELL;
+  }
 
   return env;
 }

--- a/packages/agent-shell/src/engine/sanitize-env.ts
+++ b/packages/agent-shell/src/engine/sanitize-env.ts
@@ -38,7 +38,7 @@ const WHITELIST = new Set([
  * not leak through. The user's shell rc files can still export these
  * vars themselves; we only strip the inherited app-process values.
  */
-export const BLOCKLIST = new Set([
+export const BLOCKLIST: ReadonlySet<string> = new Set([
   'NODE_ENV',
   'BUILD_MODE',
   'POSTHOG_API_KEY',
@@ -159,7 +159,12 @@ export function sanitizeEnv(
     // user's own — if they export NODE_ENV in .zshrc, that should pass
     // through. resolveShellEnv already strips BLOCKLIST vars from its
     // seed env, so the login shell never sees the app's contamination.
-    if (!hasResolvedEnv && BLOCKLIST.has(key)) continue;
+    // Case-insensitive match: env vars on Unix are case-sensitive, but
+    // the blocklist targets app-set vars that are conventionally
+    // uppercase. Matching case-insensitively is defense-in-depth against
+    // mixed-case variants (e.g. Node_Env) that would otherwise bypass
+    // sanitization while still affecting tools that check case-insensitively.
+    if (!hasResolvedEnv && BLOCKLIST.has(key.toUpperCase())) continue;
 
     if (!isWhitelisted(key) && isSensitive(key)) continue;
 

--- a/packages/agent-shell/src/engine/shell-env/resolve-shell-env.ts
+++ b/packages/agent-shell/src/engine/shell-env/resolve-shell-env.ts
@@ -1,6 +1,7 @@
 import { spawn } from 'node:child_process';
 import { homedir, userInfo } from 'node:os';
 import { normalizeWindowsPath } from './normalize-windows-path';
+import { BLOCKLIST } from '../sanitize-env';
 import type { DetectedShell } from './types.ts';
 
 const DEFAULT_RESOLVE_TIMEOUT_MS = 10_000;
@@ -183,6 +184,23 @@ export async function resolveShellEnv(
     SHELL: shell.path,
     STAGEWISE_RESOLVING_ENVIRONMENT: '1',
   } as Record<string, string>;
+
+  // Strip host-process contamination vars (NODE_ENV, BUILD_MODE, app
+  // config) so they don't leak into the resolved env via the login
+  // shell's inherited environment. Without this, `env -0` would report
+  // the app's NODE_ENV=production back in its output.
+  for (const key of BLOCKLIST) {
+    delete env[key];
+  }
+
+  // Strip ELECTRON_* vars from the seed env. sanitizeEnv removes these
+  // downstream at terminal spawn, but any consumer that uses resolvedEnv
+  // directly (e.g. worktree setup runner) would otherwise see them.
+  for (const key of Object.keys(env)) {
+    if (key.startsWith('ELECTRON_') || key.startsWith('ELECTRON ')) {
+      delete env[key];
+    }
+  }
 
   return new Promise<Record<string, string> | null>((resolve) => {
     const child = spawn(shell.path, shellArgs, {


### PR DESCRIPTION


Sanitize environment across all child-process spawn paths to prevent host-process contamination vars (NODE_ENV, BUILD_MODE, app config keys/URLs, ELECTRON_*) from leaking into terminals, git commands, and worktree setup scripts.

- sanitize-env.ts: add BLOCKLIST, remove NODE_ENV from whitelist, add forAgent option to handle inherited vars for user vs agent terminals
- resolve-shell-env.ts: strip BLOCKLIST + ELECTRON_* from login shell seed env so they don't re-enter via env -0 output
- terminal/index.ts: use sanitizeEnv instead of raw process.env merge
- git/index.ts: sanitize fallback env when resolvedEnv is unavailable
- worktree-setup-runner.ts: use sanitized base env for setup scripts
- 12 new tests covering blocklist, forAgent, and preservation semantics

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent host env vars from leaking into terminals, git commands, and worktree setup by sanitizing the environment across all spawn paths. Blocks NODE_ENV, BUILD_MODE, config URLs/keys, and ELECTRON_*, preserves user shell values, and keeps auth tokens in user terminals and setup scripts.

- **Bug Fixes**
  - All spawn paths now call sanitizeEnv unconditionally (user terminals, git, worktree); user terminals and worktree pass { forAgent: false } so credentials are retained, agent PTYs keep history disabled.
  - Toolbox no longer copies process.env when shell env resolution fails; it passes null so sanitizeEnv applies the BLOCKLIST and prevents terminal fallback leaks.
  - In `@stagewise/agent-shell`, added an immutable, case-insensitive BLOCKLIST and removed it from the public barrel; resolveShellEnv strips BLOCKLIST and ELECTRON_* from the seed env; sanitizeEnv applies BLOCKLIST only on process.env fallback and strips sensitive vars only for agent PTYs.
  - Worktree setup passes the correct shell type to sanitizeEnv (powershell on Windows, sh otherwise); added tests for case-insensitive blocklist behavior, forAgent handling, preservation of resolved env values, and credential retention for user terminals.

<sup>Written for commit 24462d3e1ad9155132d6c0d7eed10e11907c1681. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1353?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved environment isolation across terminals, git operations, and worktree setup by sanitizing inherited host environment variables and applying stricter filtering.
  * Refined handling of agent-related shell markers so they’re omitted when using non-agent terminal contexts.
* **Tests**
  * Expanded automated coverage to verify blocklist behavior, `forAgent` option handling, and correct preservation/removal of sensitive and host-contaminating environment variables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->