### PR TITLE
feat(stagewise): parse and render subscription-required error for free-tier users

### DIFF
--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/message-runtime-error.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/message-runtime-error.tsx
@@ -130,6 +130,17 @@ export function MessageRuntimeError({
     );
   }
 
+  if (error.kind === 'subscription-required') {
+    return (
+      <SubscriptionRequiredError
+        error={error}
+        canRetry={canShowRetry}
+        onRetry={onRetry}
+        {...retryProps}
+      />
+    );
+  }
+
   if (error.kind === 'waiting-for-connection') {
     return (
       <WaitingForConnectionError
@@ -311,6 +322,78 @@ function ModelRestrictedError({
             onClick={() => void openSettings({ section: 'models-providers' })}
           >
             Configure other API keys
+          </Button>
+          <Button
+            variant="primary"
+            size="xs"
+            onClick={() => void openExternalUrl(consoleUrl)}
+          >
+            Upgrade plan
+            <ArrowUpRightIcon className="size-3" />
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Shows a card when a user without a subscription tries to use AI models
+ * through the stagewise gateway. Offers CTAs to upgrade, configure BYOK,
+ * or connect a coding plan.
+ */
+function SubscriptionRequiredError({
+  canRetry,
+  onRetry,
+  retryRef,
+  showRetryHotkey,
+}: {
+  error: Extract<AgentRuntimeError, { kind: 'subscription-required' }>;
+  canRetry: boolean;
+  onRetry: () => void;
+} & RetryActionProps) {
+  const openSettings = useKartonProcedure((p) => p.appScreen.openSettings);
+  const openExternalUrl = useKartonProcedure((p) => p.openExternalUrl);
+
+  return (
+    <div className="mt-6 flex w-full flex-col gap-1.5 rounded-lg border border-derived-strong p-2 text-sm">
+      <div className="flex flex-row items-center gap-1.5">
+        <IconLockKeyOutline18 className="size-3.5 shrink-0 text-foreground" />
+        <span className="font-medium text-foreground">
+          Subscription required
+        </span>
+      </div>
+
+      <div className="text-foreground">
+        AI model access through the stagewise gateway requires a subscription.
+        Upgrade your plan, configure your own API keys, or connect a coding plan
+        to continue.
+      </div>
+
+      <div className="flex flex-row items-center justify-between gap-2 pt-1">
+        <div>
+          {canRetry && (
+            <Button ref={retryRef} variant="ghost" size="xs" onClick={onRetry}>
+              <RefreshCcwIcon className="size-3" />
+              Retry
+              {showRetryHotkey && (
+                <HotkeyCombo
+                  action={HotkeyActions.CMD_ENTER}
+                  size="xs"
+                  variant="ghost"
+                  className="ml-0.5"
+                />
+              )}
+            </Button>
+          )}
+        </div>
+        <div className="flex flex-row justify-end gap-2">
+          <Button
+            variant="ghost"
+            size="xs"
+            onClick={() => void openSettings({ section: 'models-providers' })}
+          >
+            Configure API keys
           </Button>
           <Button
             variant="primary"

--- a/apps/browser/src/ui/screens/main/command-center/sources/use-agent-command-items.ts
+++ b/apps/browser/src/ui/screens/main/command-center/sources/use-agent-command-items.ts
@@ -173,7 +173,8 @@ export function useAgentCommandItems(
               activityIsUserInput: activity.isUserInput,
               hasError:
                 !!agent.state.error &&
-                agent.state.error.kind !== 'plan-limit-exceeded',
+                agent.state.error.kind !== 'plan-limit-exceeded' &&
+                agent.state.error.kind !== 'subscription-required',
               unread: !!agent.state.unread,
               lastMessageAt: lastMsg?.metadata?.createdAt
                 ? new Date(lastMsg.metadata.createdAt).getTime()

--- a/packages/agent-core/src/agents/base-agent.ts
+++ b/packages/agent-core/src/agents/base-agent.ts
@@ -1811,6 +1811,8 @@ export abstract class BaseAgent<
           });
         }
         const parsedModelRestricted = this.parseModelRestrictedError(error);
+        const parsedSubscriptionRequired =
+          this.parseSubscriptionRequiredError(error);
         if (parsedModelRestricted?.kind === 'model-restricted') {
           this.host.telemetry?.capture('model-restricted', {
             agent_type: this.agentType,
@@ -1823,6 +1825,7 @@ export abstract class BaseAgent<
         const parsedOverloadBase =
           parsedPlanLimit ||
           parsedModelRestricted ||
+          parsedSubscriptionRequired ||
           this.isZaiBillingOrQuotaError(
             parsedProviderError,
             modelWithOptions.reasoningSignatureSource,
@@ -1851,16 +1854,21 @@ export abstract class BaseAgent<
         this.state.commands.recordStepError({
           error: parsedPlanLimit ??
             parsedModelRestricted ??
+            parsedSubscriptionRequired ??
             parsedOverload ?? {
               message: `LLM provider error: ${parsedProviderError?.message ?? error.message}`,
               stack: error.stack,
             },
           markUnread: 'mark-unread',
         });
-        // Plan-limit and model-restricted errors surface their own dedicated
-        // UI affordance, so we suppress the generic error notification in
-        // those cases (matches the browser host's pre-extraction behavior).
-        if (!parsedPlanLimit && !parsedModelRestricted) {
+        // Plan-limit, model-restricted, and subscription-required errors
+        // surface their own dedicated UI affordance, so we suppress the
+        // generic error notification in those cases.
+        if (
+          !parsedPlanLimit &&
+          !parsedModelRestricted &&
+          !parsedSubscriptionRequired
+        ) {
           this.emitNotificationEvent('error');
         }
         this.host.logger.debug(
@@ -3069,6 +3077,24 @@ export abstract class BaseAgent<
     return parts.join(', ');
   }
 
+  /**
+   * Extracts the error code from an API response body, supporting both the
+   * current shape `{ error: { code: 'CODE', message: '...' } }` and the
+   * legacy shape `{ error: 'CODE', message: '...' }`.
+   */
+  private static extractErrorCode(body: unknown): string | null {
+    if (body == null || typeof body !== 'object') return null;
+    const err = (body as Record<string, unknown>).error;
+    if (typeof err === 'string') return err;
+    if (
+      err != null &&
+      typeof err === 'object' &&
+      typeof (err as Record<string, unknown>).code === 'string'
+    )
+      return (err as Record<string, unknown>).code as string;
+    return null;
+  }
+
   private parsePlanLimitError(error: Error): AgentRuntimeError | null {
     // Read the RAW (untruncated) responseBody — classifiers must parse the
     // full JSON. `extractApiErrorContext` truncates for logging, which can
@@ -3078,7 +3104,8 @@ export abstract class BaseAgent<
     if (typeof rawBody !== 'string') return null;
     try {
       const body = JSON.parse(rawBody);
-      if (body?.error !== 'PLAN_LIMIT_EXCEEDED') return null;
+      if (BaseAgent.extractErrorCode(body) !== 'PLAN_LIMIT_EXCEEDED')
+        return null;
       const exceededWindows =
         body.details?.exceededWindows
           ?.filter(
@@ -3108,7 +3135,7 @@ export abstract class BaseAgent<
     if (typeof rawBody !== 'string') return null;
     try {
       const body = JSON.parse(rawBody);
-      if (body?.error !== 'MODEL_RESTRICTED') return null;
+      if (BaseAgent.extractErrorCode(body) !== 'MODEL_RESTRICTED') return null;
       const model =
         typeof body.details?.model === 'string'
           ? body.details.model
@@ -3120,6 +3147,27 @@ export abstract class BaseAgent<
         message: body.message ?? 'This model is not available on your plan',
         model,
         plan,
+      };
+    } catch {
+      return null;
+    }
+  }
+
+  private parseSubscriptionRequiredError(
+    error: Error,
+  ): AgentRuntimeError | null {
+    const frame = BaseAgent.unwrapApiErrorFrame(error);
+    const rawBody = frame.responseBody;
+    if (typeof rawBody !== 'string') return null;
+    try {
+      const body = JSON.parse(rawBody);
+      if (BaseAgent.extractErrorCode(body) !== 'SUBSCRIPTION_REQUIRED')
+        return null;
+      return {
+        kind: 'subscription-required',
+        message:
+          body.message ??
+          'Stagewise subscription required — upgrade your plan to continue.',
       };
     } catch {
       return null;

--- a/packages/agent-core/src/services/agent-manager/agent-manager.ts
+++ b/packages/agent-core/src/services/agent-manager/agent-manager.ts
@@ -92,6 +92,7 @@ function getNetworkRetryableErrorMessage(
   if (!error) return null;
   if (error.kind === 'plan-limit-exceeded') return null;
   if (error.kind === 'model-restricted') return null;
+  if (error.kind === 'subscription-required') return null;
   if (error.kind === 'upstream-overload') return null;
   if (error.kind === 'waiting-for-connection') return error.originalMessage;
 

--- a/packages/agent-core/src/types/agent.ts
+++ b/packages/agent-core/src/types/agent.ts
@@ -39,6 +39,10 @@ export type AgentRuntimeError =
       plan?: string;
     }
   | {
+      kind: 'subscription-required';
+      message: string;
+    }
+  | {
       kind: 'upstream-overload';
       message: string;
       providerName?: string;


### PR DESCRIPTION


- Add subscription-required kind to AgentRuntimeError union type
- Parse 402 SUBSCRIPTION_REQUIRED response in base-agent onError handler
- Mark subscription-required as non-retryable in agent-manager
- Add SubscriptionRequiredError card with upgrade/BYOK CTAs in message-runtime-error
- Suppress red error indicator for subscription-required in command center

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Handle subscription-required errors for free-tier users by parsing 402 responses from the Stagewise gateway and showing a dedicated chat card with Upgrade/BYOK actions. Treat this as non-retryable and hide generic error indicators across chat and Command Center.

- **New Features**
  - Added a new `AgentRuntimeError` kind: `subscription-required`.
  - Base agent parses 402 `SUBSCRIPTION_REQUIRED` and suppresses the generic error toast.
  - Agent manager treats this error as non-retryable.
  - Chat shows a SubscriptionRequiredError card with Upgrade plan and Configure API keys actions.
  - Command Center suppresses the red error dot for this error.

- **Bug Fixes**
  - Error-code extraction now supports both current and legacy API response shapes, improving detection for plan-limit, model-restricted, and subscription-required errors.

<sup>Written for commit 1f749139efa4c88dc9cb36f2974efc2d4b75f95f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1417?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated “Subscription required” runtime error state with a lock icon, explanatory guidance, and actions to update API settings or upgrade access.
  * Included conditional retry support when available.
* **Bug Fixes**
  * Improved classification of subscription-related failures so they no longer fall back to other error screens.
  * Updated retry logic to treat subscription-required errors as non-retryable.
  * Prevented subscription-required states from being marked as general agent errors in the command center view.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->