### PR TITLE
fix(stagewise): request terminal focus on creation and tab switch

### DIFF
--- a/apps/browser/src/ui/screens/main/_components/agent-hotkey-bindings.tsx
+++ b/apps/browser/src/ui/screens/main/_components/agent-hotkey-bindings.tsx
@@ -172,9 +172,7 @@ export function AgentHotkeyBindings({
 
       if (visibleTerminalIds.length === 0) {
         if (contentCollapsed) setContentCollapsed(false);
-        void createTerminalTabSafely().then((terminalId) => {
-          if (terminalId) requestTerminalFocus(terminalId);
-        });
+        void createTerminalTabSafely();
         return;
       }
 

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/workspace-select.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/workspace-select.tsx
@@ -81,6 +81,7 @@ import {
 import { AgentTypes } from '@shared/karton-contracts/ui/agent';
 import { useOpenAgent } from '@ui/hooks/use-open-chat';
 import { useContentCollapsed } from '@ui/screens/main/_components/content-collapsed-context';
+import { useTabUIState } from '@ui/hooks/use-tab-ui-state';
 import {
   memo,
   useCallback,
@@ -1008,6 +1009,7 @@ function WorkspacePreviewCardContent({
   );
   const { collapsed: contentCollapsed, setCollapsed: setContentCollapsed } =
     useContentCollapsed();
+  const { requestTerminalFocus } = useTabUIState();
   const setupTitle = setupRun
     ? setupRun.status === 'running'
       ? 'Worktree setup running'
@@ -1033,7 +1035,9 @@ function WorkspacePreviewCardContent({
       event.stopPropagation();
       event.preventDefault();
       if (contentCollapsed) setContentCollapsed(false);
-      void createTerminal(mount.path, openAgent);
+      void createTerminal(mount.path, openAgent).then((terminalId) => {
+        if (terminalId) requestTerminalFocus(terminalId);
+      });
     },
     [
       mount.path,
@@ -1041,6 +1045,7 @@ function WorkspacePreviewCardContent({
       createTerminal,
       contentCollapsed,
       setContentCollapsed,
+      requestTerminalFocus,
     ],
   );
 

--- a/apps/browser/src/ui/screens/main/content/index.tsx
+++ b/apps/browser/src/ui/screens/main/content/index.tsx
@@ -209,7 +209,8 @@ export function MainSection({
     (p) => p.browser.layout.togglePanelKeyboardFocus,
   );
 
-  const { setTabUiState, removeTabUiState } = useTabUIState();
+  const { setTabUiState, removeTabUiState, requestTerminalFocus } =
+    useTabUIState();
   const [openAgent] = useOpenAgent();
   const { activeTutorial } = useTutorial();
   const [pendingUnsavedClose, setPendingUnsavedClose] =
@@ -731,7 +732,11 @@ export function MainSection({
           <SortableTabs
             value={effectiveActiveTabId ?? ''}
             onValueChange={(id) => {
-              if (id) void switchTab(id);
+              if (!id) return;
+              void switchTab(id);
+              if (tabs[id]?.type === 'terminal') {
+                requestTerminalFocus(id);
+              }
             }}
             ref={tabBarScrollRef}
             style={maskStyle}
@@ -771,7 +776,9 @@ export function MainSection({
               buttonClassName="size-7"
               onCreateBrowserTab={onCreateTab}
               onCreateTerminalTab={() =>
-                void createTerminal(undefined, openAgent)
+                void createTerminal(undefined, openAgent).then((terminalId) => {
+                  if (terminalId) requestTerminalFocus(terminalId);
+                })
               }
             />
           </div>

--- a/apps/browser/src/ui/screens/main/index.tsx
+++ b/apps/browser/src/ui/screens/main/index.tsx
@@ -102,7 +102,7 @@ function DefaultLayoutInner({ show }: { show: boolean }) {
   const activeTabId = useKartonState((s) => s.contentTabs.activeTabId);
   const fileTreeVisible = useKartonState((s) => s.fileTree.visible);
   const appScreenMode = useKartonState((s) => s.appScreen.mode);
-  const { setTabUiState } = useTabUIState();
+  const { setTabUiState, requestTerminalFocus } = useTabUIState();
   const [openAgent] = useOpenAgent();
   const { collapsed: sidebarCollapsed } = useSidebarCollapsed();
   const { collapsed: contentCollapsed, setCollapsed: setContentCollapsed } =
@@ -214,8 +214,17 @@ function DefaultLayoutInner({ show }: { show: boolean }) {
 
   const handleOpenTerminal = useCallback(() => {
     if (contentCollapsed) setContentCollapsed(false);
-    return createTerminal(undefined, openAgent);
-  }, [createTerminal, openAgent, contentCollapsed, setContentCollapsed]);
+    return createTerminal(undefined, openAgent).then((terminalId) => {
+      if (terminalId) requestTerminalFocus(terminalId);
+      return terminalId;
+    });
+  }, [
+    createTerminal,
+    openAgent,
+    contentCollapsed,
+    setContentCollapsed,
+    requestTerminalFocus,
+  ]);
 
   const contentPanelTopRightActions =
     showContent && !fileTreeVisible ? (


### PR DESCRIPTION
The terminalFocusRequestId gating mechanism (introduced to prevent terminals from stealing focus on agent switch) also blocked auto-focus when creating new terminals or switching to existing terminal tabs.

Chain requestTerminalFocus after createTerminal resolves in all terminal-creation paths: handleOpenTerminal (Cmd+Option+T, chat-header "+"), tab-bar "+" button, and workspace-select "Open terminal".

Add requestTerminalFocus call when clicking an existing terminal tab in the tab bar onValueChange handler.

Remove the now-redundant requestTerminalFocus call in the Cmd+J handler.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore terminal auto-focus when creating a terminal or switching to a terminal tab. This re-enables expected focus behavior that was blocked by the terminal focus gating.

- **Bug Fixes**
  - Request focus after `createTerminal` in all creation paths: chat-header "+", tab bar "+", workspace "Open terminal", and Cmd+Option+T.
  - When selecting a terminal tab in the tab bar, request focus in `onValueChange`.
  - Remove redundant focus request in the Cmd+J handler.

<sup>Written for commit 8baf5385b9a608f8ffa2bf88b5dfb6eb86c4896b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1392?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Opening or creating a terminal tab now brings that terminal into focus automatically.
  * Using the terminal hotkey when no terminal tabs exist now creates a terminal tab without leaving focus in an unexpected state.
  * Switching to an existing terminal tab now properly activates the terminal view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->