### PR TITLE
docs(stagewise): update .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,7 +21,7 @@ POSTHOG_CLI_HOST=https://eu.posthog.com
 # ===============================
 # stagewise Auth & API
 # ===============================
-API_URL=https://api.stagewise.io
+API_URL=https://preview.api.stagewise.io
 
 # OAuth callback scheme for the Electron auth handoff is derived from RELEASE_CHANNEL:
 # - release: stagewise://
@@ -30,7 +30,7 @@ API_URL=https://api.stagewise.io
 # Google/GitHub OAuth callbacks still point to the API auth callback URLs.
 
 # Link to the standard stagewise LLM proxy service
-LLM_PROXY_URL=https://api.stagewise.io/v1/ai
+LLM_PROXY_URL=https://preview.api.stagewise.io/v1/ai
 
 # Link to console for account management (both must be same)
 STAGEWISE_CONSOLE_URL=https://console.stagewise.io


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change to example env values; no runtime or CI behavior is modified by this file alone.
> 
> **Overview**
> Updates the sample environment file so local setups default to the **preview** backend instead of production.
> 
> **`API_URL`** and **`LLM_PROXY_URL`** now use `https://preview.api.stagewise.io` (and `/v1/ai` for the proxy). Console URLs and other vars are unchanged. Also adds a trailing newline after `NUCLEO_LICENSE_KEY`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91a404cbce57c15dadebde1aa82fc2dc2f4d9872. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switch .env.example to the preview environment so local dev hits preview, not production: API_URL=https://preview.api.stagewise.io and LLM_PROXY_URL=https://preview.api.stagewise.io/v1/ai. Also adds the missing newline at the end of the file.

<sup>Written for commit 91a404cbce57c15dadebde1aa82fc2dc2f4d9872. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1454?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

