### PR TITLE
feat(website): restore GLM use-case page and footer link

### DIFF
--- a/apps/website/src/app/(home)/_components/footer.tsx
+++ b/apps/website/src/app/(home)/_components/footer.tsx
@@ -61,6 +61,15 @@ export function Footer() {
               >
                 stagewise with DeepSeek
               </Link>
+              <Link
+                href="/use-cases/glm"
+                className={cn(
+                  buttonVariants({ variant: 'ghost', size: 'xs' }),
+                  'justify-end',
+                )}
+              >
+                stagewise with GLM
+              </Link>
             </div>
             <div className="flex flex-col items-end gap-1">
               <span

--- a/apps/website/src/app/(home)/use-cases/glm/page.tsx
+++ b/apps/website/src/app/(home)/use-cases/glm/page.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from 'next';
-import { permanentRedirect } from 'next/navigation';
 import Link from 'next/link';
 import { ScrollReveal } from '@/components/landing/scroll-reveal';
 import { DownloadButtons } from '../../_components/home-client';
@@ -25,11 +24,6 @@ export const metadata: Metadata = {
 };
 
 export default function GLMUseCasePage() {
-  // Remove this redirect when the Z.ai partnership is established
-  if ('remove-when-partnership-established'.includes('partnership')) {
-    permanentRedirect('/');
-  }
-
   return (
     <>
       {/* Hero */}


### PR DESCRIPTION
Reverts the redirect guard and footer link removal from the partnership-sanitization commit. The GLM page is a legitimate use-case page, not a partnership claim.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the GLM use-case page and re-adds its footer link so the page is accessible again. Removes the temporary redirect on /use-cases/glm and adds a “stagewise with GLM” link in the footer.

<sup>Written for commit 4ce62da79dd0585c865ebd56312bec23b9997662. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1360?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new “stagewise with GLM” link in the footer’s Use cases section.
  * The GLM use case page now loads normally instead of redirecting away, making its content accessible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->