### PR TITLE
fix(stagewise): prevent switching open agent when navigating settings

### DIFF
--- a/apps/browser/src/ui/hooks/use-auto-select-agent.tsx
+++ b/apps/browser/src/ui/hooks/use-auto-select-agent.tsx
@@ -21,6 +21,8 @@ const RESUME_GRACE_MS = 2500;
 export function useAutoSelectFirstAgent(): void {
   const [openAgent, setOpenAgent, removeFromHistory] = useOpenAgent();
 
+  const isSettingsOpen = useKartonState((s) => s.appScreen.mode === 'settings');
+
   const activeAgentIdsRaw = useKartonState(
     useComparingSelector((s) => Object.keys(s.agents.instances)),
   );
@@ -59,6 +61,8 @@ export function useAutoSelectFirstAgent(): void {
   const [retryTick, setRetryTick] = useState(0);
 
   useEffect(() => {
+    if (isSettingsOpen) return;
+
     if (openAgent && !activeAgentIdSet.has(openAgent)) {
       // If the open agent was set very recently (e.g. by the user clicking
       // a history card), give the backend time to load it before concluding
@@ -87,5 +91,6 @@ export function useAutoSelectFirstAgent(): void {
     removeFromHistory,
     setOpenAgent,
     retryTick,
+    isSettingsOpen,
   ]);
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent auto-switching of the open agent while the Settings screen is open. Added `isSettingsOpen` check in `useAutoSelectFirstAgent` (early return in effect and dependency update) to avoid unintended switches when entering or leaving Settings.

<sup>Written for commit 875e927caca11e33f09629b1366d759a20edf6a3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1363?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Auto-selection for the first agent now pauses while the Settings screen is open, preventing unexpected changes during configuration.
  * The agent list behavior now re-evaluates correctly when switching between Settings and other screens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->