### PR TITLE
feat(stagewise): add xAI Grok 4.5 model support

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Included models:
 - **Anthropic**: Fable 5, Opus 4.8, Opus 4.7, Opus 4.6, Sonnet 5, Sonnet 4.6, Haiku 4.5
 - **OpenAI**: GPT-5.6 Sol, GPT-5.6 Terra, GPT-5.6 Luna, GPT-5.5, GPT-5.4, GPT-5.3 Codex, GPT-5.3 Instant, GPT-5.4 mini, GPT-5.4 nano
 - **Google**: Gemini 3.5 Flash, Gemini 3.1 Pro (Preview), Gemini 3 Flash, Gemini 3.1 Flash Lite
+- **xAI**: Grok 4.5
 
 ## License
 

--- a/apps/browser/src/backend/agents/providers/official-api.ts
+++ b/apps/browser/src/backend/agents/providers/official-api.ts
@@ -54,6 +54,7 @@ const VENDOR_TO_API_SPEC: Record<ModelProvider, ApiSpec> = {
   minimax: 'openai-chat-completions',
   'xiaomi-mimo': 'openai-chat-completions',
   mistral: 'openai-chat-completions',
+  'x-ai': 'openai-chat-completions',
 };
 
 /**
@@ -71,6 +72,7 @@ const VENDOR_VALIDATION_MODEL: Partial<Record<ModelProvider, string>> = {
   minimax: 'minimax-m2.7',
   'xiaomi-mimo': 'mimo-v2.5',
   mistral: 'mistral-small-latest',
+  'x-ai': 'grok-3-mini',
   openai: 'gpt-4o-mini',
   google: 'gemini-2.0-flash',
 };
@@ -520,6 +522,9 @@ export const xiaomiMimoApiType: ProviderType<OfficialApiConfig> =
 export const mistralApiType: ProviderType<OfficialApiConfig> =
   createOpenAICompatibleApiType('mistral');
 
+export const xAiApiType: ProviderType<OfficialApiConfig> =
+  createOpenAICompatibleApiType('x-ai');
+
 // ============================================================================
 // Registry of all official-api types, keyed by vendor
 // ============================================================================
@@ -538,6 +543,7 @@ export const OFFICIAL_API_TYPES: Record<
   minimax: minimaxApiType,
   'xiaomi-mimo': xiaomiMimoApiType,
   mistral: mistralApiType,
+  'x-ai': xAiApiType,
 };
 
 export const VENDOR_API_SPECS = VENDOR_TO_API_SPEC;

--- a/apps/browser/src/backend/agents/providers/registry.ts
+++ b/apps/browser/src/backend/agents/providers/registry.ts
@@ -13,6 +13,7 @@ import {
   minimaxApiType,
   xiaomiMimoApiType,
   mistralApiType,
+  xAiApiType,
   OFFICIAL_API_TYPES,
 } from './official-api';
 import { codingPlanProviderType } from './coding-plan';
@@ -49,6 +50,7 @@ export const PROVIDER_TYPE_REGISTRY: Record<
   'minimax-api': minimaxApiType,
   'xiaomi-mimo-api': xiaomiMimoApiType,
   'mistral-api': mistralApiType,
+  'x-ai-api': xAiApiType,
   'coding-plan': codingPlanProviderType,
   'custom-anthropic': customAnthropicType,
   'custom-openai-chat': customOpenAIChatType,

--- a/apps/browser/src/backend/utils/validate-api-keys.ts
+++ b/apps/browser/src/backend/utils/validate-api-keys.ts
@@ -17,7 +17,8 @@ export type ApiKeyProvider =
   | 'z-ai'
   | 'minimax'
   | 'xiaomi-mimo'
-  | 'mistral';
+  | 'mistral'
+  | 'x-ai';
 
 export type ApiKeyValidationResult =
   | null
@@ -128,6 +129,11 @@ const providerConfigs: Record<
       apiKey,
       baseURL: baseURL ?? 'https://api.mistral.ai/v1',
     }).chat('mistral-small-latest'),
+  'x-ai': (apiKey, baseURL) =>
+    createOpenAI({
+      apiKey,
+      baseURL: baseURL ?? 'https://api.x.ai/v1',
+    }).chat('grok-3-mini'),
 };
 
 async function validateModel(model: ValidationModel): Promise<void> {
@@ -231,6 +237,7 @@ export async function validateApiKeys(
     minimax: null,
     'xiaomi-mimo': null,
     mistral: null,
+    'x-ai': null,
   };
 
   const promises: Promise<void>[] = [];

--- a/apps/browser/src/shared/available-models.ts
+++ b/apps/browser/src/shared/available-models.ts
@@ -1824,6 +1824,50 @@ export const availableModels = [
       toolCalling: true,
     },
   },
+  {
+    officialProvider: 'x-ai',
+    modelId: 'grok-4.5',
+    modelDisplayName: 'Grok 4.5',
+    modelDescription:
+      "xAI's smartest model with frontier performance on coding, knowledge work, and STEM. 500K token context window with strong reasoning and low cost.",
+    modelContext: '500K context',
+    modelContextRaw: 500_000,
+    headers: {},
+    providerOptions: {
+      stagewise: {
+        reasoning: { enabled: true, effort: 'medium' },
+        // Only route to OpenRouter upstreams that support the `reasoning`
+        // parameter, preventing silent drops on non-reasoning upstreams.
+        provider: { require_parameters: true },
+      },
+      openai: {
+        reasoningEffort: 'medium',
+      },
+    },
+    thinkingEnabled: true,
+    pricing: {
+      inputPerMillion: 2.0,
+      outputPerMillion: 6.0,
+      relativeMultiplier: 1.4,
+    },
+    capabilities: {
+      inputModalities: {
+        text: true,
+        audio: false,
+        image: true,
+        video: false,
+        file: true,
+      },
+      outputModalities: {
+        text: true,
+        audio: false,
+        image: false,
+        video: false,
+        file: false,
+      },
+      toolCalling: true,
+    },
+  },
 ] as const satisfies ModelSettings[];
 
 export type BuiltInModel = (typeof availableModels)[number];

--- a/apps/browser/src/shared/karton-contracts/ui/shared-types.ts
+++ b/apps/browser/src/shared/karton-contracts/ui/shared-types.ts
@@ -40,6 +40,7 @@ export const modelProviderSchema = z.enum([
   'minimax',
   'xiaomi-mimo',
   'mistral',
+  'x-ai',
 ]);
 export type ModelProvider = z.infer<typeof modelProviderSchema>;
 
@@ -87,6 +88,7 @@ export const providerConfigsSchema = z.object({
   minimax: providerConfigSchema.default({ mode: 'stagewise' }),
   'xiaomi-mimo': providerConfigSchema.default({ mode: 'stagewise' }),
   mistral: providerConfigSchema.default({ mode: 'stagewise' }),
+  'x-ai': providerConfigSchema.default({ mode: 'stagewise' }),
 });
 export type ProviderConfigs = z.infer<typeof providerConfigsSchema>;
 
@@ -215,6 +217,7 @@ export const providerInstanceTypeIds = [
   'minimax-api',
   'xiaomi-mimo-api',
   'mistral-api',
+  'x-ai-api',
   'coding-plan',
   'custom-anthropic',
   'custom-openai-chat',
@@ -372,6 +375,10 @@ export const providerInstanceSchema = z.discriminatedUnion('typeId', [
   }),
   providerInstanceBaseSchema.extend({
     typeId: z.literal('mistral-api'),
+    config: officialApiConfigSchema,
+  }),
+  providerInstanceBaseSchema.extend({
+    typeId: z.literal('x-ai-api'),
     config: officialApiConfigSchema,
   }),
   providerInstanceBaseSchema.extend({
@@ -592,6 +599,14 @@ export const PROVIDER_TYPE_DISPLAY_INFO: Record<
     helpText: 'Get your API key at openrouter.ai → Keys',
     getApiKeyUrl: 'https://openrouter.ai/keys',
     defaultBaseUrl: 'https://openrouter.ai/api/v1',
+    credentialType: 'api-key',
+  },
+  'x-ai-api': {
+    displayName: 'xAI API',
+    description: 'Grok models',
+    helpText: 'Create one at console.x.ai → API Keys',
+    getApiKeyUrl: 'https://console.x.ai',
+    defaultBaseUrl: 'https://api.x.ai/v1',
     credentialType: 'api-key',
   },
 };
@@ -1176,6 +1191,7 @@ export const userPreferencesSchema = z.object({
     minimax: { mode: 'stagewise' },
     'xiaomi-mimo': { mode: 'stagewise' },
     mistral: { mode: 'stagewise' },
+    'x-ai': { mode: 'stagewise' },
   }),
   /** User-defined API endpoints */
   customEndpoints: z.array(customEndpointSchema).default([]),
@@ -1294,6 +1310,7 @@ export const defaultUserPreferences: UserPreferences = {
     minimax: { mode: 'stagewise' },
     'xiaomi-mimo': { mode: 'stagewise' },
     mistral: { mode: 'stagewise' },
+    'x-ai': { mode: 'stagewise' },
   },
   customEndpoints: [],
   customModels: [],

--- a/apps/browser/src/shared/model-thinking-capabilities.ts
+++ b/apps/browser/src/shared/model-thinking-capabilities.ts
@@ -179,6 +179,7 @@ export function getThinkingProviderForRoute({
     case 'minimax':
     case 'xiaomi-mimo':
     case 'mistral':
+    case 'x-ai':
       return 'openai-compatible';
     default:
       // Unknown routes have no proven provider-native reasoning contract.

--- a/apps/browser/src/ui/components/provider-logos/index.tsx
+++ b/apps/browser/src/ui/components/provider-logos/index.tsx
@@ -11,6 +11,7 @@ import { XiaomiMiMoLogo } from './xiaomi-mimo';
 import { ZAiLogo } from './z-ai';
 import { MistralLogo } from './mistral';
 import { OpenRouterLogo } from './openrouter';
+import { XaiLogo } from './xai';
 
 export type ProviderLogoComponent = ComponentType<SVGProps<SVGSVGElement>>;
 
@@ -31,6 +32,7 @@ export const PROVIDER_LOGOS: Record<ModelProvider, ProviderLogoComponent> = {
   minimax: MinimaxLogo,
   'xiaomi-mimo': XiaomiMiMoLogo,
   mistral: MistralLogo,
+  'x-ai': XaiLogo,
 };
 
 /**
@@ -57,4 +59,5 @@ export {
   ZAiLogo,
   MistralLogo,
   OpenRouterLogo,
+  XaiLogo,
 };

--- a/apps/browser/src/ui/components/provider-logos/xai.tsx
+++ b/apps/browser/src/ui/components/provider-logos/xai.tsx
@@ -1,0 +1,25 @@
+import type { SVGProps } from 'react';
+
+/**
+ * xAI brand mark — simplified bold X logo.
+ *
+ * Uses `currentColor` so it inherits the nearest `color` / `text-*` class.
+ */
+export function XaiLogo(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      fill="none"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="2.5"
+      viewBox="0 0 24 24"
+      xmlns="http://www.w3.org/2000/svg"
+      role="img"
+      aria-label="xAI"
+      {...props}
+    >
+      <path d="M5 5l14 14M19 5L5 19" />
+    </svg>
+  );
+}

--- a/apps/browser/src/ui/screens/onboarding/steps/06-configure-providers.tsx
+++ b/apps/browser/src/ui/screens/onboarding/steps/06-configure-providers.tsx
@@ -71,6 +71,7 @@ const VENDOR_API_TYPES: ProviderInstanceTypeId[] = [
   'minimax-api',
   'xiaomi-mimo-api',
   'mistral-api',
+  'x-ai-api',
 ];
 
 const GATEWAY_TYPES: ProviderInstanceTypeId[] = ['openrouter'];

--- a/apps/browser/src/ui/screens/settings/sections/models-providers-section.tsx
+++ b/apps/browser/src/ui/screens/settings/sections/models-providers-section.tsx
@@ -516,6 +516,7 @@ const ADDABLE_VENDOR_TYPES: ProviderInstanceTypeId[] = [
   'minimax-api',
   'xiaomi-mimo-api',
   'mistral-api',
+  'x-ai-api',
 ];
 
 const ADDABLE_GATEWAY_TYPES: ProviderInstanceTypeId[] = ['openrouter'];

--- a/apps/website/public/provider-logos/xai.svg
+++ b/apps/website/public/provider-logos/xai.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" viewBox="0 0 24 24" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg" style="flex:none;line-height:1">
+  <title>xAI</title>
+  <path d="M5 5l14 14M19 5L5 19"/>
+</svg>

--- a/apps/website/src/app/(home)/_components/model-provider-showcase.tsx
+++ b/apps/website/src/app/(home)/_components/model-provider-showcase.tsx
@@ -158,6 +158,15 @@ const PROVIDERS: ProviderInfo[] = [
     ],
   },
   {
+    id: 'x-ai',
+    name: 'xAI',
+    logo: '/provider-logos/xai.svg',
+    monoInDark: true,
+    description:
+      'Frontier reasoning models for coding, knowledge work, and STEM at competitive prices.',
+    models: [{ name: 'Grok 4.5', tier: 'frontier' }],
+  },
+  {
     id: 'openrouter',
     name: 'OpenRouter',
     logo: '/provider-logos/openrouter.svg',


### PR DESCRIPTION
Add Grok 4.5 as a new model from xAI, available through the stagewise gateway (default) and official BYOK mode via the xAI API.

- Register x-ai provider (schema, configs, URLs, display info, logo)
- Add Grok 4.5 model entry (500K context, / pricing, text+image+file)
- Wire routing: stagewise gateway (x-ai/grok-4.5), official (Chat Completions)
- Add API key validation against api.x.ai/v1
- Add xAI to provider showcase, settings PROVIDERS list, and README

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive provider and catalog wiring following existing vendor patterns; no changes to auth, billing, or core routing logic beyond new enum entries.
> 
> **Overview**
> Adds **xAI** as a first-class vendor so **Grok 4.5** is selectable via the stagewise gateway (default) or **BYOK** through the official xAI API.
> 
> The change wires `x-ai` / `x-ai-api` through the same OpenAI Chat Completions path as other vendors: provider registry, Zod schemas and defaults, credential validation against `https://api.x.ai/v1` (probe `grok-3-mini`), and thinking routed as **openai-compatible** with medium reasoning on gateway routes (`require_parameters` so reasoning isn’t dropped upstream).
> 
> **Grok 4.5** is added to the built-in catalog (500K context, tool calling, text/image/file, pricing). UI/docs pick up the xAI logo, onboarding/settings provider lists, website showcase, and README proprietary models list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 773bef257d4db80dfae3d859853f4d63e5834a9c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds xAI as a provider and exposes Grok 4.5 (500K context) via the stagewise gateway by default, with optional BYOK through xAI’s OpenAI‑compatible API. Previously xAI was unsupported; now Grok 4.5 offers reasoning (medium), tool calling, and text/image/file inputs.

- Registered `x-ai` and official `x-ai-api` types using Chat Completions; added to schemas, registry, and display info (console link, default base URL).
- Added `grok-4.5` to the catalog: 500K context, reasoning enabled (medium), tool calling, text/image/file; pricing $2/M input and $6/M output; thinking mapped to OpenAI‑compatible.
- Stagewise routing only targets upstreams that accept the `reasoning` parameter (`provider.require_parameters: true`) to avoid silent drops.
- API key validation supports xAI at `https://api.x.ai/v1` using `grok-3-mini` (custom base URL supported).
- UI/docs: xAI logo; addable `x-ai-api` in onboarding/settings; provider showcase and README updated.

**Migration**
- No action to use the stagewise default.
- To use BYOK: add your xAI key in Settings → Providers, add `x-ai-api`, and switch `x-ai` to official.

<sup>Written for commit 773bef257d4db80dfae3d859853f4d63e5834a9c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1433?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added xAI as a supported AI provider.
  * Added Grok 4.5 with text, image, file, reasoning, and tool-calling capabilities, plus a 500K context window.
  * Added xAI API-key configuration during onboarding and provider settings.
  * Added automatic API-key validation through xAI’s OpenAI-compatible API.
  * Added xAI branding and provider details across the app and website.

* **Documentation**
  * Updated the proprietary models list to include xAI and Grok 4.5.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->