### PR TITLE
feat(browser): add chat prompt history navigation

### DIFF
--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/chat-input.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/chat-input.tsx
@@ -50,6 +50,7 @@ import {
   dispatchChatHistoryScroll,
   type ChatHistoryScrollDirection,
 } from '../_lib/chat-history-scroll-event';
+import type { PromptHistoryDirection } from './prompt-history';
 // Re-export types for convenience
 export type { AttachmentAttributes, AttachmentType };
 
@@ -81,6 +82,25 @@ function getChatHistoryScrollDirectionFromEvent(
   const key = event.key.toLowerCase();
   if (key === 'u') return 'up';
   if (key === 'd') return 'down';
+
+  return null;
+}
+
+function getPromptHistoryDirectionFromEvent(
+  event: KeyboardEvent,
+): PromptHistoryDirection | null {
+  if (
+    event.isComposing ||
+    event.metaKey ||
+    event.ctrlKey ||
+    event.altKey ||
+    event.shiftKey
+  ) {
+    return null;
+  }
+
+  if (event.key === 'ArrowUp') return 'older';
+  if (event.key === 'ArrowDown') return 'newer';
 
   return null;
 }
@@ -197,6 +217,9 @@ export interface ChatInputProps {
   defaultValue?: Content; // TipTap JSON content string
   onChange?: (TipTapContent: Content) => void;
   onSubmit: () => void;
+  onPromptHistoryNavigationRequest?: (
+    direction: PromptHistoryDirection,
+  ) => boolean;
   disabled?: boolean;
   placeholder?: string;
 
@@ -258,6 +281,8 @@ export interface ChatInputHandle {
   getJsonContent: () => string;
   /** Clear all editor content */
   clear: () => void;
+  /** Replace all editor content, used for prompt-history navigation. */
+  setContent: (content: Content) => void;
   /** Replace an attachment node (by id) with plain text */
   replaceAttachmentWithText: (attachmentId: string, text: string) => void;
   /** Update attributes on an existing attachment node (by id) */
@@ -272,6 +297,7 @@ export const ChatInput = memo(function ChatInput({
   defaultValue,
   onChange,
   onSubmit,
+  onPromptHistoryNavigationRequest,
   disabled = false,
   placeholder,
   attachmentCount: _attachmentCount = 0,
@@ -418,6 +444,15 @@ export const ChatInput = memo(function ChatInput({
           event.preventDefault();
           dispatchChatHistoryScroll(scrollDirection);
           return true;
+        }
+
+        const promptHistoryDirection =
+          getPromptHistoryDirectionFromEvent(event);
+        if (promptHistoryDirection) {
+          if (onPromptHistoryNavigationRequest?.(promptHistoryDirection)) {
+            event.preventDefault();
+            return true;
+          }
         }
 
         // Handle Enter without Shift for submit
@@ -682,6 +717,10 @@ export const ChatInput = memo(function ChatInput({
     },
     clear: () => {
       editor?.commands.clearContent();
+    },
+    setContent: (content: Content) => {
+      editor?.commands.setContent(content);
+      editor?.commands.focus('end');
     },
     replaceAttachmentWithText: (attachmentId: string, text: string) => {
       if (!editor) return;

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/panel-footer.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/panel-footer.tsx
@@ -80,6 +80,10 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from '@stagewise/stage-ui/components/tooltip';
+import {
+  getPromptHistoryStep,
+  type PromptHistoryDirection,
+} from './prompt-history';
 
 // Stable empty arrays to avoid new-reference re-renders
 const EMPTY_HISTORY: AgentMessage[] = [];
@@ -89,6 +93,10 @@ const EMPTY_WORKSPACE_ACTION_CONFIGS: ReadonlyMap<
   WorkspaceActionConfig
 > = new Map();
 const CHAT_INPUT_FOCUS_REQUESTED_EVENT = 'chat-input-focus-requested';
+
+function createEmptyChatContent(): Content {
+  return { type: 'doc', content: [{ type: 'paragraph' }] };
+}
 
 function formatWorkspaceGitRef(git: MountEntry['git']): string | null {
   return git?.branch ?? git?.headSha?.slice(0, 7) ?? null;
@@ -240,12 +248,14 @@ export const ChatPanelFooter = memo(function ChatPanelFooter() {
     const initial = chatInputStateRef.current;
     return initial && initial.length > 0 ? JSON.parse(initial) : null;
   });
+  const promptHistoryCursorRef = useRef<number | null>(null);
 
   // Re-sync local input state when the active agent changes
   const prevOpenAgentRef = useRef(openAgent);
   useEffect(() => {
     if (openAgent === prevOpenAgentRef.current) return;
     prevOpenAgentRef.current = openAgent;
+    promptHistoryCursorRef.current = null;
     const serverState = chatInputStateRef.current;
     const parsed =
       serverState && serverState.length > 0 ? JSON.parse(serverState) : null;
@@ -262,9 +272,10 @@ export const ChatPanelFooter = memo(function ChatPanelFooter() {
       // The state variable is only updated for rare events (submit, error
       // restore, agent switch) where ChatInput needs an external reset.
       localInputStateRef.current = newInputState;
-      setCanSendMessage(
-        (chatInputRef.current?.getTextContent()?.trim().length ?? 0) > 0,
-      );
+      const inputIsEmpty =
+        (chatInputRef.current?.getTextContent()?.trim().length ?? 0) === 0;
+      setCanSendMessage(!inputIsEmpty);
+      promptHistoryCursorRef.current = null;
       if (openAgent) {
         void setChatInputState(openAgent, JSON.stringify(newInputState));
       }
@@ -970,10 +981,7 @@ export const ChatPanelFooter = memo(function ChatPanelFooter() {
 
     // Clear input IMMEDIATELY (before network call)
     chatInputRef.current?.clear();
-    const emptyDoc: Content = {
-      type: 'doc',
-      content: [{ type: 'paragraph' }],
-    };
+    const emptyDoc = createEmptyChatContent();
     localInputStateRef.current = emptyDoc;
     setLocalInputState(emptyDoc);
     setCanSendMessage(false);
@@ -1126,6 +1134,48 @@ export const ChatPanelFooter = memo(function ChatPanelFooter() {
     openAgent
       ? (s.agents.instances[openAgent]?.state.queuedMessages ?? EMPTY_QUEUE)
       : EMPTY_QUEUE,
+  );
+
+  const handlePromptHistoryNavigationRequest = useCallback(
+    (direction: PromptHistoryDirection) => {
+      if (!openAgent) return false;
+
+      const entries = [...historyRef.current, ...queuedMessages].filter(
+        (message) => message.role === 'user',
+      );
+
+      const step = getPromptHistoryStep({
+        direction,
+        cursor: promptHistoryCursorRef.current,
+        entryCount: entries.length,
+        canStart:
+          (chatInputRef.current?.getTextContent().trim().length ?? 0) === 0,
+      });
+      if (!step.handled) return false;
+
+      let content: Content;
+      let attachments: AttachmentMetadata[];
+
+      if (step.cursor === null) {
+        content = createEmptyChatContent();
+        attachments = [];
+      } else {
+        const message = entries[step.cursor];
+        if (!message) return false;
+        const textPart = message.parts.find((part) => part.type === 'text');
+        const text = textPart?.type === 'text' ? textPart.text : '';
+        content = enrichTipTapContent(markdownToTipTapContent(text), {
+          attachments: message.metadata?.attachments,
+        });
+        attachments = message.metadata?.attachments ?? [];
+      }
+
+      setFileAttachments(attachments);
+      chatInputRef.current?.setContent(content);
+      promptHistoryCursorRef.current = step.cursor;
+      return true;
+    },
+    [openAgent, queuedMessages, setFileAttachments],
   );
   const flushQueue = useKartonProcedure((p) => p.agents.flushQueue);
   const handleFlushQueue = useCallback(() => {
@@ -1771,6 +1821,9 @@ export const ChatPanelFooter = memo(function ChatPanelFooter() {
             value={localInputState}
             onChange={updateChatInputState}
             onSubmit={handleSubmit}
+            onPromptHistoryNavigationRequest={
+              handlePromptHistoryNavigationRequest
+            }
             disabled={!enableInputField}
             placeholder={
               hasPendingQuestion ? 'Write a message instead' : undefined

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/panel-footer.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/panel-footer.tsx
@@ -1140,7 +1140,7 @@ export const ChatPanelFooter = memo(function ChatPanelFooter() {
     (direction: PromptHistoryDirection) => {
       if (!openAgent) return false;
 
-      const entries = [...historyRef.current, ...queuedMessages].filter(
+      const entries = historyRef.current.filter(
         (message) => message.role === 'user',
       );
 
@@ -1171,11 +1171,12 @@ export const ChatPanelFooter = memo(function ChatPanelFooter() {
       }
 
       setFileAttachments(attachments);
+      setLocalInputState(content);
       chatInputRef.current?.setContent(content);
       promptHistoryCursorRef.current = step.cursor;
       return true;
     },
-    [openAgent, queuedMessages, setFileAttachments],
+    [openAgent, setFileAttachments],
   );
   const flushQueue = useKartonProcedure((p) => p.agents.flushQueue);
   const handleFlushQueue = useCallback(() => {

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/prompt-history.test.ts
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/prompt-history.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getPromptHistoryStep,
+  type PromptHistoryDirection,
+} from './prompt-history';
+
+function step(
+  direction: PromptHistoryDirection,
+  cursor: number | null,
+  options: { entryCount?: number; canStart?: boolean } = {},
+) {
+  return getPromptHistoryStep({
+    direction,
+    cursor,
+    entryCount: options.entryCount ?? 3,
+    canStart: options.canStart ?? false,
+  });
+}
+
+describe('getPromptHistoryStep', () => {
+  it('starts at the latest prompt only when the input is empty', () => {
+    expect(step('older', null, { canStart: true })).toEqual({
+      handled: true,
+      cursor: 2,
+    });
+    expect(step('older', null)).toEqual({ handled: false });
+  });
+
+  it('cycles backward and stops at the oldest prompt', () => {
+    expect(step('older', 2)).toEqual({ handled: true, cursor: 1 });
+    expect(step('older', 0)).toEqual({ handled: true, cursor: 0 });
+  });
+
+  it('cycles forward and leaves history after the latest prompt', () => {
+    expect(step('newer', 0)).toEqual({ handled: true, cursor: 1 });
+    expect(step('newer', 2)).toEqual({ handled: true, cursor: null });
+  });
+
+  it('does not consume keys when navigation cannot start', () => {
+    expect(step('newer', null, { canStart: true })).toEqual({
+      handled: false,
+    });
+    expect(step('older', null, { entryCount: 0, canStart: true })).toEqual({
+      handled: false,
+    });
+  });
+});

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/prompt-history.ts
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/prompt-history.ts
@@ -1,0 +1,35 @@
+export type PromptHistoryDirection = 'older' | 'newer';
+
+export type PromptHistoryStep =
+  | { handled: false }
+  | { handled: true; cursor: number | null };
+
+/**
+ * Resolve a shell-style history step. A null cursor means history navigation
+ * is inactive; moving newer from the latest entry returns to an empty input.
+ */
+export function getPromptHistoryStep(options: {
+  direction: PromptHistoryDirection;
+  cursor: number | null;
+  entryCount: number;
+  canStart: boolean;
+}): PromptHistoryStep {
+  const { direction, cursor, entryCount, canStart } = options;
+  if (entryCount === 0) return { handled: false };
+
+  if (cursor === null) {
+    if (direction === 'newer' || !canStart) return { handled: false };
+    return { handled: true, cursor: entryCount - 1 };
+  }
+
+  const boundedCursor = Math.min(cursor, entryCount - 1);
+  if (direction === 'older') {
+    return { handled: true, cursor: Math.max(0, boundedCursor - 1) };
+  }
+
+  if (boundedCursor === entryCount - 1) {
+    return { handled: true, cursor: null };
+  }
+
+  return { handled: true, cursor: boundedCursor + 1 };
+}


### PR DESCRIPTION
## Summary

- recall the latest user prompt by pressing Arrow Up in an empty chat input
- navigate through older and newer prompts using Arrow Up and Arrow Down
- leave prompt history navigation as soon as the input content is edited
- restore attachment badges when recalling previous prompts
- preserve normal behavior for modified arrow keys and IME composition
- added focused tests for prompt history navigation and boundary behavior

Closes #1430

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-only chat UX with guarded keyboard handling; no auth or backend changes. Minor risk of Arrow Up/Down conflicting with other input behaviors when history does not handle the key.
> 
> **Overview**
> Adds **shell-style prompt history** to the agent chat input: **Arrow Up** / **Arrow Down** (unmodified, not during IME composition) recall older and newer user prompts when navigation is active.
> 
> `ChatInput` delegates to a new `onPromptHistoryNavigationRequest` callback and exposes **`setContent`** so the footer can replace TipTap content and focus the end. `panel-footer` tracks a history cursor, resets it on agent switch or any input edit, loads prior prompts from chat **user** messages (markdown → TipTap + attachment metadata), and wires the handler into `ChatInput`.
> 
> Pure navigation rules live in **`getPromptHistoryStep`**, with **Vitest** coverage for empty input, boundaries, and when keys should not be consumed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c16366ad8d268a6372fc8bbcb985090edfc2352. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add shell-style prompt history navigation to the chat input (Linear #1430). Arrow Up/Down recall previous user prompts from chat history; attachments are restored, the editor focuses at the end, and any edit exits history.

- **New Features**
  - Arrow Up/Down navigate older/newer prompts when the input is empty; ignores modified keys and IME composition.
  - Restores attachment badges; returns to empty after the newest prompt; resets on submit and agent switch.
  - Adds `getPromptHistoryStep` helper and focused tests for navigation and boundaries.
  - Extends `ChatInput` with `onPromptHistoryNavigationRequest` and `setContent` to support navigation.

<sup>Written for commit 1c16366ad8d268a6372fc8bbcb985090edfc2352. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1460?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added prompt-history keyboard navigation in the chat editor using Arrow Up (older) and Arrow Down (newer), with safeguards to avoid interfering during text composition or when modifier keys are pressed.
  * When navigating, restored the selected prompt’s text and any related attachments, and moved focus back to the editor with the caret positioned at the end.

* **Tests**
  * Added automated coverage for prompt-history step calculation, cursor cycling, and boundary conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->