### PR TITLE
fix(stagewise): return empty record instead of throwing when no AttachmentMetadataProvider exists

### DIFF
--- a/apps/browser/src/ui/hooks/use-attachment-metadata.tsx
+++ b/apps/browser/src/ui/hooks/use-attachment-metadata.tsx
@@ -78,10 +78,10 @@ export const AttachmentMetadataProvider = ({
  */
 export function useAttachmentMetadata() {
   const context = useContext(AttachmentMetadataContext);
-  if (!context) {
-    throw new Error(
-      'useAttachmentMetadata must be used within an AttachmentMetadataProvider',
-    );
-  }
-  return context.attachmentMetadata;
+  // When no provider is present (e.g. file tab markdown preview, Storybook
+  // stories), return an empty record instead of throwing. All consumers
+  // already handle missing entries by falling back to the raw path/file
+  // name, so this is safe and avoids a hard crash on any Streamdown render
+  // that happens to contain a path:/att: link outside a chat context.
+  return context?.attachmentMetadata ?? {};
 }


### PR DESCRIPTION


useAttachmentMetadata threw when called outside an AttachmentMetadataProvider, crashing any Streamdown render containing path:/att: links in contexts without a provider (e.g. file tab markdown preview, Storybook stories). All consumers already handle missing entries by falling back to raw filenames, so returning an empty record is safe and eliminates this class of errors.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Return an empty record from useAttachmentMetadata when no AttachmentMetadataProvider is present. This prevents crashes in Streamdown renders with path:/att: links in contexts like file tab markdown preview and Storybook, and is safe because callers already fall back to raw filenames.

<sup>Written for commit 56ef5c5ed4334fffe7e02b5f060b11232a1cf544. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1403?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The app now handles missing attachment metadata more gracefully by falling back to an empty value instead of showing an error.
  * This improves reliability in views where attachment data may not be available, such as previews or standalone component usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->