### PR TITLE
feat(stagewise): add model-restricted error UI with upgrade CTAs

### DIFF
--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/message-runtime-error.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/message-runtime-error.tsx
@@ -97,6 +97,16 @@ export function MessageRuntimeError({
     );
   }
 
+  if (error.kind === 'model-restricted') {
+    return (
+      <ModelRestrictedError
+        error={error}
+        canRetry={canShowRetry}
+        onRetry={onRetry}
+      />
+    );
+  }
+
   if (error.kind === 'waiting-for-connection') {
     return (
       <WaitingForConnectionError
@@ -191,6 +201,78 @@ function PlanLimitExceededError({
             onClick={() => void openExternalUrl(ctaHref)}
           >
             {ctaLabel}
+            <ArrowUpRightIcon className="size-3" />
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Shows a card when a free-tier user tries to use a model that is not on
+ * the free-tier whitelist and they have no prepaid credits. Offers CTAs to
+ * upgrade the plan or configure BYOK API keys.
+ */
+function ModelRestrictedError({
+  error,
+  canRetry,
+  onRetry,
+}: {
+  error: Extract<AgentRuntimeError, { kind: 'model-restricted' }>;
+  canRetry: boolean;
+  onRetry: () => void;
+}) {
+  const openSettings = useKartonProcedure((p) => p.appScreen.openSettings);
+  const openExternalUrl = useKartonProcedure((p) => p.openExternalUrl);
+
+  const modelName = useMemo(() => {
+    if (!error.model) return null;
+    // Strip the provider prefix to get the bare model ID for lookup
+    const bareId = error.model.includes('/')
+      ? error.model.split('/').slice(1).join('/')
+      : error.model;
+    const m = getAvailableModel(bareId);
+    return m?.modelDisplayName ?? null;
+  }, [error.model]);
+
+  const planLabel = error.plan ?? 'free';
+  const heading = modelName
+    ? `${modelName} is not available on the ${planLabel} plan`
+    : `Model not available on the ${planLabel} plan`;
+
+  return (
+    <div className="mt-6 flex w-full flex-col gap-1.5 rounded-lg border border-derived-strong p-2 text-sm">
+      <span className="font-medium text-foreground">{heading}</span>
+
+      <div className="text-foreground">
+        This model is only accessible via BYOK or a Pro plan. Get your plan or
+        configure your own API key.
+      </div>
+
+      <div className="flex flex-row items-center justify-between gap-2 pt-1">
+        <div>
+          {canRetry && (
+            <Button variant="ghost" size="xs" onClick={onRetry}>
+              <RefreshCcwIcon className="size-3" />
+              Retry
+            </Button>
+          )}
+        </div>
+        <div className="flex flex-row justify-end gap-2">
+          <Button
+            variant="ghost"
+            size="xs"
+            onClick={() => void openSettings({ section: 'models-providers' })}
+          >
+            Configure other API keys
+          </Button>
+          <Button
+            variant="primary"
+            size="xs"
+            onClick={() => void openExternalUrl(consoleUrl)}
+          >
+            Upgrade plan
             <ArrowUpRightIcon className="size-3" />
           </Button>
         </div>

--- a/packages/agent-core/src/agents/base-agent.ts
+++ b/packages/agent-core/src/agents/base-agent.ts
@@ -1791,9 +1791,19 @@ export abstract class BaseAgent<
             exceeded_window_count: sortedWindows.length,
           });
         }
+        const parsedModelRestricted = this.parseModelRestrictedError(error);
+        if (parsedModelRestricted?.kind === 'model-restricted') {
+          this.host.telemetry?.capture('model-restricted', {
+            agent_type: this.agentType,
+            model_id: stepModelId,
+            provider_mode: this._stepProviderMode,
+            plan: parsedModelRestricted.plan ?? 'unknown',
+          });
+        }
         const parsedProviderError = this.parseProviderError(error);
         const parsedOverloadBase =
           parsedPlanLimit ||
+          parsedModelRestricted ||
           this.isZaiBillingOrQuotaError(
             parsedProviderError,
             modelWithOptions.reasoningSignatureSource,
@@ -1821,16 +1831,17 @@ export abstract class BaseAgent<
         }
         this.state.commands.recordStepError({
           error: parsedPlanLimit ??
+            parsedModelRestricted ??
             parsedOverload ?? {
               message: `LLM provider error: ${parsedProviderError?.message ?? error.message}`,
               stack: error.stack,
             },
           markUnread: 'mark-unread',
         });
-        // Plan-limit errors surface their own dedicated UI affordance, so
-        // we suppress the generic error notification in that case (matches
-        // the browser host's pre-extraction behavior).
-        if (!parsedPlanLimit) {
+        // Plan-limit and model-restricted errors surface their own dedicated
+        // UI affordance, so we suppress the generic error notification in
+        // those cases (matches the browser host's pre-extraction behavior).
+        if (!parsedPlanLimit && !parsedModelRestricted) {
           this.emitNotificationEvent('error');
         }
         this.host.logger.debug(
@@ -3065,6 +3076,30 @@ export abstract class BaseAgent<
         message: body.message ?? 'Usage limit exceeded',
         plan,
         exceededWindows,
+      };
+    } catch {
+      return null;
+    }
+  }
+
+  private parseModelRestrictedError(error: Error): AgentRuntimeError | null {
+    const frame = BaseAgent.unwrapApiErrorFrame(error);
+    const rawBody = frame.responseBody;
+    if (typeof rawBody !== 'string') return null;
+    try {
+      const body = JSON.parse(rawBody);
+      if (body?.error !== 'MODEL_RESTRICTED') return null;
+      const model =
+        typeof body.details?.model === 'string'
+          ? body.details.model
+          : undefined;
+      const plan =
+        typeof body.details?.plan === 'string' ? body.details.plan : undefined;
+      return {
+        kind: 'model-restricted',
+        message: body.message ?? 'This model is not available on your plan',
+        model,
+        plan,
       };
     } catch {
       return null;

--- a/packages/agent-core/src/services/agent-manager/agent-manager.ts
+++ b/packages/agent-core/src/services/agent-manager/agent-manager.ts
@@ -91,6 +91,7 @@ function getNetworkRetryableErrorMessage(
 ): string | null {
   if (!error) return null;
   if (error.kind === 'plan-limit-exceeded') return null;
+  if (error.kind === 'model-restricted') return null;
   if (error.kind === 'upstream-overload') return null;
   if (error.kind === 'waiting-for-connection') return error.originalMessage;
 

--- a/packages/agent-core/src/types/agent.ts
+++ b/packages/agent-core/src/types/agent.ts
@@ -33,6 +33,12 @@ export type AgentRuntimeError =
       exceededWindows: ExceededWindow[];
     }
   | {
+      kind: 'model-restricted';
+      message: string;
+      model?: string;
+      plan?: string;
+    }
+  | {
       kind: 'upstream-overload';
       message: string;
       providerName?: string;


### PR DESCRIPTION
Add a model-restricted kind to AgentRuntimeError and a dedicated error card in the chat UI that shows when a free-tier user hits the backend model whitelist. The card offers CTAs to upgrade the plan or configure BYOK API keys. Network retries are suppressed for this permanent auth failure.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new model-restricted error and a dedicated chat error card that prompts users to upgrade or add BYOK keys when they try to use a restricted model. Suppresses auto-retries and generic error toasts for this permanent failure.

- **New Features**
  - Added `model-restricted` to `AgentRuntimeError` with optional `model` and `plan`.
  - Parse `MODEL_RESTRICTED` backend responses in `BaseAgent`, capture `model-restricted` telemetry, and surface the structured error.
  - Render a ModelRestrictedError card in chat with CTAs: Upgrade plan and Configure API keys; shows Retry only when allowed and includes model/plan details when available.
  - Suppress network retries and generic error notifications for `model-restricted` errors.

<sup>Written for commit ca94289949c8ece98b5aa410ffcc85305cc73682. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1375?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

