### PR TITLE
feat(stagewise): add new folder action to file tree

### DIFF
--- a/apps/browser/src/backend/main.ts
+++ b/apps/browser/src/backend/main.ts
@@ -907,6 +907,11 @@ export async function main({ launchOptions: { verbose } }: MainParameters) {
       fileTreeService.createFile(workspaceKey, directoryPath),
   );
   uiKarton.registerServerProcedureHandler(
+    'fileTree.createFolder',
+    async (_cid, workspaceKey: string, directoryPath: string) =>
+      fileTreeService.createFolder(workspaceKey, directoryPath),
+  );
+  uiKarton.registerServerProcedureHandler(
     'fileTree.recreateDeletedFile',
     async (_cid, workspaceKey: string, relativePath: string, content: string) =>
       fileTreeService.recreateDeletedFile(workspaceKey, relativePath, content),

--- a/apps/browser/src/backend/services/file-tree/index.test.ts
+++ b/apps/browser/src/backend/services/file-tree/index.test.ts
@@ -227,6 +227,47 @@ describe('FileTreeService', () => {
     ]);
   });
 
+  it('creates a new folder in the selected directory', async () => {
+    await mkdir(path.join(root, 'parent'));
+    await service.listDirectory({
+      workspaceKey,
+      directoryPath: 'parent',
+    });
+
+    const result = await service.createFolder(workspaceKey, 'parent');
+    const listing = await service.listDirectory({
+      workspaceKey,
+      directoryPath: 'parent',
+    });
+
+    expect(result).toEqual({
+      success: true,
+      relativePath: 'parent/new folder',
+    });
+    expect(listing.entries).toEqual([
+      expect.objectContaining({
+        kind: 'directory',
+        name: 'new folder',
+        relativePath: 'parent/new folder',
+      }),
+    ]);
+  });
+
+  it('uses the next available name when creating a folder', async () => {
+    await mkdir(path.join(root, 'new folder'));
+    await writeFile(path.join(root, 'new folder 2'), 'occupied');
+
+    const result = await service.createFolder(workspaceKey, '');
+
+    expect(result).toEqual({
+      success: true,
+      relativePath: 'new folder 3',
+    });
+    await expect(realpath(path.join(root, 'new folder 3'))).resolves.toBe(
+      path.join(await realpath(root), 'new folder 3'),
+    );
+  });
+
   it('classifies text, image, svg, and binary previews', async () => {
     await writeFile(path.join(root, 'text.txt'), 'hello');
     await writeFile(

--- a/apps/browser/src/backend/services/file-tree/index.ts
+++ b/apps/browser/src/backend/services/file-tree/index.ts
@@ -645,6 +645,33 @@ export class FileTreeService extends DisposableService {
     }
   }
 
+  async createFolder(
+    workspaceKey: string,
+    directoryPath: string,
+  ): Promise<FileTreeOperationResult> {
+    if (isReadOnlyWorkspaceKey(workspaceKey)) {
+      throw new Error('This location is read-only and cannot be created in');
+    }
+    try {
+      const directory = await this.validatePath(workspaceKey, directoryPath);
+      const dirStat = await fs.stat(directory.absolutePath);
+      if (!dirStat.isDirectory()) {
+        return { success: false, error: 'Target path is not a directory.' };
+      }
+
+      const { relativePath } = await this.createAvailableNewFolder(
+        directory.absolutePath,
+        directory.relativePath,
+      );
+
+      this.bumpDirectoryRevisionsNow(directory.key, [directory.relativePath]);
+      return { success: true, relativePath };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      return { success: false, error: message };
+    }
+  }
+
   async recreateDeletedFile(
     workspaceKey: string,
     relativePath: string,
@@ -1714,6 +1741,40 @@ export class FileTreeService extends DisposableService {
     }
 
     throw new Error('Could not find an available file name');
+  }
+
+  private async createAvailableNewFolder(
+    directoryAbsolutePath: string,
+    directoryRelativePath: string,
+  ): Promise<{ folderName: string; relativePath: string }> {
+    const baseName = 'new folder';
+    const candidates = [
+      baseName,
+      ...Array.from({ length: 99 }, (_, index) => `${baseName} ${index + 2}`),
+    ];
+
+    for (const candidate of candidates) {
+      const candidatePath = path.join(directoryAbsolutePath, candidate);
+      try {
+        await fs.mkdir(candidatePath);
+      } catch (error) {
+        if (
+          error &&
+          typeof error === 'object' &&
+          'code' in error &&
+          (error as { code?: string }).code === 'EEXIST'
+        ) {
+          continue;
+        }
+        throw error;
+      }
+      const relativePath = directoryRelativePath
+        ? `${directoryRelativePath}/${candidate}`
+        : candidate;
+      return { folderName: candidate, relativePath };
+    }
+
+    throw new Error('Could not find an available folder name');
   }
 
   private updateFileTabsAfterMove(

--- a/apps/browser/src/shared/karton-contracts/ui/index.ts
+++ b/apps/browser/src/shared/karton-contracts/ui/index.ts
@@ -1970,6 +1970,10 @@ export type KartonContract = {
         workspaceKey: string,
         directoryPath: string,
       ) => Promise<FileTreeOperationResult>;
+      createFolder: (
+        workspaceKey: string,
+        directoryPath: string,
+      ) => Promise<FileTreeOperationResult>;
       recreateDeletedFile: (
         workspaceKey: string,
         relativePath: string,

--- a/apps/browser/src/ui/screens/main/file-tree/file-tree-workspace-view.tsx
+++ b/apps/browser/src/ui/screens/main/file-tree/file-tree-workspace-view.tsx
@@ -22,6 +22,7 @@ import {
   CopyIcon,
   FilePlusIcon,
   FolderOpenIcon,
+  FolderPlusIcon,
   Loader2Icon,
   PencilIcon,
   ScissorsIcon,
@@ -146,6 +147,7 @@ export function FileTreeWorkspaceView({
   const pasteEntry = useKartonProcedure((p) => p.fileTree.pasteEntry);
   const deleteEntry = useKartonProcedure((p) => p.fileTree.deleteEntry);
   const createFile = useKartonProcedure((p) => p.fileTree.createFile);
+  const createFolder = useKartonProcedure((p) => p.fileTree.createFolder);
   const copyText = useKartonProcedure((p) => p.browser.copyText);
   const [openAgent] = useOpenAgent();
   const workspaceMount = useKartonState((s) =>
@@ -185,7 +187,7 @@ export function FileTreeWorkspaceView({
     timer: number | null;
   }>({ value: '', timer: null });
   const restoreFocusTimersRef = useRef<number[]>([]);
-  const pendingNewFileRef = useRef<string[]>([]);
+  const pendingNewEntryRef = useRef<string[]>([]);
   const openAfterRenameRef = useRef<Set<string>>(new Set());
   const loadMoreRef = useRef(loadMore);
   loadMoreRef.current = loadMore;
@@ -196,7 +198,7 @@ export function FileTreeWorkspaceView({
   // previous workspace. Stale entries could otherwise match paths in the new
   // workspace (wrong rename target) or block the queue indefinitely.
   useEffect(() => {
-    pendingNewFileRef.current = [];
+    pendingNewEntryRef.current = [];
     openAfterRenameRef.current = new Set();
     setRenamingPath(null);
   }, [workspaceKey]);
@@ -492,11 +494,38 @@ export function FileTreeWorkspaceView({
         // Track the new file so the rows-watcher effect scrolls to it and
         // enters rename mode once it appears in the tree. Enqueued (not
         // overwritten) so rapid repeated creates each get their turn.
-        pendingNewFileRef.current.push(newFilePath);
+        pendingNewEntryRef.current.push(newFilePath);
         openAfterRenameRef.current.add(newFilePath);
       });
     },
     [createFile, setDirectoryExpanded, workspaceKey],
+  );
+
+  const handleCreateFolder = useCallback(
+    (directoryPath: string) => {
+      if (!workspaceKey) return;
+      const activeWorkspaceKey = workspaceKey;
+      void createFolder(activeWorkspaceKey, directoryPath).then((result) => {
+        if (workspaceKeyRef.current !== activeWorkspaceKey) return;
+        if (!result.success || !result.relativePath) {
+          toast({
+            id: `file-tree-create-folder-error-${Date.now()}`,
+            title: 'New folder failed',
+            message: result.error ?? 'Could not create a new folder.',
+            type: 'error',
+            actions: [],
+          });
+          return;
+        }
+        const newFolderPath = result.relativePath;
+        void setDirectoryExpanded(workspaceKey, directoryPath, true);
+        setFocusedEntryPath(newFolderPath);
+        setSelectedEntryPaths([]);
+        setSelectionAnchorPath(null);
+        pendingNewEntryRef.current.push(newFolderPath);
+      });
+    },
+    [createFolder, setDirectoryExpanded, workspaceKey],
   );
 
   const getActionPaths = useCallback(
@@ -942,14 +971,14 @@ export function FileTreeWorkspaceView({
     };
   }, []);
 
-  // When new files are created, wait for them to appear in the tree rows,
+  // When new entries are created, wait for them to appear in the tree rows,
   // scroll to each in turn, and enter rename mode. Only one rename is
   // active at a time; the rest wait in the queue until the current
   // rename is submitted or cancelled (which sets renamingPath back to
   // null, re-running this effect).
   useEffect(() => {
     if (renamingPath !== null) return;
-    const queue = pendingNewFileRef.current;
+    const queue = pendingNewEntryRef.current;
     const pendingPath = queue.shift();
     if (pendingPath === undefined) return;
     const index = rows.findIndex(
@@ -1015,9 +1044,9 @@ export function FileTreeWorkspaceView({
     : contextIsDirectory
       ? contextTargetPath
       : getParentDirectory(contextTargetPath);
-  // The directory where a new file would be created when the user clicks
-  // “New File” — the targeted directory itself, the parent of a targeted
-  // file, or the workspace root for empty-space right-clicks.
+  // The directory where a new entry would be created — the targeted directory
+  // itself, the parent of a targeted file, or the workspace root for
+  // empty-space right-clicks.
   const contextCreateDirectory = contextPasteDirectory;
   const workspaceIsReadOnly = workspaceKey
     ? isReadOnlyWorkspaceKey(workspaceKey)
@@ -1139,6 +1168,14 @@ export function FileTreeWorkspaceView({
             >
               <FilePlusIcon className="size-3.5 shrink-0" />
               <span className="min-w-0 flex-1 truncate">New File</span>
+            </MenuBase.Item>
+            <MenuBase.Item
+              className={contextMenuItemClassName}
+              disabled={workspaceIsReadOnly}
+              onClick={() => handleCreateFolder(contextCreateDirectory)}
+            >
+              <FolderPlusIcon className="size-3.5 shrink-0" />
+              <span className="min-w-0 flex-1 truncate">New Folder</span>
             </MenuBase.Item>
             <MenuBase.Separator className="my-0.5 h-px bg-border-subtle" />
             <MenuBase.Item


### PR DESCRIPTION
## Summary

- add a **New Folder** action to the file tree context menu
- create folders inside the selected directory, next to a selected file, or at the workspace root
- automatically focus the new folder and start inline renaming
- generate collision-free default names such as `new folder 2`
- add the required Karton procedure, backend implementation, and tests

Closes #1457

<img width="772" height="496" alt="image" src="https://github.com/user-attachments/assets/4e4236bc-b41e-4a09-b235-847afd1ba5bb" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized file-tree feature mirroring createFile; path validation and read-only guards are already established patterns.
> 
> **Overview**
> Adds **New Folder** to the file tree context menu, wired end-to-end like the existing new-file flow.
> 
> The backend exposes `fileTree.createFolder`, which validates the target directory, creates a folder with default names `new folder`, `new folder 2`, … (skipping collisions via `EEXIST`), and bumps directory revisions. Read-only workspaces are rejected the same way as for new files.
> 
> The UI calls the new procedure from context menu targets (selected folder, parent of a file, or workspace root), expands the parent, focuses the new folder, and reuses the pending-entry queue so inline rename starts once the folder appears in the tree. `pendingNewFileRef` is generalized to `pendingNewEntryRef` for both files and folders.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0f86783e7577711d30e7ca50048b34f21a15cee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a New Folder action to the file tree so users can create a folder where they click and immediately rename it. Generates collision‑free names like "new folder 2" and wires the full backend flow. Closes Linear #1457.

- **New Features**
  - UI: Adds “New Folder” to the context menu (creates in targeted directory/parent/root), expands the parent, focuses the new folder, and queues inline rename.
  - Backend: Introduces `fileTree.createFolder` in `uiKarton`; implements `createFolder` and `createAvailableNewFolder` in `FileTreeService` with read-only guard, unique-name generation, and revision bumps.
  - Tests: Covers folder creation in a selected directory and next-available naming.

<sup>Written for commit b0f86783e7577711d30e7ca50048b34f21a15cee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1459?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a **New Folder** option to the file tree context menu.
  * New folders are created in the selected directory and automatically prepared for renaming.
  * Folder names are adjusted automatically when a name conflict exists.

* **Bug Fixes**
  * Improved file tree refresh behavior after creating files or folders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->