### PR TITLE
fix(stagewise): persist switchBranchTarget in workspace git action preferences

### DIFF
--- a/apps/browser/src/shared/karton-contracts/ui/shared-types.ts
+++ b/apps/browser/src/shared/karton-contracts/ui/shared-types.ts
@@ -366,6 +366,7 @@ const workspaceGitRepositoryActionPreferenceSchema = z
     createWorktreeFrom: z.string().optional(),
     createBranchFrom: z.string().optional(),
     switchWorktreeTarget: z.string().optional(),
+    switchBranchTarget: z.string().optional(),
   })
   .default({})
   .catch({});

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/workspace-action-preferences.test.ts
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/workspace-action-preferences.test.ts
@@ -149,13 +149,43 @@ describe('applyWorkspaceGitActionPreferences', () => {
     expect(config.switchWorktreeTarget).toBe('/repo');
   });
 
-  it('does not apply branch target preferences', () => {
+  it('applies available remembered switchBranchTarget from repo prefs', () => {
     const config = applyWorkspaceGitActionPreferences(
       defaults,
       sourceBranchItems,
       worktreeItems,
       undefined,
-      { switchWorktreeTarget: '/repo/worktrees/test' },
+      { switchBranchTarget: 'develop' },
+    );
+
+    expect(config.switchBranchTarget).toBe('develop');
+  });
+
+  it('ignores remembered switchBranchTarget that is unavailable', () => {
+    const config = applyWorkspaceGitActionPreferences(
+      defaults,
+      sourceBranchItems,
+      worktreeItems,
+      undefined,
+      { switchBranchTarget: 'deleted-branch' },
+    );
+
+    expect(config.switchBranchTarget).toBe('main');
+  });
+
+  it('validates switchBranchTarget against checkoutBranchItems when distinct from sourceBranches', () => {
+    const checkoutBranchItems: SelectItem<string>[] = [
+      { value: 'main', label: 'main' },
+    ];
+
+    // 'develop' is in sourceBranchItems but NOT in checkoutBranchItems
+    const config = applyWorkspaceGitActionPreferences(
+      defaults,
+      sourceBranchItems,
+      worktreeItems,
+      undefined,
+      { switchBranchTarget: 'develop' },
+      checkoutBranchItems,
     );
 
     expect(config.switchBranchTarget).toBe('main');

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/workspace-action-preferences.ts
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/workspace-action-preferences.ts
@@ -29,9 +29,13 @@ export function applyWorkspaceGitActionPreferences(
   worktreeItems: SelectItem<string>[],
   generalPreference?: WorkspaceGitActionGeneralPreference,
   repositoryPreference?: WorkspaceGitActionRepositoryPreference,
+  checkoutBranchItems?: SelectItem<string>[],
 ): WorkspaceActionConfig {
   const sourceBranches = new Set(sourceBranchItems.map((item) => item.value));
   const worktrees = new Set(worktreeItems.map((item) => item.value));
+  const checkoutBranches = new Set(
+    (checkoutBranchItems ?? sourceBranchItems).map((item) => item.value),
+  );
   const switchWorktreeTarget = repositoryPreference?.switchWorktreeTarget;
 
   return {
@@ -61,5 +65,10 @@ export function applyWorkspaceGitActionPreferences(
       worktrees.has(switchWorktreeTarget)
         ? switchWorktreeTarget
         : defaults.switchWorktreeTarget,
+    switchBranchTarget:
+      typeof repositoryPreference?.switchBranchTarget === 'string' &&
+      checkoutBranches.has(repositoryPreference.switchBranchTarget)
+        ? repositoryPreference.switchBranchTarget
+        : defaults.switchBranchTarget,
   };
 }

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/workspace-select.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/workspace-select.tsx
@@ -1855,6 +1855,7 @@ const WorkspaceActionSelect = memo(function WorkspaceActionSelect({
         worktreeItems,
         generalWorkspaceGitActionPreference,
         repositoryWorkspaceGitActionPreference,
+        checkoutBranchItems,
       ),
       mount,
     ),
@@ -1906,6 +1907,7 @@ const WorkspaceActionSelect = memo(function WorkspaceActionSelect({
         worktreeItems,
         generalWorkspaceGitActionPreference,
         repositoryWorkspaceGitActionPreference,
+        checkoutBranchItems,
       ),
       mount,
     );
@@ -2075,6 +2077,19 @@ const WorkspaceActionSelect = memo(function WorkspaceActionSelect({
               'switchWorktreeTarget',
             ],
             value: partial.switchWorktreeTarget,
+          });
+        }
+        if (typeof partial.switchBranchTarget === 'string') {
+          patches.push({
+            op: 'add',
+            path: [
+              'agent',
+              'workspaceGitActionPreferences',
+              'repositories',
+              repositoryId,
+              'switchBranchTarget',
+            ],
+            value: partial.switchBranchTarget,
           });
         }
       }
@@ -2966,6 +2981,8 @@ const ConnectWorkspaceSelect = memo(function ConnectWorkspaceSelectInner({
         sourceBranchItems,
         worktreeItems,
         workspaceGitActionGeneralPreference,
+        undefined,
+        checkoutBranchItems,
       ),
     [workspaceGitActionGeneralPreference],
   );


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist and restore the selected branch target for workspace Git actions across sessions. We validate it against available checkout branches and default when missing.

- **Bug Fixes**
  - Added `switchBranchTarget` to repository preferences and persist/restore it in the workspace select (including connect flow).
  - Validate the saved target against `checkoutBranchItems` when provided; added tests for persistence, invalid targets, and distinct checkout/source lists.

<sup>Written for commit 79a013b2862f881442904f31e0546e5164f50b62. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1365?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for remembering and restoring a workspace Git “switch branch” target.
  * The app now validates the saved switch target against available checkout branch options.

* **Bug Fixes**
  * Automatically falls back to the default branch when a saved switch target is unavailable.
  * Keeps switch-branch preferences consistent when repository branch lists change.

* **Tests**
  * Added targeted unit tests for remembered `switchBranchTarget` behavior across valid/invalid and mismatched branch lists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->