### PR TITLE
feat(stagewise): support Esc as additional abort trigger alongside Ct…

### DIFF
--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/chat-input.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/chat-input.tsx
@@ -999,6 +999,7 @@ export const ChatInputActions = memo(function ChatInputActions({
               <span className="flex items-center gap-1.5">
                 <span>Stop agent</span>
                 <HotkeyCombo action={HotkeyActions.STOP_AGENT} size="xs" />
+                <ShortcutCombo value="Esc" size="xs" />
               </span>
             </TooltipContent>
           </Tooltip>

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/panel-footer.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/panel-footer.tsx
@@ -732,6 +732,10 @@ export const ChatPanelFooter = memo(function ChatPanelFooter() {
   }, []);
 
   const handleEscape = useCallback(() => {
+    if (isWorkingRef.current && pendingQuestionIdRef.current === null) {
+      abortAgentRef.current();
+      return;
+    }
     if (elementSelectionActive) stopContextSelector();
     else setChatInputActive(false);
   }, [elementSelectionActive, stopContextSelector]);
@@ -1322,6 +1326,11 @@ export const ChatPanelFooter = memo(function ChatPanelFooter() {
     'keydown',
     (e: KeyboardEvent) => {
       if (e.code === 'Escape' && chatInputActive) {
+        if (e.defaultPrevented) return; // ChatInput's onEscape already handled it
+        if (isWorking && !hasPendingQuestion) {
+          abortAgentRef.current();
+          return;
+        }
         if (elementSelectionActive) stopContextSelector();
         else setChatInputActive(false);
       }


### PR DESCRIPTION
…rl+C

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Esc as an additional shortcut to stop an in-progress agent run (alongside Ctrl+C). Updates the Stop tooltip to show Esc and preserves existing Escape behavior for selection and input focus.

- **New Features**
  - Press Esc to abort the agent when it’s working and there’s no pending question; otherwise it exits selection or closes the input as before.
  - Esc handling respects ChatInput’s own Escape handling and won’t double-trigger.

<sup>Written for commit 370a74a32de2c3b6caa3c24248bdf29a874e4127. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1364?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Escape key handling in the chat panel so stopping an active agent works more reliably.
  * Prevented duplicate Escape handling when typing in chat input, reducing unexpected behavior.
  * Updated the “Stop agent” tooltip to show the correct Escape shortcut.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->