### PR TITLE
fix(agent-shell): stop injecting raw terminal tail content into env-changes diffs

### DIFF
--- a/packages/agent-shell/src/env/shells-domain-adapter.test.ts
+++ b/packages/agent-shell/src/env/shells-domain-adapter.test.ts
@@ -15,6 +15,7 @@ function makeSession(
     logPath: string;
     cwd: string;
     tailContent: string;
+    lastLine: string;
     createdAt: number;
   }> = {},
 ) {
@@ -29,6 +30,7 @@ function makeSession(
     ...(over.tailContent !== undefined
       ? { tailContent: over.tailContent }
       : {}),
+    ...(over.lastLine !== undefined ? { lastLine: over.lastLine } : {}),
   };
 }
 
@@ -103,6 +105,61 @@ describe('createShellsDomainAdapter', () => {
       'Shell: bash (/opt/sh&lt;weird&gt;&amp;awful/bin/bash)',
     );
     expect(full).not.toContain('<weird>');
+  });
+
+  it('does not include tailContent in diff entries', () => {
+    const adapter = createShellsDomainAdapter({
+      getSnapshot: () => ({
+        sessions: [
+          makeSession({
+            lineCount: 10,
+            tailContent: 'some raw terminal output',
+          }),
+        ],
+      }),
+      getShellInfo: () => SHELL_INFO,
+    });
+    const curr = adapter.getState('a1') as never;
+    const prev = {
+      shellInfo: SHELL_INFO,
+      shells: { sessions: [makeSession({ lineCount: 5 })] },
+    } as never;
+    const diff = adapter.renderState(prev, curr);
+    expect(diff).toContain('shell-session-new-output');
+    expect(diff).toContain('lineCount="5"');
+    expect(diff).not.toContain('some raw terminal output');
+  });
+
+  it('equals ignores tailContent and lastLine', () => {
+    const adapter = createShellsDomainAdapter({
+      getSnapshot: () => ({ sessions: [] }),
+      getShellInfo: () => SHELL_INFO,
+    });
+    const a = {
+      shellInfo: SHELL_INFO,
+      shells: {
+        sessions: [
+          makeSession({
+            tailContent: 'aaa',
+            lastLine: 'la',
+            lineCount: 5,
+          }),
+        ],
+      },
+    } as never;
+    const b = {
+      shellInfo: SHELL_INFO,
+      shells: {
+        sessions: [
+          makeSession({
+            tailContent: 'bbb',
+            lastLine: 'lb',
+            lineCount: 5,
+          }),
+        ],
+      },
+    } as never;
+    expect(adapter.equals?.(a, b)).toBe(true);
   });
 
   it('exposes a non-empty promptSection covering shell usage keywords', () => {

--- a/packages/agent-shell/src/env/shells-domain-adapter.ts
+++ b/packages/agent-shell/src/env/shells-domain-adapter.ts
@@ -97,45 +97,39 @@ function computeShellsChanges(
   for (const [id, curr] of currMap) {
     const prev = prevMap.get(id);
     if (!prev) {
-      const entry: EnvironmentChangeEntry = {
+      changes.push({
         type: 'shell-session-started',
         attributes: {
           sessionId: id,
           lineCount: String(curr.lineCount),
           logPath: curr.logPath,
         },
-      };
-      if (curr.tailContent) entry.summary = curr.tailContent;
-      changes.push(entry);
+      });
       continue;
     }
 
     if (!prev.exited && curr.exited) {
-      const entry: EnvironmentChangeEntry = {
+      changes.push({
         type: 'shell-session-exited',
         attributes: {
           sessionId: id,
           exitCode: String(curr.exitCode ?? '?'),
           logPath: curr.logPath,
         },
-      };
-      if (curr.tailContent) entry.summary = curr.tailContent;
-      changes.push(entry);
+      });
       continue;
     }
 
     if (curr.lineCount > prev.lineCount) {
       const delta = curr.lineCount - prev.lineCount;
-      const entry: EnvironmentChangeEntry = {
+      changes.push({
         type: 'shell-session-new-output',
         attributes: {
           sessionId: id,
           lineCount: String(delta),
           logPath: curr.logPath,
         },
-      };
-      if (curr.tailContent) entry.summary = curr.tailContent;
-      changes.push(entry);
+      });
     }
   }
 
@@ -162,6 +156,30 @@ export function createShellsDomainAdapter(
     renderState(prev, curr) {
       if (prev === null) return renderFullShells(curr);
       return renderChangesXml(computeShellsChanges(prev, curr));
+    },
+    equals(a, b) {
+      if (
+        a.shellInfo?.platform !== b.shellInfo?.platform ||
+        a.shellInfo?.type !== b.shellInfo?.type ||
+        a.shellInfo?.path !== b.shellInfo?.path
+      )
+        return false;
+      if (a.shells.sessions.length !== b.shells.sessions.length) return false;
+      const bMap = new Map(b.shells.sessions.map((s) => [s.id, s]));
+      for (const sa of a.shells.sessions) {
+        const sb = bMap.get(sa.id);
+        if (!sb) return false;
+        if (
+          sa.exited !== sb.exited ||
+          sa.exitCode !== sb.exitCode ||
+          sa.lineCount !== sb.lineCount ||
+          sa.cwd !== sb.cwd ||
+          sa.createdAt !== sb.createdAt ||
+          sa.logPath !== sb.logPath
+        )
+          return false;
+      }
+      return true;
     },
   };
 }


### PR DESCRIPTION


The shells domain adapter was embedding tailContent (raw, ANSI-stripped terminal output) into every env-changes diff entry sent to the agent. This caused redundant terminal text to accumulate in the agent's context window on every step.

- Remove tailContent from shell-session-started, shell-session-exited, and shell-session-new-output diff entries; emit metadata-only attrs (sessionId, lineCount, exitCode, logPath)
- Add equals() override that ignores tailContent and lastLine so same-line output updates (progress bars, spinners) don't trigger unnecessary state captures
- Add tests verifying diffs exclude tailContent and equals ignores volatile derived fields

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop injecting raw terminal output into env-changes diffs in `agent-shell` to cut context noise and prevent repeated text across steps. Diffs are now metadata-only to reduce tokens.

- **Bug Fixes**
  - Removed `tailContent` from `shell-session-started`, `shell-session-exited`, and `shell-session-new-output`; emit only `sessionId`, `lineCount`, `exitCode`, and `logPath`.
  - Added `equals()` that ignores `tailContent` and `lastLine` and only compares stable session metadata; prevents spinner/progress-bar churn. Added tests for diff rendering and equality.

<sup>Written for commit 86610b51de8bee4586cd0493de92206516f323ff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1401?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shell session change detection so update entries no longer include raw output tail text, while continuing to report the correct line count and exit details.
  * Refined shell/session state comparisons to consider only meaningful metadata changes.
* **Tests**
  * Added coverage for diff rendering and adapter equality behavior, including scenarios where differences are limited to trailing output content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->