### PR TITLE
feat(stagewise): add new file creation in file tree

### DIFF
--- a/apps/browser/src/backend/main.ts
+++ b/apps/browser/src/backend/main.ts
@@ -901,6 +901,11 @@ export async function main({ launchOptions: { verbose } }: MainParameters) {
       fileTreeService.deleteEntry(workspaceKey, relativePath),
   );
   uiKarton.registerServerProcedureHandler(
+    'fileTree.createFile',
+    async (_cid, workspaceKey: string, directoryPath: string) =>
+      fileTreeService.createFile(workspaceKey, directoryPath),
+  );
+  uiKarton.registerServerProcedureHandler(
     'fileTree.recreateDeletedFile',
     async (_cid, workspaceKey: string, relativePath: string, content: string) =>
       fileTreeService.recreateDeletedFile(workspaceKey, relativePath, content),

--- a/apps/browser/src/backend/services/file-tree/index.ts
+++ b/apps/browser/src/backend/services/file-tree/index.ts
@@ -614,6 +614,38 @@ export class FileTreeService extends DisposableService {
     }
   }
 
+  async createFile(
+    workspaceKey: string,
+    directoryPath: string,
+  ): Promise<FileTreeOperationResult> {
+    if (isReadOnlyWorkspaceKey(workspaceKey)) {
+      throw new Error('This location is read-only and cannot be created in');
+    }
+    try {
+      const directory = await this.validatePath(workspaceKey, directoryPath);
+      const dirStat = await fs.stat(directory.absolutePath);
+      if (!dirStat.isDirectory()) {
+        return { success: false, error: 'Target path is not a directory.' };
+      }
+
+      const fileName = await this.getAvailableNewFileName(
+        directory.absolutePath,
+      );
+      const filePath = path.join(directory.absolutePath, fileName);
+      await fs.writeFile(filePath, '', 'utf-8');
+
+      const relativePath = directory.relativePath
+        ? `${directory.relativePath}/${fileName}`
+        : fileName;
+
+      this.bumpDirectoryRevisionsNow(directory.key, [directory.relativePath]);
+      return { success: true, relativePath };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      return { success: false, error: message };
+    }
+  }
+
   async recreateDeletedFile(
     workspaceKey: string,
     relativePath: string,
@@ -1640,6 +1672,26 @@ export class FileTreeService extends DisposableService {
     }
 
     throw new Error('Could not find an available destination name');
+  }
+
+  private async getAvailableNewFileName(
+    directoryAbsolutePath: string,
+  ): Promise<string> {
+    const baseName = 'new file';
+    const candidates = [
+      baseName,
+      ...Array.from({ length: 99 }, (_, index) => `${baseName} ${index + 2}`),
+    ];
+
+    for (const candidate of candidates) {
+      if (
+        !(await this.pathExists(path.join(directoryAbsolutePath, candidate)))
+      ) {
+        return candidate;
+      }
+    }
+
+    throw new Error('Could not find an available file name');
   }
 
   private updateFileTabsAfterMove(

--- a/apps/browser/src/backend/services/file-tree/index.ts
+++ b/apps/browser/src/backend/services/file-tree/index.ts
@@ -628,15 +628,14 @@ export class FileTreeService extends DisposableService {
         return { success: false, error: 'Target path is not a directory.' };
       }
 
-      const fileName = await this.getAvailableNewFileName(
+      // Atomically create the file and reserve its name in a single step
+      // using O_CREAT | O_EXCL, which fails with EEXIST if the path already
+      // exists. This prevents concurrent createFile calls from racing on
+      // the same default name.
+      const { relativePath } = await this.createAvailableNewFile(
         directory.absolutePath,
+        directory.relativePath,
       );
-      const filePath = path.join(directory.absolutePath, fileName);
-      await fs.writeFile(filePath, '', 'utf-8');
-
-      const relativePath = directory.relativePath
-        ? `${directory.relativePath}/${fileName}`
-        : fileName;
 
       this.bumpDirectoryRevisionsNow(directory.key, [directory.relativePath]);
       return { success: true, relativePath };
@@ -1674,9 +1673,10 @@ export class FileTreeService extends DisposableService {
     throw new Error('Could not find an available destination name');
   }
 
-  private async getAvailableNewFileName(
+  private async createAvailableNewFile(
     directoryAbsolutePath: string,
-  ): Promise<string> {
+    directoryRelativePath: string,
+  ): Promise<{ fileName: string; relativePath: string }> {
     const baseName = 'new file';
     const candidates = [
       baseName,
@@ -1684,11 +1684,33 @@ export class FileTreeService extends DisposableService {
     ];
 
     for (const candidate of candidates) {
-      if (
-        !(await this.pathExists(path.join(directoryAbsolutePath, candidate)))
-      ) {
-        return candidate;
+      const candidatePath = path.join(directoryAbsolutePath, candidate);
+      // O_CREAT | O_EXCL atomically creates the file only if it does not
+      // already exist. This is race-free: two concurrent calls cannot
+      // both succeed on the same path.
+      let handle: fs.FileHandle | undefined;
+      try {
+        handle = await fs.open(
+          candidatePath,
+          fs.constants.O_CREAT | fs.constants.O_EXCL | fs.constants.O_WRONLY,
+          0o644,
+        );
+      } catch (error) {
+        if (
+          error &&
+          typeof error === 'object' &&
+          'code' in error &&
+          (error as { code?: string }).code === 'EEXIST'
+        ) {
+          continue;
+        }
+        throw error;
       }
+      await handle.close();
+      const relativePath = directoryRelativePath
+        ? `${directoryRelativePath}/${candidate}`
+        : candidate;
+      return { fileName: candidate, relativePath };
     }
 
     throw new Error('Could not find an available file name');

--- a/apps/browser/src/shared/karton-contracts/ui/index.ts
+++ b/apps/browser/src/shared/karton-contracts/ui/index.ts
@@ -1960,6 +1960,10 @@ export type KartonContract = {
       setVisible: (visible: boolean) => Promise<void>;
       setActiveWorkspace: (workspaceKey: string | null) => Promise<void>;
       setViewMode: (mode: 'files' | 'diff') => Promise<void>;
+      createFile: (
+        workspaceKey: string,
+        directoryPath: string,
+      ) => Promise<FileTreeOperationResult>;
       recreateDeletedFile: (
         workspaceKey: string,
         relativePath: string,

--- a/apps/browser/src/ui/screens/main/file-tree/file-tree-utils.ts
+++ b/apps/browser/src/ui/screens/main/file-tree/file-tree-utils.ts
@@ -10,6 +10,16 @@ export function getFileTreeWorkspaceKey(mount: MountEntry): string {
   return `${mount.prefix}:${normalizePath(mount.path)}`;
 }
 
+/** Workspace prefixes that point to read-only, agent-internal mounts. */
+const READONLY_WORKSPACE_PREFIXES = new Set(['att', 'plugins', 'apps']);
+
+export function isReadOnlyWorkspaceKey(workspaceKey: string): boolean {
+  const separatorIndex = workspaceKey.indexOf(':');
+  if (separatorIndex <= 0) return false;
+  const prefix = workspaceKey.slice(0, separatorIndex);
+  return READONLY_WORKSPACE_PREFIXES.has(prefix);
+}
+
 export function getFileTreeWorkspaceName(mount: MountEntry): string {
   return getBaseName(mount.path) || mount.prefix;
 }

--- a/apps/browser/src/ui/screens/main/file-tree/file-tree-workspace-view.tsx
+++ b/apps/browser/src/ui/screens/main/file-tree/file-tree-workspace-view.tsx
@@ -189,6 +189,8 @@ export function FileTreeWorkspaceView({
   const openAfterRenameRef = useRef<Set<string>>(new Set());
   const loadMoreRef = useRef(loadMore);
   loadMoreRef.current = loadMore;
+  const workspaceKeyRef = useRef(workspaceKey);
+  workspaceKeyRef.current = workspaceKey;
 
   // When the displayed workspace changes, clear all pending state from the
   // previous workspace. Stale entries could otherwise match paths in the new
@@ -466,7 +468,11 @@ export function FileTreeWorkspaceView({
   const handleCreateFile = useCallback(
     (directoryPath: string) => {
       if (!workspaceKey) return;
-      void createFile(workspaceKey, directoryPath).then((result) => {
+      const activeWorkspaceKey = workspaceKey;
+      void createFile(activeWorkspaceKey, directoryPath).then((result) => {
+        // If the user switched workspaces while the create was in-flight,
+        // discard the result — the path belongs to the old workspace.
+        if (workspaceKeyRef.current !== activeWorkspaceKey) return;
         if (!result.success || !result.relativePath) {
           toast({
             id: `file-tree-create-error-${Date.now()}`,

--- a/apps/browser/src/ui/screens/main/file-tree/file-tree-workspace-view.tsx
+++ b/apps/browser/src/ui/screens/main/file-tree/file-tree-workspace-view.tsx
@@ -20,6 +20,7 @@ import {
   ClipboardIcon,
   ClipboardPasteIcon,
   CopyIcon,
+  FilePlusIcon,
   FolderOpenIcon,
   Loader2Icon,
   PencilIcon,
@@ -36,6 +37,7 @@ import { nativeFileManagerLabel } from '@shared/ide-url';
 import {
   getAllFileTreeWorkspaceMounts,
   getFileTreeWorkspaceKey,
+  isReadOnlyWorkspaceKey,
 } from './file-tree-utils';
 import {
   getEffectiveFileTreeActionPaths,
@@ -143,6 +145,7 @@ export function FileTreeWorkspaceView({
   const renameEntry = useKartonProcedure((p) => p.fileTree.renameEntry);
   const pasteEntry = useKartonProcedure((p) => p.fileTree.pasteEntry);
   const deleteEntry = useKartonProcedure((p) => p.fileTree.deleteEntry);
+  const createFile = useKartonProcedure((p) => p.fileTree.createFile);
   const copyText = useKartonProcedure((p) => p.browser.copyText);
   const [openAgent] = useOpenAgent();
   const workspaceMount = useKartonState((s) =>
@@ -182,12 +185,17 @@ export function FileTreeWorkspaceView({
     timer: number | null;
   }>({ value: '', timer: null });
   const restoreFocusTimersRef = useRef<number[]>([]);
+  const pendingNewFileRef = useRef<string | null>(null);
+  const openAfterRenameRef = useRef<Set<string>>(new Set());
   const [focusedEntryPath, setFocusedEntryPath] = useState<string | null>(null);
   const [selectedEntryPaths, setSelectedEntryPaths] = useState<string[]>([]);
   const [selectionAnchorPath, setSelectionAnchorPath] = useState<string | null>(
     null,
   );
   const [renamingPath, setRenamingPath] = useState<string | null>(null);
+  // Mirror of `renamingPath` for use inside stable callbacks (avoids
+  // re-creating `handleRenameCancel` on every rename state change).
+  const renamingPathRef = useRef<string | null>(null);
   const [contextTargetPath, setContextTargetPath] = useState<string | null>(
     null,
   );
@@ -417,9 +425,60 @@ export function FileTreeWorkspaceView({
         const nextPath = result.relativePath ?? relativePath;
         setRenamingPath(null);
         setFocusedEntryPath(nextPath);
+        // If this was a newly created file, open it in a tab after rename.
+        if (openAfterRenameRef.current.delete(relativePath)) {
+          void openFileTab(workspaceKey, nextPath, openAgent, {
+            preview: false,
+          });
+        }
       });
     },
-    [renameEntry, workspaceKey],
+    [openAgent, openFileTab, renameEntry, workspaceKey],
+  );
+
+  const handleRenameCancel = useCallback(() => {
+    const cancelledPath = renamingPathRef.current;
+    setRenamingPath(null);
+    // If the user cancelled renaming a newly created file, open it with
+    // the default name so they can start editing it.
+    if (
+      cancelledPath &&
+      openAfterRenameRef.current.delete(cancelledPath) &&
+      workspaceKey
+    ) {
+      void openFileTab(workspaceKey, cancelledPath, openAgent, {
+        preview: false,
+      });
+    }
+  }, [openAgent, openFileTab, workspaceKey]);
+
+  const handleCreateFile = useCallback(
+    (directoryPath: string) => {
+      if (!workspaceKey) return;
+      void createFile(workspaceKey, directoryPath).then((result) => {
+        if (!result.success || !result.relativePath) {
+          toast({
+            id: `file-tree-create-error-${Date.now()}`,
+            title: 'New file failed',
+            message: result.error ?? 'Could not create a new file.',
+            type: 'error',
+            actions: [],
+          });
+          return;
+        }
+        const newFilePath = result.relativePath;
+        // Ensure the parent directory is expanded so the new file is visible.
+        void setDirectoryExpanded(workspaceKey, directoryPath, true);
+        setFocusedEntryPath(newFilePath);
+        setSelectedEntryPaths([]);
+        setSelectionAnchorPath(null);
+        // Track the new file so the rows-watcher effect scrolls to it and
+        // enters rename mode once it appears in the tree.
+        pendingNewFileRef.current = newFilePath;
+        openAfterRenameRef.current.add(newFilePath);
+      });
+    },
+    [createFile, setDirectoryExpanded, workspaceKey],
   );
 
   const getActionPaths = useCallback(
@@ -865,6 +924,30 @@ export function FileTreeWorkspaceView({
     };
   }, []);
 
+  // When a new file is created, wait for it to appear in the tree rows,
+  // scroll to it, and enter rename mode so the user can set the name.
+  useEffect(() => {
+    const pendingPath = pendingNewFileRef.current;
+    if (!pendingPath) return;
+    const index = rows.findIndex(
+      (row) => row.type === 'entry' && row.entry.relativePath === pendingPath,
+    );
+    if (index === -1) return;
+    pendingNewFileRef.current = null;
+    virtuosoRef.current?.scrollToIndex({
+      index,
+      align: 'center',
+      behavior: 'auto',
+    });
+    setRenamingPath(pendingPath);
+  }, [rows]);
+
+  // Keep `renamingPathRef` in sync so `handleRenameCancel` can read the
+  // current value without depending on `renamingPath` state.
+  useEffect(() => {
+    renamingPathRef.current = renamingPath;
+  }, [renamingPath]);
+
   const handleTreeContextMenu = useCallback(
     (event: MouseEvent<HTMLDivElement>) => {
       const element = (
@@ -896,6 +979,13 @@ export function FileTreeWorkspaceView({
     : contextIsDirectory
       ? contextTargetPath
       : getParentDirectory(contextTargetPath);
+  // The directory where a new file would be created when the user clicks
+  // “New File” — the targeted directory itself, the parent of a targeted
+  // file, or the workspace root for empty-space right-clicks.
+  const contextCreateDirectory = contextPasteDirectory;
+  const workspaceIsReadOnly = workspaceKey
+    ? isReadOnlyWorkspaceKey(workspaceKey)
+    : false;
 
   return (
     <ContextMenu.Root>
@@ -985,7 +1075,7 @@ export function FileTreeWorkspaceView({
                 row.type === 'entry' && row.entry.relativePath === renamingPath
               }
               onRenameSubmit={handleRenameSubmit}
-              onRenameCancel={() => setRenamingPath(null)}
+              onRenameCancel={handleRenameCancel}
               onOpen={handleOpen}
               onMoveDrop={handleMoveDrop}
               onDragTargetChange={setDragOverDirectoryPath}
@@ -1006,6 +1096,15 @@ export function FileTreeWorkspaceView({
               'data-ending-style:opacity-0 data-starting-style:opacity-0',
             )}
           >
+            <MenuBase.Item
+              className={contextMenuItemClassName}
+              disabled={workspaceIsReadOnly}
+              onClick={() => handleCreateFile(contextCreateDirectory)}
+            >
+              <FilePlusIcon className="size-3.5 shrink-0" />
+              <span className="min-w-0 flex-1 truncate">New File</span>
+            </MenuBase.Item>
+            <MenuBase.Separator className="my-0.5 h-px bg-border-subtle" />
             <MenuBase.Item
               className={contextMenuItemClassName}
               disabled={!contextCanRename}

--- a/apps/browser/src/ui/screens/main/file-tree/file-tree-workspace-view.tsx
+++ b/apps/browser/src/ui/screens/main/file-tree/file-tree-workspace-view.tsx
@@ -185,8 +185,10 @@ export function FileTreeWorkspaceView({
     timer: number | null;
   }>({ value: '', timer: null });
   const restoreFocusTimersRef = useRef<number[]>([]);
-  const pendingNewFileRef = useRef<string | null>(null);
+  const pendingNewFileRef = useRef<string[]>([]);
   const openAfterRenameRef = useRef<Set<string>>(new Set());
+  const loadMoreRef = useRef(loadMore);
+  loadMoreRef.current = loadMore;
   const [focusedEntryPath, setFocusedEntryPath] = useState<string | null>(null);
   const [selectedEntryPaths, setSelectedEntryPaths] = useState<string[]>([]);
   const [selectionAnchorPath, setSelectionAnchorPath] = useState<string | null>(
@@ -473,8 +475,9 @@ export function FileTreeWorkspaceView({
         setSelectedEntryPaths([]);
         setSelectionAnchorPath(null);
         // Track the new file so the rows-watcher effect scrolls to it and
-        // enters rename mode once it appears in the tree.
-        pendingNewFileRef.current = newFilePath;
+        // enters rename mode once it appears in the tree. Enqueued (not
+        // overwritten) so rapid repeated creates each get their turn.
+        pendingNewFileRef.current.push(newFilePath);
         openAfterRenameRef.current.add(newFilePath);
       });
     },
@@ -924,23 +927,41 @@ export function FileTreeWorkspaceView({
     };
   }, []);
 
-  // When a new file is created, wait for it to appear in the tree rows,
-  // scroll to it, and enter rename mode so the user can set the name.
+  // When new files are created, wait for them to appear in the tree rows,
+  // scroll to each in turn, and enter rename mode. Only one rename is
+  // active at a time; the rest wait in the queue until the current
+  // rename is submitted or cancelled (which sets renamingPath back to
+  // null, re-running this effect).
   useEffect(() => {
-    const pendingPath = pendingNewFileRef.current;
-    if (!pendingPath) return;
+    if (renamingPath !== null) return;
+    const queue = pendingNewFileRef.current;
+    const pendingPath = queue.shift();
+    if (pendingPath === undefined) return;
     const index = rows.findIndex(
       (row) => row.type === 'entry' && row.entry.relativePath === pendingPath,
     );
-    if (index === -1) return;
-    pendingNewFileRef.current = null;
+    if (index === -1) {
+      // Not visible yet. If the parent directory is paginated, trigger
+      // a load-more to fetch the next page so the file eventually appears
+      // in the loaded rows. Otherwise (directory loaded but file missing —
+      // e.g. tree collapsed) re-queue and wait for the next row change.
+      const parentDir = getParentDirectory(pendingPath);
+      const loadMoreRow = rows.find(
+        (row) => row.type === 'load-more' && row.directoryPath === parentDir,
+      );
+      if (loadMoreRow && loadMoreRow.type === 'load-more') {
+        loadMoreRef.current(parentDir);
+      }
+      queue.unshift(pendingPath);
+      return;
+    }
     virtuosoRef.current?.scrollToIndex({
       index,
       align: 'center',
       behavior: 'auto',
     });
     setRenamingPath(pendingPath);
-  }, [rows]);
+  }, [rows, renamingPath]);
 
   // Keep `renamingPathRef` in sync so `handleRenameCancel` can read the
   // current value without depending on `renamingPath` state.

--- a/apps/browser/src/ui/screens/main/file-tree/file-tree-workspace-view.tsx
+++ b/apps/browser/src/ui/screens/main/file-tree/file-tree-workspace-view.tsx
@@ -189,6 +189,15 @@ export function FileTreeWorkspaceView({
   const openAfterRenameRef = useRef<Set<string>>(new Set());
   const loadMoreRef = useRef(loadMore);
   loadMoreRef.current = loadMore;
+
+  // When the displayed workspace changes, clear all pending state from the
+  // previous workspace. Stale entries could otherwise match paths in the new
+  // workspace (wrong rename target) or block the queue indefinitely.
+  useEffect(() => {
+    pendingNewFileRef.current = [];
+    openAfterRenameRef.current = new Set();
+    setRenamingPath(null);
+  }, [workspaceKey]);
   const [focusedEntryPath, setFocusedEntryPath] = useState<string | null>(null);
   const [selectedEntryPaths, setSelectedEntryPaths] = useState<string[]>([]);
   const [selectionAnchorPath, setSelectionAnchorPath] = useState<string | null>(


### PR DESCRIPTION
- Backend: createFile service method with unique name generation
- Contract: fileTree.createFile procedure exposed to frontend
- UI: context menu "New File" option with scroll-to-rename flow
- UI: auto-scroll to new file, enter rename mode, open after rename/cancel
- UI: disable menu item for read-only workspaces
- UI: stable handleRenameCancel via ref to avoid row re-renders

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add “New File” to the file tree with backend support and a rename-first flow. Creates a unique file atomically, scrolls to it, enters rename, then opens it after rename or cancel; works across paginated folders and workspace switches.

- **New Features**
  - Backend/Contract: `createFile(workspaceKey, directoryPath)` with atomic, collision-safe naming; blocked in read-only workspaces; exposed as `fileTree.createFile`.
  - UI: Context menu “New File”; expands parent, scrolls to the new file, focuses + rename; opens after rename/cancel; disabled in read-only; error toast on failure.

- **Bug Fixes**
  - Auto-load paginated directories to prevent rename stalls.
  - Clear pending create/rename state on workspace switch and ignore in-flight results if the workspace changes.
  - Stable rename-cancel handler via ref to avoid row re-renders.

<sup>Written for commit 5af8228a614ad6d71c8801b34b35f7e9b1ba94ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1394?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a **New File** action to the file tree context menu, creating an empty file in the selected folder.
  * Automatically guides you into rename mode and opens the file once it appears in the list.
* **Bug Fixes**
  * Prevents file creation in read-only workspaces (action disabled).
  * Improved reliability of where the new file appears and how it enters the rename flow, including handling directory visibility and name collisions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->