### PR TITLE
chore(stagewise): remove GLM partnership-implying branding and add in…

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,10 @@ Bring Your Own Key for all popular model providers — you can also register com
 
 ### Easy Import — use your existing subscription
 
-Connect any of the following subscriptions with a single API key to unlock all models the provider offers directly inside stagewise. GLM Coding Plan keys are routed through Z.ai's dedicated coding endpoint internally.
+Connect any of the following subscriptions with a single API key to unlock all models the provider offers directly inside stagewise.
 
 | **Subscription** | **Provider** | **Featured Models** | **Dashboard** |
 | ---------------- | ------------ | ------------------- | ------------- |
-| GLM Coding Plan  | [Z.ai](https://z.ai) | GLM-5.2, GLM-5.1, GLM-5V-Turbo | [Get API key](https://z.ai/manage-apikey/apikey-list) |
 | Kimi             | [Moonshot AI](https://platform.moonshot.ai) | Kimi K2.7 Code, Kimi K2.6, Kimi K2.5 | [Get API key](https://platform.moonshot.ai/console/api-keys) |
 | Qwen Coding Plan | [Alibaba DashScope](https://dashscope.console.aliyun.com) | Qwen3-Coder-30B, Qwen3-32B | [Get API key](https://dashscope.console.aliyun.com/apiKey) |
 | MiniMax          | [MiniMax](https://platform.minimax.io) | MiniMax M3, MiniMax M2.7 | [Get API key](https://platform.minimax.io/user-center/basic-information/interface-key) |

--- a/apps/browser/src/shared/coding-plans.ts
+++ b/apps/browser/src/shared/coding-plans.ts
@@ -36,6 +36,8 @@ export type CodingPlan = {
   validationModelId?: string;
   /** Additional endpoint note rendered in plan UI. */
   endpointHelpText?: string;
+  /** Optional disclaimer rendered below the help text (e.g. unofficial status). */
+  disclaimer?: string;
   /** Featured model IDs (must exist in availableModels) — for card copy. */
   featuredModelIds: string[];
 };
@@ -54,6 +56,8 @@ export const CODING_PLANS: Record<CodingPlanId, CodingPlan> = {
     validationBaseUrl: 'https://api.z.ai/api/coding/paas/v4',
     validationModelId: 'glm-5.2',
     endpointHelpText: 'Routed through api.z.ai/api/coding/paas/v4.',
+    disclaimer:
+      'stagewise is not yet an officially supported tool for the GLM Coding Plan. We are working with Z.ai on a partnership.',
     featuredModelIds: ['glm-5.2', 'glm-5.1', 'glm-5v-turbo'],
   },
   'kimi-plan': {

--- a/apps/browser/src/ui/components/coding-plan-card.tsx
+++ b/apps/browser/src/ui/components/coding-plan-card.tsx
@@ -273,6 +273,9 @@ export function CodingPlanCard({
               )}
             </p>
           )}
+        {plan.disclaimer && (
+          <p className="text-2xs text-warning-foreground">{plan.disclaimer}</p>
+        )}
       </div>
     </div>
   );

--- a/apps/website/src/app/(home)/_components/footer.tsx
+++ b/apps/website/src/app/(home)/_components/footer.tsx
@@ -61,15 +61,6 @@ export function Footer() {
               >
                 stagewise with DeepSeek
               </Link>
-              <Link
-                href="/use-cases/glm"
-                className={cn(
-                  buttonVariants({ variant: 'ghost', size: 'xs' }),
-                  'justify-end',
-                )}
-              >
-                stagewise with GLM
-              </Link>
             </div>
             <div className="flex flex-col items-end gap-1">
               <span

--- a/apps/website/src/app/(home)/_components/home-client.tsx
+++ b/apps/website/src/app/(home)/_components/home-client.tsx
@@ -343,7 +343,6 @@ function FeatureSection() {
                 </p>
                 <div className="flex flex-wrap gap-2">
                   {[
-                    'GLM Coding Plan',
                     'Kimi',
                     'Qwen Coding Plan',
                     'MiniMax',

--- a/apps/website/src/app/(home)/use-cases/glm/page.tsx
+++ b/apps/website/src/app/(home)/use-cases/glm/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next';
+import { permanentRedirect } from 'next/navigation';
 import Link from 'next/link';
 import { ScrollReveal } from '@/components/landing/scroll-reveal';
 import { DownloadButtons } from '../../_components/home-client';
@@ -24,6 +25,11 @@ export const metadata: Metadata = {
 };
 
 export default function GLMUseCasePage() {
+  // Remove this redirect when the Z.ai partnership is established
+  if ('remove-when-partnership-established'.includes('partnership')) {
+    permanentRedirect('/');
+  }
+
   return (
     <>
       {/* Hero */}


### PR DESCRIPTION
…-product disclaimer

- Redirect GLM use-case page to homepage (page retained for restoration)
- Remove "stagewise with GLM" footer link from website
- Remove GLM Coding Plan from homepage subscription chips
- Remove GLM Coding Plan row from README subscription table
- Add disclaimer field to CodingPlan type and GLM plan entry
- Render disclaimer in CodingPlanCard component (onboarding + settings)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove GLM partnership-style branding and add an in-product disclaimer clarifying the plan is not officially supported yet. Redirect the GLM use-case page and clean up UI/docs to avoid implying an official partnership.

- **New Features**
  - Add optional `disclaimer` to `CodingPlan`; set for GLM plan.
  - Render plan disclaimer in `CodingPlanCard` (onboarding and settings).

- **Refactors**
  - Redirect `/use-cases/glm` to the homepage (page kept for future restore).
  - Remove “stagewise with GLM” footer link and the GLM subscription chip on the homepage.
  - Remove GLM Coding Plan row and routing note from the README subscription section.

<sup>Written for commit 4096d504c54356a994e8f1e8e2919de2f0ead4e0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1359?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional disclaimer/warning to coding plan cards when a plan includes important availability notes.
* **Bug Fixes**
  * Removed outdated GLM coding plan entries from the supported subscriptions list and related home page UI.
  * Updated footer and “Easy Import” documentation to reflect the current GLM subscription mapping.
  * Simplified the GLM use-case page to immediately redirect visitors to the main page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->