### PR TITLE
Fix notifications UI

### DIFF
--- a/apps/browser/src/ui/screens/main/_components/sidebar-experience-survey.tsx
+++ b/apps/browser/src/ui/screens/main/_components/sidebar-experience-survey.tsx
@@ -245,7 +245,7 @@ export function SidebarExperienceSurvey() {
       >
         {!hasAnswered ? (
           <>
-            <div className="font-medium text-foreground text-xs leading-relaxed">
+            <div className="pr-7 font-medium text-foreground text-xs leading-relaxed">
               Do you enjoy your experience with stagewise?
             </div>
             <div className="flex gap-2">
@@ -275,7 +275,7 @@ export function SidebarExperienceSurvey() {
           <>
             <div
               id={feedbackLabelId}
-              className="font-medium text-foreground text-xs leading-relaxed"
+              className="pr-7 font-medium text-foreground text-xs leading-relaxed"
             >
               What could we improve?
             </div>
@@ -288,7 +288,7 @@ export function SidebarExperienceSurvey() {
               ref={textareaRef}
               aria-labelledby={feedbackLabelId}
               className="scrollbar-subtle w-full resize-none rounded-md border border-derived bg-surface-1 px-2.5 py-2 text-foreground text-xs placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-primary-foreground"
-              placeholder="What could we improve?"
+              placeholder="e.g. Add MCP support, let me fork agent chats, better error recovery…"
               rows={3}
               value={feedback}
               onChange={(e) => {
@@ -325,7 +325,7 @@ export function SidebarExperienceSurvey() {
         dismissLabel="Dismiss survey"
         onDismiss={handleDismissFounderCall}
       >
-        <div className="font-medium text-foreground text-xs leading-relaxed">
+        <div className="pr-7 font-medium text-foreground text-xs leading-relaxed">
           Tell our founders what you think about stagewise and get 1 month Pro
           for free!
         </div>

--- a/apps/browser/src/ui/screens/main/_components/sidebar-toast.tsx
+++ b/apps/browser/src/ui/screens/main/_components/sidebar-toast.tsx
@@ -33,7 +33,6 @@ export function SidebarToast({
     <div
       className={cn(
         'relative flex shrink-0 flex-col gap-2 rounded-md bg-background/60 p-2.5 shadow-elevation-1 ring-1 ring-derived-subtle dark:bg-surface-1/60',
-        onDismiss && 'pr-9',
         className,
       )}
     >

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/notification-banners.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/notification-banners.tsx
@@ -26,7 +26,7 @@ export function NotificationBanners() {
           dismissLabel="Dismiss notification"
           onDismiss={() => dismissNotification(notification.id)}
         >
-          <div className="flex flex-row items-start gap-2">
+          <div className="flex flex-row items-start gap-2 pr-7">
             <NotificationIcon type={notification.type} />
             <div className="flex min-w-0 flex-1 flex-col gap-0.5">
               {notification.title && (

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/usage-warning-badge.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/usage-warning-badge.tsx
@@ -59,7 +59,7 @@ export function UsageWarningBadge() {
         lastDismissedThreshold = activeThreshold;
         setDismissedThreshold(activeThreshold);
       }}
-      className="flex-row items-start gap-2"
+      className="flex-row items-start gap-2 pr-7"
     >
       <TriangleAlertIcon className="mt-0.5 size-3.5 shrink-0 text-warning-foreground" />
       <span className="text-foreground text-xs">

--- a/apps/browser/src/ui/screens/main/sidebar/worktree-cleanup-badge.tsx
+++ b/apps/browser/src/ui/screens/main/sidebar/worktree-cleanup-badge.tsx
@@ -56,7 +56,7 @@ export function WorktreeCleanupBadge() {
       dismissLabel="Dismiss worktree cleanup"
       onDismiss={handleDismiss}
     >
-      <div className="flex flex-col gap-1">
+      <div className="flex flex-col gap-1 pr-7">
         <div className="flex items-center gap-1.5">
           <IconTrash2Outline24 className="size-3.5 shrink-0 text-foreground" />
           <div className="mt-0.5 min-w-0 flex-1 font-medium text-foreground text-xs">


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes sidebar notification performance and layout. Removes heavy blur from `SidebarToast` to stop frame drops and restores even right padding for actions.

- **Bug Fixes**
  - `SidebarToast`: removed backdrop blur and restored `/60` background to fix GPU compositing/frame drops; removed wrapper `pr-9` to align action rows.
  - Added `pr-7` to consumers (notification banners, usage warning badge, worktree cleanup badge, experience survey text) to reserve space for the dismiss button.
  - Updated experience survey placeholder with clearer examples.

<sup>Written for commit acf88752aab3dd61d08a337cf38e3df64a3951df. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1391?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

