### PR TITLE
fix(stagewise): hydrate source-branch prefs when fallback main differ…

### DIFF
--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/workspace-action-config-utils.ts
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/workspace-action-config-utils.ts
@@ -25,16 +25,27 @@ export function hydrateWorkspaceActionConfigWithDefaults(
     'main',
   ]);
 
+  // Source-branch fields ("Create worktree from" / "Create branch from")
+  // have the same placeholder problem as checkout-branch fields: the initial
+  // controlled config from panel-footer uses a fallback default ('main') before
+  // real Git data loads. Use a set so any of those placeholder values triggers
+  // re-hydration once the real preference-backed default is available.
+  const sourceBranchPlaceholders = new Set([
+    previousDefaults.sourceBranch,
+    previousDefaults.defaultBranch,
+    'main',
+  ]);
+
   return {
     ...config,
     createWorktreeFrom:
       config.createWorktreeFromTouched !== true &&
-      config.createWorktreeFrom === previousDefaults.sourceBranch
+      sourceBranchPlaceholders.has(config.createWorktreeFrom)
         ? defaults.createWorktreeFrom
         : config.createWorktreeFrom,
     createBranchFrom:
       config.createBranchFromTouched !== true &&
-      config.createBranchFrom === previousDefaults.sourceBranch
+      sourceBranchPlaceholders.has(config.createBranchFrom)
         ? defaults.createBranchFrom
         : config.createBranchFrom,
     switchBranchTarget:

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/workspace-action-config.test.ts
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/workspace-action-config.test.ts
@@ -112,4 +112,49 @@ describe('hydrateWorkspaceActionConfigWithDefaults', () => {
       ).createBranchFrom,
     ).toBe('main');
   });
+
+  // Regression: when a new chat auto-mounts, panel-footer creates the
+  // initial config with fallback branch items (always including 'main').
+  // The stored preference (e.g. 'master') is not in that fallback set, so
+  // applyWorkspaceGitActionPreferences rejects it and the config keeps 'main'.
+  // When real git data loads, previousDefaults.sourceBranch becomes the
+  // actual git ref (e.g. 'master'), which no longer equals the config's
+  // 'main'. The old strict-equality check failed to hydrate in this case.
+  it('hydrates createWorktreeFrom when fallback main differs from previousDefaults sourceBranch', () => {
+    expect(
+      hydrateWorkspaceActionConfigWithDefaults(
+        {
+          ...defaults,
+          createWorktreeFrom: 'main',
+        },
+        {
+          ...defaults,
+          createWorktreeFrom: 'origin/master',
+        },
+        {
+          ...previousDefaults,
+          sourceBranch: 'master',
+        },
+      ).createWorktreeFrom,
+    ).toBe('origin/master');
+  });
+
+  it('hydrates createBranchFrom when fallback main differs from previousDefaults sourceBranch', () => {
+    expect(
+      hydrateWorkspaceActionConfigWithDefaults(
+        {
+          ...defaults,
+          createBranchFrom: 'main',
+        },
+        {
+          ...defaults,
+          createBranchFrom: 'origin/master',
+        },
+        {
+          ...previousDefaults,
+          sourceBranch: 'master',
+        },
+      ).createBranchFrom,
+    ).toBe('origin/master');
+  });
 });

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/workspace-select.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/workspace-select.tsx
@@ -1259,10 +1259,7 @@ export function applyMountedWorkspaceActionDefault(
     };
   }
 
-  return {
-    ...config,
-    selectedAction: 'create-worktree',
-  };
+  return config;
 }
 
 export function toWorkspaceActionPayload(


### PR DESCRIPTION
…s from git ref

In new chats, panel-footer creates the initial workspace action config using fallback branch items before real git data loads. applyWorkspaceGitActionPreferences rejects the stored preference (e.g. 'master') because it is not in the fallback set, leaving 'main' in the config. When real git data arrives, hydrateWorkspaceActionConfigWithDefaults re-validates but the source-branch fields (createWorktreeFrom, createBranchFrom) used strict equality against previousDefaults.sourceBranch, which fails when the config has 'main' but the git ref is 'master'. The checkout-branch field (switchBranchTarget) already worked because it used a placeholder set including 'main'.

Fix: mirror the checkoutBranchPlaceholders set pattern for source branches. Create a sourceBranchPlaceholders set containing previousDefaults.sourceBranch, previousDefaults.defaultBranch, and 'main', then use .has() instead of strict equality. The *Touched guard still preserves genuine user selections.

Also includes the prior fix removing the forced selectedAction 'create-worktree' override in applyMountedWorkspaceActionDefault, which prevented persisted action selection from being respected.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes hydration of source-branch defaults when a new chat starts with fallback 'main' but the repo’s real ref differs (e.g., 'master'), and preserves the previously selected action on mount.

- **Bug Fixes**
  - Rehydrate `createWorktreeFrom` and `createBranchFrom` using a `sourceBranchPlaceholders` set (`previousDefaults.sourceBranch`, `previousDefaults.defaultBranch`, 'main') with `.has()`, respecting the `*Touched` guard.
  - Remove forced `selectedAction = 'create-worktree'` in `applyMountedWorkspaceActionDefault` so persisted selections are kept; added regression tests.

<sup>Written for commit b303195a4a77e044ce2938264816dc600d3ffcac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1412?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved branch selection defaults so source-branch fields now recover correctly from multiple placeholder values, including the app’s fallback branch and `main`.
  * Fixed workspace setup behavior for non-worktree mounts so the chosen action is preserved instead of being unexpectedly changed.
  * Added regression coverage to prevent source-branch defaults from reverting to the wrong value in similar cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->