### PR TITLE
fix(stagewise): remove backdrop-blur from sidebar toasts to fix GPU c…

### DIFF
--- a/apps/browser/src/ui/screens/main/_components/sidebar-toast.tsx
+++ b/apps/browser/src/ui/screens/main/_components/sidebar-toast.tsx
@@ -7,7 +7,7 @@ import { IconXmarkOutline18 } from 'nucleo-ui-outline-18';
  * Shared container for sidebar toast/badge components.
  *
  * Provides the standardized visual wrapper (subtle background, ring,
- * backdrop blur, elevation) and an optional dismiss button rendered
+ * elevation) and an optional dismiss button rendered
  * top-right. Content is passed as children.
  *
  * Pass `dismissable={false}` to hide the close button (e.g. when the
@@ -32,7 +32,7 @@ export function SidebarToast({
   return (
     <div
       className={cn(
-        'relative flex shrink-0 flex-col gap-2 rounded-md bg-background/30 p-2.5 shadow-elevation-1 ring-1 ring-derived-subtle backdrop-blur-xl dark:bg-surface-1/30',
+        'relative flex shrink-0 flex-col gap-2 rounded-md bg-background/60 p-2.5 shadow-elevation-1 ring-1 ring-derived-subtle dark:bg-surface-1/60',
         onDismiss && 'pr-9',
         className,
       )}


### PR DESCRIPTION
…ompositing regression

The shared SidebarToast wrapper used backdrop-blur-xl with a low-opacity background (/30) on top of the native macOS vibrancy layer. This forced the GPU compositor to sample and re-blur the vibrancy layer on every frame for up to 4 simultaneously-visible sidebar elements, dropping every second frame without measurable JS overhead.

Remove backdrop-blur-xl and restore the original /60 opacity that was used before the regression was introduced in ecbcc3e78.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove backdrop blur from the shared SidebarToast to fix a GPU compositing regression that caused dropped frames with macOS vibrancy. Restore the original /60 background opacity to keep contrast without triggering re-blur.

<sup>Written for commit 80ee1bf97bcbea91a1afa2d5798ab2b76dce4eaa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1390?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the sidebar toast appearance with a slightly stronger background for better readability.
  * Removed the blur effect behind the toast while keeping its elevated, floating look.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->