### PR TITLE
feat(stagewise): add provider routing and coding-plan identity to age…

### DIFF
--- a/apps/browser/src/backend/agents/model-provider.ts
+++ b/apps/browser/src/backend/agents/model-provider.ts
@@ -72,6 +72,7 @@ export type ModelWithOptions = {
   headers: Record<string, string>;
   contextWindowSize: number;
   providerMode: ProviderMode;
+  connectedCodingPlanId?: string;
   reasoningSignatureSource: ReasoningSignatureSource;
   /**
    * When true, the agent must strip the `strict` field from every tool
@@ -128,6 +129,7 @@ export class ModelProviderService {
     apiKey: string;
     baseURL: string | undefined;
     mode: 'stagewise' | 'official' | 'custom';
+    connectedCodingPlanId?: string;
     customEndpoint?: CustomEndpoint;
   } {
     const prefs = this.preferencesService.get();
@@ -155,6 +157,7 @@ export class ModelProviderService {
               ? connectedCodingPlan.baseUrl
               : undefined,
           mode: 'official',
+          connectedCodingPlanId: config.connectedCodingPlanId,
         };
       }
       case 'custom': {
@@ -374,7 +377,7 @@ export class ModelProviderService {
     const resolved = officialProvider
       ? this.resolveProviderEndpoint(officialProvider)
       : { apiKey: '', baseURL: undefined, mode: 'stagewise' as const };
-    const { apiKey, baseURL, mode } = resolved;
+    const { apiKey, baseURL, mode, connectedCodingPlanId } = resolved;
     const headers = modelSettings.headers ?? {};
     const baseProviderOptions = modelSettings.providerOptions as Record<
       string,
@@ -515,6 +518,7 @@ export class ModelProviderService {
         posthogConfig,
       ),
       providerMode: 'official',
+      connectedCodingPlanId,
     };
   }
 

--- a/apps/browser/src/backend/services/telemetry.ts
+++ b/apps/browser/src/backend/services/telemetry.ts
@@ -41,6 +41,7 @@ const codingPlanIdSchema = z.enum([
   'kimi-plan',
   'qwen-plan',
   'minimax-plan',
+  'mimo-plan',
 ]);
 const onboardingAuthFailureKindSchema = z.enum([
   'validation-error',
@@ -152,6 +153,19 @@ export type EventProperties = {
     agent_type: string;
     agent_instance_id: string;
     model_id: string;
+    /**
+     * Provider routing mode from the most recent completed step.
+     * Empty string on the first message in a new chat (no prior step).
+     * `'stagewise'` = stagewise backend, `'official'` = own key or coding
+     * plan, `'custom'` = custom endpoint.
+     */
+    provider_mode: string;
+    /**
+     * Connected coding plan ID when `provider_mode === 'official'` and the
+     * user connected via a coding plan (e.g. `'glm-coding-plan'`).
+     * Undefined for stagewise/custom routes or plain BYOK keys.
+     */
+    coding_plan_id?: string;
     has_attachments: boolean;
     attachment_count: number;
     slash_command_ids: string[];
@@ -192,6 +206,7 @@ export type EventProperties = {
     agent_instance_id: string;
     model_id: string;
     provider_mode: string;
+    coding_plan_id?: string;
     input_tokens: number;
     output_tokens: number;
     tool_call_count: number;

--- a/packages/agent-core/src/agents/base-agent.ts
+++ b/packages/agent-core/src/agents/base-agent.ts
@@ -506,6 +506,23 @@ export abstract class BaseAgent<
   }
 
   /**
+   * Provider routing mode from the most recent completed step.
+   * Empty string before the first step runs. Used for telemetry at
+   * message-sent time (before the next step resolves routing).
+   */
+  public get lastProviderMode(): string {
+    return this._stepProviderMode;
+  }
+
+  /**
+   * Connected coding plan ID from the most recent completed step, if
+   * any. Undefined for non-plan routes or before the first step.
+   */
+  public get lastCodingPlanId(): string | undefined {
+    return this._stepCodingPlanId;
+  }
+
+  /**
    * The state of the agent is stored in a central store (the agent manager owns that store and manages it efficiently)
    * and is accessed by the agent through the getter and setter.
    */
@@ -574,6 +591,7 @@ export abstract class BaseAgent<
   private _stepGeneration = 0;
   private _stepStartTime = 0;
   private _stepProviderMode = '';
+  private _stepCodingPlanId: string | undefined;
   private _toolCallDurations = new Map<string, number>();
   private _memoryWriter: AgentMemoryWriter | null = null;
   private _memoryWriteTimer: ReturnType<typeof setTimeout> | null = null;
@@ -1612,6 +1630,7 @@ export abstract class BaseAgent<
         },
       );
       this._stepProviderMode = modelWithOptions.providerMode;
+      this._stepCodingPlanId = modelWithOptions.connectedCodingPlanId;
     } catch (error) {
       const err = error as Error;
       this.host.logger.error(
@@ -2406,6 +2425,7 @@ export abstract class BaseAgent<
       agent_instance_id: this.instanceId,
       model_id: this.state.get().activeModelId,
       provider_mode: this._stepProviderMode,
+      coding_plan_id: this._stepCodingPlanId,
       input_tokens: result.usage.inputTokens ?? 0,
       output_tokens: result.usage.outputTokens ?? 0,
       tool_call_count: result.toolCalls.length,

--- a/packages/agent-core/src/host/models.ts
+++ b/packages/agent-core/src/host/models.ts
@@ -47,6 +47,14 @@ export interface ModelWithOptions {
   /** Host-specific routing mode that produced this model. */
   providerMode: ProviderMode;
   /**
+   * Host-specific identifier for a connected coding/subscription plan
+   * (e.g. `'glm-coding-plan'`). Only populated when `providerMode ===
+   * 'official'` and the user connected via a coding plan rather than a
+   * plain API key. Core stays agnostic — passes the string through to
+   * telemetry.
+   */
+  connectedCodingPlanId?: string;
+  /**
    * Semantic owner of any signed `reasoning_details` this route produces.
    * Threaded through the step so capture tags the metadata and conversion
    * re-injects signatures only for matching future routes. Optional: hosts

--- a/packages/agent-core/src/services/agent-manager/agent-manager.ts
+++ b/packages/agent-core/src/services/agent-manager/agent-manager.ts
@@ -1433,6 +1433,8 @@ export class AgentManager extends DisposableService {
       agent_type: instance?.type ?? 'unknown',
       agent_instance_id: instanceId,
       model_id: instance?.state.activeModelId ?? 'unknown',
+      provider_mode: agent.lastProviderMode,
+      coding_plan_id: agent.lastCodingPlanId,
       has_attachments: attachmentParts.length > 0,
       attachment_count: attachmentParts.length,
       slash_command_ids: slashCommandIdsForTelemetry,


### PR DESCRIPTION
…nt telemetry

Thread connectedCodingPlanId from ModelProviderService through the core ModelWithOptions contract and BaseAgent step cache into PostHog events.

- agent-message-sent: add provider_mode and coding_plan_id (from last completed step's cached routing; empty on first message in a chat)
- agent-step-completed: add coding_plan_id alongside existing provider_mode
- Fix codingPlanIdSchema missing 'mimo-plan' entry

This enables product analytics to distinguish stagewise-backend usage, coding-plan usage (GLM/Kimi/Qwen/MiniMax/MiMo), and BYOK (own API keys).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add provider routing mode and connected coding plan ID to agent telemetry so we can distinguish stagewise backend usage, coding-plan routes (GLM/Kimi/Qwen/MiniMax/MiMo), and BYOK/custom.

- **New Features**
  - Threaded `connectedCodingPlanId` from `ModelProviderService` into `ModelWithOptions`, cached per step in `BaseAgent`, and sent with events.
  - `agent-message-sent`: now includes `provider_mode` (from the last completed step) and `coding_plan_id` when routed via a coding plan; empty on the first message.
  - `agent-step-completed`: includes `provider_mode` and `coding_plan_id` (supports `'stagewise'`, `'official'`, `'custom'`).

- **Bug Fixes**
  - Added missing `'mimo-plan'` to `codingPlanIdSchema`.

<sup>Written for commit e7643d16de81d2a1f1b8d7f91de217ae717d5b08. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1383?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

