### PR TITLE
Email via console

### DIFF
--- a/apps/browser/src/backend/services/auth/callback-scheme.ts
+++ b/apps/browser/src/backend/services/auth/callback-scheme.ts
@@ -24,3 +24,20 @@ function getDefaultAuthCallbackScheme(): AuthCallbackScheme {
 export const AUTH_CALLBACK_SCHEME = getDefaultAuthCallbackScheme();
 
 export const AUTH_CALLBACK_PROTOCOL = `${AUTH_CALLBACK_SCHEME}:`;
+
+// All valid stagewise callback protocols. The URIHandlerService registers
+// both the stable `stagewise` scheme and the build's own scheme, so the app
+// may receive callbacks on either protocol — e.g. a dev build sends
+// `callback_scheme=stagewise-dev` to the console, but the console's
+// allowlist may fall back to `stagewise://`, which the OS still routes to
+// this app. handleAuthCallbackUrl must accept any of these.
+const ALL_CALLBACK_SCHEMES: readonly AuthCallbackScheme[] = [
+  'stagewise',
+  'stagewise-prerelease',
+  'stagewise-nightly',
+  'stagewise-dev',
+];
+
+export const ALL_CALLBACK_PROTOCOLS = new Set(
+  ALL_CALLBACK_SCHEMES.map((s) => `${s}:`),
+);

--- a/apps/browser/src/backend/services/auth/index.ts
+++ b/apps/browser/src/backend/services/auth/index.ts
@@ -9,6 +9,7 @@ import {
   AuthServerInterop,
   createBetterAuthClient,
   openSocialAuthInSystemBrowser,
+  openEmailAuthInSystemBrowser,
   type BetterAuthClient,
 } from './server-interop';
 import type { SocialAuthProvider } from '@shared/karton-contracts/ui/shared-types';
@@ -64,7 +65,7 @@ export class AuthService extends DisposableService {
 
   private _refreshInterval: NodeJS.Timeout | null = null;
   private authChangeCallbacks: ((newAuthState: AuthState) => void)[] = [];
-  private pendingSocialAuth: {
+  private pendingHandoffAuth: {
     resolve: (result: { error?: string }) => void;
     timeout: NodeJS.Timeout;
   } | null = null;
@@ -162,6 +163,13 @@ export class AuthService extends DisposableService {
     );
 
     this.uiKarton.registerServerProcedureHandler(
+      'userAccount.signInEmail',
+      async (_callingClientId: string) => {
+        return this.signInEmail();
+      },
+    );
+
+    this.uiKarton.registerServerProcedureHandler(
       'userAccount.logout',
       async (_callingClientId: string) => {
         await this.logout();
@@ -206,8 +214,8 @@ export class AuthService extends DisposableService {
       this._refreshInterval = null;
     }
 
-    await this.cancelPendingSocialAuth({
-      error: 'Social sign-in was cancelled.',
+    await this.cancelPendingHandoffAuth({
+      error: 'Sign-in was cancelled.',
     });
 
     await this.disposeActiveLoopbackAuthServer();
@@ -215,6 +223,7 @@ export class AuthService extends DisposableService {
     this.uiKarton.removeServerProcedureHandler('userAccount.sendOtp');
     this.uiKarton.removeServerProcedureHandler('userAccount.verifyOtp');
     this.uiKarton.removeServerProcedureHandler('userAccount.signInSocial');
+    this.uiKarton.removeServerProcedureHandler('userAccount.signInEmail');
     this.uiKarton.removeServerProcedureHandler('userAccount.logout');
     this.uiKarton.removeServerProcedureHandler('userAccount.refreshStatus');
     this.uiKarton.removeServerProcedureHandler('userAccount.validateApiKeys');
@@ -305,22 +314,22 @@ export class AuthService extends DisposableService {
     }
   }
 
-  private completePendingSocialAuth(result: { error?: string }): void {
-    if (!this.pendingSocialAuth) return;
-    clearTimeout(this.pendingSocialAuth.timeout);
-    const { resolve } = this.pendingSocialAuth;
-    this.pendingSocialAuth = null;
+  private completePendingHandoffAuth(result: { error?: string }): void {
+    if (!this.pendingHandoffAuth) return;
+    clearTimeout(this.pendingHandoffAuth.timeout);
+    const { resolve } = this.pendingHandoffAuth;
+    this.pendingHandoffAuth = null;
     void this.disposeActiveLoopbackAuthServer();
     resolve(result);
   }
 
-  private async cancelPendingSocialAuth(result: {
+  private async cancelPendingHandoffAuth(result: {
     error?: string;
   }): Promise<void> {
-    if (!this.pendingSocialAuth) return;
-    clearTimeout(this.pendingSocialAuth.timeout);
-    const { resolve } = this.pendingSocialAuth;
-    this.pendingSocialAuth = null;
+    if (!this.pendingHandoffAuth) return;
+    clearTimeout(this.pendingHandoffAuth.timeout);
+    const { resolve } = this.pendingHandoffAuth;
+    this.pendingHandoffAuth = null;
     await this.disposeActiveLoopbackAuthServer();
     resolve(result);
   }
@@ -370,8 +379,8 @@ export class AuthService extends DisposableService {
       parsed.hash.startsWith('#token=');
 
     if (!isAuthCallback) return false;
-    if (!this.pendingSocialAuth) return false;
-    const currentPending = this.pendingSocialAuth;
+    if (!this.pendingHandoffAuth) return false;
+    const currentPending = this.pendingHandoffAuth;
 
     const fragmentParams = new URLSearchParams(parsed.hash.slice(1));
     const callbackError =
@@ -384,7 +393,7 @@ export class AuthService extends DisposableService {
       this.logger.error(
         `[AuthService] Social sign-in failed: ${callbackError}`,
       );
-      this.completePendingSocialAuth({ error: callbackError });
+      this.completePendingHandoffAuth({ error: callbackError });
       return true;
     }
 
@@ -392,30 +401,30 @@ export class AuthService extends DisposableService {
       fragmentParams.get('token') ?? parsed.searchParams.get('token');
 
     if (!token) {
-      const message = 'Social sign-in callback did not include a token.';
+      const message = 'Sign-in callback did not include a token.';
       this.logger.error(`[AuthService] ${message}`);
-      this.completePendingSocialAuth({ error: message });
+      this.completePendingHandoffAuth({ error: message });
       return true;
     }
 
     try {
       const { data, error } = await this.authClient.authenticate({ token });
-      if (this.pendingSocialAuth !== currentPending) {
+      if (this.pendingHandoffAuth !== currentPending) {
         this.logger.debug(
-          '[AuthService] Ignoring stale social sign-in callback after authentication',
+          '[AuthService] Ignoring stale sign-in callback after authentication',
         );
         return true;
       }
       if (error || !data?.token) {
-        const message = error?.message ?? 'Social sign-in failed.';
-        this.logger.error(`[AuthService] Social sign-in failed: ${message}`);
-        if (this.pendingSocialAuth !== currentPending) {
+        const message = error?.message ?? 'Sign-in failed.';
+        this.logger.error(`[AuthService] Sign-in failed: ${message}`);
+        if (this.pendingHandoffAuth !== currentPending) {
           this.logger.debug(
-            '[AuthService] Ignoring stale social sign-in failure after authentication',
+            '[AuthService] Ignoring stale sign-in failure after authentication',
           );
           return true;
         }
-        this.completePendingSocialAuth({ error: message });
+        this.completePendingHandoffAuth({ error: message });
         return true;
       }
 
@@ -437,11 +446,11 @@ export class AuthService extends DisposableService {
         };
       });
 
-      this.logger.debug('[AuthService] Completed social sign-in callback');
-      this.completePendingSocialAuth({});
+      this.logger.debug('[AuthService] Completed sign-in callback');
+      this.completePendingHandoffAuth({});
       void this.refreshSession().catch((refreshError) => {
         this.logger.warn(
-          `[AuthService] Session refresh after social sign-in failed: ${refreshError}`,
+          `[AuthService] Session refresh after sign-in failed: ${refreshError}`,
         );
       });
       return true;
@@ -449,14 +458,14 @@ export class AuthService extends DisposableService {
       this.logger.error(
         `[AuthService] Unexpected error handling auth callback: ${err}`,
       );
-      if (this.pendingSocialAuth !== currentPending) {
+      if (this.pendingHandoffAuth !== currentPending) {
         this.logger.debug(
-          '[AuthService] Ignoring stale social sign-in error after callback failure',
+          '[AuthService] Ignoring stale sign-in error after callback failure',
         );
         return true;
       }
-      this.completePendingSocialAuth({
-        error: 'Failed to complete social sign-in.',
+      this.completePendingHandoffAuth({
+        error: 'Failed to complete sign-in.',
       });
       return true;
     }
@@ -465,23 +474,23 @@ export class AuthService extends DisposableService {
   public async signInSocial(
     provider: SocialAuthProvider,
   ): Promise<{ error?: string }> {
-    if (this.pendingSocialAuth) {
+    if (this.pendingHandoffAuth) {
       this.logger.debug(
-        '[AuthService] Cancelling previous social sign-in before starting a new one',
+        '[AuthService] Cancelling previous sign-in before starting a new one',
       );
-      await this.cancelPendingSocialAuth({
-        error: 'Social sign-in was cancelled.',
+      await this.cancelPendingHandoffAuth({
+        error: 'Sign-in was cancelled.',
       });
     }
 
     const completion = new Promise<{ error?: string }>((resolve) => {
       const timeout = setTimeout(() => {
-        this.pendingSocialAuth = null;
+        this.pendingHandoffAuth = null;
         void this.disposeActiveLoopbackAuthServer();
         resolve({ error: 'Social sign-in timed out.' });
       }, SOCIAL_AUTH_TIMEOUT_MS);
 
-      this.pendingSocialAuth = { resolve, timeout };
+      this.pendingHandoffAuth = { resolve, timeout };
     });
 
     try {
@@ -504,8 +513,46 @@ export class AuthService extends DisposableService {
       this.logger.error(
         `[AuthService] Unexpected error during social sign-in: ${err}`,
       );
-      this.completePendingSocialAuth({
+      this.completePendingHandoffAuth({
         error: 'Failed to complete social sign-in.',
+      });
+      return await completion;
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Email sign-in via console (desktop handoff)
+  // ---------------------------------------------------------------------------
+
+  public async signInEmail(): Promise<{ error?: string }> {
+    if (this.pendingHandoffAuth) {
+      this.logger.debug(
+        '[AuthService] Cancelling previous sign-in before starting email sign-in',
+      );
+      await this.cancelPendingHandoffAuth({
+        error: 'Sign-in was cancelled.',
+      });
+    }
+
+    const completion = new Promise<{ error?: string }>((resolve) => {
+      const timeout = setTimeout(() => {
+        this.pendingHandoffAuth = null;
+        resolve({ error: 'Email sign-in timed out.' });
+      }, SOCIAL_AUTH_TIMEOUT_MS);
+
+      this.pendingHandoffAuth = { resolve, timeout };
+    });
+
+    try {
+      this.logger.debug('[AuthService] Starting email sign-in via console');
+      await openEmailAuthInSystemBrowser();
+      return await completion;
+    } catch (err) {
+      this.logger.error(
+        `[AuthService] Unexpected error during email sign-in: ${err}`,
+      );
+      this.completePendingHandoffAuth({
+        error: 'Failed to open email sign-in.',
       });
       return await completion;
     }

--- a/apps/browser/src/backend/services/auth/index.ts
+++ b/apps/browser/src/backend/services/auth/index.ts
@@ -13,7 +13,7 @@ import {
   type BetterAuthClient,
 } from './server-interop';
 import type { SocialAuthProvider } from '@shared/karton-contracts/ui/shared-types';
-import { AUTH_CALLBACK_PROTOCOL } from './callback-scheme';
+import { ALL_CALLBACK_PROTOCOLS } from './callback-scheme';
 import {
   createDevLoopbackAuthServer,
   type DevLoopbackAuthServer,
@@ -365,7 +365,10 @@ export class AuthService extends DisposableService {
       parsed.host === activeLoopbackCallback.host &&
       parsed.pathname === activeLoopbackCallback.pathname;
 
-    if (parsed.protocol !== AUTH_CALLBACK_PROTOCOL && !isLoopbackCallback) {
+    if (!ALL_CALLBACK_PROTOCOLS.has(parsed.protocol) && !isLoopbackCallback) {
+      this.logger.warn(
+        `[AuthService] Auth callback protocol mismatch: got ${parsed.protocol}, expected one of ${[...ALL_CALLBACK_PROTOCOLS].join(', ')}`,
+      );
       return false;
     }
 
@@ -378,8 +381,12 @@ export class AuthService extends DisposableService {
       parsed.searchParams.has('error') ||
       parsed.hash.startsWith('#token=');
 
-    if (!isAuthCallback) return false;
-    if (!this.pendingHandoffAuth) return false;
+    if (!isAuthCallback) {
+      return false;
+    }
+    if (!this.pendingHandoffAuth) {
+      return false;
+    }
     const currentPending = this.pendingHandoffAuth;
 
     const fragmentParams = new URLSearchParams(parsed.hash.slice(1));
@@ -546,7 +553,8 @@ export class AuthService extends DisposableService {
     try {
       this.logger.debug('[AuthService] Starting email sign-in via console');
       await openEmailAuthInSystemBrowser();
-      return await completion;
+      const result = await completion;
+      return result;
     } catch (err) {
       this.logger.error(
         `[AuthService] Unexpected error during email sign-in: ${err}`,

--- a/apps/browser/src/backend/services/auth/server-interop.ts
+++ b/apps/browser/src/backend/services/auth/server-interop.ts
@@ -13,6 +13,8 @@ import type {
 import type { SocialAuthProvider } from '@shared/karton-contracts/ui/shared-types';
 
 export const API_URL = process.env.API_URL || 'https://api.stagewise.io';
+const CONSOLE_URL =
+  process.env.STAGEWISE_CONSOLE_URL || 'https://console.stagewise.io';
 const ELECTRON_CLIENT_ID = 'electron';
 const STAGEWISE_PRODUCTION_API_ORIGIN = 'https://api.stagewise.io';
 const STABLE_AUTH_CALLBACK_SCHEME = 'stagewise';
@@ -104,6 +106,43 @@ export async function openSocialAuthInSystemBrowser(
   } else {
     url.searchParams.set('callback_scheme', redirectTarget.scheme);
   }
+
+  try {
+    await shell.openExternal(url.toString(), { activate: true });
+  } catch (error) {
+    authStore.delete(state);
+    throw error;
+  }
+}
+
+/**
+ * Opens the system browser to the console login page for email sign-in.
+ *
+ * This follows the same PKCE pattern as `openSocialAuthInSystemBrowser`:
+ * generates a code verifier/challenge, stores the verifier in the
+ * `@better-auth/electron` global store, and opens the console with the
+ * PKCE params in the query string. The console completes the email OTP
+ * flow on a valid origin (where Turnstile works), then redirects back
+ * to the app's callback scheme (e.g. `stagewise://`, `stagewise-nightly://`)
+ * with the electron handoff token.
+ */
+export async function openEmailAuthInSystemBrowser(): Promise<void> {
+  const state = createBase64UrlRandomString(16);
+  const codeVerifier = createBase64UrlRandomString(32);
+  const codeChallenge = createHash('sha256')
+    .update(codeVerifier)
+    .digest('base64url');
+
+  const authStore = getElectronAuthStore();
+  authStore.set(state, codeVerifier);
+
+  const url = new URL(`${CONSOLE_URL}/login`);
+  url.searchParams.set('client_id', ELECTRON_CLIENT_ID);
+  url.searchParams.set('code_challenge', codeChallenge);
+  url.searchParams.set('code_challenge_method', 'S256');
+  url.searchParams.set('state', state);
+  url.searchParams.set('callback_scheme', API_AUTH_CALLBACK_SCHEME);
+  url.searchParams.set('desktop_email', '1');
 
   try {
     await shell.openExternal(url.toString(), { activate: true });

--- a/apps/browser/src/shared/karton-contracts/ui/index.ts
+++ b/apps/browser/src/shared/karton-contracts/ui/index.ts
@@ -1468,6 +1468,7 @@ export type KartonContract = {
       signInSocial: (
         provider: SocialAuthProvider,
       ) => Promise<{ error?: string }>;
+      signInEmail: () => Promise<{ error?: string }>;
       refreshStatus: () => Promise<void>;
       logout: () => Promise<void>;
       /** Get current usage stats */

--- a/apps/browser/src/ui/components/auth/sign-in-options-panel.tsx
+++ b/apps/browser/src/ui/components/auth/sign-in-options-panel.tsx
@@ -32,6 +32,7 @@ export type SignInOptionsPanelProps = {
   ) => Promise<{ error?: string }>;
   verifyOtp: (email: string, code: string) => Promise<{ error?: string }>;
   signInSocial: (provider: SocialAuthProvider) => Promise<{ error?: string }>;
+  signInEmail: () => Promise<{ error?: string }>;
   onUseApiKeys: () => void;
   onUseSubscription: () => void;
   trackingPrefix: TrackingPrefix;
@@ -41,12 +42,16 @@ export type SignInOptionsPanelProps = {
 };
 
 const LAST_USED_SIGN_IN_METHOD_KEY = 'stagewise:last-used-sign-in-method';
-function getSocialProviderLabel(provider: SocialAuthProvider | null) {
+function getHandoffProviderLabel(
+  provider: SocialAuthProvider | 'email' | null,
+) {
   switch (provider) {
     case 'google':
       return 'Google';
     case 'github':
       return 'GitHub';
+    case 'email':
+      return 'Email';
     default:
       return 'your provider';
   }
@@ -115,6 +120,7 @@ export function SignInOptionsPanel({
   sendOtp,
   verifyOtp,
   signInSocial,
+  signInEmail,
   onUseApiKeys,
   onUseSubscription,
   trackingPrefix,
@@ -127,9 +133,9 @@ export function SignInOptionsPanel({
   const [code, setCode] = useState('');
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
-  const [socialLoading, setSocialLoading] = useState<SocialAuthProvider | null>(
-    null,
-  );
+  const [socialLoading, setSocialLoading] = useState<
+    SocialAuthProvider | 'email' | null
+  >(null);
   const [lastUsedMethod, setLastUsedMethod] = useState<SignInMethod | null>(
     null,
   );
@@ -242,6 +248,54 @@ export function SignInOptionsPanel({
       trackingPrefix,
     ],
   );
+
+  const handleEmailSignIn = useCallback(async () => {
+    if (loading) return;
+    const requestId = socialRequestIdRef.current + 1;
+    socialRequestIdRef.current = requestId;
+    setError(null);
+    setSocialLoading('email');
+    setPhase('social');
+    rememberSignInMethod('email');
+    void track(`${trackingPrefix}-email-handoff-requested`);
+    try {
+      const result = await signInEmail();
+      if (result?.error) {
+        if (socialRequestIdRef.current !== requestId) return;
+        void track(`${trackingPrefix}-method-failed`, {
+          auth_method: 'stagewise',
+          provider: 'email',
+          error_kind: 'backend-error',
+        });
+        clearRememberedSignInMethod();
+        setSocialLoading(null);
+        setError(result.error);
+        return;
+      }
+      if (!socialAuthMountedRef.current) return;
+      setSocialLoading(null);
+      void track(`${trackingPrefix}-email-handoff-verified`);
+      onAuthenticated?.('email');
+    } catch {
+      if (socialRequestIdRef.current !== requestId) return;
+      void track(`${trackingPrefix}-method-failed`, {
+        auth_method: 'stagewise',
+        provider: 'email',
+        error_kind: 'network-error',
+      });
+      clearRememberedSignInMethod();
+      setSocialLoading(null);
+      setError('Failed to complete email sign-in.');
+    }
+  }, [
+    clearRememberedSignInMethod,
+    loading,
+    onAuthenticated,
+    rememberSignInMethod,
+    signInEmail,
+    track,
+    trackingPrefix,
+  ]);
 
   const handleSendOtp = useCallback(async () => {
     if (!email.trim()) return;
@@ -357,7 +411,7 @@ export function SignInOptionsPanel({
       : phase === 'otp'
         ? `We sent a code to ${email}. Enter it below.`
         : phase === 'social'
-          ? `Please finish signing in with ${getSocialProviderLabel(socialLoading)} in your browser, then return to stagewise.`
+          ? `Please finish signing in with ${getHandoffProviderLabel(socialLoading)} in your browser, then return to stagewise.`
           : description;
 
   return (
@@ -427,10 +481,7 @@ export function SignInOptionsPanel({
               variant="secondary"
               size="sm"
               className="relative w-full overflow-visible"
-              onClick={() => {
-                setPhase('email');
-                setError(null);
-              }}
+              onClick={() => void handleEmailSignIn()}
               disabled={loading}
             >
               {lastUsedMethod === 'email' && <LastUsedBadge />}

--- a/apps/browser/src/ui/components/auth/sign-in-options-panel.tsx
+++ b/apps/browser/src/ui/components/auth/sign-in-options-panel.tsx
@@ -6,6 +6,7 @@ import { GithubMark } from '@ui/components/icons/github-mark';
 import { GoogleLogo } from '@ui/components/provider-logos/google';
 import { ProviderLogo } from '@ui/components/provider-logos';
 import { IconEnvelopeOutline18, IconKey2Outline18 } from 'nucleo-ui-outline-18';
+import { Loader2Icon } from 'lucide-react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { cn } from '@stagewise/stage-ui/lib/utils';
 import type { SocialAuthProvider } from '@shared/karton-contracts/ui/shared-types';
@@ -574,7 +575,15 @@ export function SignInOptionsPanel({
       )}
 
       {phase === 'social' && (
-        <div className="app-no-drag grid w-full max-w-sm gap-3">
+        <div className="app-no-drag grid w-full max-w-sm gap-6">
+          {socialLoading && (
+            <div className="flex flex-col items-center gap-3 py-4">
+              <Loader2Icon className="size-5 animate-spin text-muted-foreground" />
+              <p className="text-center text-muted-foreground text-sm">
+                Waiting for you to complete sign-in in your browser…
+              </p>
+            </div>
+          )}
           <Button
             variant="ghost"
             size="xs"
@@ -584,6 +593,7 @@ export function SignInOptionsPanel({
               setPhase('options');
               setError(null);
             }}
+            disabled={loading}
           >
             Back to sign-in options
           </Button>

--- a/apps/browser/src/ui/screens/onboarding/steps/02-auth.tsx
+++ b/apps/browser/src/ui/screens/onboarding/steps/02-auth.tsx
@@ -86,6 +86,7 @@ export function StepAuth({
   const sendOtp = useKartonProcedure((p) => p.userAccount.sendOtp);
   const verifyOtp = useKartonProcedure((p) => p.userAccount.verifyOtp);
   const signInSocial = useKartonProcedure((p) => p.userAccount.signInSocial);
+  const signInEmail = useKartonProcedure((p) => p.userAccount.signInEmail);
   const disconnectProvider = useKartonProcedure(
     (p) => p.preferences.disconnectProvider,
   );
@@ -382,6 +383,7 @@ export function StepAuth({
           sendOtp={(email, token) => sendOtp(email, token ?? '')}
           verifyOtp={verifyOtp}
           signInSocial={signInSocial}
+          signInEmail={signInEmail}
           trackingPrefix="onboarding-auth"
           track={track}
           onUseApiKeys={() => switchMode('api-keys')}

--- a/apps/browser/src/ui/screens/onboarding/steps/02-auth.tsx
+++ b/apps/browser/src/ui/screens/onboarding/steps/02-auth.tsx
@@ -85,8 +85,18 @@ export function StepAuth({
 }) {
   const sendOtp = useKartonProcedure((p) => p.userAccount.sendOtp);
   const verifyOtp = useKartonProcedure((p) => p.userAccount.verifyOtp);
-  const signInSocial = useKartonProcedure((p) => p.userAccount.signInSocial);
-  const signInEmail = useKartonProcedure((p) => p.userAccount.signInEmail);
+  // Auth handoff procedures wait for OS callbacks (system browser → OAuth/OTP
+  // → redirect). The default 30s RPC timeout kills these before the user
+  // finishes. Extend to match the backend's 5-min app-level timeout plus a
+  // buffer so the backend's own timeout (with a proper error message) fires
+  // first, rather than the generic RPC "connection lost" rejection.
+  const AUTH_RPC_TIMEOUT_MS = (5 * 60 + 10) * 1000; // 5 min 10 sec
+  const signInSocial = useKartonProcedure((p) =>
+    p.userAccount.signInSocial.withTimeout(AUTH_RPC_TIMEOUT_MS),
+  );
+  const signInEmail = useKartonProcedure((p) =>
+    p.userAccount.signInEmail.withTimeout(AUTH_RPC_TIMEOUT_MS),
+  );
   const disconnectProvider = useKartonProcedure(
     (p) => p.preferences.disconnectProvider,
   );

--- a/apps/browser/src/ui/screens/settings/sections/account-section.tsx
+++ b/apps/browser/src/ui/screens/settings/sections/account-section.tsx
@@ -18,6 +18,7 @@ export function AccountSection() {
   const sendOtp = useKartonProcedure((p) => p.userAccount.sendOtp);
   const verifyOtp = useKartonProcedure((p) => p.userAccount.verifyOtp);
   const signInSocial = useKartonProcedure((p) => p.userAccount.signInSocial);
+  const signInEmail = useKartonProcedure((p) => p.userAccount.signInEmail);
   const logout = useKartonProcedure((p) => p.userAccount.logout);
   const openSettings = useKartonProcedure((p) => p.appScreen.openSettings);
   // `useTrack` swallows RPC errors so a failed telemetry capture (e.g.
@@ -68,6 +69,7 @@ export function AccountSection() {
               sendOtp={(email, token) => sendOtp(email, token ?? '')}
               verifyOtp={verifyOtp}
               signInSocial={signInSocial}
+              signInEmail={signInEmail}
               trackingPrefix="account-auth"
               track={track}
               onUseApiKeys={() =>

--- a/apps/browser/src/ui/screens/settings/sections/account-section.tsx
+++ b/apps/browser/src/ui/screens/settings/sections/account-section.tsx
@@ -17,8 +17,15 @@ export function AccountSection() {
   const userAccount = useKartonState((s) => s.userAccount);
   const sendOtp = useKartonProcedure((p) => p.userAccount.sendOtp);
   const verifyOtp = useKartonProcedure((p) => p.userAccount.verifyOtp);
-  const signInSocial = useKartonProcedure((p) => p.userAccount.signInSocial);
-  const signInEmail = useKartonProcedure((p) => p.userAccount.signInEmail);
+  // Auth handoff procedures wait for OS callbacks — see 02-auth.tsx for
+  // rationale on the extended RPC timeout.
+  const AUTH_RPC_TIMEOUT_MS = (5 * 60 + 10) * 1000; // 5 min 10 sec
+  const signInSocial = useKartonProcedure((p) =>
+    p.userAccount.signInSocial.withTimeout(AUTH_RPC_TIMEOUT_MS),
+  );
+  const signInEmail = useKartonProcedure((p) =>
+    p.userAccount.signInEmail.withTimeout(AUTH_RPC_TIMEOUT_MS),
+  );
   const logout = useKartonProcedure((p) => p.userAccount.logout);
   const openSettings = useKartonProcedure((p) => p.appScreen.openSettings);
   // `useTrack` swallows RPC errors so a failed telemetry capture (e.g.

--- a/packages/karton/src/shared/procedure-proxy.ts
+++ b/packages/karton/src/shared/procedure-proxy.ts
@@ -18,6 +18,10 @@ export function createProcedureProxy(
   // produces a brand-new Proxy, breaking useMemo/useEffect dependency
   // checks and causing infinite render loops.
   const childCache = new Map<string | symbol, any>();
+  // Cache for .withTimeout(ms) results, keyed by timeout duration.
+  // This ensures repeated calls like `proc.withTimeout(310_000)` return
+  // the same proxy reference, preserving useMemo/useCallback stability.
+  const timeoutCache = new Map<number, any>();
 
   return new Proxy(() => {}, {
     get(_target, prop) {
@@ -41,6 +45,20 @@ export function createProcedureProxy(
           ...options,
           fireAndForget: true,
         });
+      } else if (prop === 'withTimeout') {
+        // .withTimeout(ms) returns a proxy variant with a custom RPC timeout.
+        // Called as: procedure.withTimeout(60_000)(args)
+        // Results are cached per-ms so repeated calls return stable references.
+        child = (ms: number) => {
+          const existing = timeoutCache.get(ms);
+          if (existing !== undefined) return existing;
+          const proxied = createProcedureProxy(call, path, {
+            ...options,
+            timeout: ms,
+          });
+          timeoutCache.set(ms, proxied);
+          return proxied;
+        };
       } else {
         const newPath = path ? `${path}.${String(prop)}` : String(prop);
         child = createProcedureProxy(call, newPath, options);

--- a/packages/karton/src/shared/types.ts
+++ b/packages/karton/src/shared/types.ts
@@ -187,13 +187,23 @@ export type KartonState<T> = T extends { state: infer S } ? S : never;
 export type AsyncFunction = (...args: any[]) => Promise<any>;
 
 /**
- * Augments procedure types with a `.fire` accessor for fire-and-forget calls.
- * `procedure.fire(args)` sends the RPC without waiting for a response.
+ * Augments procedure types with:
+ * - `.fire` accessor for fire-and-forget calls (no response awaited).
+ * - `.withTimeout(ms)` accessor to override the default RPC timeout.
+ *
+ * Both return a callable proxy, so they can be chained:
+ *   procedure.fire(args)                  // fire-and-forget
+ *   procedure.withTimeout(60_000)(args)   // 60s timeout
  */
+type AugmentedFunction<A extends any[], R> = ((...args: A) => Promise<R>) & {
+  fire: (...args: A) => void;
+  withTimeout: (ms: number) => AugmentedFunction<A, R>;
+};
+
 export type WithFireAndForget<T> = T extends (
   ...args: infer A
 ) => Promise<infer R>
-  ? ((...args: A) => Promise<R>) & { fire: (...args: A) => void }
+  ? AugmentedFunction<A, R>
   : T extends object
     ? { [K in keyof T]: WithFireAndForget<T[K]> }
     : T;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Email sign-in now opens the system browser to the Stagewise console and hands the session back to the app via PKCE. This replaces the in-app OTP flow that failed on non-web origins and makes sign-in more reliable.

- **New Features**
  - Added `userAccount.signInEmail` and `openEmailAuthInSystemBrowser()` for console-based email sign-in.
  - Updated onboarding, account settings, and the sign-in panel to use the new flow, with a spinner and clear instructions during browser handoff.
  - Added `.withTimeout(ms)` to Karton procedure proxies and used it to extend auth handoff calls to 5m10s; includes stable-reference caching.
  - Generalized auth handoff handling in `AuthService` (single pending flow for social and email; unified logs).

- **Bug Fixes**
  - Accept auth callbacks on all valid Stagewise protocols (`stagewise://`, `stagewise-prerelease://`, `stagewise-nightly://`, `stagewise-dev://`) to avoid protocol mismatches.
  - Prevent stale or overlapping handoff attempts by cancelling any in-progress flow before starting a new one.

<sup>Written for commit 077f763bd0f37a8411e3446666932f1ea3bafa1b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1376?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

