### PR TITLE
fix(stagewise): restore worktree cleanup scan on startup

### DIFF
--- a/apps/browser/src/backend/main.ts
+++ b/apps/browser/src/backend/main.ts
@@ -1184,6 +1184,14 @@ export async function main({ launchOptions: { verbose } }: MainParameters) {
 
   logger.debug('[Main] Normal operation services bootstrapped');
 
+  void toolboxService
+    .scanWorkspaceGitCleanupCandidatesOnStartup()
+    .catch((error) => {
+      logger.warn(
+        `[Main] Failed to scan worktree cleanup candidates: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    });
+
   logger.debug('[Main] Startup complete');
 
   // Handle command line arguments for URLs on initial startup


### PR DESCRIPTION
The scanWorkspaceGitCleanupCandidatesOnStartup() call was dropped in commit 2f96310ed (move settings into main UI). Re-add the fire-and-forget call in main.ts so the worktree cleanup badge triggers again on restart.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the startup scan for Git worktree cleanup candidates so the cleanup badge appears after restart. Adds a fire-and-forget call to `toolboxService.scanWorkspaceGitCleanupCandidatesOnStartup()` in `apps/browser/src/backend/main.ts`, with `logger.warn` error handling to avoid blocking startup.

<sup>Written for commit 947573ef7688dc8836df014341b1dbf7628cf032. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1355?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup behavior by checking for workspace cleanup opportunities in the background, helping keep projects tidy without delaying app launch.
  * Startup errors from this check are now handled more gracefully and logged safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->