### PR TITLE
feat(stagewise): enable AGENTS.md context by default for new workspace mounts

### DIFF
--- a/apps/browser/src/backend/env-domains/host-environment-sources.ts
+++ b/apps/browser/src/backend/env-domains/host-environment-sources.ts
@@ -65,7 +65,7 @@ export function createBrowserHostEnvironmentSources(
         const wsPath = mountManager.getWorkspacePathForPrefix(prefix);
         if (!wsPath) continue;
         const entry = workspaceSettings[wsPath] ?? {
-          respectAgentsMd: false,
+          respectAgentsMd: true,
           disabledSkills: [],
         };
         result.set(wsPath, {

--- a/apps/browser/src/backend/services/toolbox/index.ts
+++ b/apps/browser/src/backend/services/toolbox/index.ts
@@ -1041,7 +1041,7 @@ export class ToolboxService
       for (const mount of mounts) {
         const settings = this.uiKarton.state.preferences?.agent
           ?.workspaceSettings?.[mount.path] ?? {
-          respectAgentsMd: false,
+          respectAgentsMd: true,
           disabledSkills: [],
         };
         const disabled = new Set(settings.disabledSkills);
@@ -1139,7 +1139,7 @@ export class ToolboxService
         mount.prefix,
         this.uiKarton.state.preferences?.agent?.workspaceSettings?.[
           mount.path
-        ] ?? { respectAgentsMd: false, disabledSkills: [] },
+        ] ?? { respectAgentsMd: true, disabledSkills: [] },
       );
     }
     return result;

--- a/apps/browser/src/shared/karton-contracts/ui/shared-types.ts
+++ b/apps/browser/src/shared/karton-contracts/ui/shared-types.ts
@@ -334,7 +334,7 @@ export type PageSetting = z.infer<typeof pageSettingSchema>;
 /** Per-workspace agent settings (keyed by workspace absolute path) */
 export const workspaceAgentSettingsSchema = z.object({
   /** Whether the AGENTS.md file is included in the agent's system prompt */
-  respectAgentsMd: z.boolean().default(false),
+  respectAgentsMd: z.boolean().default(true),
   /** Skill names that have been disabled by the user */
   disabledSkills: z.array(z.string()).default([]),
 });

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/workspace-select.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/workspace-select.tsx
@@ -150,7 +150,7 @@ const WorkspaceBadge = memo(function WorkspaceBadge({
   const respectAgentsMd = useKartonState(
     (s: KartonState) =>
       s.preferences?.agent?.workspaceSettings?.[mount.path]?.respectAgentsMd ??
-      false,
+      true,
   );
   const preferences = useKartonState((s: KartonState) => s.preferences);
   const preferencesUpdate = useKartonProcedure(
@@ -237,7 +237,7 @@ const WorkspaceBadge = memo(function WorkspaceBadge({
             {
               op: 'add' as const,
               path: ['agent', 'workspaceSettings', mount.path],
-              value: { respectAgentsMd: false, disabledSkills: next },
+              value: { respectAgentsMd: true, disabledSkills: next },
             },
           ];
       void preferencesUpdate(patches);

--- a/apps/browser/src/ui/screens/settings/sections/skills-context-section.tsx
+++ b/apps/browser/src/ui/screens/settings/sections/skills-context-section.tsx
@@ -112,7 +112,7 @@ function WorkspaceSkillsList({
             {
               op: 'add' as const,
               path: ['agent', 'workspaceSettings', workspacePath],
-              value: { respectAgentsMd: false, disabledSkills: next },
+              value: { respectAgentsMd: true, disabledSkills: next },
             },
           ];
 
@@ -475,7 +475,7 @@ function WorkspaceContextFilesList({
 
   const respectAgentsMd =
     preferences?.agent?.workspaceSettings?.[workspacePath]?.respectAgentsMd ??
-    false;
+    true;
 
   const handleGenerate = useCallback(async () => {
     await generateWorkspaceMd(workspacePath);


### PR DESCRIPTION
Users expected the 'Use AGENTS.md' toggle to be enabled by default when mounting a workspace. Flip the default from false to true across the Zod schema default, backend fallbacks, and UI state reads.

Backward compatible: existing Preferences.json entries with an explicit respectAgentsMd value are preserved; only mounts with no stored preference get the new default.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable AGENTS.md context by default for new workspace mounts. Existing workspaces keep their saved setting.

- **New Features**
  - Set `respectAgentsMd` default to true in `workspaceAgentSettingsSchema`.
  - Updated backend fallbacks in host environment sources and `ToolboxService` to use the new default.
  - Updated UI reads and initial writes in workspace select and settings to start with the toggle on.

<sup>Written for commit f33a0f975f8966e3e6d0218640272f749e7e740e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1415?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Workspaces now default to respecting `agents.md` when no per-workspace preference is set.
  * Skill and context settings screens now reflect the updated default consistently.
  * New workspace preference entries created from the UI now start with the correct default behavior.
  * Workspace settings used by backend logic now align with the same default across the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->