### PR TITLE
refactor(stagewise): remove duplicated telemetryLevel and clean up sound pack config

### DIFF
--- a/apps/browser/src/backend/main.ts
+++ b/apps/browser/src/backend/main.ts
@@ -378,27 +378,22 @@ export async function main({ launchOptions: { verbose } }: MainParameters) {
   const syncAvailableSoundPacks = async (
     selectedPack?: string,
   ): Promise<void> => {
-    const cfg = globalConfigService.get();
     const packs = notificationSoundsService.listPacks();
     const displayNames = notificationSoundsService.getPackDisplayNames();
-    const packsChanged =
-      cfg.availableSoundPacks.length !== packs.length ||
-      !cfg.availableSoundPacks.every((p, i) => p === packs[i]);
-    const namesChanged =
-      Object.keys(cfg.packDisplayNames).length !==
-        Object.keys(displayNames).length ||
-      Object.entries(displayNames).some(
-        ([id, name]) => cfg.packDisplayNames[id] !== name,
-      );
 
-    if (!packsChanged && !namesChanged && !selectedPack) return;
-
-    await globalConfigService.set({
-      ...cfg,
-      availableSoundPacks: packs,
-      packDisplayNames: displayNames,
-      ...(selectedPack ? { notificationSoundPack: selectedPack } : {}),
+    uiKarton.setState((draft) => {
+      draft.notificationSoundPacks = {
+        available: packs,
+        displayNames,
+      };
     });
+
+    if (selectedPack) {
+      await globalConfigService.set({
+        ...globalConfigService.get(),
+        notificationSoundPack: selectedPack,
+      });
+    }
   };
 
   void syncAvailableSoundPacks().catch((err) => {

--- a/apps/browser/src/backend/services/notification-sounds.ts
+++ b/apps/browser/src/backend/services/notification-sounds.ts
@@ -834,16 +834,7 @@ export class NotificationSoundsService extends DisposableService {
 // ---------------------------------------------------------------------------
 
 function normalizeLoudness(config: GlobalConfig): SoundLoudness {
-  const loudness = (
-    config as GlobalConfig & {
-      notificationSoundLoudness?: SoundLoudness;
-    }
-  ).notificationSoundLoudness;
-  if (loudness === 'off' || loudness === 'subtle' || loudness === 'default') {
-    return loudness;
-  }
-  // Backwards compatibility for existing configs.
-  return config.notificationSoundsEnabled === false ? 'off' : 'subtle';
+  return config.notificationSoundLoudness;
 }
 
 function bufferToDataUrl(buffer: ArrayBuffer, mimeType: string): string | null {

--- a/apps/browser/src/shared/karton-contracts/pages-api/index.ts
+++ b/apps/browser/src/shared/karton-contracts/pages-api/index.ts
@@ -105,12 +105,8 @@ export const defaultState: PagesApiState = {
   pendingEditsByAgentInstanceId: {},
   pendingAppMessagesByAgentInstanceId: {},
   globalConfig: {
-    telemetryLevel: 'full',
-    notificationSoundsEnabled: true,
     notificationSoundLoudness: 'subtle',
     notificationSoundPack: 'bubble-pops',
-    availableSoundPacks: ['bubble-pops'],
-    packDisplayNames: {},
     dockBounceEnabled: true,
     blockAppSuspensionWhenAgentsActive: true,
     personalizationThemeId: 'default',

--- a/apps/browser/src/shared/karton-contracts/ui/index.ts
+++ b/apps/browser/src/shared/karton-contracts/ui/index.ts
@@ -1109,6 +1109,11 @@ export type AppState = {
   };
   // The global configuration of the CLI.
   globalConfig: GlobalConfig;
+  // Discovered notification sound packs (runtime, not persisted).
+  notificationSoundPacks: {
+    available: string[];
+    displayNames: Record<string, string>;
+  };
   // State of the current user experience (getting started etc.)
   userExperience: {
     storedExperienceData: StoredExperienceData;
@@ -2154,16 +2159,16 @@ export const defaultState: KartonContract['state'] = {
     errorMessage: null,
   },
   globalConfig: {
-    telemetryLevel: 'full',
-    notificationSoundsEnabled: true,
     notificationSoundLoudness: 'subtle',
     notificationSoundPack: 'bubble-pops',
-    availableSoundPacks: ['bubble-pops'],
-    packDisplayNames: {},
     dockBounceEnabled: true,
     blockAppSuspensionWhenAgentsActive: true,
     personalizationThemeId: 'default',
     appColorScheme: 'system',
+  },
+  notificationSoundPacks: {
+    available: ['bubble-pops'],
+    displayNames: {},
   },
   userExperience: {
     storedExperienceData: {

--- a/apps/browser/src/shared/karton-contracts/ui/shared-types.ts
+++ b/apps/browser/src/shared/karton-contracts/ui/shared-types.ts
@@ -303,14 +303,10 @@ export type AppColorScheme = z.infer<typeof appColorSchemeSchema>;
 
 export const globalConfigSchema = z
   .object({
-    telemetryLevel: z.enum(['off', 'anonymous', 'full']).default('anonymous'),
-    notificationSoundsEnabled: z.boolean().default(true),
     notificationSoundLoudness: z
       .enum(['off', 'subtle', 'default'])
       .default('subtle'),
     notificationSoundPack: z.string().default('bubble-pops'),
-    availableSoundPacks: z.array(z.string()).default(['bubble-pops']),
-    packDisplayNames: z.record(z.string(), z.string()).default({}),
     dockBounceEnabled: z.boolean().default(true),
     blockAppSuspensionWhenAgentsActive: z.boolean().default(true),
     personalizationThemeId: personalizationThemeIdSchema

--- a/apps/browser/src/ui/hooks/use-posthog.tsx
+++ b/apps/browser/src/ui/hooks/use-posthog.tsx
@@ -18,12 +18,13 @@ interface PostHogProviderProps {
 export function PostHogProvider({ children }: PostHogProviderProps) {
   const internalData = useKartonState((s) => s.internalData);
   const userAccount = useKartonState((s) => s.userAccount);
-  const globalConfig = useKartonState((s) => s.globalConfig);
+  const telemetryLevel = useKartonState(
+    (s) => s.preferences.privacy.telemetryLevel,
+  );
 
   // Add custom logic based on karton state
   useEffect(() => {
     if (!posthog) return;
-    const telemetryLevel = globalConfig.telemetryLevel;
     if (
       telemetryLevel === 'off' ||
       (import.meta.env.NODE_ENV === 'development' &&
@@ -75,14 +76,12 @@ export function PostHogProvider({ children }: PostHogProviderProps) {
       posthog.opt_in_capturing();
     }
   }, [
-    globalConfig.telemetryLevel,
+    telemetryLevel,
     internalData.posthog?.apiKey,
     internalData.posthog?.host,
   ]);
 
   useEffect(() => {
-    const telemetryLevel = globalConfig.telemetryLevel;
-
     if (
       telemetryLevel === 'full' &&
       userAccount?.user?.id &&
@@ -105,14 +104,14 @@ export function PostHogProvider({ children }: PostHogProviderProps) {
       }
 
       posthog.identify(userAccount.user.id, {
-        telemetryLevel: globalConfig.telemetryLevel,
+        telemetryLevel,
         email: userAccount.user.email,
         machineId: userAccount.machineId,
       });
       if (userAccount?.user?.id && userAccount?.machineId)
         posthog.alias(userAccount.user.id, userAccount.machineId);
     }
-  }, [globalConfig, userAccount]);
+  }, [telemetryLevel, userAccount]);
 
   return (
     <PostHogProviderOriginal client={posthog}>

--- a/apps/browser/src/ui/screens/settings/sections/custom-providers-section.tsx
+++ b/apps/browser/src/ui/screens/settings/sections/custom-providers-section.tsx
@@ -595,7 +595,9 @@ function CustomEndpointDialog({
   // `full` the user has consented to detailed analytics; at `basic` we
   // keep the event but redact the URL; at `off` the backend drops the
   // event entirely and this check is moot.
-  const telemetryLevel = useKartonState((s) => s.globalConfig.telemetryLevel);
+  const telemetryLevel = useKartonState(
+    (s) => s.preferences.privacy.telemetryLevel,
+  );
   const isAddMode = !endpoint;
   // Set to true when onSave() fires; distinguishes a save-initiated close
   // from a cancel/dismiss close inside the shared `handleDialogOpenChange`.

--- a/apps/browser/src/ui/screens/settings/sections/general-settings-section.tsx
+++ b/apps/browser/src/ui/screens/settings/sections/general-settings-section.tsx
@@ -76,6 +76,9 @@ type SoundLoudness = (typeof NOTIFICATION_LOUDNESS_OPTIONS)[number]['value'];
 
 export function NotificationsSetting() {
   const globalConfig = useKartonState((s) => s.globalConfig);
+  const notificationSoundPacks = useKartonState(
+    (s) => s.notificationSoundPacks,
+  );
   const isMacOs = useKartonState((s) => s.appInfo.platform === 'darwin');
   const setGlobalConfig = useKartonProcedure((p) => p.config.set);
   const previewSoundPack = useKartonProcedure((p) => p.config.previewSoundPack);
@@ -83,11 +86,10 @@ export function NotificationsSetting() {
   const track = useTrack();
 
   const soundLoudness: SoundLoudness =
-    globalConfig.notificationSoundLoudness ??
-    (globalConfig.notificationSoundsEnabled === false ? 'off' : 'subtle');
+    globalConfig.notificationSoundLoudness ?? 'subtle';
   const availablePacks =
-    globalConfig.availableSoundPacks.length > 0
-      ? globalConfig.availableSoundPacks
+    notificationSoundPacks.available.length > 0
+      ? notificationSoundPacks.available
       : [DEFAULT_SOUND_PACK];
   const configuredPack = globalConfig.notificationSoundPack?.trim();
   const currentPack =
@@ -106,7 +108,7 @@ export function NotificationsSetting() {
 
   const soundPackItems = packOptions.map((pack) => ({
     value: pack,
-    label: globalConfig.packDisplayNames[pack] ?? pack,
+    label: notificationSoundPacks.displayNames[pack] ?? pack,
   }));
 
   const previewSound = (pack = currentPack, loudness = soundLoudness) => {
@@ -127,7 +129,6 @@ export function NotificationsSetting() {
     previewSound(currentPack, notificationSoundLoudness);
 
     await setGlobalConfig({
-      notificationSoundsEnabled: notificationSoundLoudness !== 'off',
       notificationSoundLoudness,
     });
     track('changed-notification-sound-loudness', {


### PR DESCRIPTION
- Remove telemetryLevel from globalConfigSchema (config.json); it was duplicated in userPreferencesSchema.privacy (preferences.json) which is the canonical source. UI consumers (use-posthog, custom-providers-section) now read from preferences.privacy.telemetryLevel. The config.json copy was never written when the user changed the setting, causing stale reads.

- Remove redundant notificationSoundsEnabled from globalConfigSchema; notificationSoundLoudness === 'off' fully covers the disabled state. Simplified normalizeLoudness to a direct read.

- Move availableSoundPacks and packDisplayNames out of config.json into a runtime-only Karton state field (notificationSoundPacks). These are filesystem-discovered values that were round-tripped through config.json on every startup; they are now pushed directly to UI state without persistence.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the duplicated telemetry setting and stops persisting sound pack metadata. Telemetry now reads from user preferences, and sound packs are discovered at runtime via UI state to avoid stale config.

- **Refactors**
  - Remove `telemetryLevel` from `globalConfig`; UI now uses `preferences.privacy.telemetryLevel` in `use-posthog` and `custom-providers-section`.
  - Remove `notificationSoundsEnabled`; use `notificationSoundLoudness === 'off'` to represent disabled. Simplify loudness normalization to a direct read.
  - Move sound pack metadata out of config; add runtime `notificationSoundPacks` state with `available` and `displayNames` populated by the backend. Settings read from this state and persist only `notificationSoundPack`.

<sup>Written for commit 9590812bd5a75cd60736dc6cbd5d4fc9a8eed54f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1379?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sound pack options in Settings now come from a dedicated app state, keeping available packs and display names consistent.
  * Updates to telemetry settings now follow privacy telemetry level more directly.
* **Bug Fixes**
  * Notification sound loudness handling is simplified for more consistent sound preference behavior.
  * Sound pack syncing in Settings no longer relies on previously cached configuration data, preventing stale/partial updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->