### PR TITLE
feat(stagewise): distinguish MiniMax Token Plan from Pay-as-you-go auth

### DIFF
--- a/apps/browser/src/backend/utils/validate-api-keys.ts
+++ b/apps/browser/src/backend/utils/validate-api-keys.ts
@@ -37,6 +37,75 @@ const validationMessages: ModelMessage[] = [
   },
 ];
 
+/**
+ * MiniMax Token Plan regions. Both Global and CN endpoints accept
+ * the same Token Plan API keys — we probe both and pick the one
+ * that responds successfully.
+ */
+const MINIMAX_TOKEN_PLAN_REGIONS = [
+  'https://api.minimax.io',
+  'https://api.minimaxi.com',
+] as const;
+
+/**
+ * Validate a MiniMax Token Plan key by probing the lightweight
+ * `/v1/token_plan/remains` quota endpoint on both Global and CN
+ * regions. This is faster and more reliable than making a chat
+ * completion request.
+ *
+ * Returns `{ success: true, baseUrl }` with the detected region's
+ * base URL, or `{ success: false, error }` if neither region accepts
+ * the key.
+ */
+export async function validateMiniMaxTokenPlanKey(
+  apiKey: string,
+): Promise<
+  { success: true; baseUrl: string } | { success: false; error: string }
+> {
+  const probeRegion = async (baseUrl: string): Promise<boolean> => {
+    const url = `${baseUrl}/v1/token_plan/remains`;
+    // MiniMax endpoints accept both Bearer and x-api-key auth styles.
+    const authHeaders: Record<string, string>[] = [
+      { Authorization: `Bearer ${apiKey}` },
+      { 'x-api-key': apiKey },
+    ];
+    for (const authHeader of authHeaders) {
+      try {
+        const res = await fetch(url, {
+          headers: { ...authHeader, 'Content-Type': 'application/json' },
+          signal: AbortSignal.timeout(5000),
+        });
+        if (!res.ok) continue;
+        const data = (await res.json()) as {
+          base_resp?: { status_code?: number };
+        };
+        if (data.base_resp?.status_code === 0) return true;
+      } catch {
+        // try next auth style
+      }
+    }
+    return false;
+  };
+
+  const results = await Promise.all(
+    MINIMAX_TOKEN_PLAN_REGIONS.map(async (baseUrl) => ({
+      baseUrl,
+      ok: await probeRegion(baseUrl),
+    })),
+  );
+
+  const match = results.find((r) => r.ok);
+  if (match) {
+    return { success: true, baseUrl: match.baseUrl };
+  }
+
+  return {
+    success: false,
+    error:
+      'Invalid MiniMax Token Plan key. Ensure the key belongs to an active Token Plan subscription.',
+  };
+}
+
 const providerConfigs: Record<
   ApiKeyProvider,
   (apiKey: string, baseURL?: string) => ValidationModel
@@ -100,6 +169,12 @@ export async function validateCodingPlanApiKey(
   plan: CodingPlan,
   apiKey: string,
 ): Promise<ApiKeyValidationResult> {
+  // MiniMax Token Plan keys use a dedicated lightweight quota endpoint
+  // with auto-region detection instead of a chat completion probe.
+  if (plan.id === 'minimax-plan') {
+    return validateMiniMaxTokenPlanKey(apiKey);
+  }
+
   const validationBaseURL = plan.validationBaseUrl ?? plan.baseUrl;
 
   if (validationBaseURL && plan.validationModelId) {

--- a/apps/browser/src/backend/utils/validate-api-keys.ts
+++ b/apps/browser/src/backend/utils/validate-api-keys.ts
@@ -38,65 +38,34 @@ const validationMessages: ModelMessage[] = [
 ];
 
 /**
- * MiniMax Token Plan regions. Both Global and CN endpoints accept
- * the same Token Plan API keys — we probe both and pick the one
- * that responds successfully.
- */
-const MINIMAX_TOKEN_PLAN_REGIONS = [
-  'https://api.minimax.io',
-  'https://api.minimaxi.com',
-] as const;
-
-/**
  * Validate a MiniMax Token Plan key by probing the lightweight
- * `/v1/token_plan/remains` quota endpoint on both Global and CN
- * regions. This is faster and more reliable than making a chat
- * completion request.
- *
- * Returns `{ success: true, baseUrl }` with the detected region's
- * base URL, or `{ success: false, error }` if neither region accepts
- * the key.
+ * `/v1/token_plan/remains` quota endpoint on the Global region.
+ * This is faster and more reliable than making a chat completion
+ * request.
  */
 export async function validateMiniMaxTokenPlanKey(
   apiKey: string,
-): Promise<
-  { success: true; baseUrl: string } | { success: false; error: string }
-> {
-  const probeRegion = async (baseUrl: string): Promise<boolean> => {
-    const url = `${baseUrl}/v1/token_plan/remains`;
-    // MiniMax endpoints accept both Bearer and x-api-key auth styles.
-    const authHeaders: Record<string, string>[] = [
-      { Authorization: `Bearer ${apiKey}` },
-      { 'x-api-key': apiKey },
-    ];
-    for (const authHeader of authHeaders) {
-      try {
-        const res = await fetch(url, {
-          headers: { ...authHeader, 'Content-Type': 'application/json' },
-          signal: AbortSignal.timeout(5000),
-        });
-        if (!res.ok) continue;
-        const data = (await res.json()) as {
-          base_resp?: { status_code?: number };
-        };
-        if (data.base_resp?.status_code === 0) return true;
-      } catch {
-        // try next auth style
-      }
+): Promise<{ success: true } | { success: false; error: string }> {
+  const url = 'https://api.minimax.io/v1/token_plan/remains';
+  // MiniMax endpoints accept both Bearer and x-api-key auth styles.
+  const authHeaders: Record<string, string>[] = [
+    { Authorization: `Bearer ${apiKey}` },
+    { 'x-api-key': apiKey },
+  ];
+  for (const authHeader of authHeaders) {
+    try {
+      const res = await fetch(url, {
+        headers: { ...authHeader, 'Content-Type': 'application/json' },
+        signal: AbortSignal.timeout(5000),
+      });
+      if (!res.ok) continue;
+      const data = (await res.json()) as {
+        base_resp?: { status_code?: number };
+      };
+      if (data.base_resp?.status_code === 0) return { success: true };
+    } catch {
+      // try next auth style
     }
-    return false;
-  };
-
-  const results = await Promise.all(
-    MINIMAX_TOKEN_PLAN_REGIONS.map(async (baseUrl) => ({
-      baseUrl,
-      ok: await probeRegion(baseUrl),
-    })),
-  );
-
-  const match = results.find((r) => r.ok);
-  if (match) {
-    return { success: true, baseUrl: match.baseUrl };
   }
 
   return {

--- a/apps/browser/src/shared/coding-plans.ts
+++ b/apps/browser/src/shared/coding-plans.ts
@@ -85,12 +85,16 @@ export const CODING_PLANS: Record<CodingPlanId, CodingPlan> = {
   'minimax-plan': {
     id: 'minimax-plan',
     provider: 'minimax',
-    displayName: 'MiniMax',
-    tagline: 'MiniMax M-series via platform.minimax.io',
+    displayName: 'MiniMax Token Plan',
+    tagline: 'MiniMax M-series via Token Plan subscription',
     subscribeUrl: 'https://platform.minimax.io/subscribe/token-plan',
     apiKeyUrl:
       'https://platform.minimax.io/user-center/basic-information/interface-key',
-    helpText: 'Create one at platform.minimax.io → User Center → Interface key',
+    helpText:
+      'Token Plan keys start with sk-cp-. Subscribe at platform.minimax.io → Token Plan.',
+    apiKeyPattern: '^sk-cp-',
+    endpointHelpText:
+      'Token Plan keys are validated against the /v1/token_plan/remains endpoint. Both Global (api.minimax.io) and China (api.minimaxi.com) regions are auto-detected.',
     featuredModelIds: ['minimax-m3', 'minimax-m2.7'],
   },
   'mimo-plan': {

--- a/apps/browser/src/shared/coding-plans.ts
+++ b/apps/browser/src/shared/coding-plans.ts
@@ -94,7 +94,7 @@ export const CODING_PLANS: Record<CodingPlanId, CodingPlan> = {
       'Token Plan keys start with sk-cp-. Subscribe at platform.minimax.io → Token Plan.',
     apiKeyPattern: '^sk-cp-',
     endpointHelpText:
-      'Token Plan keys are validated against the /v1/token_plan/remains endpoint. Both Global (api.minimax.io) and China (api.minimaxi.com) regions are auto-detected.',
+      'Token Plan keys are validated against the /v1/token_plan/remains endpoint.',
     featuredModelIds: ['minimax-m3', 'minimax-m2.7'],
   },
   'mimo-plan': {

--- a/apps/browser/src/shared/karton-contracts/ui/shared-types.ts
+++ b/apps/browser/src/shared/karton-contracts/ui/shared-types.ts
@@ -226,7 +226,7 @@ export const PROVIDER_DISPLAY_INFO: Record<
     description: 'GLM models',
   },
   minimax: {
-    name: 'MiniMax',
+    name: 'MiniMax Pay-as-you-go',
     description: 'MiniMax M-series models',
   },
   'xiaomi-mimo': {

--- a/apps/browser/src/shared/karton-contracts/ui/shared-types.ts
+++ b/apps/browser/src/shared/karton-contracts/ui/shared-types.ts
@@ -226,7 +226,7 @@ export const PROVIDER_DISPLAY_INFO: Record<
     description: 'GLM models',
   },
   minimax: {
-    name: 'MiniMax Pay-as-you-go',
+    name: 'MiniMax',
     description: 'MiniMax M-series models',
   },
   'xiaomi-mimo': {

--- a/apps/browser/src/ui/screens/onboarding/steps/02-auth.tsx
+++ b/apps/browser/src/ui/screens/onboarding/steps/02-auth.tsx
@@ -381,8 +381,8 @@ export function StepAuth({
             )}
             {mode === 'coding-plan' && (
               <p className="text-muted-foreground text-sm">
-                Connect a GLM, Kimi, Qwen, or MiniMax coding plan to
-                authenticate.
+                Connect a GLM, Kimi, Qwen, MiniMax Token Plan, or MiMo
+                subscription to authenticate.
               </p>
             )}
           </div>


### PR DESCRIPTION
Adding token plan setup for Minimax authorization

Validate MiniMax Token Plan keys against the lightweight /v1/token_plan/remains quota endpoint with auto-detection of both Global (api.minimax.io) and China (api.minimaxi.com) regions, instead of the heavier chat-completion probe used for Pay-as-you-go keys.

Surface the two auth flows as separate entries in onboarding and settings: the Coding Plans lane renders a 'MiniMax Token Plan' card for sk-cp- prefixed keys, while the API Keys lane keeps 'MiniMax Pay-as-you-go' for direct-billed keys.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Separates MiniMax Token Plan from Pay‑as‑you‑go in auth and UI. Validates Token Plan keys via the lightweight Global quota endpoint for faster, more reliable checks.

- **New Features**
  - Added `validateMiniMaxTokenPlanKey` to probe https://api.minimax.io/v1/token_plan/remains using Bearer or `x-api-key`; removed region auto‑detection and the base URL return.
  - Split flows: Coding Plans shows “MiniMax Token Plan” for `sk-cp-` keys; API Keys keeps “MiniMax Pay‑as‑you‑go”; provider name stays “MiniMax” in model lists; updated `minimax-plan` help text, key pattern, and onboarding copy.

<sup>Written for commit 5b5cb5ae88e173ada9786862a70f933bf9d41218. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1366?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for validating MiniMax Token Plan API keys.
  * Updated MiniMax Token Plan UI details (name, help text, and onboarding messaging) to reflect Token Plan subscriptions.
* **Bug Fixes**
  * Fixed MiniMax Token Plan key verification to use the correct Token Plan remains endpoint and validation behavior.
  * Improved key format detection and clipboard guidance to align with the `sk-cp-` prefix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->