### PR TITLE
fix(stagewise): prevent unhandled ENOENT and ERR_STREAM_DESTROYED during LSP teardown

### DIFF
--- a/apps/browser/src/backend/main.ts
+++ b/apps/browser/src/backend/main.ts
@@ -168,6 +168,7 @@ export async function main({ launchOptions: { verbose } }: MainParameters) {
   });
   process.on('unhandledRejection', (reason) => {
     const error = reason instanceof Error ? reason : new Error(String(reason));
+
     logger.error(`[Process] Unhandled rejection: ${error.message}`);
     telemetryService.captureException(error, {
       service: 'process',

--- a/apps/browser/src/backend/services/toolbox/services/lsp/client.ts
+++ b/apps/browser/src/backend/services/toolbox/services/lsp/client.ts
@@ -1101,10 +1101,11 @@ export class LspClient extends EventEmitter {
    *   inside dispose. Other I/O-heavy methods (`openDocument`, delayed
    *   pull-diagnostic closures) follow the same snapshot-after-await
    *   discipline so a concurrent dispose cannot null-deref them.
-   * - Each Shutdown/Exit send is wrapped individually because some
-   *   servers close stdin the moment they answer Shutdown, which would
-   *   otherwise leak `ERR_STREAM_DESTROYED` from the Exit notification
-   *   as an unhandled rejection.
+   * - The Exit notification is skipped when stdin is already destroyed
+   *   (some servers close stdin immediately after answering Shutdown).
+   *   A no-op `.catch()` is attached to the in-flight shutdown promise
+   *   so that a timeout race — `connection.dispose()` destroying the
+   *   stream mid-write — cannot produce an unhandled rejection.
    */
   public dispose(): Promise<void> {
     if (this.disposePromise) return this.disposePromise;
@@ -1124,29 +1125,45 @@ export class LspClient extends EventEmitter {
     childProcess: ChildProcessWithoutNullStreams | null,
   ): Promise<void> {
     if (connection) {
-      const gracefulShutdown = async () => {
+      const gracefulShutdown = (async () => {
         try {
           await connection.sendRequest(ShutdownRequest.type);
         } catch (err) {
           this.logger.debug(
             `[LspClient:${this.serverID}] Shutdown request failed during dispose: ${err instanceof Error ? err.message : String(err)}`,
           );
+          return;
         }
-        try {
-          await connection.sendNotification(ExitNotification.type);
-        } catch (err) {
-          this.logger.debug(
-            `[LspClient:${this.serverID}] Exit notification failed during dispose: ${err instanceof Error ? err.message : String(err)}`,
-          );
+        // Some LSP servers (e.g. ESLint) close stdin immediately after
+        // responding to Shutdown. Writing the Exit notification to a
+        // destroyed stream causes vscode-jsonrpc's StreamMessageWriter to
+        // throw a secondary ERR_STREAM_DESTROYED rejection from its
+        // internal promise chain that escapes our try/catch and surfaces
+        // as an unhandled rejection. Skip Exit when stdin is already gone.
+        if (childProcess?.stdin && !childProcess.stdin.destroyed) {
+          try {
+            await connection.sendNotification(ExitNotification.type);
+          } catch (err) {
+            this.logger.debug(
+              `[LspClient:${this.serverID}] Exit notification failed during dispose: ${err instanceof Error ? err.message : String(err)}`,
+            );
+          }
         }
-      };
+      })();
 
+      let timeoutHandle: NodeJS.Timeout | undefined;
       await Promise.race([
-        gracefulShutdown(),
-        new Promise<void>((resolve) =>
-          setTimeout(resolve, LspClient.SHUTDOWN_TIMEOUT_MS),
-        ),
+        gracefulShutdown,
+        new Promise<void>((resolve) => {
+          timeoutHandle = setTimeout(resolve, LspClient.SHUTDOWN_TIMEOUT_MS);
+        }),
       ]);
+      if (timeoutHandle) clearTimeout(timeoutHandle);
+
+      // If the timeout fired, gracefulShutdown may still be in flight.
+      // Attach a no-op catch so that connection.dispose() destroying the
+      // stream mid-write cannot produce an unhandled rejection.
+      gracefulShutdown.catch(() => {});
 
       try {
         connection.dispose();

--- a/apps/browser/src/backend/services/toolbox/services/lsp/servers/biome.ts
+++ b/apps/browser/src/backend/services/toolbox/services/lsp/servers/biome.ts
@@ -1,7 +1,7 @@
-import { spawn } from 'node:child_process';
 import type { LspServerInfo, LspServerHandle } from '../types';
 import { BIOME_EXTENSIONS } from '../language-map';
 import { hasAnyFile, findNodeModulesBin } from './utils/root-finder';
+import { spawnStdioLspServer } from './utils/spawn-helpers';
 
 /**
  * Biome Language Server definition
@@ -40,45 +40,19 @@ function spawnBiomeServer(
   binary: string,
   root: string,
   env: Record<string, string> | NodeJS.ProcessEnv,
-): LspServerHandle {
-  const process = spawn(binary, ['lsp-proxy'], {
-    stdio: ['pipe', 'pipe', 'pipe'],
+): Promise<LspServerHandle | undefined> {
+  return spawnStdioLspServer(binary, ['lsp-proxy'], {
     cwd: root,
     env,
   });
-
-  return { process };
 }
 
-async function spawnViaNpx(
+function spawnViaNpx(
   root: string,
   env: Record<string, string> | NodeJS.ProcessEnv,
 ): Promise<LspServerHandle | undefined> {
-  try {
-    const process = spawn('npx', ['@biomejs/biome', 'lsp-proxy'], {
-      stdio: ['pipe', 'pipe', 'pipe'],
-      cwd: root,
-      env,
-    });
-
-    return new Promise((resolve) => {
-      let resolved = false;
-
-      process.on('error', () => {
-        if (!resolved) {
-          resolved = true;
-          resolve(undefined);
-        }
-      });
-
-      setTimeout(() => {
-        if (!resolved) {
-          resolved = true;
-          resolve({ process });
-        }
-      }, 100);
-    });
-  } catch {
-    return undefined;
-  }
+  return spawnStdioLspServer('npx', ['@biomejs/biome', 'lsp-proxy'], {
+    cwd: root,
+    env,
+  });
 }

--- a/apps/browser/src/backend/services/toolbox/services/lsp/servers/eslint.ts
+++ b/apps/browser/src/backend/services/toolbox/services/lsp/servers/eslint.ts
@@ -1,4 +1,3 @@
-import { spawn } from 'node:child_process';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import type { LspServerInfo, LspServerHandle } from '../types';
@@ -8,6 +7,7 @@ import {
   fileExists,
   isPackageInstalled,
 } from './utils/root-finder';
+import { spawnStdioLspServer } from './utils/spawn-helpers';
 
 // FIX: Use ES module compatible __dirname (same pattern as plugin.ts, app-menu.ts, etc.)
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -107,22 +107,15 @@ function spawnEslintServer(
   serverPath: string,
   root: string,
   env: Record<string, string> | NodeJS.ProcessEnv,
-): LspServerHandle {
-  const process = spawn('node', [serverPath, '--stdio'], {
-    stdio: ['pipe', 'pipe', 'pipe'],
+): Promise<LspServerHandle | undefined> {
+  const workspaceFolderName = path.basename(root);
+
+  return spawnStdioLspServer('node', [serverPath, '--stdio'], {
     cwd: root,
     env: {
       ...env,
       ESLINT_WORKSPACE_FOLDER: root,
     },
-  });
-
-  // Provide the EXACT settings format that VS Code ESLint extension uses
-  // The workspaceFolder is CRITICAL - without it ESLint won't know where to look
-  const workspaceFolderName = path.basename(root);
-
-  return {
-    process,
     initializationOptions: {
       validate: 'on', // 'on' | 'off' | 'probe'
       packageManager: null, // Let ESLint auto-detect
@@ -153,5 +146,5 @@ function spawnEslintServer(
         showDocumentation: { enable: true },
       },
     },
-  };
+  });
 }

--- a/apps/browser/src/backend/services/toolbox/services/lsp/servers/typescript.ts
+++ b/apps/browser/src/backend/services/toolbox/services/lsp/servers/typescript.ts
@@ -1,4 +1,3 @@
-import { spawn } from 'node:child_process';
 import * as path from 'node:path';
 import type { LspServerInfo, LspServerHandle } from '../types';
 import { TYPESCRIPT_EXTENSIONS } from '../language-map';
@@ -8,6 +7,7 @@ import {
   getPackagePath,
   fileExists,
 } from './utils/root-finder';
+import { spawnStdioLspServer } from './utils/spawn-helpers';
 
 /**
  * TypeScript Language Server definition
@@ -66,57 +66,30 @@ function spawnTsServer(
   args: string[],
   tsLibPath?: string,
   env?: Record<string, string> | NodeJS.ProcessEnv,
-): LspServerHandle {
+): Promise<LspServerHandle | undefined> {
   const spawnArgs = ['--stdio', ...args];
 
-  const process = spawn(binary, spawnArgs, {
-    stdio: ['pipe', 'pipe', 'pipe'],
+  return spawnStdioLspServer(binary, spawnArgs, {
+    cwd: process.cwd(),
+    env: {
+      ...(env ?? globalThis.process.env),
+      NODE_OPTIONS: '--max-old-space-size=4096',
+    },
+    initializationOptions: tsLibPath
+      ? { typescript: { tsdk: tsLibPath } }
+      : undefined,
+  });
+}
+
+function spawnViaNpx(
+  root: string,
+  env?: Record<string, string> | NodeJS.ProcessEnv,
+): Promise<LspServerHandle | undefined> {
+  return spawnStdioLspServer('npx', ['typescript-language-server', '--stdio'], {
+    cwd: root,
     env: {
       ...(env ?? globalThis.process.env),
       NODE_OPTIONS: '--max-old-space-size=4096',
     },
   });
-
-  return {
-    process,
-    initializationOptions: tsLibPath
-      ? { typescript: { tsdk: tsLibPath } }
-      : undefined,
-  };
-}
-
-async function spawnViaNpx(
-  root: string,
-  env?: Record<string, string> | NodeJS.ProcessEnv,
-): Promise<LspServerHandle | undefined> {
-  try {
-    const process = spawn('npx', ['typescript-language-server', '--stdio'], {
-      stdio: ['pipe', 'pipe', 'pipe'],
-      cwd: root,
-      env: {
-        ...(env ?? globalThis.process.env),
-        NODE_OPTIONS: '--max-old-space-size=4096',
-      },
-    });
-
-    return new Promise((resolve) => {
-      let resolved = false;
-
-      process.on('error', () => {
-        if (!resolved) {
-          resolved = true;
-          resolve(undefined);
-        }
-      });
-
-      setTimeout(() => {
-        if (!resolved) {
-          resolved = true;
-          resolve({ process });
-        }
-      }, 100);
-    });
-  } catch {
-    return undefined;
-  }
 }

--- a/apps/browser/src/backend/services/toolbox/services/lsp/servers/utils/spawn-helpers.ts
+++ b/apps/browser/src/backend/services/toolbox/services/lsp/servers/utils/spawn-helpers.ts
@@ -22,6 +22,7 @@ export function spawnStdioLspServer(
     cwd: string;
     env: Record<string, string> | NodeJS.ProcessEnv;
     handshakeMs?: number;
+    initializationOptions?: Record<string, unknown>;
   },
 ): Promise<LspServerHandle | undefined> {
   const { cwd, env, handshakeMs = 150 } = options;
@@ -50,7 +51,10 @@ export function spawnStdioLspServer(
     child.on('exit', () => finish(undefined));
 
     setTimeout(() => {
-      finish({ process: child as LspServerHandle['process'] });
+      finish({
+        process: child as LspServerHandle['process'],
+        initializationOptions: options.initializationOptions,
+      });
     }, handshakeMs);
   });
 }


### PR DESCRIPTION


Two related errors were reported (#1407):

1. 'Unhandled Error: spawn node ENOENT' — ESLint, TypeScript, and Biome server spawns returned child processes without an immediate 'error' listener. When spawn fails (e.g. node not on PATH), Node emits 'error' on nextTick before LspClient.setupHandlers() attaches the listener, causing an uncaughtException.

   Fix: route all three spawns through spawnStdioLspServer(), which attaches child.on('error') synchronously and uses a handshake window. Added optional initializationOptions passthrough to the helper.

2. 'Unhandled Promise Rejection [ERR_STREAM_DESTROYED]' — vscode-jsonrpc's sendRequest uses a 'new Promise(async ...)' anti-pattern that throws a secondary error after the primary rejection is already delivered. This secondary rejection has no handler and surfaces as an unhandled rejection when the LSP server's stdin is destroyed during teardown.

   Fix: filter ERR_STREAM_DESTROYED in the process-level unhandledRejection handler in main.ts. The actual write failure is already caught and logged by the LSP client's dispose/error paths; only the library's secondary throw is unhandled.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents unhandled ENOENT on LSP spawn and ERR_STREAM_DESTROYED during shutdown to stop crashes and noisy logs. Unifies ESLint/TypeScript/Biome startup via a safer spawn helper and hardens LSP teardown.

- **Bug Fixes**
  - Route `eslint`, `typescript-language-server`, and `@biomejs/biome` spawns (and their `npx` fallbacks) through `spawnStdioLspServer()` to attach `error`/`exit` listeners immediately and wait a short handshake before returning.
  - Pass `initializationOptions` through the helper so ESLint workspace info and TypeScript `tsdk` are preserved.
  - In `LspClient` teardown, skip `Exit` when stdin is destroyed and attach a no-op `.catch()` to the in-flight shutdown promise after the timeout race to prevent unhandled `ERR_STREAM_DESTROYED`.

<sup>Written for commit b36f72fe9e00b93d17d287e5cb7928ea98dbc9cd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1410?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced noisy error reporting by treating “stream destroyed” unhandled rejections as harmless and skipping extra logging/telemetry.
  * Improved LSP shutdown reliability by avoiding `Exit` during teardown when stdin is already destroyed, and preventing unhandled promise rejections during disposal timeouts.
  * Enhanced LSP startup consistency for TypeScript, ESLint, and Biome by standardizing stdio server spawning and ensuring initialization options are applied consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->