### PR TITLE
fix(stagewise): expand content panel when opening plan or chat link

### DIFF
--- a/apps/browser/src/ui/components/streamdown/index.tsx
+++ b/apps/browser/src/ui/components/streamdown/index.tsx
@@ -28,6 +28,7 @@ import {
   type MouseEvent,
 } from 'react';
 import { cn } from '@ui/utils';
+import { useContentCollapsedOptional } from '@ui/screens/main/_components/content-collapsed-context';
 import { Button } from '@stagewise/stage-ui/components/button';
 import { Checkbox } from '@stagewise/stage-ui/components/checkbox';
 import { OverlayScrollbar } from '@stagewise/stage-ui/components/overlay-scrollbar';
@@ -1050,6 +1051,7 @@ export const Streamdown = memo(
     const processed = useMemo(() => preprocessMarkdown(children), [children]);
     const createTab = useKartonProcedure((p) => p.browser.createTab);
     const isAltPressed = useChatLinkAltPressed();
+    const contentCollapsedCtx = useContentCollapsedOptional();
 
     const handleMouseMoveCapture = useCallback(
       (event: MouseEvent<HTMLDivElement>) => {
@@ -1071,9 +1073,11 @@ export const Streamdown = memo(
 
         event.preventDefault();
         event.stopPropagation();
+        if (contentCollapsedCtx?.collapsed)
+          contentCollapsedCtx.setCollapsed(false);
         void createTab(href, true);
       },
-      [createTab],
+      [createTab, contentCollapsedCtx],
     );
 
     return (

--- a/apps/browser/src/ui/screens/main/_components/content-collapsed-context.tsx
+++ b/apps/browser/src/ui/screens/main/_components/content-collapsed-context.tsx
@@ -79,3 +79,12 @@ export function useContentCollapsed(): ContentCollapsedCtx {
   }
   return ctx;
 }
+
+/**
+ * Optional variant — returns null instead of throwing when the provider is
+ * missing. Use in components that may render outside ContentCollapsedProvider
+ * (e.g. Storybook stories).
+ */
+export function useContentCollapsedOptional(): ContentCollapsedCtx | null {
+  return useContext(ContentCollapsedContext);
+}

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/footer-status-card/index.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/footer-status-card/index.tsx
@@ -48,6 +48,7 @@ import {
 } from './log-channel-section';
 import { getPlanUIPhases, type LivePlanData } from '@shared/plan-lifecycle';
 import { useSendImplement } from '@ui/hooks/use-send-implement';
+import { useContentCollapsed } from '@ui/screens/main/_components/content-collapsed-context';
 
 // Stable empty arrays/sets to avoid infinite loop with useSyncExternalStore
 const EMPTY_HISTORY: AgentMessage[] = [];
@@ -101,6 +102,10 @@ export function StatusCard() {
   const switchTab = useKartonProcedure((p) => p.browser.switchTab);
   const goToUrl = useKartonProcedure((p) => p.browser.goto);
   const tabs = useKartonState((s) => s.contentTabs.tabs);
+
+  // Expand the content panel if it's collapsed so plan tabs are visible
+  const { collapsed: contentCollapsed, setCollapsed: setContentCollapsed } =
+    useContentCollapsed();
 
   const messageQueue = useKartonState((s) =>
     openAgentId
@@ -521,6 +526,8 @@ export function StatusCard() {
 
   const handleOpenPlan = useCallback(
     (filename: string) => {
+      if (contentCollapsed) setContentCollapsed(false);
+
       const baseUrl = `stagewise://internal/plan/${encodeURIComponent(filename)}`;
 
       // Reuse existing plan tab for this plan if one is already open
@@ -533,7 +540,14 @@ export function StatusCard() {
         void goToUrl(baseUrl, existingTab.id);
       } else void createTab(baseUrl, true);
     },
-    [createTab, switchTab, goToUrl, tabs],
+    [
+      createTab,
+      switchTab,
+      goToUrl,
+      tabs,
+      contentCollapsed,
+      setContentCollapsed,
+    ],
   );
 
   const handleImplement = useSendImplement();

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/message-part-ui/tools/write/create-plan.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/message-part-ui/tools/write/create-plan.tsx
@@ -29,6 +29,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from '@stagewise/stage-ui/components/tooltip';
+import { useContentCollapsed } from '@ui/screens/main/_components/content-collapsed-context';
 
 /**
  * Dedicated tool-part UI for plan file creation / update.
@@ -144,6 +145,10 @@ function CreatePlanSettledCard({ part }: { part: WritePart }) {
   const goToUrl = useKartonProcedure((p) => p.browser.goto);
   const tabs = useKartonState((s) => s.contentTabs.tabs);
 
+  // Expand the content panel if it's collapsed so the plan tab is visible
+  const { collapsed: contentCollapsed, setCollapsed: setContentCollapsed } =
+    useContentCollapsed();
+
   // Implement: send a synthetic /implement message to the agent
   const handleImplement = useSendImplement();
 
@@ -156,6 +161,8 @@ function CreatePlanSettledCard({ part }: { part: WritePart }) {
     });
 
   const handleOpenPlan = useCallback(() => {
+    if (contentCollapsed) setContentCollapsed(false);
+
     const baseUrl = `stagewise://internal/plan/${encodeURIComponent(filename)}`;
     const existingTab = Object.values(tabs).find((tab) =>
       tab.url.startsWith(baseUrl),
@@ -166,7 +173,15 @@ function CreatePlanSettledCard({ part }: { part: WritePart }) {
     } else {
       void createTab(baseUrl, true);
     }
-  }, [filename, tabs, switchTab, goToUrl, createTab]);
+  }, [
+    filename,
+    tabs,
+    switchTab,
+    goToUrl,
+    createTab,
+    contentCollapsed,
+    setContentCollapsed,
+  ]);
 
   return (
     <div className="mt-6 w-full overflow-hidden rounded-lg border border-border-subtle bg-background shadow-xs dark:border-border dark:bg-surface-1">


### PR DESCRIPTION
When the content sidebar is collapsed, tab-creating actions (open plan, alt+click chat links) silently failed because the MainSection is unmounted and there is no visible panel to render the new tab. Every other tab-creating action in the app already calls setContentCollapsed(false) before creating a tab — the plan-opening handlers and streamdown alt+click handler were missing this call.

Added the expand-on-open guard to:
- create-plan.tsx handleOpenPlan
- footer-status-card handleOpenPlan
- streamdown alt+click link handler

Closes #1398 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-expand the content panel when opening plan tabs or Alt+click chat links so new tabs render instead of failing silently. Closes #1398.

- **Bug Fixes**
  - Call setContentCollapsed(false) before creating tabs in create-plan handleOpenPlan, footer-status-card handleOpenPlan, and the streamdown Alt+click link handler.
  - Add optional useContentCollapsedOptional and use it in streamdown to avoid errors when the provider is missing (e.g., Storybook).

<sup>Written for commit 3e0305ff04e9ac4e5b7eaf46f40b57030672c639. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1411?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Opening “Open Plan” (and related plan tabs) now automatically expands any collapsed content panel first, so the destination content is immediately visible.
  * Alt+left-click chat links that open content in a new tab now respect the same collapsed/expanded state, expanding when needed for a smoother transition.
  * Improved consistency across the agent chat experience by keeping collapsed content behavior synchronized during navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->