### PR TITLE
Global skill settings

### DIFF
--- a/apps/browser/src/backend/env-domains/host-environment-sources.ts
+++ b/apps/browser/src/backend/env-domains/host-environment-sources.ts
@@ -16,7 +16,6 @@
  * This adapter stays thin on purpose — the orchestrator invokes it on
  * every capture, so avoid any heavy caching or invalidation logic here.
  */
-import { existsSync } from 'node:fs';
 import type {
   HostEnvironmentSources,
   ResolvedSkillEntry,
@@ -25,7 +24,7 @@ import type {
 } from '@stagewise/agent-core';
 import type { KartonService } from '../services/karton';
 import type { ToolboxService } from '../services/toolbox';
-import { getGlobalSkillsMounts } from '../services/toolbox';
+import { getEnabledGlobalSkillsMounts } from '../services/toolbox';
 
 export interface BrowserHostEnvironmentSourcesDeps {
   karton: KartonService;
@@ -78,10 +77,15 @@ export function createBrowserHostEnvironmentSources(
     },
 
     getGlobalSkillsMounts(): GlobalSkillsMount[] {
-      return getGlobalSkillsMounts().map((m) => ({
+      // Only surface enabled mounts to the core env-snapshot (symlinks
+      // table + EnabledSkillsDomainAdapter). External dirs (codex/claude)
+      // are opt-in via `preferences.agent.enabledGlobalSkillDirs`.
+      const enabled =
+        karton.state.preferences?.agent?.enabledGlobalSkillDirs ?? [];
+      return getEnabledGlobalSkillsMounts(enabled).map((m) => ({
         prefix: m.prefix,
         absolutePath: m.absolutePath,
-        exists: existsSync(m.absolutePath),
+        exists: true,
       }));
     },
   };

--- a/apps/browser/src/backend/services/toolbox/global-skills.test.ts
+++ b/apps/browser/src/backend/services/toolbox/global-skills.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { existsSync } from 'node:fs';
+import { homedir } from 'node:os';
+import path from 'node:path';
+
+vi.mock('node:fs', () => ({
+  existsSync: vi.fn(),
+  mkdirSync: vi.fn(),
+  truncateSync: vi.fn(),
+}));
+
+// We test the pure helper functions that drive the global-skills
+// filtering. Import from the lightweight module that has no heavy
+// transitive dependencies (ToolboxService, mount-manager, etc.).
+const { getGlobalSkillsMounts, getEnabledGlobalSkillsMounts } = await import(
+  './global-skills'
+);
+
+describe('getGlobalSkillsMounts', () => {
+  it('returns all 4 global skill directories', () => {
+    const mounts = getGlobalSkillsMounts();
+    expect(mounts).toHaveLength(4);
+    const prefixes = mounts.map((m) => m.prefix);
+    expect(prefixes).toContain('globalskills-sw');
+    expect(prefixes).toContain('globalskills-agents');
+    expect(prefixes).toContain('globalskills-codex');
+    expect(prefixes).toContain('globalskills-claude');
+  });
+
+  it('resolves paths under the home directory', () => {
+    const home = homedir();
+    const mounts = getGlobalSkillsMounts();
+    const sw = mounts.find((m) => m.prefix === 'globalskills-codex');
+    expect(sw?.absolutePath).toBe(path.resolve(home, '.codex', 'skills'));
+  });
+});
+
+describe('getEnabledGlobalSkillsMounts', () => {
+  beforeEach(() => {
+    vi.mocked(existsSync).mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('always includes stagewise and agents dirs regardless of preferences', () => {
+    const mounts = getEnabledGlobalSkillsMounts([]);
+    const prefixes = mounts.map((m) => m.prefix);
+    expect(prefixes).toContain('globalskills-sw');
+    expect(prefixes).toContain('globalskills-agents');
+    expect(prefixes).not.toContain('globalskills-codex');
+    expect(prefixes).not.toContain('globalskills-claude');
+  });
+
+  it('includes codex dir when opted in', () => {
+    const mounts = getEnabledGlobalSkillsMounts(['globalskills-codex']);
+    const prefixes = mounts.map((m) => m.prefix);
+    expect(prefixes).toContain('globalskills-codex');
+    expect(prefixes).not.toContain('globalskills-claude');
+  });
+
+  it('includes both codex and claude when both opted in', () => {
+    const mounts = getEnabledGlobalSkillsMounts([
+      'globalskills-codex',
+      'globalskills-claude',
+    ]);
+    const prefixes = mounts.map((m) => m.prefix);
+    expect(prefixes).toContain('globalskills-codex');
+    expect(prefixes).toContain('globalskills-claude');
+  });
+
+  it('excludes dirs that do not exist on disk', () => {
+    vi.mocked(existsSync).mockImplementation((p) => {
+      const s = String(p);
+      // Only stagewise exists; codex/claude/agents do not.
+      return s.endsWith(path.join('.stagewise', 'skills'));
+    });
+    const mounts = getEnabledGlobalSkillsMounts([
+      'globalskills-codex',
+      'globalskills-claude',
+    ]);
+    const prefixes = mounts.map((m) => m.prefix);
+    expect(prefixes).toContain('globalskills-sw');
+    expect(prefixes).not.toContain('globalskills-agents');
+    expect(prefixes).not.toContain('globalskills-codex');
+    expect(prefixes).not.toContain('globalskills-claude');
+  });
+
+  it('ignores unknown prefixes in the enabled list', () => {
+    const mounts = getEnabledGlobalSkillsMounts([
+      'globalskills-unknown',
+      'globalskills-codex',
+    ]);
+    const prefixes = mounts.map((m) => m.prefix);
+    expect(prefixes).not.toContain('globalskills-unknown');
+    expect(prefixes).toContain('globalskills-codex');
+  });
+});

--- a/apps/browser/src/backend/services/toolbox/global-skills.ts
+++ b/apps/browser/src/backend/services/toolbox/global-skills.ts
@@ -1,0 +1,56 @@
+import { existsSync } from 'node:fs';
+import { homedir } from 'node:os';
+import path from 'node:path';
+import { ALWAYS_ENABLED_GLOBAL_SKILL_PREFIXES } from '@shared/global-skill-prefixes';
+
+/**
+ * Return all known global skill mount descriptors (stagewise, agents,
+ * codex, claude). This is the canonical list — every other consumer
+ * derives from it.
+ */
+export function getGlobalSkillsMounts(): Array<{
+  prefix: string;
+  absolutePath: string;
+}> {
+  const home = homedir();
+  return [
+    {
+      prefix: 'globalskills-sw',
+      absolutePath: path.resolve(home, '.stagewise', 'skills'),
+    },
+    {
+      prefix: 'globalskills-agents',
+      absolutePath: path.resolve(home, '.agents', 'skills'),
+    },
+    {
+      prefix: 'globalskills-codex',
+      absolutePath: path.resolve(home, '.codex', 'skills'),
+    },
+    {
+      prefix: 'globalskills-claude',
+      absolutePath: path.resolve(home, '.claude', 'skills'),
+    },
+  ];
+}
+
+/**
+ * Return the subset of global skill mounts the user has enabled.
+ *
+ * The built-in `globalskills-sw` and `globalskills-agents` mounts are
+ * always enabled. External mounts (`globalskills-codex`,
+ * `globalskills-claude`) are gated by the
+ * `preferences.agent.enabledGlobalSkillDirs` opt-in list.
+ *
+ * Only mounts whose directory exists on disk are returned.
+ */
+export function getEnabledGlobalSkillsMounts(
+  enabledGlobalSkillDirs: readonly string[],
+): Array<{ prefix: string; absolutePath: string }> {
+  const enabled = new Set(enabledGlobalSkillDirs);
+  return getGlobalSkillsMounts().filter(
+    (m) =>
+      existsSync(m.absolutePath) &&
+      (ALWAYS_ENABLED_GLOBAL_SKILL_PREFIXES.has(m.prefix) ||
+        enabled.has(m.prefix)),
+  );
+}

--- a/apps/browser/src/backend/services/toolbox/index.ts
+++ b/apps/browser/src/backend/services/toolbox/index.ts
@@ -967,10 +967,11 @@ export class ToolboxService
         .filter((c) => c.userInvocable !== false)
         .map(toSkillDefinitionUI);
     });
-    // Also refresh the full unfiltered global-skills index used by
-    // the Settings UI (per-dir + per-skill toggles). Cheap to do
-    // here since we already triggered discovery above.
-    void this.rebuildGlobalSkillsIndex();
+    // Note: rebuildGlobalSkillsIndex is NOT called here to avoid
+    // N+1 filesystem scans when this method is invoked in a per-agent
+    // loop. The global index is independent of per-agent state (it
+    // discovers ALL skills from ALL dirs regardless of preferences),
+    // so it is rebuilt once per event at the call sites that need it.
   }
 
   /**

--- a/apps/browser/src/backend/services/toolbox/index.ts
+++ b/apps/browser/src/backend/services/toolbox/index.ts
@@ -94,7 +94,6 @@ import type { ContextFilesResult } from '@shared/karton-contracts/pages-api/type
 import {
   getSkills,
   discoverSkills,
-  discoverGlobalSkills,
 } from '@/agents/shared/prompts/utils/get-skills';
 import type { SkillDefinition } from '@shared/skills';
 import { toSkillDefinitionUI } from '@shared/skills';
@@ -105,27 +104,14 @@ import { readLogChannels } from '@stagewise/agent-core/logs/read';
 import { LogIngestService } from '../log-ingest';
 import { ClientRuntimeNode } from '@stagewise/agent-runtime-node';
 import chokidar, { type FSWatcher } from 'chokidar';
-import { homedir } from 'node:os';
+import {
+  getGlobalSkillsMounts,
+  getEnabledGlobalSkillsMounts,
+} from './global-skills';
+export { getGlobalSkillsMounts, getEnabledGlobalSkillsMounts };
 
 type MountedPrefix = string;
 type MountedPath = string;
-
-export function getGlobalSkillsMounts(): Array<{
-  prefix: string;
-  absolutePath: string;
-}> {
-  const home = homedir();
-  return [
-    {
-      prefix: 'globalskills-sw',
-      absolutePath: path.resolve(home, '.stagewise', 'skills'),
-    },
-    {
-      prefix: 'globalskills-agents',
-      absolutePath: path.resolve(home, '.agents', 'skills'),
-    },
-  ];
-}
 
 export class ToolboxService
   extends DisposableService
@@ -193,7 +179,9 @@ export class ToolboxService
       this.mountManagerService?.getMountedRuntimes(agentInstanceId);
     if (!runtimes) return undefined;
     if (this.pluginsRuntime) runtimes.set('plugins', this.pluginsRuntime);
-    for (const mount of getGlobalSkillsMounts()) {
+    for (const mount of getEnabledGlobalSkillsMounts(
+      this.uiKarton.state.preferences?.agent?.enabledGlobalSkillDirs ?? [],
+    )) {
       const rt = this.getOrCreateGlobalSkillsRuntime(
         mount.prefix,
         mount.absolutePath,
@@ -222,13 +210,13 @@ export class ToolboxService
       agentInstanceId,
       hostPaths: getBrowserHostPaths(),
       mountManager: this.mountManagerService,
-      staticMounts: getGlobalSkillsMounts()
-        .filter((mount) => existsSync(mount.absolutePath))
-        .map((mount) => ({
-          prefix: mount.prefix,
-          absolutePath: mount.absolutePath,
-          permissions: ['read'] satisfies readonly CoreMountPermission[],
-        })),
+      staticMounts: getEnabledGlobalSkillsMounts(
+        this.uiKarton.state.preferences?.agent?.enabledGlobalSkillDirs ?? [],
+      ).map((mount) => ({
+        prefix: mount.prefix,
+        absolutePath: mount.absolutePath,
+        permissions: ['read'] satisfies readonly CoreMountPermission[],
+      })),
       diffHistoryService: this.diffHistoryService,
       logger: this.logger,
       rgBinaryBasePath: getRipgrepBasePath(),
@@ -255,6 +243,8 @@ export class ToolboxService
 
   /** Monotonically increasing counter to discard stale `rebuildSkillsList` results. */
   private skillsRebuildGeneration = 0;
+  /** Counter for stale `rebuildGlobalSkillsIndex` results. */
+  private globalSkillsRebuildGeneration = 0;
 
   private plansRuntime: ClientRuntimeNode | null = null;
   private plansWatcher: FSWatcher | null = null;
@@ -796,14 +786,14 @@ export class ToolboxService
       permissions: READ_ONLY_PERMISSIONS,
     });
 
-    for (const gs of getGlobalSkillsMounts()) {
-      if (existsSync(gs.absolutePath)) {
-        mounts.push({
-          prefix: gs.prefix,
-          absolutePath: gs.absolutePath,
-          permissions: READ_ONLY_PERMISSIONS,
-        });
-      }
+    for (const gs of getEnabledGlobalSkillsMounts(
+      this.uiKarton.state.preferences?.agent?.enabledGlobalSkillDirs ?? [],
+    )) {
+      mounts.push({
+        prefix: gs.prefix,
+        absolutePath: gs.absolutePath,
+        permissions: READ_ONLY_PERMISSIONS,
+      });
     }
 
     const appsDir = getAgentAppsDir(agentInstanceId);
@@ -956,6 +946,9 @@ export class ToolboxService
         draft.skills = cmds.map(toSkillDefinitionUI);
       });
     }
+    // Always populate the global skills index for the Settings UI,
+    // even before any agent is created.
+    void this.rebuildGlobalSkillsIndex();
   }
 
   /**
@@ -973,6 +966,57 @@ export class ToolboxService
       draft.skills = commands
         .filter((c) => c.userInvocable !== false)
         .map(toSkillDefinitionUI);
+    });
+    // Also refresh the full unfiltered global-skills index used by
+    // the Settings UI (per-dir + per-skill toggles). Cheap to do
+    // here since we already triggered discovery above.
+    void this.rebuildGlobalSkillsIndex();
+  }
+
+  /**
+   * Discover ALL global skills from every global skill directory
+   * (including disabled ones), deduped by name with `.stagewise` >
+   * `.agents` > `.codex` > `.claude` ordering, and push the result
+   * to `state.globalSkills` for the Settings UI. Unlike
+   * `getSkillsList`, this does NOT filter by enabled dirs or
+   * disabled skill names — the UI needs the full roster to render
+   * toggles.
+   */
+  private async rebuildGlobalSkillsIndex(): Promise<void> {
+    const gen = ++this.globalSkillsRebuildGeneration;
+    const mounts = getGlobalSkillsMounts();
+    const perMount = await Promise.all(
+      mounts.map(async (m) => ({
+        mount: m,
+        skills: existsSync(m.absolutePath)
+          ? await discoverSkills(m.absolutePath)
+          : [],
+      })),
+    );
+    if (gen !== this.globalSkillsRebuildGeneration) return;
+
+    const seen = new Set<string>();
+    const result: Array<{
+      name: string;
+      description: string;
+      mountPrefix: string;
+    }> = [];
+    // Preserve mount order from getGlobalSkillsMounts() (stagewise >
+    // agents > codex > claude) for dedupe priority.
+    for (const { mount, skills } of perMount) {
+      for (const skill of skills) {
+        if (seen.has(skill.name)) continue;
+        seen.add(skill.name);
+        result.push({
+          name: skill.name,
+          description: skill.description,
+          mountPrefix: mount.prefix,
+        });
+      }
+    }
+
+    this.uiKarton.setState((draft) => {
+      draft.globalSkills = result;
     });
   }
 
@@ -1025,31 +1069,35 @@ export class ToolboxService
     }
 
     // Global (user-level) skills — after workspace so workspace wins on dupes.
-    // Also suppressed by workspace-level disabledSkills.
-    const globalSkills = await discoverGlobalSkills();
-    const globalMounts = getGlobalSkillsMounts();
-    for (const skill of globalSkills) {
-      if (allDisabled.has(skill.name)) continue;
-      const id = `skill:${skill.name}`;
-      if (seen.has(id)) continue;
-      seen.add(id);
-      const mount = globalMounts.find(
-        (m) =>
-          skill.path === m.absolutePath ||
-          skill.path.startsWith(m.absolutePath + path.sep),
-      );
-      if (!mount) continue;
-      const relativePath = path.relative(mount.absolutePath, skill.path);
-      result.push({
-        id,
-        displayName: skill.name,
-        description: skill.description,
-        source: 'global',
-        contentPath: path.resolve(skill.path, 'SKILL.md'),
-        skillPath: `${mount.prefix}/${relativePath}`,
-        userInvocable: skill.userInvocable,
-        agentInvocable: skill.agentInvocable,
-      });
+    // Also suppressed by workspace-level disabledSkills and global-level
+    // disabledGlobalSkills. Discovery is per-mount (only enabled dirs) so
+    // that external dirs (codex/claude) are opt-in.
+    const disabledGlobalSkills = new Set(
+      this.uiKarton.state.preferences?.agent?.disabledGlobalSkills ?? [],
+    );
+    const enabledGlobalMounts = getEnabledGlobalSkillsMounts(
+      this.uiKarton.state.preferences?.agent?.enabledGlobalSkillDirs ?? [],
+    );
+    for (const mount of enabledGlobalMounts) {
+      const skills = await discoverSkills(mount.absolutePath);
+      for (const skill of skills) {
+        if (allDisabled.has(skill.name) || disabledGlobalSkills.has(skill.name))
+          continue;
+        const id = `skill:${skill.name}`;
+        if (seen.has(id)) continue;
+        seen.add(id);
+        const relativePath = path.relative(mount.absolutePath, skill.path);
+        result.push({
+          id,
+          displayName: skill.name,
+          description: skill.description,
+          source: 'global',
+          contentPath: path.resolve(skill.path, 'SKILL.md'),
+          skillPath: `${mount.prefix}/${relativePath}`,
+          userInvocable: skill.userInvocable,
+          agentInvocable: skill.agentInvocable,
+        });
+      }
     }
 
     // Plugin skills
@@ -1223,10 +1271,10 @@ export class ToolboxService
     result.set(LOGS_PREFIX, getLogsDir());
     result.set('memory', getMemoryDir());
 
-    for (const gs of getGlobalSkillsMounts()) {
-      if (existsSync(gs.absolutePath)) {
-        result.set(gs.prefix, gs.absolutePath);
-      }
+    for (const gs of getEnabledGlobalSkillsMounts(
+      this.uiKarton.state.preferences?.agent?.enabledGlobalSkillDirs ?? [],
+    )) {
+      result.set(gs.prefix, gs.absolutePath);
     }
 
     return result;
@@ -1358,6 +1406,8 @@ export class ToolboxService
       (state) => ({
         ws: state.preferences?.agent?.workspaceSettings,
         plugins: state.preferences?.agent?.disabledPluginIds,
+        globalSkillDirs: state.preferences?.agent?.enabledGlobalSkillDirs,
+        disabledGlobalSkills: state.preferences?.agent?.disabledGlobalSkills,
       }),
       () => {
         const activeIds = Object.keys(this.uiKarton.state.agents.instances);
@@ -1617,10 +1667,12 @@ export class ToolboxService
   }
 
   /**
-   * Watch parent dirs (`~/.stagewise/`, `~/.agents/`) for changes to their
-   * `skills/` subdirectories. Follows the workspace watcher pattern: watch
-   * parents with an ignored filter so we detect `skills/` being created
-   * for the first time.
+   * Watch parent dirs (`~/.stagewise/`, `~/.agents/`, `~/.codex/`,
+   * `~/.claude/`) for changes to their `skills/` subdirectories. Follows
+   * the workspace watcher pattern: watch parents with an ignored filter
+   * so we detect `skills/` being created for the first time. Watches all
+   * global mounts regardless of enabled/disabled state so toggling a dir
+   * on picks up its contents immediately.
    */
   private startGlobalSkillsWatchers(): void {
     const scheduleRefresh = () => {
@@ -1636,6 +1688,9 @@ export class ToolboxService
           )
             this.globalSkillsRuntimes.delete(mount.prefix);
         }
+        // Always refresh the global skills index for the Settings UI,
+        // even when no agents are active.
+        void this.rebuildGlobalSkillsIndex();
         // Rebuild skills list for all active agents.
         const activeIds = Object.keys(this.uiKarton.state.agents.instances);
         for (const id of activeIds) void this.rebuildSkillsList(id);

--- a/apps/browser/src/shared/global-skill-prefixes.ts
+++ b/apps/browser/src/shared/global-skill-prefixes.ts
@@ -1,0 +1,9 @@
+/**
+ * Mount prefixes for global skill directories that are always enabled
+ * (not gated by user preference). Stagewise and Agents dirs are core
+ * to the product and always loaded when they exist on disk.
+ */
+export const ALWAYS_ENABLED_GLOBAL_SKILL_PREFIXES = new Set([
+  'globalskills-sw',
+  'globalskills-agents',
+]);

--- a/apps/browser/src/shared/karton-contracts/ui/index.ts
+++ b/apps/browser/src/shared/karton-contracts/ui/index.ts
@@ -1209,6 +1209,20 @@ export type AppState = {
   /** Skill definitions (builtins, workspace skills, plugin skills) */
   skills: SkillDefinitionUI[];
 
+  /**
+   * All global skills discovered from every global skill directory
+   * (stagewise, agents, codex, claude), regardless of enabled/disabled
+   * state. Used by the Settings UI to render per-dir and per-skill
+   * toggles. Each entry carries its mount prefix so the UI can group
+   * by directory.
+   */
+  globalSkills: Array<{
+    name: string;
+    description: string;
+    /** Mount prefix (e.g. `globalskills-codex`) identifying the dir. */
+    mountPrefix: string;
+  }>;
+
   /** Global plans (workspace-independent, from user-data/plans/) */
   plans: PlanEntry[];
 
@@ -2181,6 +2195,7 @@ export const defaultState: KartonContract['state'] = {
   workspaceMdGenerating: {},
   plugins: [],
   skills: [],
+  globalSkills: [],
   plans: [],
   logChannels: [],
   logIngest: null,

--- a/apps/browser/src/shared/karton-contracts/ui/shared-types.ts
+++ b/apps/browser/src/shared/karton-contracts/ui/shared-types.ts
@@ -555,6 +555,20 @@ export const userPreferencesSchema = z.object({
         .record(z.string(), modelThinkingOverrideSchema)
         .default({})
         .catch({}),
+      /**
+       * External global skill directories the user has opted in to.
+       * Contains mount prefixes (e.g. `globalskills-codex`,
+       * `globalskills-claude`). The built-in `globalskills-sw` and
+       * `globalskills-agents` dirs are always enabled and never appear
+       * here. Empty array = no external dirs loaded.
+       */
+      enabledGlobalSkillDirs: z.array(z.string()).default([]),
+      /**
+       * Skill names disabled at the global level (analogous to the
+       * per-workspace `disabledSkills`). Applies to skills discovered
+       * from any global skill directory.
+       */
+      disabledGlobalSkills: z.array(z.string()).default([]),
     })
     .default({
       workspaceSettings: {},
@@ -563,6 +577,8 @@ export const userPreferencesSchema = z.object({
       workspaceGitActionPreferences: defaultWorkspaceGitActionPreferences,
       workspaceGitCleanup: defaultWorkspaceGitCleanupPreferences,
       modelThinkingOverrides: {},
+      enabledGlobalSkillDirs: [],
+      disabledGlobalSkills: [],
     }),
   /** LLM provider endpoint configurations (API keys, custom URLs) */
   providerConfigs: providerConfigsSchema.default({
@@ -677,6 +693,8 @@ export const defaultUserPreferences: UserPreferences = {
     workspaceGitActionPreferences: defaultWorkspaceGitActionPreferences,
     workspaceGitCleanup: defaultWorkspaceGitCleanupPreferences,
     modelThinkingOverrides: {},
+    enabledGlobalSkillDirs: [],
+    disabledGlobalSkills: [],
   },
   providerConfigs: {
     anthropic: { mode: 'stagewise' },

--- a/apps/browser/src/ui/screens/settings/sections/skills-context-section.tsx
+++ b/apps/browser/src/ui/screens/settings/sections/skills-context-section.tsx
@@ -330,7 +330,9 @@ function GlobalSkillsDetails() {
     async (prefix: string, enabled: boolean) => {
       const current = enabledGlobalSkillDirs;
       const next = enabled
-        ? [...current, prefix]
+        ? current.includes(prefix)
+          ? current
+          : [...current, prefix]
         : current.filter((p) => p !== prefix);
       await updatePreferences([
         {
@@ -687,8 +689,12 @@ export function SkillsContextSection() {
   );
 
   // Compute the effective tab ID: when the user hasn't clicked
-  // anything yet, fall back to the first tab ("Global").
-  const effectiveTabId = selectedTabId ?? tabItems[0]?.id ?? null;
+  // anything yet (or the previously selected tab no longer exists),
+  // fall back to the first tab ("Global").
+  const effectiveTabId =
+    selectedTabId != null && tabItems.some((t) => t.id === selectedTabId)
+      ? selectedTabId
+      : (tabItems[0]?.id ?? null);
   const isGlobalTab = effectiveTabId === GLOBAL_TAB_ID;
 
   return (

--- a/apps/browser/src/ui/screens/settings/sections/skills-context-section.tsx
+++ b/apps/browser/src/ui/screens/settings/sections/skills-context-section.tsx
@@ -16,7 +16,7 @@ import {
 } from 'react';
 import { cn } from '@ui/utils';
 import type { ContextFilesResult } from '@shared/karton-contracts/pages-api/types';
-import type { MountEntry } from '@shared/karton-contracts/ui';
+import type { MountEntry, AppState } from '@shared/karton-contracts/ui';
 import type { Patch } from '@shared/karton-contracts/ui/shared-types';
 import { Button } from '@stagewise/stage-ui/components/button';
 import { Loader2Icon, RefreshCwIcon } from 'lucide-react';
@@ -29,6 +29,7 @@ import {
 } from '@stagewise/stage-ui/components/tooltip';
 import type { RefObject } from 'react';
 import { SettingsScrollTabs } from '../_components/settings-scroll-tabs';
+import { ALWAYS_ENABLED_GLOBAL_SKILL_PREFIXES } from '@shared/global-skill-prefixes';
 
 // =============================================================================
 // Vertical overflow detection (like useIsTruncated but for height)
@@ -258,6 +259,199 @@ function WorkspaceDetails({
 }
 
 // =============================================================================
+// Global Skills Section
+// =============================================================================
+
+/** Mount prefixes that are always enabled (not toggleable in the UI). */
+/** Display metadata for each global skill directory. */
+const GLOBAL_SKILL_DIR_META: Record<string, { label: string; dir: string }> = {
+  'globalskills-sw': { label: 'Stagewise', dir: '~/.stagewise/skills' },
+  'globalskills-agents': { label: 'Agents', dir: '~/.agents/skills' },
+  'globalskills-codex': { label: 'Codex', dir: '~/.codex/skills' },
+  'globalskills-claude': { label: 'Claude Code', dir: '~/.claude/skills' },
+};
+
+/** Stable ordering for global skill directory display. */
+const GLOBAL_SKILL_DIR_ORDER = [
+  'globalskills-sw',
+  'globalskills-agents',
+  'globalskills-codex',
+  'globalskills-claude',
+] as const;
+
+/**
+ * Lookup metadata for a global skill dir prefix. Throws if the prefix
+ * is not in `GLOBAL_SKILL_DIR_META` — all callers use
+ * `GLOBAL_SKILL_DIR_ORDER` so the key is always valid.
+ */
+function getGlobalSkillDirMeta(prefix: string): {
+  label: string;
+  dir: string;
+} {
+  const meta = GLOBAL_SKILL_DIR_META[prefix];
+  if (!meta) throw new Error(`Unknown global skill dir prefix: ${prefix}`);
+  return meta;
+}
+
+type GlobalSkillEntry = AppState['globalSkills'][number];
+
+function GlobalSkillsDetails() {
+  const preferences = useKartonState((s) => s.preferences);
+  const updatePreferences = useKartonProcedure((p) => p.preferences.update);
+  const globalSkills = useKartonState((s) => s.globalSkills);
+
+  const enabledGlobalSkillDirs = useMemo(
+    () => preferences?.agent?.enabledGlobalSkillDirs ?? [],
+    [preferences],
+  );
+  const disabledGlobalSkills = useMemo(
+    () => preferences?.agent?.disabledGlobalSkills ?? [],
+    [preferences],
+  );
+
+  // Group skills by mount prefix for per-dir rendering.
+  const skillsByPrefix = useMemo(() => {
+    const map = new Map<string, GlobalSkillEntry[]>();
+    for (const skill of globalSkills) {
+      const arr = map.get(skill.mountPrefix) ?? [];
+      arr.push(skill);
+      map.set(skill.mountPrefix, arr);
+    }
+    // Sort skills within each group by name.
+    for (const arr of Array.from(map.values())) {
+      arr.sort((a: GlobalSkillEntry, b: GlobalSkillEntry) =>
+        a.name.localeCompare(b.name),
+      );
+    }
+    return map;
+  }, [globalSkills]);
+
+  const handleToggleDir = useCallback(
+    async (prefix: string, enabled: boolean) => {
+      const current = enabledGlobalSkillDirs;
+      const next = enabled
+        ? [...current, prefix]
+        : current.filter((p) => p !== prefix);
+      await updatePreferences([
+        {
+          op: 'replace' as const,
+          path: ['agent', 'enabledGlobalSkillDirs'],
+          value: next,
+        },
+      ]);
+    },
+    [enabledGlobalSkillDirs, updatePreferences],
+  );
+
+  const handleToggleSkill = useCallback(
+    async (skillName: string, enabled: boolean) => {
+      const current = disabledGlobalSkills;
+      const next = enabled
+        ? current.filter((s) => s !== skillName)
+        : [...current, skillName];
+      await updatePreferences([
+        {
+          op: 'replace' as const,
+          path: ['agent', 'disabledGlobalSkills'],
+          value: next,
+        },
+      ]);
+    },
+    [disabledGlobalSkills, updatePreferences],
+  );
+
+  return (
+    <div className="space-y-8">
+      {GLOBAL_SKILL_DIR_ORDER.map((prefix) => {
+        const meta = getGlobalSkillDirMeta(prefix);
+        const isAlwaysEnabled =
+          ALWAYS_ENABLED_GLOBAL_SKILL_PREFIXES.has(prefix);
+        const dirEnabled =
+          isAlwaysEnabled || enabledGlobalSkillDirs.includes(prefix);
+        const skills = skillsByPrefix.get(prefix) ?? [];
+
+        return (
+          <div key={prefix}>
+            {prefix !== GLOBAL_SKILL_DIR_ORDER[0] && (
+              <hr className="border-derived-subtle border-t" />
+            )}
+            <section className="space-y-3 pt-8 first:pt-0">
+              {/* Header with inline dir toggle next to name */}
+              <div
+                className={isAlwaysEnabled ? undefined : 'cursor-pointer'}
+                role={isAlwaysEnabled ? undefined : 'button'}
+                tabIndex={isAlwaysEnabled ? undefined : 0}
+                onClick={() => {
+                  if (!isAlwaysEnabled)
+                    void handleToggleDir(prefix, !dirEnabled);
+                }}
+                onKeyDown={(e) => {
+                  if (
+                    !isAlwaysEnabled &&
+                    (e.key === 'Enter' || e.key === ' ')
+                  ) {
+                    e.preventDefault();
+                    void handleToggleDir(prefix, !dirEnabled);
+                  }
+                }}
+              >
+                <div className="flex items-center gap-3">
+                  <h3 className="font-medium text-foreground text-lg">
+                    {meta.label} skills
+                  </h3>
+                  {!isAlwaysEnabled && (
+                    <div onClick={(e) => e.stopPropagation()}>
+                      <Switch
+                        checked={dirEnabled}
+                        onCheckedChange={() =>
+                          void handleToggleDir(prefix, !dirEnabled)
+                        }
+                        size="xs"
+                      />
+                    </div>
+                  )}
+                </div>
+                <p className="text-muted-foreground text-sm">
+                  {meta.dir}
+                  {skills.length > 0 &&
+                    ` · ${skills.length} skill${skills.length === 1 ? '' : 's'}`}
+                </p>
+              </div>
+              {/* Per-skill toggles (only when dir is enabled) */}
+              {dirEnabled && skills.length > 0 && (
+                <div className="divide-y divide-border-subtle overflow-hidden rounded-lg border border-derived">
+                  {skills.map((skill) => {
+                    const isSkillEnabled = !disabledGlobalSkills.includes(
+                      skill.name,
+                    );
+                    return (
+                      <SkillRow
+                        key={`${prefix}:${skill.name}`}
+                        skill={skill}
+                        isEnabled={isSkillEnabled}
+                        onToggle={() =>
+                          handleToggleSkill(skill.name, !isSkillEnabled)
+                        }
+                      />
+                    );
+                  })}
+                </div>
+              )}
+              {/* Empty state when dir is enabled but no skills found */}
+              {dirEnabled && skills.length === 0 && (
+                <p className="text-sm text-subtle-foreground italic">
+                  No skills found in this directory.
+                </p>
+              )}
+            </section>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+// =============================================================================
 // Context Files Section
 // =============================================================================
 
@@ -461,18 +655,35 @@ export function SkillsContextSection() {
     }
   }, [workspaceMdGenerating]);
 
-  const [selectedWorkspacePath, setSelectedWorkspacePath] = useState<
-    string | null
-  >(null);
-  const selectedMount = useMemo(
-    () =>
-      workspaceMounts.find((m) => m.path === selectedWorkspacePath) ??
-      workspaceMounts[0] ??
-      null,
-    [workspaceMounts, selectedWorkspacePath],
+  const GLOBAL_TAB_ID = '__global__';
+
+  const [selectedTabId, setSelectedTabId] = useState<string | null>(null);
+
+  // Build the tab list: "Global" first, then workspace tabs.
+  const tabItems = useMemo(
+    () => [
+      { id: GLOBAL_TAB_ID, label: 'Global' },
+      ...workspaceMounts.map((mount) => ({
+        id: mount.path,
+        label: getBaseName(mount.path) || mount.path,
+        subLabel: mount.path,
+      })),
+    ],
+    [workspaceMounts],
   );
 
-  const hasWorkspaces = workspaceMounts.length > 0;
+  const selectedMount = useMemo(
+    () =>
+      workspaceMounts.find((m) => m.path === selectedTabId) ??
+      workspaceMounts[0] ??
+      null,
+    [workspaceMounts, selectedTabId],
+  );
+
+  // Compute the effective tab ID: when the user hasn't clicked
+  // anything yet, fall back to the first tab ("Global").
+  const effectiveTabId = selectedTabId ?? tabItems[0]?.id ?? null;
+  const isGlobalTab = effectiveTabId === GLOBAL_TAB_ID;
 
   return (
     <div className="h-full w-full">
@@ -489,33 +700,22 @@ export function SkillsContextSection() {
               stagewise agent.
             </p>
           </div>
-          {!hasWorkspaces ? (
-            <div className="rounded-lg border border-derived p-4">
-              <p className="text-muted-foreground text-sm">
-                No workspaces are currently connected. Connect a workspace to an
-                agent to configure workspace-specific settings.
-              </p>
-            </div>
-          ) : (
-            <div className="space-y-8">
-              <SettingsScrollTabs
-                selectedId={selectedMount?.path ?? null}
-                onSelect={setSelectedWorkspacePath}
-                truncateSubLabelFromStart
-                items={workspaceMounts.map((mount) => ({
-                  id: mount.path,
-                  label: getBaseName(mount.path) || mount.path,
-                  subLabel: mount.path,
-                }))}
+          <div className="space-y-8">
+            <SettingsScrollTabs
+              selectedId={effectiveTabId}
+              onSelect={setSelectedTabId}
+              truncateSubLabelFromStart
+              items={tabItems}
+            />
+            {isGlobalTab ? (
+              <GlobalSkillsDetails />
+            ) : selectedMount ? (
+              <WorkspaceDetails
+                mount={selectedMount}
+                contextFiles={contextFiles}
               />
-              {selectedMount ? (
-                <WorkspaceDetails
-                  mount={selectedMount}
-                  contextFiles={contextFiles}
-                />
-              ) : null}
-            </div>
-          )}
+            ) : null}
+          </div>
         </div>
       </OverlayScrollbar>
     </div>

--- a/apps/browser/src/ui/screens/settings/sections/skills-context-section.tsx
+++ b/apps/browser/src/ui/screens/settings/sections/skills-context-section.tsx
@@ -20,7 +20,7 @@ import type { MountEntry, AppState } from '@shared/karton-contracts/ui';
 import type { Patch } from '@shared/karton-contracts/ui/shared-types';
 import { Button } from '@stagewise/stage-ui/components/button';
 import { Loader2Icon, RefreshCwIcon } from 'lucide-react';
-import { getBaseName } from '@shared/path-utils';
+import { getWorkspaceDisplayInfo } from '@ui/utils/workspace-display';
 import { createRafResizeObserver } from '@ui/utils/resize-observer';
 import {
   Tooltip,
@@ -663,11 +663,17 @@ export function SkillsContextSection() {
   const tabItems = useMemo(
     () => [
       { id: GLOBAL_TAB_ID, label: 'Global' },
-      ...workspaceMounts.map((mount) => ({
-        id: mount.path,
-        label: getBaseName(mount.path) || mount.path,
-        subLabel: mount.path,
-      })),
+      ...workspaceMounts.map((mount) => {
+        const display = getWorkspaceDisplayInfo({
+          path: mount.path,
+          git: mount.git,
+        });
+        return {
+          id: mount.path,
+          label: display.title,
+          subLabel: mount.path,
+        };
+      }),
     ],
     [workspaceMounts],
   );


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds opt‑in global skills from ~/.codex/skills and ~/.claude/skills, plus a Global tab in Settings with per‑directory and per‑skill control. `.stagewise` and `.agents` remain always‑on; agents and the host env now only load enabled global mounts.

- **New Features**
  - Opt‑in external dirs via `preferences.agent.enabledGlobalSkillDirs`; disable specific skills via `preferences.agent.disabledGlobalSkills`.
  - Settings > Skills & Context: new Global tab lists all discovered global skills grouped by dir with per‑dir and per‑skill toggles; uses `globalSkills` state and shows even with no active agents.
  - Discovery runs per enabled mount and dedupes with priority `.stagewise` > `.agents` > `.codex` > `.claude`; env/toolbox surface only enabled mounts; watchers monitor all global dirs and refresh the index.

- **Bug Fixes**
  - Prevent duplicate dir toggles, stale tab selection, and N+1 global index rebuilds in Settings.
  - Workspace tabs use project names via `getWorkspaceDisplayInfo` for clearer titles.

<sup>Written for commit 00c88b0743fc6406b54b6bc6b510126f8e2ef09c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1382?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Global Skills section in Settings with its own tab.
  * Users can enable/disable global skill directories and toggle individual global skills.
  * Global skills are now discovered into the Settings roster based on enabled directory preferences (including “always enabled” directories when present).
* **Bug Fixes**
  * Global skill availability now follows saved preferences more reliably, including respect for disabled skills and updated rebuild timing.
* **Tests**
  * Added a new test suite covering global-skill mount discovery and enabled-directory filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->