### PR TITLE
fix(stagewise): prevent agent reset on settings toggle and widen default sidebar

### DIFF
--- a/apps/browser/src/ui/hooks/use-auto-select-agent.tsx
+++ b/apps/browser/src/ui/hooks/use-auto-select-agent.tsx
@@ -21,6 +21,12 @@ const RESUME_GRACE_MS = 2500;
 export function useAutoSelectFirstAgent(): void {
   const [openAgent, setOpenAgent, removeFromHistory] = useOpenAgent();
 
+  // Gate the auto-select effect on the main view so it doesn't fire
+  // during settings transitions — the Sidebar/AgentChat unmount-remount
+  // can cause transient state desyncs that would otherwise evict the
+  // active agent.
+  const appScreenMode = useKartonState((s) => s.appScreen.mode);
+
   const activeAgentIdsRaw = useKartonState(
     useComparingSelector((s) => Object.keys(s.agents.instances)),
   );
@@ -59,6 +65,7 @@ export function useAutoSelectFirstAgent(): void {
   const [retryTick, setRetryTick] = useState(0);
 
   useEffect(() => {
+    if (appScreenMode !== 'main') return;
     if (openAgent && !activeAgentIdSet.has(openAgent)) {
       // If the open agent was set very recently (e.g. by the user clicking
       // a history card), give the backend time to load it before concluding
@@ -81,6 +88,7 @@ export function useAutoSelectFirstAgent(): void {
       setOpenAgent(activeAgentIds[0]!);
     }
   }, [
+    appScreenMode,
     openAgent,
     activeAgentIdSet,
     activeAgentIds,

--- a/apps/browser/src/ui/screens/main/_components/sidebar-panel-config.ts
+++ b/apps/browser/src/ui/screens/main/_components/sidebar-panel-config.ts
@@ -1,6 +1,6 @@
 export const SIDEBAR_PANEL_ID = 'new-sidebar-panel';
 export const SIDEBAR_PANEL_ORDER = 0;
-export const DEFAULT_EXPANDED_SIDEBAR_SIZE = 12;
+export const DEFAULT_EXPANDED_SIDEBAR_SIZE = 18;
 export const SIDEBAR_PANEL_MIN_SIZE = 6;
 export const SIDEBAR_PANEL_MAX_SIZE = 50;
 export const SIDEBAR_PANEL_CLASS_NAME =


### PR DESCRIPTION
Gate useAutoSelectFirstAgent effect on appScreenMode === 'main' so the auto-select logic cannot fire during settings transitions where Sidebar/AgentChat unmount-remount may cause transient state desyncs. Also remove leftover debug console statements and increase default sidebar width from 12% to 18%.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop agent resets when toggling Settings by running `useAutoSelectFirstAgent` only on the main screen (`appScreen.mode === 'main'`), avoiding transient unmount/remount desyncs. Also widen the default sidebar to 18% (was 12%).

<sup>Written for commit e814c610faca929a433dfe9e6c02f2f4877c1c4d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1388?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Auto-selection now only runs on the main app screen, preventing unintended agent changes in other views.
* **Style**
  * Increased the default expanded sidebar width for a more spacious layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->