### PR TITLE
feat(stagewise): enable Turnstile token on stagewise:// via on-demand solver

### DIFF
--- a/apps/browser/src/ui/components/auth/sign-in-options-panel.tsx
+++ b/apps/browser/src/ui/components/auth/sign-in-options-panel.tsx
@@ -144,6 +144,8 @@ export function SignInOptionsPanel({
     error: turnstileError,
     enabled: turnstileEnabled,
     reset: resetTurnstile,
+    solveToken: solveTurnstileToken,
+    isSolverMode: turnstileSolverMode,
   } = useTurnstile();
 
   useEffect(() => {
@@ -243,18 +245,39 @@ export function SignInOptionsPanel({
 
   const handleSendOtp = useCallback(async () => {
     if (!email.trim()) return;
-    if (turnstileEnabled && !turnstileToken && !turnstileError) {
+    if (
+      turnstileEnabled &&
+      !turnstileSolverMode &&
+      !turnstileToken &&
+      !turnstileError
+    ) {
       void track(`${trackingPrefix}-otp-failed`, {
         error_kind: 'turnstile-not-ready',
       });
       setError('Security verification not ready. Please wait a moment.');
       return;
     }
-    void track(`${trackingPrefix}-otp-requested`);
     setError(null);
     setLoading(true);
+
+    // In solver mode (stagewise://), acquire the token on demand
+    let token = turnstileToken;
+    if (turnstileSolverMode) {
+      token = await solveTurnstileToken();
+      if (!token) {
+        void track(`${trackingPrefix}-otp-failed`, {
+          error_kind: 'turnstile-solve-failed',
+        });
+        setError('Security verification failed. Please try again.');
+        setLoading(false);
+        return;
+      }
+    }
+
+    void track(`${trackingPrefix}-otp-requested`);
+
     try {
-      const result = await sendOtp(email.trim(), turnstileToken ?? '');
+      const result = await sendOtp(email.trim(), token ?? '');
       if (result?.error) {
         void track(`${trackingPrefix}-otp-failed`, {
           error_kind: 'backend-error',
@@ -279,8 +302,10 @@ export function SignInOptionsPanel({
     sendOtp,
     track,
     trackingPrefix,
+    solveTurnstileToken,
     turnstileEnabled,
     turnstileError,
+    turnstileSolverMode,
     turnstileToken,
   ]);
 
@@ -470,7 +495,10 @@ export function SignInOptionsPanel({
             disabled={
               loading ||
               !email.trim() ||
-              (turnstileEnabled && !turnstileError && !turnstileToken)
+              (turnstileEnabled &&
+                !turnstileSolverMode &&
+                !turnstileError &&
+                !turnstileToken)
             }
           >
             {lastUsedMethod === 'email' && <LastUsedBadge />}

--- a/apps/browser/src/ui/hooks/use-turnstile.ts
+++ b/apps/browser/src/ui/hooks/use-turnstile.ts
@@ -32,20 +32,42 @@ const TURNSTILE_SITE_KEY = import.meta.env.VITE_TURNSTILE_SITE_KEY ?? '';
  * When `VITE_TURNSTILE_SITE_KEY` is not set, the hook is inert —
  * `enabled` is false and `token` stays null.
  *
- * Internal app pages run on the custom `stagewise://` scheme. Turnstile is
- * intentionally disabled there because custom-scheme origins are not reliable
- * challenge targets; OTP still goes through the backend auth flow without a
- * captcha token and surfaces any server-side rejection normally.
+ * On the custom `stagewise://` scheme, the widget cannot be rendered
+ * directly (custom-scheme origins are not reliable challenge targets).
+ * Instead, the hook delegates to `window.__solveTurnstile()` — a global
+ * solver registered by `turnstile-solver.ts` that renders an off-screen
+ * widget and returns the token on demand.
  */
 export function useTurnstile() {
+  const isSolverMode =
+    window.location.protocol === 'stagewise:' && !!TURNSTILE_SITE_KEY;
+  const enabled = !!TURNSTILE_SITE_KEY;
+
   const [token, setToken] = useState<string | null>(null);
-  const [ready, setReady] = useState(false);
+  const [ready, setReady] = useState(isSolverMode);
   const [error, setError] = useState(false);
   const widgetIdRef = useRef<string | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
 
-  const isUnsupportedOrigin = window.location.protocol === 'stagewise:';
-  const enabled = !!TURNSTILE_SITE_KEY && !isUnsupportedOrigin;
+  const solveToken = useCallback(async (): Promise<string | null> => {
+    if (!window.__solveTurnstile) {
+      setError(true);
+      return null;
+    }
+    try {
+      const solved = await window.__solveTurnstile();
+      if (!solved) {
+        setError(true);
+        return null;
+      }
+      setToken(solved);
+      setError(false);
+      return solved;
+    } catch {
+      setError(true);
+      return null;
+    }
+  }, []);
 
   const initWidget = useCallback(() => {
     if (!window.turnstile || !containerRef.current) return;
@@ -77,7 +99,7 @@ export function useTurnstile() {
   }, []);
 
   useEffect(() => {
-    if (!enabled) return;
+    if (!enabled || isSolverMode) return;
 
     let raf: number | undefined;
     let existingScript: Element | null = null;
@@ -131,7 +153,7 @@ export function useTurnstile() {
         widgetIdRef.current = null;
       }
     };
-  }, [enabled, initWidget]);
+  }, [enabled, isSolverMode, initWidget]);
 
   const reset = useCallback(() => {
     setToken(null);
@@ -141,5 +163,14 @@ export function useTurnstile() {
     }
   }, []);
 
-  return { containerRef, token, ready, error, enabled, reset };
+  return {
+    containerRef,
+    token,
+    ready,
+    error,
+    enabled,
+    reset,
+    solveToken,
+    isSolverMode,
+  };
 }


### PR DESCRIPTION
The in-app sign-in panel runs on the stagewise:// custom protocol where Cloudflare Turnstile widgets cannot render directly. Previously the useTurnstile hook disabled itself entirely on this origin, sending no captcha token — which would cause API rejections once CAPTCHA_ENFORCEMENT is set to enforce.

The hook now detects stagewise:// as solver mode and delegates to window.__solveTurnstile() (already registered by turnstile-solver.ts) to acquire a token on demand at submit time. This mirrors the captcha proxy pattern already used by the console webview.

Non-stagewise:// origins (http://localhost, etc.) continue to render the widget directly as before.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables Cloudflare Turnstile on `stagewise://` sign-in via an on-demand solver using `window.__solveTurnstile`, so OTP requests include a token and pass enforcement. Web origins still use the inline widget.

- **New Features**
  - `useTurnstile` detects `stagewise://`, sets `isSolverMode`, keeps `enabled` true, marks `ready` without injecting a widget, and exposes `solveToken()`.
  - Sign-in panel solves on submit in solver mode; tracks solve failures, shows a clear error, and sends OTP with the solved token.
  - Button disable logic skips the pre-fetched token requirement in solver mode.

<sup>Written for commit 71b257c5e900fb68b0d5bd44a8a41eb1e34e1c7c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1367?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled a faster Turnstile “solver mode” for email sign-in when using the Stagewise protocol.
  * OTP delivery can now request a Turnstile token on demand in solver mode.

* **Bug Fixes**
  * Prevents sending OTP codes until Turnstile is ready (or a solver token is successfully obtained).
  * Adds dedicated handling for Turnstile solve failures to stop invalid OTP requests.
  * Updates the “Send code” button availability to match the new solver-mode gating.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->