### PR TITLE
fix(agent-shell): handle large commands and clarify multiline input

### DIFF
--- a/packages/agent-shell/src/engine/session-manager.test.ts
+++ b/packages/agent-shell/src/engine/session-manager.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach, vi } from 'vitest';
+import { describe, it, expect, afterEach } from 'vitest';
 import os from 'node:os';
 import fs from 'node:fs';
 import path from 'node:path';
@@ -28,7 +28,7 @@ import {
   SHELL_RESPONSE_TAIL_MAX_CHARS,
   TAIL_LINES,
 } from './types';
-import type { DetectedShell, PtySession } from './types';
+import type { DetectedShell } from './types';
 
 // ─── Section A: applyHeadTailCap (pure) ──────────────────────────
 
@@ -193,75 +193,7 @@ describe('command timeout/idle selection', () => {
   });
 });
 
-// ─── Section D: Chunked PTY input cancellation ──────────────────
-
-describe('chunked PTY input cancellation', () => {
-  it('stops writing an older command when a new command replaces it', async () => {
-    vi.useFakeTimers();
-
-    try {
-      const writes: Buffer[] = [];
-      const sessionId = 'test-session';
-      const sm = new SessionManager({ type: 'bash', path: '/bin/bash' });
-      const session = {
-        id: sessionId,
-        agentInstanceId: 'test-agent',
-        pty: {
-          write: (data: string | Uint8Array) => {
-            writes.push(Buffer.from(data));
-          },
-        },
-        parser: { currentMode: 'detecting' },
-        shellIntegrationActive: true,
-        createdAt: Date.now(),
-        lastActivityAt: Date.now(),
-        exited: false,
-        exitCode: null,
-        deactivated: false,
-        detectTimerHandle: null,
-        ready: true,
-        readyPromise: Promise.resolve(),
-        readyResolve: () => {},
-        onData: null,
-        logger: null,
-        cwd: process.cwd(),
-        currentCwd: process.cwd(),
-        initScriptPath: null,
-      } as unknown as PtySession;
-      const internals = sm as unknown as {
-        sessions: Map<string, PtySession>;
-      };
-      internals.sessions.set(sessionId, session);
-
-      const firstResultPromise = sm.executeCommand(sessionId, {
-        command: 'a'.repeat(2048),
-      });
-      await Promise.resolve();
-      expect(writes).toHaveLength(1);
-
-      const replacementAbort = new AbortController();
-      const replacementResultPromise = sm.executeCommand(sessionId, {
-        command: '',
-        abortSignal: replacementAbort.signal,
-      });
-      replacementAbort.abort();
-
-      await vi.advanceTimersByTimeAsync(5);
-      const [firstResult, replacementResult] = await Promise.all([
-        firstResultPromise,
-        replacementResultPromise,
-      ]);
-
-      expect(firstResult.resolvedBy).toBe('abort');
-      expect(replacementResult.resolvedBy).toBe('abort');
-      expect(writes).toHaveLength(1);
-    } finally {
-      vi.useRealTimers();
-    }
-  });
-});
-
-// ─── Section E: Integration tests (real PTY sessions) ───────────
+// ─── Section D: Integration tests (real PTY sessions) ────────────
 
 const shell = detectShell();
 

--- a/packages/agent-shell/src/engine/session-manager.test.ts
+++ b/packages/agent-shell/src/engine/session-manager.test.ts
@@ -269,6 +269,20 @@ async function waitForReady(
 }
 
 /**
+ * WinPTY defers writes and kills until its data pipe is ready. Tests that
+ * create and immediately tear down sessions can otherwise close the pipe
+ * while the deferred shell-integration write is still pending, surfacing as
+ * an asynchronous EAGAIN after the test environment has been torn down.
+ */
+async function waitForWindowsPtyReadyBeforeTeardown(
+  sm: SessionManager,
+  sessionIds: string[],
+): Promise<void> {
+  if (process.platform !== 'win32') return;
+  await Promise.all(sessionIds.map((id) => waitForReady(sm, id)));
+}
+
+/**
  * Wait until the session's PTY has exited and `session.exited` has been
  * flipped by `handleSessionExit`. On Windows ConPTY, the shell-integration
  * exit trap can emit OSC 133;D (firing the command's promise) before
@@ -754,6 +768,8 @@ describeIfShell('SessionManager (integration)', { retry: 2 }, () => {
     const sid2 = sm.createSession('agent-destroy', cwd, env);
     const sidOther = sm.createSession('agent-other', cwd, env);
 
+    await waitForWindowsPtyReadyBeforeTeardown(sm, [sid1, sid2, sidOther]);
+
     sm.destroyAgent('agent-destroy');
 
     expect(sm.getSession(sid1)).toBeUndefined();
@@ -802,25 +818,31 @@ describeIfShell('SessionManager (integration)', { retry: 2 }, () => {
 
   // ─── Concurrency limits ──────────────────────────────────────
 
-  it('enforces max concurrent sessions per agent', () => {
+  it('enforces max concurrent sessions per agent', async () => {
     sm = createSM();
+    const sessionIds: string[] = [];
     for (let i = 0; i < MAX_SESSIONS_PER_AGENT; i++) {
-      sm.createSession('agent-max', cwd, env);
+      sessionIds.push(sm.createSession('agent-max', cwd, env));
     }
 
     expect(() => sm.createSession('agent-max', cwd, env)).toThrow(
       /Maximum.*concurrent sessions/,
     );
+
+    await waitForWindowsPtyReadyBeforeTeardown(sm, sessionIds);
   });
 
-  it('max sessions is per-agent — other agents unaffected', () => {
+  it('max sessions is per-agent — other agents unaffected', async () => {
     sm = createSM();
+    const sessionIds: string[] = [];
     for (let i = 0; i < MAX_SESSIONS_PER_AGENT; i++) {
-      sm.createSession('agent-a', cwd, env);
+      sessionIds.push(sm.createSession('agent-a', cwd, env));
     }
 
     // Different agent can still create sessions
-    expect(() => sm.createSession('agent-b', cwd, env)).not.toThrow();
+    sessionIds.push(sm.createSession('agent-b', cwd, env));
+
+    await waitForWindowsPtyReadyBeforeTeardown(sm, sessionIds);
   });
 
   // ─── Edge cases ──────────────────────────────────────────────
@@ -841,15 +863,19 @@ describeIfShell('SessionManager (integration)', { retry: 2 }, () => {
     expect(sm.killSession('nonexistent')).toBe(false);
   });
 
-  it('getSessionsForAgent returns only that agent sessions', () => {
+  it('getSessionsForAgent returns only that agent sessions', async () => {
     sm = createSM();
-    sm.createSession('agent-x', cwd, env);
-    sm.createSession('agent-x', cwd, env);
-    sm.createSession('agent-y', cwd, env);
+    const sessionIds = [
+      sm.createSession('agent-x', cwd, env),
+      sm.createSession('agent-x', cwd, env),
+      sm.createSession('agent-y', cwd, env),
+    ];
 
     expect(sm.getSessionsForAgent('agent-x')).toHaveLength(2);
     expect(sm.getSessionsForAgent('agent-y')).toHaveLength(1);
     expect(sm.getSessionsForAgent('agent-z')).toHaveLength(0);
+
+    await waitForWindowsPtyReadyBeforeTeardown(sm, sessionIds);
   });
 });
 

--- a/packages/agent-shell/src/engine/session-manager.test.ts
+++ b/packages/agent-shell/src/engine/session-manager.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, afterEach, vi } from 'vitest';
 import os from 'node:os';
 import fs from 'node:fs';
 import path from 'node:path';
@@ -28,7 +28,7 @@ import {
   SHELL_RESPONSE_TAIL_MAX_CHARS,
   TAIL_LINES,
 } from './types';
-import type { DetectedShell } from './types';
+import type { DetectedShell, PtySession } from './types';
 
 // ─── Section A: applyHeadTailCap (pure) ──────────────────────────
 
@@ -193,7 +193,75 @@ describe('command timeout/idle selection', () => {
   });
 });
 
-// ─── Section D: Integration tests (real PTY sessions) ────────────
+// ─── Section D: Chunked PTY input cancellation ──────────────────
+
+describe('chunked PTY input cancellation', () => {
+  it('stops writing an older command when a new command replaces it', async () => {
+    vi.useFakeTimers();
+
+    try {
+      const writes: Buffer[] = [];
+      const sessionId = 'test-session';
+      const sm = new SessionManager({ type: 'bash', path: '/bin/bash' });
+      const session = {
+        id: sessionId,
+        agentInstanceId: 'test-agent',
+        pty: {
+          write: (data: string | Uint8Array) => {
+            writes.push(Buffer.from(data));
+          },
+        },
+        parser: { currentMode: 'detecting' },
+        shellIntegrationActive: true,
+        createdAt: Date.now(),
+        lastActivityAt: Date.now(),
+        exited: false,
+        exitCode: null,
+        deactivated: false,
+        detectTimerHandle: null,
+        ready: true,
+        readyPromise: Promise.resolve(),
+        readyResolve: () => {},
+        onData: null,
+        logger: null,
+        cwd: process.cwd(),
+        currentCwd: process.cwd(),
+        initScriptPath: null,
+      } as unknown as PtySession;
+      const internals = sm as unknown as {
+        sessions: Map<string, PtySession>;
+      };
+      internals.sessions.set(sessionId, session);
+
+      const firstResultPromise = sm.executeCommand(sessionId, {
+        command: 'a'.repeat(2048),
+      });
+      await Promise.resolve();
+      expect(writes).toHaveLength(1);
+
+      const replacementAbort = new AbortController();
+      const replacementResultPromise = sm.executeCommand(sessionId, {
+        command: '',
+        abortSignal: replacementAbort.signal,
+      });
+      replacementAbort.abort();
+
+      await vi.advanceTimersByTimeAsync(5);
+      const [firstResult, replacementResult] = await Promise.all([
+        firstResultPromise,
+        replacementResultPromise,
+      ]);
+
+      expect(firstResult.resolvedBy).toBe('abort');
+      expect(replacementResult.resolvedBy).toBe('abort');
+      expect(writes).toHaveLength(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+// ─── Section E: Integration tests (real PTY sessions) ───────────
 
 const shell = detectShell();
 

--- a/packages/agent-shell/src/engine/session-manager.test.ts
+++ b/packages/agent-shell/src/engine/session-manager.test.ts
@@ -344,6 +344,23 @@ describeIfShell('SessionManager (integration)', { retry: 2 }, () => {
     expect(r.resolvedBy).toBe('exit');
   });
 
+  it('executes a command larger than 1024 bytes', async () => {
+    sm = createSM();
+    const sid = sm.createSession('agent-test', cwd, env);
+    await waitForReady(sm, sid);
+    const marker = 'LONG_COMMAND_COMPLETED';
+    const payload = 'x'.repeat(1100);
+
+    const r = await sm.executeCommand(sid, {
+      command: `printf '%s\\n' "${payload}"; printf '%s\\n' '${marker}'`,
+      waitUntil: { timeoutMs: 5000, idleMs: 0 },
+    });
+
+    expect(r.output).toContain(marker);
+    expect(r.exitCode).toBe(0);
+    expect(r.resolvedBy).toBe('exit');
+  });
+
   it('propagates non-zero exit codes', async () => {
     sm = createSM();
     const sid = sm.createSession('agent-test', cwd, env);

--- a/packages/agent-shell/src/engine/session-manager.ts
+++ b/packages/agent-shell/src/engine/session-manager.ts
@@ -32,6 +32,38 @@ import {
 /** Cap for rawOutput accumulator used only for pattern matching. */
 const MAX_RAW_OUTPUT_BYTES = 1_024 * 1_024;
 
+// Some PTYs limit terminal input to 1024 bytes. Writing a larger command in one
+// burst can silently drop its tail, leaving the shell waiting for input (for
+// example, when the closing quote is lost). Small paced writes give the shell
+// enough time to drain the input queue between chunks.
+const PTY_INPUT_CHUNK_THRESHOLD_BYTES = 768;
+const PTY_INPUT_CHUNK_BYTES = 256;
+const PTY_INPUT_CHUNK_DELAY_MS = 5;
+
+async function writePtyInput(
+  ptyProcess: pty.IPty,
+  input: string,
+): Promise<void> {
+  const buffer = Buffer.from(input, 'utf8');
+  if (buffer.length <= PTY_INPUT_CHUNK_THRESHOLD_BYTES) {
+    ptyProcess.write(buffer);
+    return;
+  }
+
+  for (
+    let offset = 0;
+    offset < buffer.length;
+    offset += PTY_INPUT_CHUNK_BYTES
+  ) {
+    ptyProcess.write(buffer.subarray(offset, offset + PTY_INPUT_CHUNK_BYTES));
+    if (offset + PTY_INPUT_CHUNK_BYTES < buffer.length) {
+      await new Promise<void>((resolve) =>
+        setTimeout(resolve, PTY_INPUT_CHUNK_DELAY_MS),
+      );
+    }
+  }
+}
+
 // ─── Command timeout/idle policy ────────────────────────────────
 // Exported so tests can exercise the selection logic as pure helpers.
 // Kept here (not inlined in `executeCommand`) so the policy is easy to
@@ -646,7 +678,7 @@ export class SessionManager {
       this.resolveCommandWithTimeout(existingCommandId, 'abort');
     }
 
-    return new Promise<SessionCommandResult>((resolve) => {
+    const resultPromise = new Promise<SessionCommandResult>((resolve) => {
       const mark = session.logger?.getMarkPosition() ?? 0;
       const idleMs = getCommandIdleMs(request);
       const pending: PendingCommand = {
@@ -696,36 +728,36 @@ export class SessionManager {
         // The exit handler is already wired via handleSessionExit
         // which will resolve any pending commands when the session exits.
       }
-
-      const command = request.command;
-
-      if (request.rawInput) {
-        // Raw stdin: write bytes verbatim — no \r, no sentinel
-        session.pty.write(command);
-      } else if (command.length === 0) {
-        // Empty command, no rawInput — don't write anything to the PTY.
-        // The agent is just waiting for output; the pending command will
-        // resolve via timeout, pattern match, or session exit.
-      } else if (session.shellIntegrationActive) {
-        // Shell integration handles output boundaries via OSC 133 and emits
-        // OSC 7 cwd metadata at prompt time for session cwd tracking.
-        session.pty.write(`${command}\r`);
-      } else if (session.parser.currentMode === 'sentinel') {
-        // Wrap with sentinel for exit code detection
-        session.pty.write(
-          wrapWithSentinel(
-            commandId,
-            command,
-            this.shell.type === 'powershell',
-          ),
-        );
-      } else {
-        // Still in detecting mode — write normally, might get OSC or sentinel
-        session.pty.write(`${command}\r`);
-      }
-
-      session.lastActivityAt = Date.now();
     });
+
+    if (!this.pendingCommands.has(commandId)) return resultPromise;
+
+    const command = request.command;
+
+    if (request.rawInput) {
+      // Raw stdin: write bytes verbatim — no \r, no sentinel
+      session.pty.write(command);
+    } else if (command.length === 0) {
+      // Empty command, no rawInput — don't write anything to the PTY.
+      // The agent is just waiting for output; the pending command will
+      // resolve via timeout, pattern match, or session exit.
+    } else if (session.shellIntegrationActive) {
+      // Shell integration handles output boundaries via OSC 133 and emits
+      // OSC 7 cwd metadata at prompt time for session cwd tracking.
+      await writePtyInput(session.pty, `${command}\r`);
+    } else if (session.parser.currentMode === 'sentinel') {
+      // Wrap with sentinel for exit code detection
+      await writePtyInput(
+        session.pty,
+        wrapWithSentinel(commandId, command, this.shell.type === 'powershell'),
+      );
+    } else {
+      // Still in detecting mode — write normally, might get OSC or sentinel
+      await writePtyInput(session.pty, `${command}\r`);
+    }
+
+    session.lastActivityAt = Date.now();
+    return resultPromise;
   }
 
   // ─── Live snapshot (UI streaming) ───────────────────────────────

--- a/packages/agent-shell/src/engine/session-manager.ts
+++ b/packages/agent-shell/src/engine/session-manager.ts
@@ -40,6 +40,30 @@ const PTY_INPUT_CHUNK_THRESHOLD_BYTES = 768;
 const PTY_INPUT_CHUNK_BYTES = 256;
 const PTY_INPUT_CHUNK_DELAY_MS = 5;
 
+async function writePtyInput(
+  ptyProcess: pty.IPty,
+  input: string,
+): Promise<void> {
+  const buffer = Buffer.from(input, 'utf8');
+  if (buffer.length <= PTY_INPUT_CHUNK_THRESHOLD_BYTES) {
+    ptyProcess.write(buffer);
+    return;
+  }
+
+  for (
+    let offset = 0;
+    offset < buffer.length;
+    offset += PTY_INPUT_CHUNK_BYTES
+  ) {
+    ptyProcess.write(buffer.subarray(offset, offset + PTY_INPUT_CHUNK_BYTES));
+    if (offset + PTY_INPUT_CHUNK_BYTES < buffer.length) {
+      await new Promise<void>((resolve) =>
+        setTimeout(resolve, PTY_INPUT_CHUNK_DELAY_MS),
+      );
+    }
+  }
+}
+
 // ─── Command timeout/idle policy ────────────────────────────────
 // Exported so tests can exercise the selection logic as pure helpers.
 // Kept here (not inlined in `executeCommand`) so the policy is easy to
@@ -601,34 +625,6 @@ export class SessionManager {
 
   // ─── Command execution ───────────────────────────────────────
 
-  private async writePtyInput(
-    ptyProcess: pty.IPty,
-    input: string,
-    commandId: string,
-  ): Promise<void> {
-    const buffer = Buffer.from(input, 'utf8');
-    if (!this.pendingCommands.has(commandId)) return;
-
-    if (buffer.length <= PTY_INPUT_CHUNK_THRESHOLD_BYTES) {
-      ptyProcess.write(buffer);
-      return;
-    }
-
-    for (
-      let offset = 0;
-      offset < buffer.length;
-      offset += PTY_INPUT_CHUNK_BYTES
-    ) {
-      if (!this.pendingCommands.has(commandId)) return;
-      ptyProcess.write(buffer.subarray(offset, offset + PTY_INPUT_CHUNK_BYTES));
-      if (offset + PTY_INPUT_CHUNK_BYTES < buffer.length) {
-        await new Promise<void>((resolve) =>
-          setTimeout(resolve, PTY_INPUT_CHUNK_DELAY_MS),
-        );
-      }
-    }
-  }
-
   async executeCommand(
     sessionId: string,
     request: SessionCommandRequest,
@@ -748,17 +744,16 @@ export class SessionManager {
     } else if (session.shellIntegrationActive) {
       // Shell integration handles output boundaries via OSC 133 and emits
       // OSC 7 cwd metadata at prompt time for session cwd tracking.
-      await this.writePtyInput(session.pty, `${command}\r`, commandId);
+      await writePtyInput(session.pty, `${command}\r`);
     } else if (session.parser.currentMode === 'sentinel') {
       // Wrap with sentinel for exit code detection
-      await this.writePtyInput(
+      await writePtyInput(
         session.pty,
         wrapWithSentinel(commandId, command, this.shell.type === 'powershell'),
-        commandId,
       );
     } else {
       // Still in detecting mode — write normally, might get OSC or sentinel
-      await this.writePtyInput(session.pty, `${command}\r`, commandId);
+      await writePtyInput(session.pty, `${command}\r`);
     }
 
     session.lastActivityAt = Date.now();

--- a/packages/agent-shell/src/engine/session-manager.ts
+++ b/packages/agent-shell/src/engine/session-manager.ts
@@ -40,30 +40,6 @@ const PTY_INPUT_CHUNK_THRESHOLD_BYTES = 768;
 const PTY_INPUT_CHUNK_BYTES = 256;
 const PTY_INPUT_CHUNK_DELAY_MS = 5;
 
-async function writePtyInput(
-  ptyProcess: pty.IPty,
-  input: string,
-): Promise<void> {
-  const buffer = Buffer.from(input, 'utf8');
-  if (buffer.length <= PTY_INPUT_CHUNK_THRESHOLD_BYTES) {
-    ptyProcess.write(buffer);
-    return;
-  }
-
-  for (
-    let offset = 0;
-    offset < buffer.length;
-    offset += PTY_INPUT_CHUNK_BYTES
-  ) {
-    ptyProcess.write(buffer.subarray(offset, offset + PTY_INPUT_CHUNK_BYTES));
-    if (offset + PTY_INPUT_CHUNK_BYTES < buffer.length) {
-      await new Promise<void>((resolve) =>
-        setTimeout(resolve, PTY_INPUT_CHUNK_DELAY_MS),
-      );
-    }
-  }
-}
-
 // ─── Command timeout/idle policy ────────────────────────────────
 // Exported so tests can exercise the selection logic as pure helpers.
 // Kept here (not inlined in `executeCommand`) so the policy is easy to
@@ -625,6 +601,34 @@ export class SessionManager {
 
   // ─── Command execution ───────────────────────────────────────
 
+  private async writePtyInput(
+    ptyProcess: pty.IPty,
+    input: string,
+    commandId: string,
+  ): Promise<void> {
+    const buffer = Buffer.from(input, 'utf8');
+    if (!this.pendingCommands.has(commandId)) return;
+
+    if (buffer.length <= PTY_INPUT_CHUNK_THRESHOLD_BYTES) {
+      ptyProcess.write(buffer);
+      return;
+    }
+
+    for (
+      let offset = 0;
+      offset < buffer.length;
+      offset += PTY_INPUT_CHUNK_BYTES
+    ) {
+      if (!this.pendingCommands.has(commandId)) return;
+      ptyProcess.write(buffer.subarray(offset, offset + PTY_INPUT_CHUNK_BYTES));
+      if (offset + PTY_INPUT_CHUNK_BYTES < buffer.length) {
+        await new Promise<void>((resolve) =>
+          setTimeout(resolve, PTY_INPUT_CHUNK_DELAY_MS),
+        );
+      }
+    }
+  }
+
   async executeCommand(
     sessionId: string,
     request: SessionCommandRequest,
@@ -744,16 +748,17 @@ export class SessionManager {
     } else if (session.shellIntegrationActive) {
       // Shell integration handles output boundaries via OSC 133 and emits
       // OSC 7 cwd metadata at prompt time for session cwd tracking.
-      await writePtyInput(session.pty, `${command}\r`);
+      await this.writePtyInput(session.pty, `${command}\r`, commandId);
     } else if (session.parser.currentMode === 'sentinel') {
       // Wrap with sentinel for exit code detection
-      await writePtyInput(
+      await this.writePtyInput(
         session.pty,
         wrapWithSentinel(commandId, command, this.shell.type === 'powershell'),
+        commandId,
       );
     } else {
       // Still in detecting mode — write normally, might get OSC or sentinel
-      await writePtyInput(session.pty, `${command}\r`);
+      await this.writePtyInput(session.pty, `${command}\r`, commandId);
     }
 
     session.lastActivityAt = Date.now();

--- a/packages/agent-shell/src/env/shells-domain-adapter.prompt.md
+++ b/packages/agent-shell/src/env/shells-domain-adapter.prompt.md
@@ -11,6 +11,7 @@ Persistent interactive PTY sessions. State (variables, cwd, aliases) persists ac
 - **New session:** Omit `session_id`, set `cwd` (mount prefix). **Reuse:** pass the `session_id` from the result. `cwd` is ignored on reuse — the shell stays wherever `cd` left it.
 - **Reuse sessions.** Creating a session is expensive (shell init delay). Reuse an existing session (`session_id`) whenever one is available — active sessions are listed in `<shell-sessions>` in the env-snapshot. Only create a new session when no suitable one exists or when you need parallel execution (e.g. long-running dev server in one session, short commands in another).
 - **`command`:** Writes text + Enter to the shell.
+- **`command` input:** `command` is sent to an interactive shell as terminal input, so raw line breaks act like Enter. Keep it on one physical line. If a bash/zsh/sh command must span lines, put `\` immediately before each line break (PowerShell: backtick). Join multiple commands on the same physical line with `&&` or `;`.
 - **`wait_until`:** Optional; controls when the tool returns.
   - `timeout_ms` — hard cap. Normal `wait_until` max is 60 s (default 15 s). With `exited: true`, max/default is 5 min. Without `wait_until`, default is 10 s. **Leave at default unless you know the command needs a different cap.**
   - `output_pattern` — regex on output; resolves early when matched. Use for dev servers and watchers that do not exit on their own.

--- a/packages/agent-shell/src/env/shells-domain-adapter.test.ts
+++ b/packages/agent-shell/src/env/shells-domain-adapter.test.ts
@@ -171,5 +171,6 @@ describe('createShellsDomainAdapter', () => {
     const section = adapter.promptSection ?? '';
     expect(section).toContain('executeShellCommand');
     expect(section).toContain('wait_until');
+    expect(section).toContain('raw line breaks act like Enter');
   });
 });


### PR DESCRIPTION
## Summary

- Write terminal input larger than 768 bytes in paced 256-byte chunks to prevent PTY input truncation.
- Clarify how raw line breaks behave when commands are sent to an interactive shell.
- Add regression coverage for large commands and the multiline-input prompt guidance.

## Problem

On macOS, large terminal inputs can be truncated at the 1024-byte input limit. If the discarded portion contains a closing quote or the final Enter, the shell remains in continuation mode and the command waits until timeout.

Fixes https://github.com/stagewise-io/stagewise/issues/1443

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core PTY command delivery and async write timing in `executeCommand`; mistakes could affect all shell tool calls, though scope is limited to chunked non-raw writes and abort guards.
> 
> **Overview**
> Fixes PTY input truncation when shell commands exceed the ~1024-byte terminal limit (e.g. macOS), which could drop closing quotes and leave the shell hanging until timeout.
> 
> **`SessionManager`** now routes non-raw `command` writes through **`writePtyInput`**: payloads over **768** bytes are sent in **256**-byte chunks with a short delay between chunks. **`rawInput`** stays a single write. **`executeCommand`** registers the pending command before writing and skips the PTY write if that command was already cleared (abort or superseded by a newer call).
> 
> Adds an integration test for commands **>1024** bytes, a WinPTY **ready-before-teardown** helper for flaky Windows tests, and agent prompt text that **raw line breaks in `command` act like Enter** (use line continuations or `&&`/`;`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06e3b223ecfc677d95eee2be1f6edc7d9e175a28. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved interactive-shell command execution for large inputs (over 1024 bytes) with chunked PTY input to prevent truncation.
  * Prevented queued command writes from continuing when a newer command supersedes the pending one.
* **Tests**
  * Added an integration test for sending command payloads larger than 1024 bytes and verifying successful completion.
  * Updated concurrency/cleanup-related tests to reduce Windows teardown races.
* **Documentation**
  * Clarified that interactive-shell commands should be a single physical line; use explicit line-continuation escaping (`\` or backtick) for multi-line constructs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent PTY input truncation for long shell commands by pacing writes, and ensure no partial writes occur if a command is canceled or replaced. Also clarifies how multiline input works in the interactive shell. Fixes #1443.

- **Bug Fixes**
  - Added `writePtyInput` to send inputs >768 bytes in 256-byte chunks with 5 ms delays, avoiding the ~1024-byte PTY limit on macOS.
  - Routed non-raw `executeCommand` writes (shell-integration, sentinel-wrapped, detecting) through `writePtyInput`; `rawInput` remains a single write.
  - Stopped stale writes on abort/replace and skip the write if the pending command is gone. Added a cancellation unit test, a >1024-byte integration test, prompt docs noting that raw line breaks act like Enter, and stabilized Windows PTY teardown in tests by waiting for readiness before teardown.

<sup>Written for commit 06e3b223ecfc677d95eee2be1f6edc7d9e175a28. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1445?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

