### PR TITLE
Add feedback toast notifications

### DIFF
--- a/apps/browser/src/backend/main.ts
+++ b/apps/browser/src/backend/main.ts
@@ -490,6 +490,7 @@ export async function main({ launchOptions: { verbose } }: MainParameters) {
     uiKarton,
     telemetryService,
     gitService,
+    () => persistence.agentDb.getOldestAgentCreatedAt(),
   );
 
   const credentialsService = await CredentialsService.create(logger);

--- a/apps/browser/src/backend/main.ts
+++ b/apps/browser/src/backend/main.ts
@@ -491,6 +491,7 @@ export async function main({ launchOptions: { verbose } }: MainParameters) {
     telemetryService,
     gitService,
     () => persistence.agentDb.getOldestAgentCreatedAt(),
+    () => persistence.agentDb.getAgentCount(),
   );
 
   const credentialsService = await CredentialsService.create(logger);

--- a/apps/browser/src/backend/services/experience.test.ts
+++ b/apps/browser/src/backend/services/experience.test.ts
@@ -112,6 +112,7 @@ function createGitService(
 function createService(
   gitService: GitService,
   getOldestAgentCreatedAt?: () => Promise<Date | null>,
+  getAgentCount?: () => Promise<number>,
 ) {
   const state = {
     agents: { instances: {} },
@@ -120,6 +121,7 @@ function createService(
         recentlyOpenedWorkspaces: [],
         hasSeenOnboardingFlow: null,
         lastViewedChats: {},
+        totalAgentCount: 0,
       },
     },
   };
@@ -147,6 +149,7 @@ function createService(
     telemetryService,
     gitService,
     getOldestAgentCreatedAt,
+    getAgentCount,
   );
 }
 
@@ -402,5 +405,24 @@ describe('UserExperienceService firstUsedAt backfill', () => {
     const firstUsedAt = persistedData.get('first-used-at') as number;
     expect(firstUsedAt).toBeGreaterThanOrEqual(before);
     expect(firstUsedAt).toBeLessThanOrEqual(after);
+  });
+
+  it('treats implausible persisted firstUsedAt as null (self-heal)', async () => {
+    // Simulate a corrupted value (e.g. 0 or 100 from epoch-0 agent records)
+    persistedData.set('first-used-at', 100);
+    const oldestDate = new Date('2025-01-15T10:00:00Z');
+    const service = await createService(
+      createGitService({}),
+      async () => oldestDate,
+    );
+
+    // readFirstUsedAt should return null for the corrupted value
+    const readResult = await (service as any).readFirstUsedAt();
+    expect(readResult).toBeNull();
+
+    // setFirstUsedAt should backfill from the oldest agent createdAt
+    await (service as any).setFirstUsedAt();
+    const firstUsedAt = persistedData.get('first-used-at') as number;
+    expect(firstUsedAt).toBe(oldestDate.getTime());
   });
 });

--- a/apps/browser/src/backend/services/experience.test.ts
+++ b/apps/browser/src/backend/services/experience.test.ts
@@ -109,8 +109,12 @@ function createGitService(
   } as unknown as GitService;
 }
 
-function createService(gitService: GitService) {
+function createService(
+  gitService: GitService,
+  getOldestAgentCreatedAt?: () => Promise<Date | null>,
+) {
   const state = {
+    agents: { instances: {} },
     userExperience: {
       storedExperienceData: {
         recentlyOpenedWorkspaces: [],
@@ -120,6 +124,7 @@ function createService(gitService: GitService) {
     },
   };
   const uiKarton = {
+    state,
     setState: vi.fn((updater: (draft: typeof state) => void) => {
       updater(state);
     }),
@@ -141,6 +146,7 @@ function createService(gitService: GitService) {
     uiKarton,
     telemetryService,
     gitService,
+    getOldestAgentCreatedAt,
   );
 }
 
@@ -350,5 +356,51 @@ describe('UserExperienceService recent workspace normalization', () => {
     expect(getRecentWorkspaces()).toEqual([
       { path: '/repo', name: 'repo', openedAt: 10 },
     ]);
+  });
+});
+
+describe('UserExperienceService firstUsedAt backfill', () => {
+  beforeEach(() => {
+    persistedData.clear();
+    existingPaths.clear();
+    persistedData.set('onboarding-state', { hasSeenOnboardingFlow: false });
+  });
+
+  it('backfills firstUsedAt from oldest agent createdAt when messages exist', async () => {
+    const oldestDate = new Date('2025-01-15T10:00:00Z');
+    const service = await createService(
+      createGitService({}),
+      async () => oldestDate,
+    );
+
+    // Access the private method via any to trigger the backfill
+    await (service as any).setFirstUsedAt();
+
+    const firstUsedAt = persistedData.get('first-used-at') as number;
+    expect(firstUsedAt).toBe(oldestDate.getTime());
+  });
+
+  it('falls back to Date.now() when no agents exist', async () => {
+    const before = Date.now();
+    const service = await createService(createGitService({}), async () => null);
+
+    await (service as any).setFirstUsedAt();
+    const after = Date.now();
+
+    const firstUsedAt = persistedData.get('first-used-at') as number;
+    expect(firstUsedAt).toBeGreaterThanOrEqual(before);
+    expect(firstUsedAt).toBeLessThanOrEqual(after);
+  });
+
+  it('falls back to Date.now() when no callback is provided', async () => {
+    const before = Date.now();
+    const service = await createService(createGitService({}));
+
+    await (service as any).setFirstUsedAt();
+    const after = Date.now();
+
+    const firstUsedAt = persistedData.get('first-used-at') as number;
+    expect(firstUsedAt).toBeGreaterThanOrEqual(before);
+    expect(firstUsedAt).toBeLessThanOrEqual(after);
   });
 });

--- a/apps/browser/src/backend/services/experience.ts
+++ b/apps/browser/src/backend/services/experience.ts
@@ -314,40 +314,50 @@ export class UserExperienceService extends DisposableService {
 
     // Set firstUsedAt on first user message in any agent
     const currentState = this.uiKarton.state;
-    if (this.isSettingFirstUsedAt) return;
-    if (currentState.userExperience.storedExperienceData.firstUsedAt !== null)
-      return;
-    const hasMessages = Object.values(currentState.agents.instances).some(
-      (instance) => instance.state.history.length > 0,
-    );
-    if (hasMessages) {
-      void this.setFirstUsedAt();
+    if (
+      !this.isSettingFirstUsedAt &&
+      currentState.userExperience.storedExperienceData.firstUsedAt === null
+    ) {
+      const hasMessages = Object.values(currentState.agents.instances).some(
+        (instance) => instance.state.history.length > 0,
+      );
+      if (hasMessages) {
+        void this.setFirstUsedAt();
+      }
     }
 
     // Refresh totalAgentCount from DB — the DB is the source of truth,
     // not the in-memory agent instances (which may be a subset).
-    // The guard prevents concurrent queries from rapid state changes.
+    // Only query when the loaded instance count exceeds the stored count,
+    // indicating new agents may have been created. The guard prevents
+    // concurrent queries from rapid state changes.
     if (this.getAgentCount && !this.isRefreshingAgentCount) {
-      this.isRefreshingAgentCount = true;
-      void this.getAgentCount()
-        .then((count) => {
-          // Read storedCount fresh from state — the closure value may be stale
-          // if an earlier callback already updated it.
-          const currentStored =
-            this.uiKarton.state.userExperience.storedExperienceData
-              .totalAgentCount;
-          if (count > currentStored) {
-            this.uiKarton.setState((draft) => {
-              draft.userExperience.storedExperienceData.totalAgentCount = count;
-            });
-          }
-        })
-        .catch((error) => {
-          this.report(error as Error, 'refreshAgentCount');
-        })
-        .finally(() => {
-          this.isRefreshingAgentCount = false;
-        });
+      const loadedCount = Object.keys(currentState.agents.instances).length;
+      const storedCount =
+        currentState.userExperience.storedExperienceData.totalAgentCount;
+      if (loadedCount > storedCount) {
+        this.isRefreshingAgentCount = true;
+        void this.getAgentCount()
+          .then((count) => {
+            // Read storedCount fresh from state — the closure value may
+            // be stale if an earlier callback already updated it.
+            const currentStored =
+              this.uiKarton.state.userExperience.storedExperienceData
+                .totalAgentCount;
+            if (count > currentStored) {
+              this.uiKarton.setState((draft) => {
+                draft.userExperience.storedExperienceData.totalAgentCount =
+                  count;
+              });
+            }
+          })
+          .catch((error) => {
+            this.report(error as Error, 'refreshAgentCount');
+          })
+          .finally(() => {
+            this.isRefreshingAgentCount = false;
+          });
+      }
     }
   }
 

--- a/apps/browser/src/backend/services/experience.ts
+++ b/apps/browser/src/backend/services/experience.ts
@@ -851,9 +851,12 @@ export class UserExperienceService extends DisposableService {
         const oldest = await this.getOldestAgentCreatedAt();
         if (oldest !== null) {
           const oldestMs = oldest.getTime();
-          // Guard against corrupted records (e.g. created_at = 0 = Unix
-          // epoch). If the value is impossibly old, fall back to now.
-          if (oldestMs > 0) {
+          // Use the same plausibility threshold as readFirstUsedAt() /
+          // validateTimestamp(). Only persist if the value is plausible
+          // (>= Jan 1, 2000 and not in the future); otherwise fall back
+          // to now so a valid timestamp is always written and the
+          // backfill is not retried on every state change.
+          if (this.validateTimestamp(oldestMs, 'firstUsedAt') !== null) {
             timestamp = oldestMs;
           }
         }

--- a/apps/browser/src/backend/services/experience.ts
+++ b/apps/browser/src/backend/services/experience.ts
@@ -40,11 +40,14 @@ function redactWorkspacePathForTelemetry(workspacePath: string): string {
   return createHash('sha256').update(workspacePath).digest('hex').slice(0, 12);
 }
 
+export type GetOldestAgentCreatedAt = () => Promise<Date | null>;
+
 export class UserExperienceService extends DisposableService {
   private readonly logger: Logger;
   private readonly uiKarton: KartonService;
   private readonly telemetryService: TelemetryService;
   private readonly gitService: GitService;
+  private readonly getOldestAgentCreatedAt?: GetOldestAgentCreatedAt;
   // Store bound callback reference for proper unregistration
   private readonly boundHandleServiceStateChange: () => void;
 
@@ -63,12 +66,14 @@ export class UserExperienceService extends DisposableService {
     uiKarton: KartonService,
     telemetryService: TelemetryService,
     gitService: GitService,
+    getOldestAgentCreatedAt?: GetOldestAgentCreatedAt,
   ) {
     super();
     this.logger = logger;
     this.uiKarton = uiKarton;
     this.telemetryService = telemetryService;
     this.gitService = gitService;
+    this.getOldestAgentCreatedAt = getOldestAgentCreatedAt;
 
     // Bind once and store reference for later unregistration
     this.boundHandleServiceStateChange =
@@ -92,6 +97,7 @@ export class UserExperienceService extends DisposableService {
     uiKarton: KartonService,
     telemetryService: TelemetryService,
     gitService: GitService,
+    getOldestAgentCreatedAt?: GetOldestAgentCreatedAt,
   ) {
     logger.debug('[UserExperienceService] Creating service');
     const instance = new UserExperienceService(
@@ -99,6 +105,7 @@ export class UserExperienceService extends DisposableService {
       uiKarton,
       telemetryService,
       gitService,
+      getOldestAgentCreatedAt,
     );
     await instance.initialize();
     logger.debug('[UserExperienceService] Created service');
@@ -763,12 +770,24 @@ export class UserExperienceService extends DisposableService {
   private async setFirstUsedAt() {
     this.isSettingFirstUsedAt = true;
     try {
-      const now = Date.now();
-      await this.writeFirstUsedAt(now);
+      // For existing users with chat history, backfill from the oldest
+      // agent instance's createdAt instead of using Date.now(). This
+      // ensures long-time users are immediately eligible for the founder
+      // call survey instead of having to wait 4 more days.
+      let timestamp = Date.now();
+      if (this.getOldestAgentCreatedAt) {
+        const oldest = await this.getOldestAgentCreatedAt();
+        if (oldest !== null) {
+          timestamp = oldest.getTime();
+        }
+      }
+      await this.writeFirstUsedAt(timestamp);
       this.uiKarton.setState((draft) => {
-        draft.userExperience.storedExperienceData.firstUsedAt = now;
+        draft.userExperience.storedExperienceData.firstUsedAt = timestamp;
       });
-      this.logger.debug('[UserExperienceService] Set firstUsedAt');
+      this.logger.debug(
+        `[UserExperienceService] Set firstUsedAt to ${new Date(timestamp).toISOString()}`,
+      );
     } catch (error) {
       this.logger.error(
         `[UserExperienceService] Failed to set firstUsedAt. Error: ${error}`,

--- a/apps/browser/src/backend/services/experience.ts
+++ b/apps/browser/src/backend/services/experience.ts
@@ -6,6 +6,7 @@
  * @warning The state of workspace-specific experiences is to be managed by the workspace manager etc.
  */
 
+import { z } from 'zod';
 import { createHash } from 'node:crypto';
 import fs from 'node:fs/promises';
 import path from 'node:path';
@@ -13,8 +14,12 @@ import {
   recentlyOpenedWorkspacesArraySchema,
   onboardingStateSchema,
   tutorialStateSchema,
+  experienceSurveySchema,
+  founderCallSurveySchema,
   type StoredExperienceData,
   type RecentlyOpenedWorkspace,
+  type ExperienceSurvey,
+  type FounderCallSurvey,
 } from '@shared/karton-contracts/ui';
 import type { KartonService } from './karton';
 import type { Logger } from './logger';
@@ -49,6 +54,9 @@ export class UserExperienceService extends DisposableService {
 
   // Serialize tutorial step writes to prevent races from fire-and-forget saves
   private tutorialStepLock: Promise<void> = Promise.resolve();
+
+  // Prevent concurrent firstUsedAt writes
+  private isSettingFirstUsedAt = false;
 
   private constructor(
     logger: Logger,
@@ -98,14 +106,29 @@ export class UserExperienceService extends DisposableService {
   }
 
   private async initialize() {
-    const [hasSeenOnboarding, tutorialState] = await Promise.all([
+    const [
+      hasSeenOnboarding,
+      tutorialState,
+      surveyState,
+      founderCallSurveyState,
+      firstUsedAt,
+    ] = await Promise.all([
       this.readOnboardingState(),
       this.readTutorialState(),
+      this.readSurveyState(),
+      this.readFounderCallSurveyState(),
+      this.readFirstUsedAt(),
     ]);
     this.uiKarton.setState((draft) => {
       draft.userExperience.storedExperienceData.hasSeenOnboardingFlow =
         hasSeenOnboarding;
       draft.userExperience.storedExperienceData.tutorialState = tutorialState;
+      draft.userExperience.storedExperienceData.experienceSurvey = surveyState;
+      draft.userExperience.storedExperienceData.founderCallSurvey =
+        founderCallSurveyState;
+      draft.userExperience.storedExperienceData.firstUsedAt = firstUsedAt;
+      draft.userExperience.experienceSurvey = surveyState;
+      draft.userExperience.founderCallSurvey = founderCallSurveyState;
     });
 
     this.uiKarton.registerStateChangeCallback(
@@ -176,6 +199,36 @@ export class UserExperienceService extends DisposableService {
         await this.setHasSeenOnboardingFlow(value, auth);
       },
     );
+    this.uiKarton.registerServerProcedureHandler(
+      'userExperience.survey.answer',
+      async (_callingClientId: string, answer: 'yes' | 'no') => {
+        await this.answerSurvey(answer);
+      },
+    );
+    this.uiKarton.registerServerProcedureHandler(
+      'userExperience.survey.dismiss',
+      async (_callingClientId: string) => {
+        await this.dismissSurvey();
+      },
+    );
+    this.uiKarton.registerServerProcedureHandler(
+      'userExperience.survey.submitFeedback',
+      async (_callingClientId: string, feedback: string) => {
+        await this.submitSurveyFeedback(feedback);
+      },
+    );
+    this.uiKarton.registerServerProcedureHandler(
+      'userExperience.founderCall.survey.open',
+      async (_callingClientId: string) => {
+        await this.openFounderCallSurvey();
+      },
+    );
+    this.uiKarton.registerServerProcedureHandler(
+      'userExperience.founderCall.survey.dismiss',
+      async (_callingClientId: string) => {
+        await this.dismissFounderCallSurvey();
+      },
+    );
   }
 
   protected onTeardown(): void {
@@ -196,6 +249,17 @@ export class UserExperienceService extends DisposableService {
     );
     this.uiKarton.removeServerProcedureHandler(
       'userExperience.tutorial.setStep',
+    );
+    this.uiKarton.removeServerProcedureHandler('userExperience.survey.answer');
+    this.uiKarton.removeServerProcedureHandler('userExperience.survey.dismiss');
+    this.uiKarton.removeServerProcedureHandler(
+      'userExperience.survey.submitFeedback',
+    );
+    this.uiKarton.removeServerProcedureHandler(
+      'userExperience.founderCall.survey.open',
+    );
+    this.uiKarton.removeServerProcedureHandler(
+      'userExperience.founderCall.survey.dismiss',
     );
     this.logger.debug('[UserExperienceService] Teardown complete');
   }
@@ -220,8 +284,24 @@ export class UserExperienceService extends DisposableService {
 
         this.uiKarton.setState((draft) => {
           draft.userExperience.storedExperienceData = storedExperienceData;
+          draft.userExperience.experienceSurvey =
+            storedExperienceData.experienceSurvey;
+          draft.userExperience.founderCallSurvey =
+            storedExperienceData.founderCallSurvey;
         });
       });
+    }
+
+    // Set firstUsedAt on first user message in any agent
+    const currentState = this.uiKarton.state;
+    if (this.isSettingFirstUsedAt) return;
+    if (currentState.userExperience.storedExperienceData.firstUsedAt !== null)
+      return;
+    const hasMessages = Object.values(currentState.agents.instances).some(
+      (instance) => instance.state.history.length > 0,
+    );
+    if (hasMessages) {
+      void this.setFirstUsedAt();
     }
   }
 
@@ -473,18 +553,238 @@ export class UserExperienceService extends DisposableService {
    * This combines data from recently-opened-workspaces.json and onboarding-state.json.
    */
   public async getStoredExperienceData(): Promise<StoredExperienceData> {
-    const [recentlyOpenedWorkspaces, hasSeenOnboardingFlow, tutorialState] =
-      await Promise.all([
-        this.getRecentlyOpenedWorkspaces(),
-        this.readOnboardingState(),
-        this.readTutorialState(),
-      ]);
+    const [
+      recentlyOpenedWorkspaces,
+      hasSeenOnboardingFlow,
+      tutorialState,
+      experienceSurvey,
+      founderCallSurvey,
+      firstUsedAt,
+    ] = await Promise.all([
+      this.getRecentlyOpenedWorkspaces(),
+      this.readOnboardingState(),
+      this.readTutorialState(),
+      this.readSurveyState(),
+      this.readFounderCallSurveyState(),
+      this.readFirstUsedAt(),
+    ]);
     return {
       recentlyOpenedWorkspaces,
       hasSeenOnboardingFlow,
       lastViewedChats: {},
       tutorialState,
+      experienceSurvey,
+      firstUsedAt,
+      founderCallSurvey,
     };
+  }
+
+  /**
+   * Read the experience survey state from persisted data.
+   */
+  private async readSurveyState(): Promise<ExperienceSurvey> {
+    return readPersistedData('experience-survey', experienceSurveySchema, {
+      dismissedAt: null,
+      dismissedCount: 0,
+      answered: false,
+      answeredAt: null,
+    });
+  }
+
+  /**
+   * Write the experience survey state to persisted data.
+   */
+  private async writeSurveyState(state: ExperienceSurvey): Promise<void> {
+    await writePersistedData(
+      'experience-survey',
+      experienceSurveySchema,
+      state,
+    );
+  }
+
+  public async answerSurvey(answer: 'yes' | 'no') {
+    try {
+      const now = Date.now();
+      const survey = await this.readSurveyState();
+      survey.answered = true;
+      survey.answeredAt = now;
+      await this.writeSurveyState(survey);
+
+      // Update UI state
+      const storedData = await this.getStoredExperienceData();
+      this.uiKarton.setState((draft) => {
+        draft.userExperience.storedExperienceData = storedData;
+        draft.userExperience.experienceSurvey = survey;
+      });
+
+      // Fire telemetry even if telemetry is off (bypass list).
+      this.telemetryService.capture('experience-survey-answered', { answer });
+
+      this.logger.debug(`[UserExperienceService] Survey answered: ${answer}`);
+    } catch (error) {
+      this.logger.error(
+        `[UserExperienceService] Failed to save survey answer. Error: ${error}`,
+      );
+      this.report(error as Error, 'saveSurveyAnswer');
+    }
+  }
+
+  public async dismissSurvey() {
+    try {
+      const survey = await this.readSurveyState();
+      if (survey.answered) return;
+
+      survey.dismissedAt = Date.now();
+      survey.dismissedCount = Math.min(survey.dismissedCount + 1, 3);
+      await this.writeSurveyState(survey);
+
+      const storedData = await this.getStoredExperienceData();
+      this.uiKarton.setState((draft) => {
+        draft.userExperience.storedExperienceData = storedData;
+        draft.userExperience.experienceSurvey = survey;
+      });
+
+      this.logger.debug(
+        `[UserExperienceService] Survey dismissed (count: ${survey.dismissedCount})`,
+      );
+    } catch (error) {
+      this.logger.error(
+        `[UserExperienceService] Failed to dismiss survey. Error: ${error}`,
+      );
+      this.report(error as Error, 'dismissSurvey');
+    }
+  }
+
+  public async submitSurveyFeedback(feedback: string) {
+    try {
+      // Fire telemetry even if telemetry is off (bypass list).
+      this.telemetryService.capture('experience-survey-feedback-submitted', {
+        feedback,
+        feedback_length: feedback.length,
+      });
+
+      this.logger.debug('[UserExperienceService] Survey feedback submitted');
+    } catch (error) {
+      this.logger.error(
+        `[UserExperienceService] Failed to submit survey feedback. Error: ${error}`,
+      );
+      this.report(error as Error, 'submitSurveyFeedback');
+    }
+  }
+
+  /**
+   * Read the founder call survey state from persisted data.
+   */
+  private async readFounderCallSurveyState(): Promise<FounderCallSurvey> {
+    return readPersistedData(
+      'experience-founder-call-survey',
+      founderCallSurveySchema,
+      {
+        dismissedAt: null,
+        dismissedCount: 0,
+        answered: false,
+        answeredAt: null,
+      },
+    );
+  }
+
+  /**
+   * Write the founder call survey state to persisted data.
+   */
+  private async writeFounderCallSurveyState(
+    state: FounderCallSurvey,
+  ): Promise<void> {
+    await writePersistedData(
+      'experience-founder-call-survey',
+      founderCallSurveySchema,
+      state,
+    );
+  }
+
+  public async openFounderCallSurvey() {
+    try {
+      const now = Date.now();
+      const survey = await this.readFounderCallSurveyState();
+      survey.answered = true;
+      survey.answeredAt = now;
+      await this.writeFounderCallSurveyState(survey);
+
+      const storedData = await this.getStoredExperienceData();
+      this.uiKarton.setState((draft) => {
+        draft.userExperience.storedExperienceData = storedData;
+        draft.userExperience.founderCallSurvey = survey;
+      });
+
+      this.telemetryService.capture(
+        'experience-founder-call-survey-opened',
+        undefined,
+      );
+
+      this.logger.debug('[UserExperienceService] Founder call survey opened');
+    } catch (error) {
+      this.logger.error(
+        `[UserExperienceService] Failed to save founder call survey answer. Error: ${error}`,
+      );
+      this.report(error as Error, 'saveFounderCallSurveyAnswer');
+    }
+  }
+
+  public async dismissFounderCallSurvey() {
+    try {
+      const survey = await this.readFounderCallSurveyState();
+      if (survey.answered) return;
+
+      survey.dismissedAt = Date.now();
+      survey.dismissedCount = Math.min(survey.dismissedCount + 1, 3);
+      await this.writeFounderCallSurveyState(survey);
+
+      const storedData = await this.getStoredExperienceData();
+      this.uiKarton.setState((draft) => {
+        draft.userExperience.storedExperienceData = storedData;
+        draft.userExperience.founderCallSurvey = survey;
+      });
+
+      this.telemetryService.capture(
+        'experience-founder-call-survey-dismissed',
+        undefined,
+      );
+
+      this.logger.debug(
+        `[UserExperienceService] Founder call survey dismissed (count: ${survey.dismissedCount})`,
+      );
+    } catch (error) {
+      this.logger.error(
+        `[UserExperienceService] Failed to dismiss founder call survey. Error: ${error}`,
+      );
+      this.report(error as Error, 'dismissFounderCallSurvey');
+    }
+  }
+
+  private async setFirstUsedAt() {
+    this.isSettingFirstUsedAt = true;
+    try {
+      const now = Date.now();
+      await this.writeFirstUsedAt(now);
+      this.uiKarton.setState((draft) => {
+        draft.userExperience.storedExperienceData.firstUsedAt = now;
+      });
+      this.logger.debug('[UserExperienceService] Set firstUsedAt');
+    } catch (error) {
+      this.logger.error(
+        `[UserExperienceService] Failed to set firstUsedAt. Error: ${error}`,
+      );
+      this.report(error as Error, 'setFirstUsedAt');
+    } finally {
+      this.isSettingFirstUsedAt = false;
+    }
+  }
+
+  private async readFirstUsedAt(): Promise<number | null> {
+    return readPersistedData('first-used-at', z.number().nullable(), null);
+  }
+
+  private async writeFirstUsedAt(value: number): Promise<void> {
+    await writePersistedData('first-used-at', z.number().nullable(), value);
   }
 
   public async setHasSeenOnboardingFlow(

--- a/apps/browser/src/backend/services/experience.ts
+++ b/apps/browser/src/backend/services/experience.ts
@@ -41,6 +41,7 @@ function redactWorkspacePathForTelemetry(workspacePath: string): string {
 }
 
 export type GetOldestAgentCreatedAt = () => Promise<Date | null>;
+export type GetAgentCount = () => Promise<number>;
 
 export class UserExperienceService extends DisposableService {
   private readonly logger: Logger;
@@ -48,6 +49,7 @@ export class UserExperienceService extends DisposableService {
   private readonly telemetryService: TelemetryService;
   private readonly gitService: GitService;
   private readonly getOldestAgentCreatedAt?: GetOldestAgentCreatedAt;
+  private readonly getAgentCount?: GetAgentCount;
   // Store bound callback reference for proper unregistration
   private readonly boundHandleServiceStateChange: () => void;
 
@@ -67,6 +69,7 @@ export class UserExperienceService extends DisposableService {
     telemetryService: TelemetryService,
     gitService: GitService,
     getOldestAgentCreatedAt?: GetOldestAgentCreatedAt,
+    getAgentCount?: GetAgentCount,
   ) {
     super();
     this.logger = logger;
@@ -74,6 +77,7 @@ export class UserExperienceService extends DisposableService {
     this.telemetryService = telemetryService;
     this.gitService = gitService;
     this.getOldestAgentCreatedAt = getOldestAgentCreatedAt;
+    this.getAgentCount = getAgentCount;
 
     // Bind once and store reference for later unregistration
     this.boundHandleServiceStateChange =
@@ -98,6 +102,7 @@ export class UserExperienceService extends DisposableService {
     telemetryService: TelemetryService,
     gitService: GitService,
     getOldestAgentCreatedAt?: GetOldestAgentCreatedAt,
+    getAgentCount?: GetAgentCount,
   ) {
     logger.debug('[UserExperienceService] Creating service');
     const instance = new UserExperienceService(
@@ -106,6 +111,7 @@ export class UserExperienceService extends DisposableService {
       telemetryService,
       gitService,
       getOldestAgentCreatedAt,
+      getAgentCount,
     );
     await instance.initialize();
     logger.debug('[UserExperienceService] Created service');
@@ -119,12 +125,14 @@ export class UserExperienceService extends DisposableService {
       surveyState,
       founderCallSurveyState,
       firstUsedAt,
+      totalAgentCount,
     ] = await Promise.all([
       this.readOnboardingState(),
       this.readTutorialState(),
       this.readSurveyState(),
       this.readFounderCallSurveyState(),
       this.readFirstUsedAt(),
+      this.readAgentCount(),
     ]);
     this.uiKarton.setState((draft) => {
       draft.userExperience.storedExperienceData.hasSeenOnboardingFlow =
@@ -134,6 +142,8 @@ export class UserExperienceService extends DisposableService {
       draft.userExperience.storedExperienceData.founderCallSurvey =
         founderCallSurveyState;
       draft.userExperience.storedExperienceData.firstUsedAt = firstUsedAt;
+      draft.userExperience.storedExperienceData.totalAgentCount =
+        totalAgentCount;
       draft.userExperience.experienceSurvey = surveyState;
       draft.userExperience.founderCallSurvey = founderCallSurveyState;
     });
@@ -309,6 +319,21 @@ export class UserExperienceService extends DisposableService {
     );
     if (hasMessages) {
       void this.setFirstUsedAt();
+    }
+
+    // Refresh totalAgentCount from DB when loaded agent count increases
+    // beyond the last known value — new agents may have been created.
+    const loadedCount = Object.keys(currentState.agents.instances).length;
+    const storedCount =
+      currentState.userExperience.storedExperienceData.totalAgentCount;
+    if (this.getAgentCount && loadedCount > storedCount) {
+      void this.getAgentCount().then((count) => {
+        if (count > storedCount) {
+          this.uiKarton.setState((draft) => {
+            draft.userExperience.storedExperienceData.totalAgentCount = count;
+          });
+        }
+      });
     }
   }
 
@@ -567,6 +592,7 @@ export class UserExperienceService extends DisposableService {
       experienceSurvey,
       founderCallSurvey,
       firstUsedAt,
+      totalAgentCount,
     ] = await Promise.all([
       this.getRecentlyOpenedWorkspaces(),
       this.readOnboardingState(),
@@ -574,6 +600,7 @@ export class UserExperienceService extends DisposableService {
       this.readSurveyState(),
       this.readFounderCallSurveyState(),
       this.readFirstUsedAt(),
+      this.readAgentCount(),
     ]);
     return {
       recentlyOpenedWorkspaces,
@@ -583,6 +610,7 @@ export class UserExperienceService extends DisposableService {
       experienceSurvey,
       firstUsedAt,
       founderCallSurvey,
+      totalAgentCount,
     };
   }
 
@@ -590,12 +618,31 @@ export class UserExperienceService extends DisposableService {
    * Read the experience survey state from persisted data.
    */
   private async readSurveyState(): Promise<ExperienceSurvey> {
-    return readPersistedData('experience-survey', experienceSurveySchema, {
-      dismissedAt: null,
-      dismissedCount: 0,
-      answered: false,
-      answeredAt: null,
-    });
+    const state = await readPersistedData(
+      'experience-survey',
+      experienceSurveySchema,
+      {
+        dismissedAt: null,
+        dismissedCount: 0,
+        answered: false,
+        answeredAt: null,
+      },
+    );
+    const answeredAt = this.validateTimestamp(
+      state.answeredAt,
+      'survey.answeredAt',
+    );
+    const dismissedAt = this.validateTimestamp(
+      state.dismissedAt,
+      'survey.dismissedAt',
+    );
+    // If the survey was answered but the timestamp is corrupted, use now
+    // as a fallback so the founder-call stagger check has a valid baseline.
+    return {
+      ...state,
+      answeredAt: answeredAt ?? (state.answered ? Date.now() : null),
+      dismissedAt,
+    };
   }
 
   /**
@@ -683,7 +730,7 @@ export class UserExperienceService extends DisposableService {
    * Read the founder call survey state from persisted data.
    */
   private async readFounderCallSurveyState(): Promise<FounderCallSurvey> {
-    return readPersistedData(
+    const state = await readPersistedData(
       'experience-founder-call-survey',
       founderCallSurveySchema,
       {
@@ -693,6 +740,17 @@ export class UserExperienceService extends DisposableService {
         answeredAt: null,
       },
     );
+    return {
+      ...state,
+      answeredAt: this.validateTimestamp(
+        state.answeredAt,
+        'founderCallSurvey.answeredAt',
+      ),
+      dismissedAt: this.validateTimestamp(
+        state.dismissedAt,
+        'founderCallSurvey.dismissedAt',
+      ),
+    };
   }
 
   /**
@@ -778,7 +836,12 @@ export class UserExperienceService extends DisposableService {
       if (this.getOldestAgentCreatedAt) {
         const oldest = await this.getOldestAgentCreatedAt();
         if (oldest !== null) {
-          timestamp = oldest.getTime();
+          const oldestMs = oldest.getTime();
+          // Guard against corrupted records (e.g. created_at = 0 = Unix
+          // epoch). If the value is impossibly old, fall back to now.
+          if (oldestMs > 0) {
+            timestamp = oldestMs;
+          }
         }
       }
       await this.writeFirstUsedAt(timestamp);
@@ -798,8 +861,45 @@ export class UserExperienceService extends DisposableService {
     }
   }
 
+  // Minimum plausible timestamp: Jan 1, 2000. Anything below this is
+  // corrupted (e.g. 0, 100 from epoch-0 agent records) and should be
+  // treated as null so setFirstUsedAt() re-runs and backfills correctly.
+  private static readonly MIN_PLAUSIBLE_TIMESTAMP = 946684800000;
+
+  /**
+   * Returns the timestamp if plausible, or null if corrupted (pre-2000
+   * or in the future). Logs a debug message for diagnostics.
+   */
+  private validateTimestamp(raw: number | null, field: string): number | null {
+    if (raw === null) return null;
+    if (
+      raw < UserExperienceService.MIN_PLAUSIBLE_TIMESTAMP ||
+      raw > Date.now()
+    ) {
+      this.logger.debug(
+        `[UserExperienceService] Detected implausible ${field} value ${raw}, treating as null.`,
+      );
+      return null;
+    }
+    return raw;
+  }
+
   private async readFirstUsedAt(): Promise<number | null> {
-    return readPersistedData('first-used-at', z.number().nullable(), null);
+    const raw = await readPersistedData(
+      'first-used-at',
+      z.number().nullable(),
+      null,
+    );
+    return this.validateTimestamp(raw, 'firstUsedAt');
+  }
+
+  private async readAgentCount(): Promise<number> {
+    if (!this.getAgentCount) return 0;
+    try {
+      return await this.getAgentCount();
+    } catch {
+      return 0;
+    }
   }
 
   private async writeFirstUsedAt(value: number): Promise<void> {

--- a/apps/browser/src/backend/services/experience.ts
+++ b/apps/browser/src/backend/services/experience.ts
@@ -63,6 +63,9 @@ export class UserExperienceService extends DisposableService {
   // Prevent concurrent firstUsedAt writes
   private isSettingFirstUsedAt = false;
 
+  // Prevent concurrent totalAgentCount refresh queries
+  private isRefreshingAgentCount = false;
+
   private constructor(
     logger: Logger,
     uiKarton: KartonService,
@@ -321,19 +324,30 @@ export class UserExperienceService extends DisposableService {
       void this.setFirstUsedAt();
     }
 
-    // Refresh totalAgentCount from DB when loaded agent count increases
-    // beyond the last known value — new agents may have been created.
-    const loadedCount = Object.keys(currentState.agents.instances).length;
-    const storedCount =
-      currentState.userExperience.storedExperienceData.totalAgentCount;
-    if (this.getAgentCount && loadedCount > storedCount) {
-      void this.getAgentCount().then((count) => {
-        if (count > storedCount) {
-          this.uiKarton.setState((draft) => {
-            draft.userExperience.storedExperienceData.totalAgentCount = count;
-          });
-        }
-      });
+    // Refresh totalAgentCount from DB — the DB is the source of truth,
+    // not the in-memory agent instances (which may be a subset).
+    // The guard prevents concurrent queries from rapid state changes.
+    if (this.getAgentCount && !this.isRefreshingAgentCount) {
+      this.isRefreshingAgentCount = true;
+      void this.getAgentCount()
+        .then((count) => {
+          // Read storedCount fresh from state — the closure value may be stale
+          // if an earlier callback already updated it.
+          const currentStored =
+            this.uiKarton.state.userExperience.storedExperienceData
+              .totalAgentCount;
+          if (count > currentStored) {
+            this.uiKarton.setState((draft) => {
+              draft.userExperience.storedExperienceData.totalAgentCount = count;
+            });
+          }
+        })
+        .catch((error) => {
+          this.report(error as Error, 'refreshAgentCount');
+        })
+        .finally(() => {
+          this.isRefreshingAgentCount = false;
+        });
     }
   }
 

--- a/apps/browser/src/backend/services/telemetry.ts
+++ b/apps/browser/src/backend/services/telemetry.ts
@@ -473,6 +473,17 @@ export type EventProperties = {
   'changed-notification-sound-theme': {
     theme: string;
   };
+
+  // Experience survey
+  'experience-survey-answered': {
+    answer: 'yes' | 'no';
+  };
+  'experience-survey-feedback-submitted': {
+    feedback: string;
+    feedback_length: number;
+  };
+  'experience-founder-call-survey-opened': undefined;
+  'experience-founder-call-survey-dismissed': undefined;
 };
 
 export const UI_TELEMETRY_EVENT_NAMES = [
@@ -524,6 +535,10 @@ export const UI_TELEMETRY_EVENT_NAMES = [
   'changed-theme',
   'changed-notification-sound-loudness',
   'changed-notification-sound-theme',
+  'experience-survey-answered',
+  'experience-survey-feedback-submitted',
+  'experience-founder-call-survey-opened',
+  'experience-founder-call-survey-dismissed',
 ] as const satisfies ReadonlyArray<keyof EventProperties>;
 
 export type UIEventName = (typeof UI_TELEMETRY_EVENT_NAMES)[number];
@@ -676,6 +691,15 @@ const UI_TELEMETRY_EVENT_SCHEMAS = {
   'changed-notification-sound-theme': z.object({
     theme: z.string(),
   }),
+  'experience-survey-answered': z.object({
+    answer: z.enum(['yes', 'no']),
+  }),
+  'experience-survey-feedback-submitted': z.object({
+    feedback: z.string(),
+    feedback_length: z.number(),
+  }),
+  'experience-founder-call-survey-opened': z.undefined().optional(),
+  'experience-founder-call-survey-dismissed': z.undefined().optional(),
 } satisfies {
   [K in UIEventName]: z.ZodType<UIEventProperties[K]>;
 };
@@ -864,6 +888,10 @@ export class TelemetryService extends DisposableService {
         'app-launched',
         'telemetry-level-changed',
         'onboarding-completed',
+        'experience-survey-answered',
+        'experience-survey-feedback-submitted',
+        'experience-founder-call-survey-opened',
+        'experience-founder-call-survey-dismissed',
       ];
       if (telemetryLevel === 'off' && !bypassOptOut.includes(eventName)) return;
 

--- a/apps/browser/src/backend/utils/paths.ts
+++ b/apps/browser/src/backend/utils/paths.ts
@@ -37,7 +37,10 @@ export type JsonName =
   | 'downloads-state'
   | 'window-state'
   | 'tab-state'
-  | 'tutorial-state';
+  | 'tutorial-state'
+  | 'experience-survey'
+  | 'experience-founder-call-survey'
+  | 'first-used-at';
 
 export const getJsonPath = (name: JsonName): string =>
   path.join(getDataRoot(), `${name}.json`);

--- a/apps/browser/src/shared/karton-contracts/ui/index.ts
+++ b/apps/browser/src/shared/karton-contracts/ui/index.ts
@@ -429,6 +429,7 @@ export const storedExperienceDataSchema = z.object({
   experienceSurvey: experienceSurveySchema,
   firstUsedAt: z.number().nullable(),
   founderCallSurvey: founderCallSurveySchema,
+  totalAgentCount: z.number(),
 });
 
 export type StoredExperienceData = z.infer<typeof storedExperienceDataSchema>;
@@ -2183,6 +2184,7 @@ export const defaultState: KartonContract['state'] = {
         answered: false,
         answeredAt: null,
       },
+      totalAgentCount: 0,
     },
     pendingOnboardingSuggestion: null,
     devAppPreview: {

--- a/apps/browser/src/shared/karton-contracts/ui/index.ts
+++ b/apps/browser/src/shared/karton-contracts/ui/index.ts
@@ -403,11 +403,32 @@ export type TutorialState = z.infer<typeof tutorialStateSchema>;
 
 export const lastViewedChatsSchema = z.record(z.string(), z.number());
 
+export const experienceSurveySchema = z.object({
+  dismissedAt: z.number().nullable(),
+  dismissedCount: z.number(),
+  answered: z.boolean(),
+  answeredAt: z.number().nullable(),
+});
+
+export type ExperienceSurvey = z.infer<typeof experienceSurveySchema>;
+
+export const founderCallSurveySchema = z.object({
+  dismissedAt: z.number().nullable(),
+  dismissedCount: z.number(),
+  answered: z.boolean(),
+  answeredAt: z.number().nullable(),
+});
+
+export type FounderCallSurvey = z.infer<typeof founderCallSurveySchema>;
+
 export const storedExperienceDataSchema = z.object({
   recentlyOpenedWorkspaces: recentlyOpenedWorkspacesArraySchema,
   hasSeenOnboardingFlow: z.boolean().nullable(),
   lastViewedChats: lastViewedChatsSchema,
   tutorialState: tutorialStateSchema,
+  experienceSurvey: experienceSurveySchema,
+  firstUsedAt: z.number().nullable(),
+  founderCallSurvey: founderCallSurveySchema,
 });
 
 export type StoredExperienceData = z.infer<typeof storedExperienceDataSchema>;
@@ -1104,6 +1125,8 @@ export type AppState = {
         presetName: string; // Preset can be a name like "mobile" or "iPhone 13" or whatever
       } | null;
     };
+    experienceSurvey: ExperienceSurvey;
+    founderCallSurvey: FounderCallSurvey;
   };
   // State of the notification service.
   notifications: {
@@ -1555,6 +1578,17 @@ export type KartonContract = {
           tutorialId: string;
           stepIndex: number;
         }) => Promise<void>;
+      };
+      survey: {
+        answer: (answer: 'yes' | 'no') => Promise<void>;
+        dismiss: () => Promise<void>;
+        submitFeedback: (feedback: string) => Promise<void>;
+      };
+      founderCall: {
+        survey: {
+          open: () => Promise<void>;
+          dismiss: () => Promise<void>;
+        };
       };
     };
     filePicker: {
@@ -2136,12 +2170,37 @@ export const defaultState: KartonContract['state'] = {
       hasSeenOnboardingFlow: null,
       lastViewedChats: {},
       tutorialState: {},
+      experienceSurvey: {
+        dismissedAt: null,
+        dismissedCount: 0,
+        answered: false,
+        answeredAt: null,
+      },
+      firstUsedAt: null,
+      founderCallSurvey: {
+        dismissedAt: null,
+        dismissedCount: 0,
+        answered: false,
+        answeredAt: null,
+      },
     },
     pendingOnboardingSuggestion: null,
     devAppPreview: {
       isFullScreen: false,
       inShowCodeMode: false,
       customScreenSize: null,
+    },
+    experienceSurvey: {
+      dismissedAt: null,
+      dismissedCount: 0,
+      answered: false,
+      answeredAt: null,
+    },
+    founderCallSurvey: {
+      dismissedAt: null,
+      dismissedCount: 0,
+      answered: false,
+      answeredAt: null,
     },
   },
   notifications: [],

--- a/apps/browser/src/ui/screens/main/_components/sidebar-experience-survey.tsx
+++ b/apps/browser/src/ui/screens/main/_components/sidebar-experience-survey.tsx
@@ -68,6 +68,7 @@ export function SidebarExperienceSurvey() {
 
   const [hasAnswered, setHasAnswered] = useState(false);
   const [submitError, setSubmitError] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
   const feedbackLabelId = useId();
 
   // Tick to force memo recomputation at cooldown boundaries.
@@ -214,14 +215,17 @@ export function SidebarExperienceSurvey() {
 
   const handleSubmitFeedback = useCallback(async () => {
     const trimmed = feedback.trim();
-    if (!trimmed) return;
+    if (!trimmed || isSubmitting) return;
+    setIsSubmitting(true);
     try {
       await submitFeedback(trimmed);
       setSubmitted(true);
     } catch {
       setSubmitError(true);
+    } finally {
+      setIsSubmitting(false);
     }
-  }, [feedback, submitFeedback]);
+  }, [feedback, submitFeedback, isSubmitting]);
 
   const handleOpenFounderCall = useCallback(() => {
     void openFounderCallSurvey();
@@ -302,7 +306,7 @@ export function SidebarExperienceSurvey() {
               <Button
                 variant="primary"
                 size="xs"
-                disabled={!feedback.trim()}
+                disabled={!feedback.trim() || isSubmitting}
                 onClick={handleSubmitFeedback}
               >
                 Send

--- a/apps/browser/src/ui/screens/main/_components/sidebar-experience-survey.tsx
+++ b/apps/browser/src/ui/screens/main/_components/sidebar-experience-survey.tsx
@@ -1,16 +1,22 @@
 import { useCallback, useMemo, useRef, useState } from 'react';
 import { Button } from '@stagewise/stage-ui/components/button';
 import { useKartonProcedure, useKartonState } from '@ui/hooks/use-karton';
-import { XIcon, MessageSquareTextIcon, PresentationIcon } from 'lucide-react';
+import {
+  IconXmarkOutline18,
+  IconVideoOutline18,
+  IconThumbsUpOutline18,
+  IconThumbsDownOutline18,
+} from 'nucleo-ui-outline-18';
 
-const MESSAGE_THRESHOLD = 3;
+const MESSAGE_THRESHOLD = 5;
 const DISMISS_COOLDOWN_MS = 48 * 60 * 60 * 1000; // 48 hours
 const MAX_DISMISS_COUNT = 3;
 
-const FOUNDER_CALL_MESSAGE_THRESHOLD = 20;
+const FOUNDER_CALL_AGENT_THRESHOLD = 10;
 const FOUNDER_CALL_USAGE_DAYS = 4;
 const FOUNDER_CALL_STAGGER_MS = 24 * 60 * 60 * 1000; // 24 hours
-const BOOKING_URL = 'https://stagewise.io/call';
+const FOUNDER_CALL_DISMISS_COOLDOWN_MS = 96 * 60 * 60 * 1000; // 96 hours
+const BOOKING_URL = 'https://calendar.app.google/McsonxboNHu7oyUF8';
 
 export function SidebarExperienceSurvey() {
   const [feedback, setFeedback] = useState('');
@@ -45,20 +51,29 @@ export function SidebarExperienceSurvey() {
     (p) => p.userExperience.founderCall.survey.dismiss,
   );
 
-  // Count total messages across all active agents
-  const totalMessages = useKartonState((s) => {
+  // Total agent count from DB (via storedExperienceData)
+  const totalAgentCount = useKartonState(
+    (s) => s.userExperience.storedExperienceData.totalAgentCount,
+  );
+
+  // Count total user messages across all active agents (first survey trigger)
+  const totalUserMessages = useKartonState((s) => {
     let count = 0;
     for (const instance of Object.values(s.agents.instances)) {
-      count += instance.state.history.length;
+      count += instance.state.history.filter((m) => m.role === 'user').length;
     }
     return count;
   });
 
+  const [hasAnswered, setHasAnswered] = useState(false);
+
   // ── First survey visibility ──
   const shouldShow = useMemo(() => {
     if (submitted) return false;
-    if (survey.answered) return false;
-    if (totalMessages <= MESSAGE_THRESHOLD) return false;
+    // Keep the survey visible while the user is in the feedback phase,
+    // even though the backend already marked it as answered.
+    if (survey.answered && !hasAnswered) return false;
+    if (totalUserMessages <= MESSAGE_THRESHOLD) return false;
 
     // If never dismissed, show
     if (survey.dismissedAt === null || survey.dismissedCount === 0) return true;
@@ -68,7 +83,7 @@ export function SidebarExperienceSurvey() {
 
     // Show again after cooldown
     return Date.now() - survey.dismissedAt >= DISMISS_COOLDOWN_MS;
-  }, [survey, totalMessages, submitted]);
+  }, [survey, totalUserMessages, submitted, hasAnswered]);
 
   // ── Second (founder call) survey visibility ──
   const shouldShowFounderCall = useMemo(() => {
@@ -76,7 +91,7 @@ export function SidebarExperienceSurvey() {
     if (shouldShow) return false;
 
     if (founderCallSurvey.answered) return false;
-    if (totalMessages < FOUNDER_CALL_MESSAGE_THRESHOLD) return false;
+    if (totalAgentCount < FOUNDER_CALL_AGENT_THRESHOLD) return false;
 
     // Must have used stagewise for at least 4 days
     if (firstUsedAt === null) return false;
@@ -91,17 +106,18 @@ export function SidebarExperienceSurvey() {
       return false;
     }
 
-    // Dismiss logic (same pattern as first survey)
+    // Dismiss logic: reappear after 96h cooldown, up to 3 dismissals total.
     if (
       founderCallSurvey.dismissedAt === null ||
       founderCallSurvey.dismissedCount === 0
     )
       return true;
     if (founderCallSurvey.dismissedCount >= MAX_DISMISS_COUNT) return false;
-    return Date.now() - founderCallSurvey.dismissedAt >= DISMISS_COOLDOWN_MS;
-  }, [shouldShow, founderCallSurvey, totalMessages, firstUsedAt, survey]);
-
-  const [hasAnswered, setHasAnswered] = useState(false);
+    return (
+      Date.now() - founderCallSurvey.dismissedAt >=
+      FOUNDER_CALL_DISMISS_COOLDOWN_MS
+    );
+  }, [shouldShow, founderCallSurvey, totalAgentCount, firstUsedAt, survey]);
 
   const handleAnswer = useCallback(
     (answer: 'yes' | 'no') => {
@@ -136,50 +152,57 @@ export function SidebarExperienceSurvey() {
   // ── First survey ──
   if (shouldShow) {
     return (
-      <div className="relative flex shrink-0 flex-col gap-2 rounded-md bg-background/60 p-2.5 shadow-elevation-1 ring-1 ring-derived-strong backdrop-blur-xl dark:bg-surface-1/60">
+      <div className="relative flex shrink-0 flex-col gap-2 rounded-md bg-background/30 p-2.5 shadow-elevation-1 ring-1 ring-derived-subtle backdrop-blur-xl dark:bg-surface-1/30">
         {!hasAnswered ? (
           <>
-            <div className="flex items-center gap-1.5">
-              <MessageSquareTextIcon className="size-3.5 shrink-0 text-foreground" />
-              <div className="mt-0.5 min-w-0 flex-1 font-medium text-foreground text-xs">
-                Do you enjoy your experience with stagewise?
-              </div>
-              <Button
-                variant="ghost"
-                size="icon-2xs"
-                className="ml-auto shrink-0"
-                aria-label="Dismiss survey"
-                onClick={handleDismiss}
-              >
-                <XIcon className="size-3" />
-              </Button>
+            <Button
+              variant="ghost"
+              size="icon-2xs"
+              className="absolute top-1.5 right-1.5 z-10 shrink-0"
+              aria-label="Dismiss survey"
+              onClick={handleDismiss}
+            >
+              <IconXmarkOutline18 className="size-3" />
+            </Button>
+            <div className="pr-7 font-medium text-foreground text-xs leading-relaxed">
+              Do you enjoy your experience with stagewise?
             </div>
             <div className="flex gap-2">
               <Button
                 variant="secondary"
                 size="xs"
                 className="flex-1"
+                aria-label="No"
                 onClick={() => handleAnswer('no')}
               >
+                <IconThumbsDownOutline18 className="size-3.5" />
                 No
               </Button>
               <Button
                 variant="secondary"
                 size="xs"
                 className="flex-1"
+                aria-label="Yes"
                 onClick={() => handleAnswer('yes')}
               >
+                <IconThumbsUpOutline18 className="size-3.5" />
                 Yes
               </Button>
             </div>
           </>
         ) : (
           <>
-            <div className="flex items-center gap-1.5">
-              <MessageSquareTextIcon className="size-3.5 shrink-0 text-foreground" />
-              <div className="mt-0.5 min-w-0 flex-1 font-medium text-foreground text-xs">
-                What could we improve?
-              </div>
+            <Button
+              variant="ghost"
+              size="icon-2xs"
+              className="absolute top-1.5 right-1.5 z-10 shrink-0"
+              aria-label="Dismiss survey"
+              onClick={() => setSubmitted(true)}
+            >
+              <IconXmarkOutline18 className="size-3" />
+            </Button>
+            <div className="pr-7 font-medium text-foreground text-xs leading-relaxed">
+              What could we improve?
             </div>
             <textarea
               ref={textareaRef}
@@ -189,7 +212,7 @@ export function SidebarExperienceSurvey() {
               value={feedback}
               onChange={(e) => setFeedback(e.target.value)}
               onKeyDown={(e) => {
-                if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+                if (e.key === 'Enter' && !e.shiftKey) {
                   e.preventDefault();
                   handleSubmitFeedback();
                 }
@@ -197,14 +220,7 @@ export function SidebarExperienceSurvey() {
             />
             <div className="flex justify-end gap-2">
               <Button
-                variant="ghost"
-                size="xs"
-                onClick={() => setSubmitted(true)}
-              >
-                Skip
-              </Button>
-              <Button
-                variant="secondary"
+                variant="primary"
                 size="xs"
                 disabled={!feedback.trim()}
                 onClick={handleSubmitFeedback}
@@ -221,29 +237,27 @@ export function SidebarExperienceSurvey() {
   // ── Second (founder call) survey ──
   if (shouldShowFounderCall) {
     return (
-      <div className="relative flex shrink-0 flex-col gap-2 rounded-md bg-background/60 p-2.5 shadow-elevation-1 ring-1 ring-derived-strong backdrop-blur-xl dark:bg-surface-1/60">
-        <div className="flex items-start gap-1.5">
-          <PresentationIcon className="mt-0.5 size-3.5 shrink-0 text-foreground" />
-          <div className="min-w-0 flex-1 font-medium text-foreground text-xs">
-            Tell our founders what you think and get free Pro subscription for
-            one month!
-          </div>
-          <Button
-            variant="ghost"
-            size="icon-2xs"
-            className="ml-auto shrink-0"
-            aria-label="Dismiss survey"
-            onClick={handleDismissFounderCall}
-          >
-            <XIcon className="size-3" />
-          </Button>
+      <div className="relative flex shrink-0 flex-col gap-2 rounded-md bg-background/30 p-2.5 shadow-elevation-1 ring-1 ring-derived-subtle backdrop-blur-xl dark:bg-surface-1/30">
+        <Button
+          variant="ghost"
+          size="icon-2xs"
+          className="absolute top-1.5 right-1.5 z-10 shrink-0"
+          aria-label="Dismiss survey"
+          onClick={handleDismissFounderCall}
+        >
+          <IconXmarkOutline18 className="size-3" />
+        </Button>
+        <div className="pr-7 font-medium text-foreground text-xs leading-relaxed">
+          Tell our founders what you think about stagewise and get 1 month Pro
+          for free!
         </div>
         <Button
-          variant="secondary"
+          variant="primary"
           size="xs"
           className="w-full"
           onClick={handleOpenFounderCall}
         >
+          <IconVideoOutline18 className="size-3.5" />
           Book a call
         </Button>
       </div>

--- a/apps/browser/src/ui/screens/main/_components/sidebar-experience-survey.tsx
+++ b/apps/browser/src/ui/screens/main/_components/sidebar-experience-survey.tsx
@@ -1,0 +1,254 @@
+import { useCallback, useMemo, useRef, useState } from 'react';
+import { Button } from '@stagewise/stage-ui/components/button';
+import { useKartonProcedure, useKartonState } from '@ui/hooks/use-karton';
+import { XIcon, MessageSquareTextIcon, PresentationIcon } from 'lucide-react';
+
+const MESSAGE_THRESHOLD = 3;
+const DISMISS_COOLDOWN_MS = 48 * 60 * 60 * 1000; // 48 hours
+const MAX_DISMISS_COUNT = 3;
+
+const FOUNDER_CALL_MESSAGE_THRESHOLD = 20;
+const FOUNDER_CALL_USAGE_DAYS = 4;
+const FOUNDER_CALL_STAGGER_MS = 24 * 60 * 60 * 1000; // 24 hours
+const BOOKING_URL = 'https://stagewise.io/call';
+
+export function SidebarExperienceSurvey() {
+  const [feedback, setFeedback] = useState('');
+  const [submitted, setSubmitted] = useState(false);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  // ── First survey state ──
+  const survey = useKartonState(
+    (s) => s.userExperience.storedExperienceData.experienceSurvey,
+  );
+  const answerSurvey = useKartonProcedure(
+    (p) => p.userExperience.survey.answer,
+  );
+  const dismissSurvey = useKartonProcedure(
+    (p) => p.userExperience.survey.dismiss,
+  );
+  const submitFeedback = useKartonProcedure(
+    (p) => p.userExperience.survey.submitFeedback,
+  );
+
+  // ── Second (founder call) survey state ──
+  const founderCallSurvey = useKartonState(
+    (s) => s.userExperience.storedExperienceData.founderCallSurvey,
+  );
+  const firstUsedAt = useKartonState(
+    (s) => s.userExperience.storedExperienceData.firstUsedAt,
+  );
+  const openFounderCallSurvey = useKartonProcedure(
+    (p) => p.userExperience.founderCall.survey.open,
+  );
+  const dismissFounderCallSurvey = useKartonProcedure(
+    (p) => p.userExperience.founderCall.survey.dismiss,
+  );
+
+  // Count total messages across all active agents
+  const totalMessages = useKartonState((s) => {
+    let count = 0;
+    for (const instance of Object.values(s.agents.instances)) {
+      count += instance.state.history.length;
+    }
+    return count;
+  });
+
+  // ── First survey visibility ──
+  const shouldShow = useMemo(() => {
+    if (submitted) return false;
+    if (survey.answered) return false;
+    if (totalMessages <= MESSAGE_THRESHOLD) return false;
+
+    // If never dismissed, show
+    if (survey.dismissedAt === null || survey.dismissedCount === 0) return true;
+
+    // If dismissed max times, don't show
+    if (survey.dismissedCount >= MAX_DISMISS_COUNT) return false;
+
+    // Show again after cooldown
+    return Date.now() - survey.dismissedAt >= DISMISS_COOLDOWN_MS;
+  }, [survey, totalMessages, submitted]);
+
+  // ── Second (founder call) survey visibility ──
+  const shouldShowFounderCall = useMemo(() => {
+    // Never show at the same time as the first survey
+    if (shouldShow) return false;
+
+    if (founderCallSurvey.answered) return false;
+    if (totalMessages < FOUNDER_CALL_MESSAGE_THRESHOLD) return false;
+
+    // Must have used stagewise for at least 4 days
+    if (firstUsedAt === null) return false;
+    const daysSinceFirstUse =
+      (Date.now() - firstUsedAt) / (1000 * 60 * 60 * 24);
+    if (daysSinceFirstUse < FOUNDER_CALL_USAGE_DAYS) return false;
+
+    // Must appear at least 24h after the first survey was resolved
+    const firstSurveyResolvedAt = survey.answeredAt ?? survey.dismissedAt;
+    if (firstSurveyResolvedAt === null) return false;
+    if (Date.now() - firstSurveyResolvedAt < FOUNDER_CALL_STAGGER_MS) {
+      return false;
+    }
+
+    // Dismiss logic (same pattern as first survey)
+    if (
+      founderCallSurvey.dismissedAt === null ||
+      founderCallSurvey.dismissedCount === 0
+    )
+      return true;
+    if (founderCallSurvey.dismissedCount >= MAX_DISMISS_COUNT) return false;
+    return Date.now() - founderCallSurvey.dismissedAt >= DISMISS_COOLDOWN_MS;
+  }, [shouldShow, founderCallSurvey, totalMessages, firstUsedAt, survey]);
+
+  const [hasAnswered, setHasAnswered] = useState(false);
+
+  const handleAnswer = useCallback(
+    (answer: 'yes' | 'no') => {
+      setHasAnswered(true);
+      void answerSurvey(answer);
+      // Focus the textarea on next render
+      requestAnimationFrame(() => textareaRef.current?.focus());
+    },
+    [answerSurvey],
+  );
+
+  const handleDismiss = useCallback(() => {
+    void dismissSurvey();
+  }, [dismissSurvey]);
+
+  const handleSubmitFeedback = useCallback(() => {
+    const trimmed = feedback.trim();
+    if (!trimmed) return;
+    void submitFeedback(trimmed);
+    setSubmitted(true);
+  }, [feedback, submitFeedback]);
+
+  const handleOpenFounderCall = useCallback(() => {
+    void openFounderCallSurvey();
+    window.open(BOOKING_URL, '_blank');
+  }, [openFounderCallSurvey]);
+
+  const handleDismissFounderCall = useCallback(() => {
+    void dismissFounderCallSurvey();
+  }, [dismissFounderCallSurvey]);
+
+  // ── First survey ──
+  if (shouldShow) {
+    return (
+      <div className="relative flex shrink-0 flex-col gap-2 rounded-md bg-background/60 p-2.5 shadow-elevation-1 ring-1 ring-derived-strong backdrop-blur-xl dark:bg-surface-1/60">
+        {!hasAnswered ? (
+          <>
+            <div className="flex items-center gap-1.5">
+              <MessageSquareTextIcon className="size-3.5 shrink-0 text-foreground" />
+              <div className="mt-0.5 min-w-0 flex-1 font-medium text-foreground text-xs">
+                Do you enjoy your experience with stagewise?
+              </div>
+              <Button
+                variant="ghost"
+                size="icon-2xs"
+                className="ml-auto shrink-0"
+                aria-label="Dismiss survey"
+                onClick={handleDismiss}
+              >
+                <XIcon className="size-3" />
+              </Button>
+            </div>
+            <div className="flex gap-2">
+              <Button
+                variant="secondary"
+                size="xs"
+                className="flex-1"
+                onClick={() => handleAnswer('no')}
+              >
+                No
+              </Button>
+              <Button
+                variant="secondary"
+                size="xs"
+                className="flex-1"
+                onClick={() => handleAnswer('yes')}
+              >
+                Yes
+              </Button>
+            </div>
+          </>
+        ) : (
+          <>
+            <div className="flex items-center gap-1.5">
+              <MessageSquareTextIcon className="size-3.5 shrink-0 text-foreground" />
+              <div className="mt-0.5 min-w-0 flex-1 font-medium text-foreground text-xs">
+                What could we improve?
+              </div>
+            </div>
+            <textarea
+              ref={textareaRef}
+              className="scrollbar-subtle w-full resize-none rounded-md border border-derived bg-surface-1 px-2.5 py-2 text-foreground text-xs placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-primary-foreground"
+              placeholder="What could we improve?"
+              rows={3}
+              value={feedback}
+              onChange={(e) => setFeedback(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+                  e.preventDefault();
+                  handleSubmitFeedback();
+                }
+              }}
+            />
+            <div className="flex justify-end gap-2">
+              <Button
+                variant="ghost"
+                size="xs"
+                onClick={() => setSubmitted(true)}
+              >
+                Skip
+              </Button>
+              <Button
+                variant="secondary"
+                size="xs"
+                disabled={!feedback.trim()}
+                onClick={handleSubmitFeedback}
+              >
+                Send
+              </Button>
+            </div>
+          </>
+        )}
+      </div>
+    );
+  }
+
+  // ── Second (founder call) survey ──
+  if (shouldShowFounderCall) {
+    return (
+      <div className="relative flex shrink-0 flex-col gap-2 rounded-md bg-background/60 p-2.5 shadow-elevation-1 ring-1 ring-derived-strong backdrop-blur-xl dark:bg-surface-1/60">
+        <div className="flex items-start gap-1.5">
+          <PresentationIcon className="mt-0.5 size-3.5 shrink-0 text-foreground" />
+          <div className="min-w-0 flex-1 font-medium text-foreground text-xs">
+            Tell our founders what you think and get free Pro subscription for
+            one month!
+          </div>
+          <Button
+            variant="ghost"
+            size="icon-2xs"
+            className="ml-auto shrink-0"
+            aria-label="Dismiss survey"
+            onClick={handleDismissFounderCall}
+          >
+            <XIcon className="size-3" />
+          </Button>
+        </div>
+        <Button
+          variant="secondary"
+          size="xs"
+          className="w-full"
+          onClick={handleOpenFounderCall}
+        >
+          Book a call
+        </Button>
+      </div>
+    );
+  }
+
+  return null;
+}

--- a/apps/browser/src/ui/screens/main/_components/sidebar-experience-survey.tsx
+++ b/apps/browser/src/ui/screens/main/_components/sidebar-experience-survey.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useId } from 'react';
 import { Button } from '@stagewise/stage-ui/components/button';
 import { useKartonProcedure, useKartonState } from '@ui/hooks/use-karton';
 import {
@@ -66,6 +67,8 @@ export function SidebarExperienceSurvey() {
   });
 
   const [hasAnswered, setHasAnswered] = useState(false);
+  const [submitError, setSubmitError] = useState(false);
+  const feedbackLabelId = useId();
 
   // Tick to force memo recomputation at cooldown boundaries.
   // Without this, Date.now() inside the memos would stay stale while
@@ -209,16 +212,20 @@ export function SidebarExperienceSurvey() {
     void dismissSurvey();
   }, [dismissSurvey]);
 
-  const handleSubmitFeedback = useCallback(() => {
+  const handleSubmitFeedback = useCallback(async () => {
     const trimmed = feedback.trim();
     if (!trimmed) return;
-    void submitFeedback(trimmed);
-    setSubmitted(true);
+    try {
+      await submitFeedback(trimmed);
+      setSubmitted(true);
+    } catch {
+      setSubmitError(true);
+    }
   }, [feedback, submitFeedback]);
 
   const handleOpenFounderCall = useCallback(() => {
     void openFounderCallSurvey();
-    window.open(BOOKING_URL, '_blank');
+    window.open(BOOKING_URL, '_blank', 'noopener,noreferrer');
   }, [openFounderCallSurvey]);
 
   const handleDismissFounderCall = useCallback(() => {
@@ -234,7 +241,7 @@ export function SidebarExperienceSurvey() {
       >
         {!hasAnswered ? (
           <>
-            <div className="pr-7 font-medium text-foreground text-xs leading-relaxed">
+            <div className="font-medium text-foreground text-xs leading-relaxed">
               Do you enjoy your experience with stagewise?
             </div>
             <div className="flex gap-2">
@@ -262,20 +269,32 @@ export function SidebarExperienceSurvey() {
           </>
         ) : (
           <>
-            <div className="pr-7 font-medium text-foreground text-xs leading-relaxed">
+            <div
+              id={feedbackLabelId}
+              className="font-medium text-foreground text-xs leading-relaxed"
+            >
               What could we improve?
             </div>
+            {submitError && (
+              <p className="text-error-foreground text-xs">
+                Failed to submit. Please try again.
+              </p>
+            )}
             <textarea
               ref={textareaRef}
+              aria-labelledby={feedbackLabelId}
               className="scrollbar-subtle w-full resize-none rounded-md border border-derived bg-surface-1 px-2.5 py-2 text-foreground text-xs placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-primary-foreground"
               placeholder="What could we improve?"
               rows={3}
               value={feedback}
-              onChange={(e) => setFeedback(e.target.value)}
+              onChange={(e) => {
+                setFeedback(e.target.value);
+                if (submitError) setSubmitError(false);
+              }}
               onKeyDown={(e) => {
                 if (e.key === 'Enter' && !e.shiftKey) {
                   e.preventDefault();
-                  handleSubmitFeedback();
+                  void handleSubmitFeedback();
                 }
               }}
             />
@@ -302,7 +321,7 @@ export function SidebarExperienceSurvey() {
         dismissLabel="Dismiss survey"
         onDismiss={handleDismissFounderCall}
       >
-        <div className="pr-7 font-medium text-foreground text-xs leading-relaxed">
+        <div className="font-medium text-foreground text-xs leading-relaxed">
           Tell our founders what you think about stagewise and get 1 month Pro
           for free!
         </div>

--- a/apps/browser/src/ui/screens/main/_components/sidebar-experience-survey.tsx
+++ b/apps/browser/src/ui/screens/main/_components/sidebar-experience-survey.tsx
@@ -2,11 +2,11 @@ import { useCallback, useMemo, useRef, useState } from 'react';
 import { Button } from '@stagewise/stage-ui/components/button';
 import { useKartonProcedure, useKartonState } from '@ui/hooks/use-karton';
 import {
-  IconXmarkOutline18,
   IconVideoOutline18,
   IconThumbsUpOutline18,
   IconThumbsDownOutline18,
 } from 'nucleo-ui-outline-18';
+import { SidebarToast } from './sidebar-toast';
 
 const MESSAGE_THRESHOLD = 5;
 const DISMISS_COOLDOWN_MS = 48 * 60 * 60 * 1000; // 48 hours
@@ -152,18 +152,12 @@ export function SidebarExperienceSurvey() {
   // ── First survey ──
   if (shouldShow) {
     return (
-      <div className="relative flex shrink-0 flex-col gap-2 rounded-md bg-background/30 p-2.5 shadow-elevation-1 ring-1 ring-derived-subtle backdrop-blur-xl dark:bg-surface-1/30">
+      <SidebarToast
+        dismissLabel="Dismiss survey"
+        onDismiss={!hasAnswered ? handleDismiss : () => setSubmitted(true)}
+      >
         {!hasAnswered ? (
           <>
-            <Button
-              variant="ghost"
-              size="icon-2xs"
-              className="absolute top-1.5 right-1.5 z-10 shrink-0"
-              aria-label="Dismiss survey"
-              onClick={handleDismiss}
-            >
-              <IconXmarkOutline18 className="size-3" />
-            </Button>
             <div className="pr-7 font-medium text-foreground text-xs leading-relaxed">
               Do you enjoy your experience with stagewise?
             </div>
@@ -192,15 +186,6 @@ export function SidebarExperienceSurvey() {
           </>
         ) : (
           <>
-            <Button
-              variant="ghost"
-              size="icon-2xs"
-              className="absolute top-1.5 right-1.5 z-10 shrink-0"
-              aria-label="Dismiss survey"
-              onClick={() => setSubmitted(true)}
-            >
-              <IconXmarkOutline18 className="size-3" />
-            </Button>
             <div className="pr-7 font-medium text-foreground text-xs leading-relaxed">
               What could we improve?
             </div>
@@ -230,23 +215,17 @@ export function SidebarExperienceSurvey() {
             </div>
           </>
         )}
-      </div>
+      </SidebarToast>
     );
   }
 
   // ── Second (founder call) survey ──
   if (shouldShowFounderCall) {
     return (
-      <div className="relative flex shrink-0 flex-col gap-2 rounded-md bg-background/30 p-2.5 shadow-elevation-1 ring-1 ring-derived-subtle backdrop-blur-xl dark:bg-surface-1/30">
-        <Button
-          variant="ghost"
-          size="icon-2xs"
-          className="absolute top-1.5 right-1.5 z-10 shrink-0"
-          aria-label="Dismiss survey"
-          onClick={handleDismissFounderCall}
-        >
-          <IconXmarkOutline18 className="size-3" />
-        </Button>
+      <SidebarToast
+        dismissLabel="Dismiss survey"
+        onDismiss={handleDismissFounderCall}
+      >
         <div className="pr-7 font-medium text-foreground text-xs leading-relaxed">
           Tell our founders what you think about stagewise and get 1 month Pro
           for free!
@@ -260,7 +239,7 @@ export function SidebarExperienceSurvey() {
           <IconVideoOutline18 className="size-3.5" />
           Book a call
         </Button>
-      </div>
+      </SidebarToast>
     );
   }
 

--- a/apps/browser/src/ui/screens/main/_components/sidebar-experience-survey.tsx
+++ b/apps/browser/src/ui/screens/main/_components/sidebar-experience-survey.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Button } from '@stagewise/stage-ui/components/button';
 import { useKartonProcedure, useKartonState } from '@ui/hooks/use-karton';
 import {
@@ -67,6 +67,11 @@ export function SidebarExperienceSurvey() {
 
   const [hasAnswered, setHasAnswered] = useState(false);
 
+  // Tick to force memo recomputation at cooldown boundaries.
+  // Without this, Date.now() inside the memos would stay stale while
+  // the app is idle, and surveys wouldn't appear when cooldowns expire.
+  const [tick, setTick] = useState(0);
+
   // ── First survey visibility ──
   const shouldShow = useMemo(() => {
     if (submitted) return false;
@@ -83,7 +88,7 @@ export function SidebarExperienceSurvey() {
 
     // Show again after cooldown
     return Date.now() - survey.dismissedAt >= DISMISS_COOLDOWN_MS;
-  }, [survey, totalUserMessages, submitted, hasAnswered]);
+  }, [survey, totalUserMessages, submitted, hasAnswered, tick]);
 
   // ── Second (founder call) survey visibility ──
   const shouldShowFounderCall = useMemo(() => {
@@ -117,7 +122,78 @@ export function SidebarExperienceSurvey() {
       Date.now() - founderCallSurvey.dismissedAt >=
       FOUNDER_CALL_DISMISS_COOLDOWN_MS
     );
-  }, [shouldShow, founderCallSurvey, totalAgentCount, firstUsedAt, survey]);
+  }, [
+    shouldShow,
+    founderCallSurvey,
+    totalAgentCount,
+    firstUsedAt,
+    survey,
+    tick,
+  ]);
+
+  // Schedule a re-render at the earliest upcoming cooldown boundary
+  // so surveys appear without waiting for an unrelated state change.
+  useEffect(() => {
+    if (shouldShow || shouldShowFounderCall) return;
+
+    const now = Date.now();
+    const boundaries: number[] = [];
+
+    // First survey: cooldown after dismissal
+    if (
+      !survey.answered &&
+      survey.dismissedAt !== null &&
+      survey.dismissedCount < MAX_DISMISS_COUNT &&
+      totalUserMessages > MESSAGE_THRESHOLD
+    ) {
+      boundaries.push(survey.dismissedAt + DISMISS_COOLDOWN_MS);
+    }
+
+    // Founder call survey: only if preconditions are met
+    if (
+      !founderCallSurvey.answered &&
+      totalAgentCount >= FOUNDER_CALL_AGENT_THRESHOLD &&
+      firstUsedAt !== null
+    ) {
+      // Usage days boundary
+      boundaries.push(
+        firstUsedAt + FOUNDER_CALL_USAGE_DAYS * 24 * 60 * 60 * 1000,
+      );
+
+      // Stagger after first survey resolution
+      const firstSurveyResolvedAt = survey.answeredAt ?? survey.dismissedAt;
+      if (firstSurveyResolvedAt !== null) {
+        boundaries.push(firstSurveyResolvedAt + FOUNDER_CALL_STAGGER_MS);
+      }
+
+      // Dismiss cooldown
+      if (
+        founderCallSurvey.dismissedAt !== null &&
+        founderCallSurvey.dismissedCount < MAX_DISMISS_COUNT
+      ) {
+        boundaries.push(
+          founderCallSurvey.dismissedAt + FOUNDER_CALL_DISMISS_COOLDOWN_MS,
+        );
+      }
+    }
+
+    const nextBoundary = boundaries
+      .filter((b) => b > now)
+      .sort((a, b) => a - b)[0];
+    if (nextBoundary === undefined) return;
+
+    const delay = nextBoundary - now;
+    const timer = setTimeout(() => setTick((t) => t + 1), delay);
+    return () => clearTimeout(timer);
+  }, [
+    shouldShow,
+    shouldShowFounderCall,
+    survey,
+    founderCallSurvey,
+    firstUsedAt,
+    totalUserMessages,
+    totalAgentCount,
+  ]);
 
   const handleAnswer = useCallback(
     (answer: 'yes' | 'no') => {

--- a/apps/browser/src/ui/screens/main/_components/sidebar-toast.tsx
+++ b/apps/browser/src/ui/screens/main/_components/sidebar-toast.tsx
@@ -33,6 +33,7 @@ export function SidebarToast({
     <div
       className={cn(
         'relative flex shrink-0 flex-col gap-2 rounded-md bg-background/30 p-2.5 shadow-elevation-1 ring-1 ring-derived-subtle backdrop-blur-xl dark:bg-surface-1/30',
+        onDismiss && 'pr-9',
         className,
       )}
     >

--- a/apps/browser/src/ui/screens/main/_components/sidebar-toast.tsx
+++ b/apps/browser/src/ui/screens/main/_components/sidebar-toast.tsx
@@ -1,0 +1,53 @@
+import type { ReactNode } from 'react';
+import { Button } from '@stagewise/stage-ui/components/button';
+import { cn } from '@stagewise/stage-ui/lib/utils';
+import { IconXmarkOutline18 } from 'nucleo-ui-outline-18';
+
+/**
+ * Shared container for sidebar toast/badge components.
+ *
+ * Provides the standardized visual wrapper (subtle background, ring,
+ * backdrop blur, elevation) and an optional dismiss button rendered
+ * top-right. Content is passed as children.
+ *
+ * Pass `dismissable={false}` to hide the close button (e.g. when the
+ * toast has action buttons that handle dismissal instead).
+ */
+type SidebarToastProps = {
+  /** Accessible label for the dismiss button. */
+  dismissLabel?: string;
+  /** Called when the dismiss button is clicked. Omit to hide the button. */
+  onDismiss?: () => void;
+  /** Extra classes merged onto the container. */
+  className?: string;
+  children: ReactNode;
+};
+
+export function SidebarToast({
+  dismissLabel = 'Dismiss',
+  onDismiss,
+  className,
+  children,
+}: SidebarToastProps) {
+  return (
+    <div
+      className={cn(
+        'relative flex shrink-0 flex-col gap-2 rounded-md bg-background/30 p-2.5 shadow-elevation-1 ring-1 ring-derived-subtle backdrop-blur-xl dark:bg-surface-1/30',
+        className,
+      )}
+    >
+      {onDismiss && (
+        <Button
+          variant="ghost"
+          size="icon-2xs"
+          className="absolute top-1.5 right-1.5 z-10 shrink-0"
+          aria-label={dismissLabel}
+          onClick={onDismiss}
+        >
+          <IconXmarkOutline18 className="size-3" />
+        </Button>
+      )}
+      {children}
+    </div>
+  );
+}

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/agent/stories/agent-lifecycle-scenarios.stories.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/agent/stories/agent-lifecycle-scenarios.stories.tsx
@@ -69,6 +69,7 @@ const baseState: Partial<AppState> = {
         dismissedAt: null,
         dismissedCount: 0,
       },
+      totalAgentCount: 0,
     },
     devAppPreview: {
       isFullScreen: false,

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/agent/stories/agent-lifecycle-scenarios.stories.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/agent/stories/agent-lifecycle-scenarios.stories.tsx
@@ -39,11 +39,36 @@ const baseState: Partial<AppState> = {
   }),
   userExperience: {
     pendingOnboardingSuggestion: null,
+    experienceSurvey: {
+      answered: false,
+      answeredAt: null,
+      dismissedAt: null,
+      dismissedCount: 0,
+    },
+    founderCallSurvey: {
+      answered: false,
+      answeredAt: null,
+      dismissedAt: null,
+      dismissedCount: 0,
+    },
     storedExperienceData: {
       recentlyOpenedWorkspaces: [],
       hasSeenOnboardingFlow: false,
       lastViewedChats: {},
       tutorialState: {},
+      experienceSurvey: {
+        answered: false,
+        answeredAt: null,
+        dismissedAt: null,
+        dismissedCount: 0,
+      },
+      firstUsedAt: null,
+      founderCallSurvey: {
+        answered: false,
+        answeredAt: null,
+        dismissedAt: null,
+        dismissedCount: 0,
+      },
     },
     devAppPreview: {
       isFullScreen: false,

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/agent/stories/agent-messages.stories.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/agent/stories/agent-messages.stories.tsx
@@ -29,11 +29,36 @@ const createStoryState = (
     {
       userExperience: {
         pendingOnboardingSuggestion: null,
+        experienceSurvey: {
+          answered: false,
+          answeredAt: null,
+          dismissedAt: null,
+          dismissedCount: 0,
+        },
+        founderCallSurvey: {
+          answered: false,
+          answeredAt: null,
+          dismissedAt: null,
+          dismissedCount: 0,
+        },
         storedExperienceData: {
           recentlyOpenedWorkspaces: [],
           hasSeenOnboardingFlow: false,
           lastViewedChats: {},
           tutorialState: {},
+          experienceSurvey: {
+            answered: false,
+            answeredAt: null,
+            dismissedAt: null,
+            dismissedCount: 0,
+          },
+          firstUsedAt: null,
+          founderCallSurvey: {
+            answered: false,
+            answeredAt: null,
+            dismissedAt: null,
+            dismissedCount: 0,
+          },
         },
         devAppPreview: {
           isFullScreen: false,

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/agent/stories/agent-messages.stories.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/agent/stories/agent-messages.stories.tsx
@@ -59,6 +59,7 @@ const createStoryState = (
             dismissedAt: null,
             dismissedCount: 0,
           },
+          totalAgentCount: 0,
         },
         devAppPreview: {
           isFullScreen: false,

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/agent/stories/copy-tool.stories.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/agent/stories/copy-tool.stories.tsx
@@ -53,6 +53,7 @@ const createStoryState = (
             dismissedAt: null,
             dismissedCount: 0,
           },
+          totalAgentCount: 0,
         },
         devAppPreview: {
           isFullScreen: false,

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/agent/stories/copy-tool.stories.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/agent/stories/copy-tool.stories.tsx
@@ -23,11 +23,36 @@ const createStoryState = (
     {
       userExperience: {
         pendingOnboardingSuggestion: null,
+        experienceSurvey: {
+          answered: false,
+          answeredAt: null,
+          dismissedAt: null,
+          dismissedCount: 0,
+        },
+        founderCallSurvey: {
+          answered: false,
+          answeredAt: null,
+          dismissedAt: null,
+          dismissedCount: 0,
+        },
         storedExperienceData: {
           recentlyOpenedWorkspaces: [],
           hasSeenOnboardingFlow: false,
           lastViewedChats: {},
           tutorialState: {},
+          experienceSurvey: {
+            answered: false,
+            answeredAt: null,
+            dismissedAt: null,
+            dismissedCount: 0,
+          },
+          firstUsedAt: null,
+          founderCallSurvey: {
+            answered: false,
+            answeredAt: null,
+            dismissedAt: null,
+            dismissedCount: 0,
+          },
         },
         devAppPreview: {
           isFullScreen: false,

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/agent/stories/delete-tool.stories.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/agent/stories/delete-tool.stories.tsx
@@ -53,6 +53,7 @@ const createStoryState = (
             dismissedAt: null,
             dismissedCount: 0,
           },
+          totalAgentCount: 0,
         },
         devAppPreview: {
           isFullScreen: false,

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/agent/stories/delete-tool.stories.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/agent/stories/delete-tool.stories.tsx
@@ -23,11 +23,36 @@ const createStoryState = (
     {
       userExperience: {
         pendingOnboardingSuggestion: null,
+        experienceSurvey: {
+          answered: false,
+          answeredAt: null,
+          dismissedAt: null,
+          dismissedCount: 0,
+        },
+        founderCallSurvey: {
+          answered: false,
+          answeredAt: null,
+          dismissedAt: null,
+          dismissedCount: 0,
+        },
         storedExperienceData: {
           recentlyOpenedWorkspaces: [],
           hasSeenOnboardingFlow: false,
           lastViewedChats: {},
           tutorialState: {},
+          experienceSurvey: {
+            answered: false,
+            answeredAt: null,
+            dismissedAt: null,
+            dismissedCount: 0,
+          },
+          firstUsedAt: null,
+          founderCallSurvey: {
+            answered: false,
+            answeredAt: null,
+            dismissedAt: null,
+            dismissedCount: 0,
+          },
         },
         devAppPreview: {
           isFullScreen: false,

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/agent/stories/list-files-tool.stories.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/agent/stories/list-files-tool.stories.tsx
@@ -53,6 +53,7 @@ const createStoryState = (
             dismissedAt: null,
             dismissedCount: 0,
           },
+          totalAgentCount: 0,
         },
         devAppPreview: {
           isFullScreen: false,

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/agent/stories/list-files-tool.stories.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/agent/stories/list-files-tool.stories.tsx
@@ -23,11 +23,36 @@ const createStoryState = (
     {
       userExperience: {
         pendingOnboardingSuggestion: null,
+        experienceSurvey: {
+          answered: false,
+          answeredAt: null,
+          dismissedAt: null,
+          dismissedCount: 0,
+        },
+        founderCallSurvey: {
+          answered: false,
+          answeredAt: null,
+          dismissedAt: null,
+          dismissedCount: 0,
+        },
         storedExperienceData: {
           recentlyOpenedWorkspaces: [],
           hasSeenOnboardingFlow: false,
           lastViewedChats: {},
           tutorialState: {},
+          experienceSurvey: {
+            answered: false,
+            answeredAt: null,
+            dismissedAt: null,
+            dismissedCount: 0,
+          },
+          firstUsedAt: null,
+          founderCallSurvey: {
+            answered: false,
+            answeredAt: null,
+            dismissedAt: null,
+            dismissedCount: 0,
+          },
         },
         devAppPreview: {
           isFullScreen: false,

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/agent/stories/mkdir-tool.stories.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/agent/stories/mkdir-tool.stories.tsx
@@ -52,6 +52,7 @@ const createStoryState = (
             dismissedAt: null,
             dismissedCount: 0,
           },
+          totalAgentCount: 0,
         },
         devAppPreview: {
           isFullScreen: false,

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/agent/stories/mkdir-tool.stories.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/agent/stories/mkdir-tool.stories.tsx
@@ -22,11 +22,36 @@ const createStoryState = (
     {
       userExperience: {
         pendingOnboardingSuggestion: null,
+        experienceSurvey: {
+          answered: false,
+          answeredAt: null,
+          dismissedAt: null,
+          dismissedCount: 0,
+        },
+        founderCallSurvey: {
+          answered: false,
+          answeredAt: null,
+          dismissedAt: null,
+          dismissedCount: 0,
+        },
         storedExperienceData: {
           recentlyOpenedWorkspaces: [],
           hasSeenOnboardingFlow: false,
           lastViewedChats: {},
           tutorialState: {},
+          experienceSurvey: {
+            answered: false,
+            answeredAt: null,
+            dismissedAt: null,
+            dismissedCount: 0,
+          },
+          firstUsedAt: null,
+          founderCallSurvey: {
+            answered: false,
+            answeredAt: null,
+            dismissedAt: null,
+            dismissedCount: 0,
+          },
         },
         devAppPreview: {
           isFullScreen: false,

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/agent/stories/sandbox-tool.stories.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/agent/stories/sandbox-tool.stories.tsx
@@ -52,6 +52,7 @@ const createStoryState = (
             dismissedAt: null,
             dismissedCount: 0,
           },
+          totalAgentCount: 0,
         },
         devAppPreview: {
           isFullScreen: false,

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/agent/stories/sandbox-tool.stories.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/agent/stories/sandbox-tool.stories.tsx
@@ -22,11 +22,36 @@ const createStoryState = (
     {
       userExperience: {
         pendingOnboardingSuggestion: null,
+        experienceSurvey: {
+          answered: false,
+          answeredAt: null,
+          dismissedAt: null,
+          dismissedCount: 0,
+        },
+        founderCallSurvey: {
+          answered: false,
+          answeredAt: null,
+          dismissedAt: null,
+          dismissedCount: 0,
+        },
         storedExperienceData: {
           recentlyOpenedWorkspaces: [],
           hasSeenOnboardingFlow: false,
           lastViewedChats: {},
           tutorialState: {},
+          experienceSurvey: {
+            answered: false,
+            answeredAt: null,
+            dismissedAt: null,
+            dismissedCount: 0,
+          },
+          firstUsedAt: null,
+          founderCallSurvey: {
+            answered: false,
+            answeredAt: null,
+            dismissedAt: null,
+            dismissedCount: 0,
+          },
         },
         devAppPreview: {
           isFullScreen: false,

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/agent/stories/shell-tool.stories.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/agent/stories/shell-tool.stories.tsx
@@ -58,6 +58,7 @@ const createStoryState = (
             dismissedAt: null,
             dismissedCount: 0,
           },
+          totalAgentCount: 0,
         },
         devAppPreview: {
           isFullScreen: false,

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/agent/stories/shell-tool.stories.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/agent/stories/shell-tool.stories.tsx
@@ -28,11 +28,36 @@ const createStoryState = (
     {
       userExperience: {
         pendingOnboardingSuggestion: null,
+        experienceSurvey: {
+          answered: false,
+          answeredAt: null,
+          dismissedAt: null,
+          dismissedCount: 0,
+        },
+        founderCallSurvey: {
+          answered: false,
+          answeredAt: null,
+          dismissedAt: null,
+          dismissedCount: 0,
+        },
         storedExperienceData: {
           recentlyOpenedWorkspaces: [],
           hasSeenOnboardingFlow: false,
           lastViewedChats: {},
           tutorialState: {},
+          experienceSurvey: {
+            answered: false,
+            answeredAt: null,
+            dismissedAt: null,
+            dismissedCount: 0,
+          },
+          firstUsedAt: null,
+          founderCallSurvey: {
+            answered: false,
+            answeredAt: null,
+            dismissedAt: null,
+            dismissedCount: 0,
+          },
         },
         devAppPreview: {
           isFullScreen: false,

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/notification-banners.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/notification-banners.tsx
@@ -5,7 +5,7 @@ import {
   IconTriangleWarningOutline18,
   IconCircleInfoOutline18,
 } from 'nucleo-ui-outline-18';
-import { IconXmark } from 'nucleo-micro-bold';
+import { SidebarToast } from '../../../_components/sidebar-toast';
 
 export function NotificationBanners() {
   const notifications = useKartonState((s) => s.notifications);
@@ -21,11 +21,10 @@ export function NotificationBanners() {
   return (
     <div className="flex shrink-0 flex-col gap-2">
       {notifications.map((notification) => (
-        <div
+        <SidebarToast
           key={notification.id}
-          className={cn(
-            'relative flex shrink-0 flex-col gap-1.5 rounded-md bg-background/60 p-2.5 shadow-elevation-1 ring-1 ring-derived-strong backdrop-blur-xl dark:bg-surface-1/60',
-          )}
+          dismissLabel="Dismiss notification"
+          onDismiss={() => dismissNotification(notification.id)}
         >
           <div className="flex flex-row items-start gap-2">
             <NotificationIcon type={notification.type} />
@@ -49,15 +48,6 @@ export function NotificationBanners() {
                 </p>
               )}
             </div>
-            <Button
-              variant="ghost"
-              size="icon-2xs"
-              className="ml-auto shrink-0"
-              aria-label="Dismiss notification"
-              onClick={() => dismissNotification(notification.id)}
-            >
-              <IconXmark className="size-3" />
-            </Button>
           </div>
           {notification.actions.length > 0 && (
             <div className="flex flex-row-reverse items-center gap-2">
@@ -76,7 +66,7 @@ export function NotificationBanners() {
               ))}
             </div>
           )}
-        </div>
+        </SidebarToast>
       ))}
     </div>
   );

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/usage-warning-badge.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/usage-warning-badge.tsx
@@ -1,7 +1,7 @@
 import { useState, useMemo } from 'react';
 import { useKartonState } from '@ui/hooks/use-karton';
-import { Button } from '@stagewise/stage-ui/components/button';
-import { XIcon, TriangleAlertIcon } from 'lucide-react';
+import { TriangleAlertIcon } from 'lucide-react';
+import { SidebarToast } from '../../../_components/sidebar-toast';
 
 const THRESHOLDS = [80, 90, 100] as const;
 
@@ -53,24 +53,19 @@ export function UsageWarningBadge() {
   const window = stateUsageWarning.windowType;
 
   return (
-    <div className="relative flex shrink-0 flex-row items-start gap-2 rounded-md bg-background/60 p-2.5 shadow-elevation-1 ring-1 ring-derived-strong backdrop-blur-xl dark:bg-surface-1/60">
+    <SidebarToast
+      dismissLabel="Dismiss usage warning"
+      onDismiss={() => {
+        lastDismissedThreshold = activeThreshold;
+        setDismissedThreshold(activeThreshold);
+      }}
+      className="flex-row items-start gap-2"
+    >
       <TriangleAlertIcon className="mt-0.5 size-3.5 shrink-0 text-warning-foreground" />
       <span className="text-foreground text-xs">
         You&apos;ve used {pct}% of your {window} limit. Consider switching to a
         cheaper model.
       </span>
-      <Button
-        variant="ghost"
-        size="icon-2xs"
-        className="ml-auto shrink-0"
-        aria-label="Dismiss usage warning"
-        onClick={() => {
-          lastDismissedThreshold = activeThreshold;
-          setDismissedThreshold(activeThreshold);
-        }}
-      >
-        <XIcon className="size-3" />
-      </Button>
-    </div>
+    </SidebarToast>
   );
 }

--- a/apps/browser/src/ui/screens/main/sidebar/index.tsx
+++ b/apps/browser/src/ui/screens/main/sidebar/index.tsx
@@ -15,6 +15,7 @@ import { NotificationBanners } from '../agent-chat/chat/_components/notification
 import { UsageWarningBadge } from '../agent-chat/chat/_components/usage-warning-badge';
 import { WorktreeCleanupBadge } from './worktree-cleanup-badge';
 import { SidebarAuthFooter } from '../_components/sidebar-auth-footer';
+import { SidebarExperienceSurvey } from '../_components/sidebar-experience-survey';
 import {
   DEFAULT_EXPANDED_SIDEBAR_SIZE,
   SIDEBAR_PANEL_CLASS_NAME,
@@ -84,6 +85,7 @@ export function Sidebar() {
           <AgentsList />
 
           <div className="mt-8 flex shrink-0 flex-col gap-2">
+            <SidebarExperienceSurvey />
             <NotificationBanners />
             <UsageWarningBadge />
             <WorktreeCleanupBadge />

--- a/apps/browser/src/ui/screens/main/sidebar/worktree-cleanup-badge.tsx
+++ b/apps/browser/src/ui/screens/main/sidebar/worktree-cleanup-badge.tsx
@@ -2,9 +2,9 @@ import { useMemo, useRef } from 'react';
 import { Button } from '@stagewise/stage-ui/components/button';
 import { useKartonProcedure, useKartonState } from '@ui/hooks/use-karton';
 import { useScrollFadeMask } from '@ui/hooks/use-scroll-fade-mask';
-import { XIcon } from 'lucide-react';
 import { IconTrash2Outline24 } from 'nucleo-core-outline-24';
 import { IconBranchOutOutline18 } from 'nucleo-ui-outline-18';
+import { SidebarToast } from '../_components/sidebar-toast';
 
 function getBaseName(value: string): string {
   return value.split(/[\\/]/).filter(Boolean).at(-1) ?? value;
@@ -52,22 +52,16 @@ export function WorktreeCleanupBadge() {
   };
 
   return (
-    <div className="relative flex shrink-0 flex-col gap-2 rounded-md bg-background/60 p-2.5 shadow-elevation-1 ring-1 ring-derived-strong backdrop-blur-xl dark:bg-surface-1/60">
+    <SidebarToast
+      dismissLabel="Dismiss worktree cleanup"
+      onDismiss={handleDismiss}
+    >
       <div className="flex flex-col gap-1">
         <div className="flex items-center gap-1.5">
           <IconTrash2Outline24 className="size-3.5 shrink-0 text-foreground" />
           <div className="mt-0.5 min-w-0 flex-1 font-medium text-foreground text-xs">
             Clean old worktrees?
           </div>
-          <Button
-            variant="ghost"
-            size="icon-2xs"
-            className="ml-auto shrink-0"
-            aria-label="Dismiss worktree cleanup"
-            onClick={handleDismiss}
-          >
-            <XIcon className="size-3" />
-          </Button>
         </div>
         <p className="text-muted-foreground text-xs leading-snug">
           {count} clean, inactive{' '}
@@ -132,6 +126,6 @@ export function WorktreeCleanupBadge() {
           {cleanup.cleaning ? 'Cleaning…' : 'Clean worktrees'}
         </Button>
       </div>
-    </div>
+    </SidebarToast>
   );
 }

--- a/packages/agent-core/src/services/agent-persistence/db.ts
+++ b/packages/agent-core/src/services/agent-persistence/db.ts
@@ -6,6 +6,7 @@ import {
   notInArray,
   inArray,
   desc,
+  asc,
   isNull,
   eq,
   sql,
@@ -665,5 +666,20 @@ export class AgentPersistenceDB {
 
     // Clean up dirty-tracking state
     this._lastPersistedIds.delete(id);
+  }
+
+  /**
+   * Returns the earliest `createdAt` among all agent instances, or null if
+   * no agents exist. Used to backfill `firstUsedAt` for existing users who
+   * already have chat history before the founder-call survey feature was
+   * introduced.
+   */
+  public async getOldestAgentCreatedAt(): Promise<Date | null> {
+    const result = await this._db
+      .select({ createdAt: schema.agentInstances.createdAt })
+      .from(schema.agentInstances)
+      .orderBy(asc(schema.agentInstances.createdAt))
+      .limit(1);
+    return result[0]?.createdAt ?? null;
   }
 }

--- a/packages/agent-core/src/services/agent-persistence/db.ts
+++ b/packages/agent-core/src/services/agent-persistence/db.ts
@@ -675,11 +675,32 @@ export class AgentPersistenceDB {
    * introduced.
    */
   public async getOldestAgentCreatedAt(): Promise<Date | null> {
+    // Filter out invalid timestamps (0, negative, or impossibly old).
+    // Some legacy/corrupted records have created_at = 0 (Unix epoch),
+    // which would poison the firstUsedAt backfill.
     const result = await this._db
       .select({ createdAt: schema.agentInstances.createdAt })
       .from(schema.agentInstances)
+      .where(sql`${schema.agentInstances.createdAt} > 0`)
       .orderBy(asc(schema.agentInstances.createdAt))
       .limit(1);
     return result[0]?.createdAt ?? null;
+  }
+
+  /**
+   * Returns the total number of top-level chat agents (excluding sub-agents).
+   * Used by the founder-call survey to determine eligibility.
+   */
+  public async getAgentCount(): Promise<number> {
+    const result = await this._db
+      .select({ count: sql<number>`count(*)` })
+      .from(schema.agentInstances)
+      .where(
+        and(
+          isNull(schema.agentInstances.parentAgentInstanceId),
+          eq(schema.agentInstances.type, AgentTypes.CHAT),
+        ),
+      );
+    return result[0]?.count ?? 0;
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds sidebar feedback toasts and a founder call invite with persisted state, smart timing, and telemetry. Standardizes the sidebar toast UI, backfills the first‑used date safely, uses the DB for agent count, and includes small UX/a11y fixes.

- New Features
  - Two sidebar toasts:
    - Experience survey: shows after 5+ user messages; 48h dismiss cooldown (max 3); optional follow‑up feedback; telemetry for answer and feedback (bypass opt‑out).
    - Founder call: shows after 4+ days of use, 10+ agents, and 24h after the first survey; 96h dismiss cooldown (max 3); booking opens a link and marks as answered. Never show both at once.
  - Persistence and timing: new JSON stores `experience-survey`, `experience-founder-call-survey`, `first-used-at`; `firstUsedAt` set on first user message or backfilled from the oldest agent `createdAt` with plausibility checks; `totalAgentCount` sourced from the DB with a concurrency guard and only refreshed when loaded count exceeds stored count.
  - UI/Contracts: `SidebarExperienceSurvey` in the sidebar; shared `SidebarToast` wrapper reused by `NotificationBanners`, `WorktreeCleanupBadge`, and `UsageWarningBadge`; Karton procedures `userExperience.survey.answer|dismiss|submitFeedback` and `userExperience.founderCall.survey.open|dismiss`; icons unified to nucleo; telemetry events added (bypass opt‑out).

- Bug Fixes
  - Reliability: self‑healing timestamp validation for `firstUsedAt` (ignore pre‑2000/future values); cooldown boundary timer so toasts reappear exactly when cooldowns expire even while idle; guard concurrent DB refreshes and ensure agent‑count refresh still runs after `firstUsedAt` initializes.
  - UX/A11y: await feedback submission and keep the form open on failure with an inline error; prevent duplicate feedback submissions while pending; feedback textarea labeled via `aria-labelledby`; founder‑call link opens with `noopener,noreferrer`; `SidebarToast` reserves space for the dismiss button to prevent content overlap.

<sup>Written for commit 025d4c8fe998b785e9a2295d5fd771733134f3ad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1381?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added sidebar-driven “experience survey” and “founder call” prompts with eligibility rules and persisted answer/dismiss/feedback state.
  * Introduced “first used” timestamp tracking (with backfill) and periodic agent-count updates to refine prompt timing.
* **Bug Fixes**
  * Improved reliability of saved timestamp data via self-healing backfill when values are missing or implausible.
* **Telemetry**
  * Added events for survey answered, feedback submitted, and founder-call opened/dismissed.
* **UI / Tests**
  * Added a reusable sidebar toast component and updated sidebar notification components to use it.
  * Updated service tests and Storybook fixtures for the expanded saved state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->