### PR TITLE
feat(stagewise): add priority-based CMD+Enter shortcut registry

### DIFF
--- a/apps/browser/src/shared/hotkeys.ts
+++ b/apps/browser/src/shared/hotkeys.ts
@@ -63,7 +63,7 @@ export enum HotkeyActions {
   COMMAND_CENTER_TOGGLE_GITIGNORED = 'command_center_toggle_gitignored',
   COMMAND_CENTER_TOGGLE_SEARCH_IN_CONTENT = 'command_center_toggle_search_in_content',
   NEW_CHAT = 'new_chat',
-  IMPLEMENT_CREATED_PLAN = 'implement_created_plan',
+  CMD_ENTER = 'cmd_enter',
   STOP_AGENT = 'stop_agent',
 
   // Tab & window navigation
@@ -234,7 +234,7 @@ export const hotkeyDefinitions: Record<HotkeyActions, HotkeyDefinition> = {
     accelerator: 'Mod+N',
     captureDominantly: false,
   },
-  [HotkeyActions.IMPLEMENT_CREATED_PLAN]: {
+  [HotkeyActions.CMD_ENTER]: {
     accelerator: 'Mod+Enter',
     captureDominantly: true,
   },

--- a/apps/browser/src/ui/hooks/use-cmd-enter-dispatcher.ts
+++ b/apps/browser/src/ui/hooks/use-cmd-enter-dispatcher.ts
@@ -1,0 +1,22 @@
+import { useCallback } from 'react';
+import { useHotKeyListener } from './use-hotkey-listener';
+import { HotkeyActions } from '@shared/hotkeys';
+import { cmdEnterRegistry } from '@ui/utils/cmd-enter-registry';
+
+/**
+ * Single global CMD+Enter listener that dispatches to the registry's
+ * current winner. Mount this once in ChatPanel — every CMD+Enter-eligible
+ * component registers itself via `useCmdEnterTarget` and the registry
+ * resolves which one wins based on priority + viewport visibility.
+ */
+export function useCmdEnterDispatcher() {
+  useHotKeyListener(
+    useCallback(() => {
+      const winner = cmdEnterRegistry.getWinner();
+      if (!winner) return false;
+      winner.action();
+    }, []),
+    HotkeyActions.CMD_ENTER,
+    true,
+  );
+}

--- a/apps/browser/src/ui/hooks/use-cmd-enter-target.ts
+++ b/apps/browser/src/ui/hooks/use-cmd-enter-target.ts
@@ -1,0 +1,83 @@
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from 'react';
+import {
+  cmdEnterRegistry,
+  type CmdEnterPriority,
+} from '@ui/utils/cmd-enter-registry';
+
+export interface UseCmdEnterTargetOptions {
+  id: string;
+  priority: CmdEnterPriority;
+  action: () => void;
+  enabled: boolean;
+}
+
+export interface UseCmdEnterTargetResult {
+  setRef: (element: HTMLElement | null) => void;
+  isWinner: boolean;
+}
+
+/**
+ * Registers a CMD+Enter-eligible button with the global registry.
+ *
+ * - The DOM element is tracked via a callback ref (`setRef`).
+ * - The `action` callback is stored in a ref so action changes never
+ *   trigger re-registration — the registry always calls the latest one.
+ * - `isWinner` is driven by `useSyncExternalStore`, so only the old
+ *   winner and the new winner re-render when the winner changes.
+ */
+export function useCmdEnterTarget(
+  options: UseCmdEnterTargetOptions,
+): UseCmdEnterTargetResult {
+  const { id, priority, action, enabled } = options;
+
+  // Always-current action — registration callback reads from this ref,
+  // so we never need to re-register when the closure changes.
+  const actionRef = useRef(action);
+  actionRef.current = action;
+
+  const [element, setElement] = useState<HTMLElement | null>(null);
+  const setRef = useCallback((el: HTMLElement | null) => {
+    setElement(el);
+  }, []);
+
+  // Register / unregister with the registry when id, element, or enabled
+  // changes. Priority is intentionally excluded — the update effect below
+  // propagates priority changes in-place without a full re-registration,
+  // avoiding a transient unregister gap where a keystroke could be dropped.
+  useEffect(() => {
+    if (!enabled || !element) return;
+    const unregister = cmdEnterRegistry.register({
+      id,
+      priority,
+      action: () => actionRef.current(),
+      element,
+    });
+    return unregister;
+  }, [id, enabled, element]);
+
+  // Update priority in-place when it changes (no re-registration).
+  useEffect(() => {
+    if (!enabled) return;
+    cmdEnterRegistry.update(id, { priority });
+  }, [id, priority, enabled]);
+
+  // Subscribe to winner changes — only re-renders when this target
+  // becomes or stops being the winner.
+  const getIsWinner = useCallback(
+    () => cmdEnterRegistry.getSnapshot() === id,
+    [id],
+  );
+  const isWinner = useSyncExternalStore(
+    cmdEnterRegistry.subscribe,
+    getIsWinner,
+    () => false,
+  );
+
+  return { setRef, isWinner };
+}

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/footer-status-card/file-diff-section.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/footer-status-card/file-diff-section.tsx
@@ -14,6 +14,10 @@ import { stripMountPrefix } from '@ui/utils';
 import type { MountEntry } from '@shared/karton-contracts/ui';
 import type { Mount } from '@shared/karton-contracts/ui/agent/metadata';
 import { getWorkspaceDisplayLabel } from '@ui/utils/workspace-display';
+import { useCmdEnterTarget } from '@ui/hooks/use-cmd-enter-target';
+import { CmdEnterPriority } from '@ui/utils/cmd-enter-registry';
+import { HotkeyCombo } from '@ui/components/hotkey-combo';
+import { HotkeyActions } from '@shared/hotkeys';
 import {
   type StatusCardSection,
   type FormattedFileDiff,
@@ -261,6 +265,43 @@ function FileDiffList({
   );
 }
 
+function AcceptAllButton({
+  hunkIds,
+  onAcceptAll,
+}: {
+  hunkIds: string[];
+  onAcceptAll: (hunkIds: string[]) => void;
+}) {
+  const { setRef, isWinner } = useCmdEnterTarget({
+    id: 'file-diff-accept-all',
+    priority: CmdEnterPriority.FILE_DIFF_ACCEPT,
+    action: () => onAcceptAll(hunkIds),
+    enabled: true,
+  });
+  return (
+    <Button
+      ref={setRef}
+      variant="primary"
+      size="xs"
+      className="cursor-pointer"
+      onClick={(e) => {
+        e.stopPropagation();
+        onAcceptAll(hunkIds);
+      }}
+    >
+      Accept all
+      {isWinner && (
+        <HotkeyCombo
+          action={HotkeyActions.CMD_ENTER}
+          size="xs"
+          variant="solid"
+          className="ml-0.5"
+        />
+      )}
+    </Button>
+  );
+}
+
 export function FileDiffSection(
   props: FileDiffSectionProps,
 ): StatusCardSection | null {
@@ -319,19 +360,10 @@ export function FileDiffSection(
             >
               Reject
             </Button>
-            <Button
-              variant="primary"
-              size="xs"
-              className="cursor-pointer"
-              onClick={(e) => {
-                e.stopPropagation();
-                onAcceptAll(
-                  pendingDiffs?.flatMap((diff) => getHunkIds(diff)) ?? [],
-                );
-              }}
-            >
-              Accept all
-            </Button>
+            <AcceptAllButton
+              hunkIds={pendingDiffs?.flatMap((diff) => getHunkIds(diff)) ?? []}
+              onAcceptAll={onAcceptAll}
+            />
           </div>
         ) : (
           <div className="ml-auto h-6" />

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/footer-status-card/plan-section.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/footer-status-card/plan-section.tsx
@@ -7,6 +7,10 @@ import type { StatusCardSection } from './shared';
 import type { PlanTask, TaskGroup } from '@stagewise/agent-core/plans';
 import type { PlanUIPhase } from '@shared/plan-lifecycle';
 import { IconClipboardContentOutline18 } from 'nucleo-ui-outline-18';
+import { useCmdEnterTarget } from '@ui/hooks/use-cmd-enter-target';
+import { CmdEnterPriority } from '@ui/utils/cmd-enter-registry';
+import { HotkeyCombo } from '@ui/components/hotkey-combo';
+import { HotkeyActions } from '@shared/hotkeys';
 
 export type { PlanTask, TaskGroup };
 
@@ -57,6 +61,49 @@ function TaskRow({ task, isCurrent }: { task: PlanTask; isCurrent: boolean }) {
         {task.text}
       </span>
     </div>
+  );
+}
+
+function PlanImplementButton({
+  planFilename,
+  onImplement,
+  isImplementing,
+}: {
+  planFilename: string;
+  onImplement: () => void;
+  isImplementing: boolean;
+}) {
+  const { setRef, isWinner } = useCmdEnterTarget({
+    id: `plan-section-implement-${planFilename}`,
+    priority: CmdEnterPriority.PLAN_SECTION,
+    action: onImplement,
+    enabled: !isImplementing,
+  });
+  return (
+    <Button
+      ref={setRef}
+      variant="primary"
+      size="xs"
+      className={cn(
+        'shrink-0',
+        isImplementing ? 'cursor-default' : 'cursor-pointer',
+      )}
+      disabled={isImplementing}
+      onClick={(e: MouseEvent) => {
+        e.stopPropagation();
+        onImplement();
+      }}
+    >
+      {isImplementing ? 'Implementing' : 'Implement'}
+      {isWinner && (
+        <HotkeyCombo
+          action={HotkeyActions.CMD_ENTER}
+          size="xs"
+          variant="solid"
+          className="ml-0.5"
+        />
+      )}
+    </Button>
   );
 }
 
@@ -153,21 +200,11 @@ export function buildPlanSections({
               </Button>
             )}
             {showImplement && (
-              <Button
-                variant="primary"
-                size="xs"
-                className={cn(
-                  'shrink-0',
-                  isImplementing ? 'cursor-default' : 'cursor-pointer',
-                )}
-                disabled={isImplementing}
-                onClick={(e: MouseEvent) => {
-                  e.stopPropagation();
-                  onImplement();
-                }}
-              >
-                {isImplementing ? 'Implementing' : 'Implement'}
-              </Button>
+              <PlanImplementButton
+                planFilename={plan.filename}
+                onImplement={onImplement}
+                isImplementing={isImplementing}
+              />
             )}
           </div>
         </div>

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/footer-status-card/user-question-section.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/footer-status-card/user-question-section.tsx
@@ -15,7 +15,7 @@ import {
 } from '@stagewise/stage-ui/components/radio';
 import { OverlayScrollbar } from '@stagewise/stage-ui/components/overlay-scrollbar';
 import { useScrollFadeMask } from '@ui/hooks/use-scroll-fade-mask';
-import { ChevronDownIcon, CornerDownLeftIcon, XIcon } from 'lucide-react';
+import { ChevronDownIcon, XIcon } from 'lucide-react';
 import { cn } from '@ui/utils';
 import { Streamdown, InlineMarkdown } from '@ui/components/streamdown';
 import type { StatusCardSection } from './shared';
@@ -25,6 +25,10 @@ import type {
 } from '@shared/karton-contracts/ui/agent/tools/types';
 import type { PendingUserQuestion } from '@shared/karton-contracts/ui/index';
 import { dispatchArrowFromCtrl } from '@ui/utils/keyboard-nav';
+import { useCmdEnterTarget } from '@ui/hooks/use-cmd-enter-target';
+import { CmdEnterPriority } from '@ui/utils/cmd-enter-registry';
+import { HotkeyCombo } from '@ui/components/hotkey-combo';
+import { HotkeyActions } from '@shared/hotkeys';
 import { IconHelpChatOutline18 } from 'nucleo-ui-outline-18';
 
 /**
@@ -251,7 +255,26 @@ function UserQuestionForm({
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
-      if (e.key === 'Enter' && !e.shiftKey && isStepComplete && !isSubmitting) {
+      if (
+        e.key === 'Enter' &&
+        !e.shiftKey &&
+        !e.metaKey &&
+        !e.ctrlKey &&
+        isStepComplete &&
+        !isSubmitting
+      ) {
+        // Don't intercept Enter from interactive elements (buttons, links,
+        // non-text inputs) — let them activate normally.
+        const target = e.target as HTMLElement;
+        const tagName = target.tagName;
+        const isInteractive =
+          tagName === 'BUTTON' ||
+          tagName === 'A' ||
+          (tagName === 'INPUT' &&
+            ['button', 'submit', 'reset', 'radio', 'checkbox'].includes(
+              (target as HTMLInputElement).type,
+            ));
+        if (isInteractive) return;
         e.preventDefault();
         void handleSubmit();
       }
@@ -289,6 +312,13 @@ function UserQuestionForm({
   const { maskStyle } = useScrollFadeMask(viewportRef, {
     axis: 'vertical',
     fadeDistances: { top: 12, bottom: 20 },
+  });
+
+  const { setRef: submitRef, isWinner: submitIsWinner } = useCmdEnterTarget({
+    id: 'user-question-submit',
+    priority: CmdEnterPriority.USER_QUESTION,
+    action: handleSubmit,
+    enabled: isStepComplete && !isSubmitting,
   });
 
   if (!currentStepData) return null;
@@ -339,13 +369,21 @@ function UserQuestionForm({
           </Button>
         )}
         <Button
+          ref={submitRef}
           variant="primary"
           size="xs"
           onClick={() => void handleSubmit()}
           disabled={!isStepComplete || isSubmitting}
         >
           {isLastStep ? 'Send' : 'Next'}
-          <CornerDownLeftIcon className="ml-1 size-3" />
+          {submitIsWinner && (
+            <HotkeyCombo
+              action={HotkeyActions.CMD_ENTER}
+              size="xs"
+              variant="solid"
+              className="ml-0.5"
+            />
+          )}
         </Button>
       </div>
       {/* Focus sentinel: catches Tab past the last element and redirects to chat input */}

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/index.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/index.tsx
@@ -15,10 +15,15 @@ import {
   OpenAgentContext,
   noopAgentSwitcher,
 } from '@ui/hooks/use-open-chat';
+import { useCmdEnterDispatcher } from '@ui/hooks/use-cmd-enter-dispatcher';
 
 export function ChatPanel() {
   const { forwardDropEvent } = useMessageEditState();
   const [openAgent, setOpenAgent, removeFromHistory] = useOpenAgent();
+
+  // Single global CMD+Enter listener — dispatches to the highest-priority
+  // visible target registered via `useCmdEnterTarget`.
+  useCmdEnterDispatcher();
 
   // Narrow selectors: only extract primitive/stable values so streaming
   // chunks on unrelated agents don't trigger a re-render.

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/message-part-ui/tools/execute-shell-command.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/message-part-ui/tools/execute-shell-command.tsx
@@ -24,6 +24,10 @@ import {
   TooltipTrigger,
 } from '@stagewise/stage-ui/components/tooltip';
 import { ShortcutCombo } from '@stagewise/stage-ui/components/shortcut-key';
+import { useCmdEnterTarget } from '@ui/hooks/use-cmd-enter-target';
+import { CmdEnterPriority } from '@ui/utils/cmd-enter-registry';
+import { HotkeyCombo } from '@ui/components/hotkey-combo';
+import { HotkeyActions } from '@shared/hotkeys';
 
 export const ExecuteShellCommandToolPart = ({
   part,
@@ -135,6 +139,13 @@ export const ExecuteShellCommandToolPart = ({
       return;
     sendApproval(openAgentId, part.approval.id, true);
   }, [openAgentId, part.state, part.approval, sendApproval]);
+
+  const { setRef: allowRef, isWinner: allowIsWinner } = useCmdEnterTarget({
+    id: `shell-approval-${part.toolCallId}`,
+    priority: CmdEnterPriority.SHELL_APPROVAL,
+    action: handleApprove,
+    enabled: state === 'approval' && part.state !== 'input-streaming',
+  });
 
   const sessionId =
     output?.session_id ??
@@ -452,6 +463,7 @@ export const ExecuteShellCommandToolPart = ({
               </Tooltip>
             )}
             <Button
+              ref={allowRef}
               variant="primary"
               size="xs"
               onClick={handleApprove}
@@ -461,6 +473,14 @@ export const ExecuteShellCommandToolPart = ({
                 <IconLoader6Outline18 className="size-3 shrink-0 animate-spin" />
               )}
               Allow
+              {allowIsWinner && (
+                <HotkeyCombo
+                  action={HotkeyActions.CMD_ENTER}
+                  size="xs"
+                  variant="solid"
+                  className="ml-0.5"
+                />
+              )}
             </Button>
           </div>
         </div>
@@ -474,6 +494,8 @@ export const ExecuteShellCommandToolPart = ({
     currentApprovalMode,
     classifierExplanation,
     part.state,
+    allowRef,
+    allowIsWinner,
   ]);
 
   if (useMinimalShellRow) {

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/message-part-ui/tools/write/create-plan.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/message-part-ui/tools/write/create-plan.tsx
@@ -22,7 +22,8 @@ import { IconClipboardOutline18 } from 'nucleo-ui-outline-18';
 import { usePlanPhase } from '@ui/hooks/use-plan-phase';
 import { useSendImplement } from '@ui/hooks/use-send-implement';
 import { HotkeyCombo } from '@ui/components/hotkey-combo';
-import { useHotKeyListener } from '@ui/hooks/use-hotkey-listener';
+import { useCmdEnterTarget } from '@ui/hooks/use-cmd-enter-target';
+import { CmdEnterPriority } from '@ui/utils/cmd-enter-registry';
 import {
   Tooltip,
   TooltipContent,
@@ -146,11 +147,13 @@ function CreatePlanSettledCard({ part }: { part: WritePart }) {
   // Implement: send a synthetic /implement message to the agent
   const handleImplement = useSendImplement();
 
-  useHotKeyListener(
-    handleImplement,
-    HotkeyActions.IMPLEMENT_CREATED_PLAN,
-    phase === 'just-created',
-  );
+  const { setRef: implementRef, isWinner: implementIsWinner } =
+    useCmdEnterTarget({
+      id: `create-plan-implement-${part.toolCallId}`,
+      priority: CmdEnterPriority.CREATE_PLAN,
+      action: handleImplement,
+      enabled: phase === 'just-created',
+    });
 
   const handleOpenPlan = useCallback(() => {
     const baseUrl = `stagewise://internal/plan/${encodeURIComponent(filename)}`;
@@ -219,6 +222,7 @@ function CreatePlanSettledCard({ part }: { part: WritePart }) {
         </Button>
         {phase === 'just-created' && (
           <Button
+            ref={implementRef}
             variant="primary"
             size="xs"
             className="pr-1"
@@ -226,11 +230,14 @@ function CreatePlanSettledCard({ part }: { part: WritePart }) {
           >
             <span className="flex items-center gap-1.5">
               <span>Implement</span>
-              <HotkeyCombo
-                action={HotkeyActions.IMPLEMENT_CREATED_PLAN}
-                size="xs"
-                variant="solid"
-              />
+              {implementIsWinner && (
+                <HotkeyCombo
+                  action={HotkeyActions.CMD_ENTER}
+                  size="xs"
+                  variant="solid"
+                  className="ml-0.5"
+                />
+              )}
             </span>
           </Button>
         )}

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/message-runtime-error.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/message-runtime-error.tsx
@@ -20,6 +20,15 @@ import { useOpenAgent } from '@ui/hooks/use-open-chat';
 import { getAvailableModel } from '@shared/available-models';
 import type { ModelProvider } from '@shared/karton-contracts/ui/shared-types';
 import type { AgentRuntimeError } from '@shared/karton-contracts/ui/agent';
+import { useCmdEnterTarget } from '@ui/hooks/use-cmd-enter-target';
+import { CmdEnterPriority } from '@ui/utils/cmd-enter-registry';
+import { HotkeyCombo } from '@ui/components/hotkey-combo';
+import { HotkeyActions } from '@shared/hotkeys';
+
+interface RetryActionProps {
+  retryRef?: (element: HTMLElement | null) => void;
+  showRetryHotkey?: boolean;
+}
 
 const consoleUrl =
   import.meta.env.VITE_STAGEWISE_CONSOLE_URL || 'https://console.stagewise.io';
@@ -77,12 +86,24 @@ export function MessageRuntimeError({
 }) {
   const canShowRetry = canRetry || !isWorking;
 
+  const { setRef: retryRef, isWinner: retryIsWinner } = useCmdEnterTarget({
+    id: `message-runtime-error-retry-${agentInstanceId}`,
+    priority: CmdEnterPriority.ERROR_RETRY,
+    action: onRetry,
+    enabled: canShowRetry,
+  });
+  const retryProps: RetryActionProps = {
+    retryRef,
+    showRetryHotkey: retryIsWinner,
+  };
+
   if (error.kind === 'upstream-overload') {
     return (
       <UpstreamOverloadError
         error={error}
         isWorking={isWorking}
         onRetry={onRetry}
+        {...retryProps}
       />
     );
   }
@@ -93,6 +114,7 @@ export function MessageRuntimeError({
         error={error}
         canRetry={canShowRetry}
         onRetry={onRetry}
+        {...retryProps}
       />
     );
   }
@@ -103,6 +125,7 @@ export function MessageRuntimeError({
         error={error}
         canRetry={canShowRetry}
         onRetry={onRetry}
+        {...retryProps}
       />
     );
   }
@@ -113,6 +136,7 @@ export function MessageRuntimeError({
         error={error}
         canRetry={canShowRetry}
         onRetry={onRetry}
+        {...retryProps}
       />
     );
   }
@@ -123,6 +147,7 @@ export function MessageRuntimeError({
       error={error}
       canRetry={canShowRetry}
       onRetry={onRetry}
+      {...retryProps}
     />
   );
 }
@@ -131,11 +156,13 @@ function PlanLimitExceededError({
   error,
   canRetry,
   onRetry,
+  retryRef,
+  showRetryHotkey,
 }: {
   error: Extract<AgentRuntimeError, { kind: 'plan-limit-exceeded' }>;
   canRetry: boolean;
   onRetry: () => void;
-}) {
+} & RetryActionProps) {
   const subscription = useKartonState((s) => s.userAccount.subscription);
   const openSettings = useKartonProcedure((p) => p.appScreen.openSettings);
   const openExternalUrl = useKartonProcedure((p) => p.openExternalUrl);
@@ -181,9 +208,17 @@ function PlanLimitExceededError({
       <div className="flex flex-row items-center justify-between gap-2 pt-1">
         <div>
           {canRetry && (
-            <Button variant="ghost" size="xs" onClick={onRetry}>
+            <Button ref={retryRef} variant="ghost" size="xs" onClick={onRetry}>
               <RefreshCcwIcon className="size-3" />
               Retry
+              {showRetryHotkey && (
+                <HotkeyCombo
+                  action={HotkeyActions.CMD_ENTER}
+                  size="xs"
+                  variant="ghost"
+                  className="ml-0.5"
+                />
+              )}
             </Button>
           )}
         </div>
@@ -218,11 +253,13 @@ function ModelRestrictedError({
   error,
   canRetry,
   onRetry,
+  retryRef,
+  showRetryHotkey,
 }: {
   error: Extract<AgentRuntimeError, { kind: 'model-restricted' }>;
   canRetry: boolean;
   onRetry: () => void;
-}) {
+} & RetryActionProps) {
   const openSettings = useKartonProcedure((p) => p.appScreen.openSettings);
   const openExternalUrl = useKartonProcedure((p) => p.openExternalUrl);
 
@@ -253,9 +290,17 @@ function ModelRestrictedError({
       <div className="flex flex-row items-center justify-between gap-2 pt-1">
         <div>
           {canRetry && (
-            <Button variant="ghost" size="xs" onClick={onRetry}>
+            <Button ref={retryRef} variant="ghost" size="xs" onClick={onRetry}>
               <RefreshCcwIcon className="size-3" />
               Retry
+              {showRetryHotkey && (
+                <HotkeyCombo
+                  action={HotkeyActions.CMD_ENTER}
+                  size="xs"
+                  variant="ghost"
+                  className="ml-0.5"
+                />
+              )}
             </Button>
           )}
         </div>
@@ -296,11 +341,13 @@ function UpstreamOverloadError({
   error,
   isWorking,
   onRetry,
+  retryRef,
+  showRetryHotkey,
 }: {
   error: Extract<AgentRuntimeError, { kind: 'upstream-overload' }>;
   isWorking: boolean;
   onRetry: () => void;
-}) {
+} & RetryActionProps) {
   const description =
     'The upstream AI provider is temporarily at capacity. Please switch to another model or try again.';
 
@@ -323,9 +370,17 @@ function UpstreamOverloadError({
 
       {!isWorking && (
         <div className="flex flex-row items-center justify-end gap-2 pt-2">
-          <Button variant="primary" size="xs" onClick={onRetry}>
+          <Button ref={retryRef} variant="primary" size="xs" onClick={onRetry}>
             <RefreshCcwIcon className="size-3" />
             Retry
+            {showRetryHotkey && (
+              <HotkeyCombo
+                action={HotkeyActions.CMD_ENTER}
+                size="xs"
+                variant="solid"
+                className="ml-0.5"
+              />
+            )}
           </Button>
         </div>
       )}
@@ -337,11 +392,13 @@ function WaitingForConnectionError({
   error,
   canRetry,
   onRetry,
+  retryRef,
+  showRetryHotkey,
 }: {
   error: Extract<AgentRuntimeError, { kind: 'waiting-for-connection' }>;
   canRetry: boolean;
   onRetry: () => void;
-}) {
+} & RetryActionProps) {
   return (
     <div className="mt-6 flex w-full flex-col gap-1.5 rounded-lg border border-warning-solid/30 bg-warning-background p-2 text-sm">
       <div className="flex flex-row items-center gap-1.5">
@@ -362,9 +419,17 @@ function WaitingForConnectionError({
 
       {canRetry && (
         <div className="flex flex-row justify-end pt-1">
-          <Button variant="primary" size="xs" onClick={onRetry}>
+          <Button ref={retryRef} variant="primary" size="xs" onClick={onRetry}>
             <RefreshCcwIcon className="size-3" />
             Retry
+            {showRetryHotkey && (
+              <HotkeyCombo
+                action={HotkeyActions.CMD_ENTER}
+                size="xs"
+                variant="solid"
+                className="ml-0.5"
+              />
+            )}
           </Button>
         </div>
       )}
@@ -377,12 +442,14 @@ function GenericError({
   error,
   canRetry,
   onRetry,
+  retryRef,
+  showRetryHotkey,
 }: {
   agentInstanceId: string;
   error: GenericRuntimeError;
   canRetry: boolean;
   onRetry: () => void;
-}) {
+} & RetryActionProps) {
   const [helpExpanded, setHelpExpanded] = useState(false);
   const openExternalUrl = useKartonProcedure((p) => p.openExternalUrl);
   const [hasCopied, setHasCopied] = useState(false);
@@ -423,9 +490,22 @@ function GenericError({
         <div className="flex flex-row items-center justify-between gap-2 pt-1">
           <div>
             {canRetry && (
-              <Button variant="ghost" size="xs" onClick={onRetry}>
+              <Button
+                ref={retryRef}
+                variant="ghost"
+                size="xs"
+                onClick={onRetry}
+              >
                 <RefreshCcwIcon className="size-3" />
                 Retry
+                {showRetryHotkey && (
+                  <HotkeyCombo
+                    action={HotkeyActions.CMD_ENTER}
+                    size="xs"
+                    variant="ghost"
+                    className="ml-0.5"
+                  />
+                )}
               </Button>
             )}
           </div>
@@ -522,9 +602,17 @@ function GenericError({
 
       {canRetry && (
         <div className="flex flex-row justify-end pt-1">
-          <Button variant="primary" size="xs" onClick={onRetry}>
+          <Button ref={retryRef} variant="primary" size="xs" onClick={onRetry}>
             <RefreshCcwIcon className="size-3" />
             Retry
+            {showRetryHotkey && (
+              <HotkeyCombo
+                action={HotkeyActions.CMD_ENTER}
+                size="xs"
+                variant="solid"
+                className="ml-0.5"
+              />
+            )}
           </Button>
         </div>
       )}

--- a/apps/browser/src/ui/utils/cmd-enter-registry.ts
+++ b/apps/browser/src/ui/utils/cmd-enter-registry.ts
@@ -1,0 +1,159 @@
+/**
+ * Priority levels for CMD+Enter targets.
+ * Lower number = higher priority (wins over higher numbers).
+ * On equal priority, the target registered first wins (seq tiebreaker).
+ */
+export enum CmdEnterPriority {
+  USER_QUESTION = 10,
+  SHELL_APPROVAL = 20,
+  CREATE_PLAN = 30,
+  ERROR_RETRY = 40,
+  PLAN_SECTION = 50,
+  FILE_DIFF_ACCEPT = 60,
+}
+
+export interface CmdEnterTarget {
+  id: string;
+  priority: number;
+  action: () => void;
+  element: HTMLElement;
+}
+
+interface InternalTarget extends CmdEnterTarget {
+  isVisible: boolean;
+  seq: number;
+}
+
+/**
+ * Module-level singleton registry that tracks CMD+Enter-eligible buttons
+ * across both the virtualized chat history tree and the footer status card.
+ *
+ * Uses an IntersectionObserver for viewport visibility tracking and
+ * `useSyncExternalStore` (via the hook) for badge display — no React
+ * Context, no prop drilling, no tree-wide re-renders.
+ *
+ * Registration is O(1). Winner computation is O(n) where n is typically
+ * 1–3 registered targets.
+ */
+class CmdEnterRegistry {
+  private targets = new Map<string, InternalTarget>();
+  private winnerId: string | null = null;
+  private listeners = new Set<() => void>();
+  private seqCounter = 0;
+
+  private _observer: IntersectionObserver | null = null;
+
+  private get observer(): IntersectionObserver {
+    if (this._observer === null) {
+      this._observer = new IntersectionObserver(
+        (entries) => {
+          let changed = false;
+          for (const entry of entries) {
+            const id = entry.target.getAttribute('data-cmd-enter-id');
+            if (!id) continue;
+            const target = this.targets.get(id);
+            if (!target) continue;
+            const wasVisible = target.isVisible;
+            target.isVisible = entry.isIntersecting;
+            if (wasVisible !== entry.isIntersecting) changed = true;
+          }
+          if (changed) this.recalculate();
+        },
+        { threshold: 0 },
+      );
+    }
+    return this._observer;
+  }
+
+  /** Register a target. Returns an unregister function. */
+  register(target: CmdEnterTarget): () => void {
+    // Guard: if a target with this id is already registered, unregister it
+    // first to prevent IntersectionObserver leaks from stale elements.
+    if (this.targets.has(target.id)) {
+      this.unregister(target.id);
+    }
+    // Seed visibility from the element's current geometric state so the
+    // first recalculate can select an immediately visible target without
+    // waiting for the async IntersectionObserver callback.
+    const rect = target.element.getBoundingClientRect();
+    const isVisible =
+      rect.width > 0 &&
+      rect.height > 0 &&
+      rect.top < window.innerHeight &&
+      rect.bottom > 0;
+    const internal: InternalTarget = {
+      ...target,
+      isVisible,
+      seq: this.seqCounter++,
+    };
+    target.element.setAttribute('data-cmd-enter-id', target.id);
+    this.targets.set(target.id, internal);
+    this.observer.observe(target.element);
+    this.recalculate();
+    return () => this.unregister(target.id);
+  }
+
+  unregister(id: string): void {
+    const target = this.targets.get(id);
+    if (!target) return;
+    this.observer.unobserve(target.element);
+    target.element.removeAttribute('data-cmd-enter-id');
+    this.targets.delete(id);
+    this.recalculate();
+  }
+
+  /** Update a target's priority in-place (no re-observation). */
+  update(id: string, updates: { priority?: number }): void {
+    const target = this.targets.get(id);
+    if (!target) return;
+    if (updates.priority !== undefined) target.priority = updates.priority;
+    this.recalculate();
+  }
+
+  /**
+   * Synchronously compute the current winner: the visible target with
+   * the lowest (priority, seq) tuple.
+   */
+  private computeWinner(): InternalTarget | null {
+    let best: InternalTarget | null = null;
+    for (const target of Array.from(this.targets.values())) {
+      if (!target.isVisible) continue;
+      if (
+        !best ||
+        target.priority < best.priority ||
+        (target.priority === best.priority && target.seq < best.seq)
+      ) {
+        best = target;
+      }
+    }
+    return best;
+  }
+
+  /** Recalculate winner and notify subscribers if it changed. */
+  private recalculate(): void {
+    const winner = this.computeWinner();
+    const newWinnerId = winner?.id ?? null;
+    if (newWinnerId === this.winnerId) return;
+    this.winnerId = newWinnerId;
+    Array.from(this.listeners).forEach((listener) => listener());
+  }
+
+  /** Get the current winner (for the keydown dispatcher). */
+  getWinner(): CmdEnterTarget | null {
+    return this.computeWinner();
+  }
+
+  // Stable arrow-function properties for useSyncExternalStore
+  subscribe = (listener: () => void): (() => void) => {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  };
+
+  getSnapshot = (): string | null => {
+    return this.winnerId;
+  };
+}
+
+export const cmdEnterRegistry = new CmdEnterRegistry();

--- a/packages/stage-ui/src/components/button.tsx
+++ b/packages/stage-ui/src/components/button.tsx
@@ -35,15 +35,19 @@ export const buttonVariants = cva(
 );
 
 export type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> &
-  VariantProps<typeof buttonVariants>;
+  VariantProps<typeof buttonVariants> & {
+    ref?: React.Ref<HTMLButtonElement>;
+  };
 
 export function Button({
+  ref,
   variant = 'primary',
   size = 'sm',
   ...props
 }: ButtonProps) {
   return (
     <button
+      ref={ref}
       {...props}
       className={cn(buttonVariants({ variant, size }), props.className)}
     />

--- a/packages/stage-ui/src/components/shortcut-key.tsx
+++ b/packages/stage-ui/src/components/shortcut-key.tsx
@@ -30,6 +30,8 @@ const shortcutKeyVariants = cva(
         default: 'border-derived bg-active-derived',
         subtle: 'border-derived bg-active-derived opacity-80',
         surface: 'border-derived-strong bg-active-derived',
+        ghost:
+          'border-derived bg-transparent group-hover/button:bg-active-derived group-focus-visible/button:bg-active-derived group-active/button:bg-active-derived',
         solid:
           'border-transparent bg-shortcut-solid-derived group-hover/button:bg-shortcut-solid-hover-derived group-focus-visible/button:bg-shortcut-solid-hover-derived group-active/button:bg-shortcut-solid-active-derived',
       },


### PR DESCRIPTION
Replace per-component keyboard listeners with a centralized registry that routes CMD+Enter to the highest-priority visible action across the chat interface. Uses IntersectionObserver for viewport tracking and useSyncExternalStore for badge display — no React Context, no prop drilling, no tree-wide re-renders.

New infrastructure:
- CmdEnterRegistry singleton (cmd-enter-registry.ts) — priority-sorted target registry with IntersectionObserver visibility gating
- useCmdEnterTarget hook — registers/unregisters components on mount
- useCmdEnterDispatcher hook — single global keydown listener

Integrated targets (by priority):
- UserQuestionForm "Send"/"Next" (P10)
- ExecuteShellCommand "Allow" (P20)
- CreatePlan "Implement" (P30)
- MessageRuntimeError "Retry" (P40, 6 button variants)
- PlanSection "Implement" (P50)
- FileDiffSection "Accept all" (P60)

Also:
- Add ref support to Button component
- Add ghost variant to ShortcutKey for transparent badges on ghost buttons
- Rename IMPLEMENT_CREATED_PLAN hotkey to CMD_ENTER
- Add ml-0.5 spacing between button labels and hotkey badges

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a global CMD+Enter shortcut registry that routes to the highest‑priority visible action in chat. Replaces per-component listeners and shows a badge on the active button without tree-wide re-renders.

- **New Features**
  - Priority-based `CmdEnterRegistry` with viewport gating and a single `useCmdEnterDispatcher`; `useCmdEnterTarget` uses `useSyncExternalStore` so only winner changes re-render and to show the badge.
  - Integrated targets: User question Send/Next (P10), Shell Allow (P20), Create plan Implement (P30), Error Retry (P40), Plan Implement (P50), File diff Accept all (P60).
  - UI tweaks: `Button` supports `ref`; `ShortcutKey` adds `ghost`; small spacing between labels and badges; hotkey renamed to `CMD_ENTER`.

- **Bug Fixes**
  - Mod+Enter falls through when no target is active.
  - Registry hardened: priority updates happen in place; same‑id guard prevents leaks; visibility is seeded on register; IntersectionObserver is lazy-inited.
  - User question form ignores Meta/Ctrl+Enter and Enter from interactive elements to avoid conflicts; error Retry uses per-instance ids to avoid collisions.

<sup>Written for commit 7b2d991f596d848f52af8ccd0cd9c89c3c608603. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1385?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a unified Cmd+Enter hotkey system across the chat experience (plan creation/implementation, accepting diffs, shell command approval, error retry, and question submission).
  * Shows Cmd+Enter hints only for the currently eligible (“winning”) action, and wires actions to the focused button.
* **Bug Fixes**
  * Tightened Enter key handling to avoid interfering with standard interactions and only submit when appropriate.
* **Style**
  * Refreshed shortcut key hover/focus styling for improved visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->