### PR TITLE
feat(browser): increase initial expanded sidebar width

### DIFF
--- a/apps/browser/src/ui/screens/main/_components/sidebar-panel-config.ts
+++ b/apps/browser/src/ui/screens/main/_components/sidebar-panel-config.ts
@@ -1,6 +1,6 @@
 export const SIDEBAR_PANEL_ID = 'new-sidebar-panel';
 export const SIDEBAR_PANEL_ORDER = 0;
-export const DEFAULT_EXPANDED_SIDEBAR_SIZE = 12;
+export const DEFAULT_EXPANDED_SIDEBAR_SIZE = 16;
 export const SIDEBAR_PANEL_MIN_SIZE = 6;
 export const SIDEBAR_PANEL_MAX_SIZE = 50;
 export const SIDEBAR_PANEL_CLASS_NAME =

--- a/apps/browser/src/ui/screens/main/sidebar/index.tsx
+++ b/apps/browser/src/ui/screens/main/sidebar/index.tsx
@@ -26,7 +26,7 @@ import {
 
 // Read the persisted collapsed state *once* at module eval so we can seed
 // `defaultSize` on first render. Without this the panel mounts expanded
-// (`defaultSize={12}`) and then collapses via effect on the next frame,
+// (`defaultSize={16}`) and then collapses via effect on the next frame,
 // producing a visible flash when the user last left the sidebar collapsed.
 const INITIAL_COLLAPSED = readInitialSidebarCollapsed();
 export function Sidebar() {


### PR DESCRIPTION
## What

After onboarding, the sidebar mounts quite narrow. This bumps the initial expanded sidebar width from `12` to `16` so it has a bit more breathing room on first render, as requested in #1271.

## Changes

- `DEFAULT_EXPANDED_SIDEBAR_SIZE`: `12` → `16` in `sidebar-panel-config.ts` (the single source of truth — it also seeds `preCollapseSizeRef` and the collapse/expand restore logic in `sidebar/index.tsx`).
- Updated the stale `defaultSize={12}` reference in the `Sidebar` doc comment to keep it accurate.

## Notes

- The new value stays comfortably within the existing `SIDEBAR_PANEL_MIN_SIZE` (6) and `SIDEBAR_PANEL_MAX_SIZE` (50) bounds.
- This only affects the **initial** width. Any width the user resizes to still persists via the existing `autoSaveId` panel-layout storage, so returning users are unaffected.

Closes #1271


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increases the initial expanded sidebar width from 12 to 16 so the sidebar feels roomier on first render after onboarding (addresses #1271). Updates `DEFAULT_EXPANDED_SIDEBAR_SIZE` and the `Sidebar` doc comment; stays within existing min/max and does not affect persisted user widths.

<sup>Written for commit e3081b4d72cb1ac934b994633d1b492d2a6341bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1386?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased the default expanded sidebar size, so the sidebar opens wider by default and shows more content at a glance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->