### PR TITLE
fix(stagewise): improve provider model management

### DIFF
--- a/apps/browser/src/ui/screens/settings/sections/models-providers-section.tsx
+++ b/apps/browser/src/ui/screens/settings/sections/models-providers-section.tsx
@@ -67,6 +67,11 @@ import { Input } from '@stagewise/stage-ui/components/input';
 import { Button, buttonVariants } from '@stagewise/stage-ui/components/button';
 import { Switch } from '@stagewise/stage-ui/components/switch';
 import {
+  Tabs,
+  TabsList,
+  TabsTrigger,
+} from '@stagewise/stage-ui/components/tabs';
+import {
   Dialog,
   DialogContent,
   DialogTitle,
@@ -89,6 +94,7 @@ import {
   IconArrowUpRightOutline18,
   IconDotsOutline18,
   IconRefreshAnticlockwiseOutline18,
+  IconLoader6Outline18,
   IconCheck2Outline18,
   IconBanOutline18,
 } from '@stagewise/icons';
@@ -98,7 +104,6 @@ import {
   MenuTrigger,
   MenuContent,
   MenuItem,
-  MenuSeparator,
 } from '@stagewise/stage-ui/components/menu';
 import { ContextMenu } from '@base-ui/react/context-menu';
 import { Menu as MenuBase } from '@base-ui/react/menu';
@@ -109,6 +114,8 @@ const consoleUrl =
 enablePatches();
 
 const EMPTY_CUSTOM_MODELS: UserPreferences['customModels'] = [];
+
+type ModelVisibility = 'all' | 'enabled';
 
 // =============================================================================
 // Provider Instance Logo
@@ -2105,6 +2112,7 @@ function VendorModelGroup({
   onEditCustomModel,
   onDeleteCustomModel,
   defaultExpanded,
+  onlyEnabled = false,
 }: {
   instance: ProviderInstance;
   group: VendorGroup;
@@ -2118,16 +2126,18 @@ function VendorModelGroup({
   onEditCustomModel: (model: CustomModel) => void;
   onDeleteCustomModel: (modelId: string) => void;
   defaultExpanded?: boolean;
+  onlyEnabled?: boolean;
 }) {
   const [expanded, setExpanded] = useState(defaultExpanded ?? true);
   const disabledSet = useMemo(
     () => new Set(getInstanceDisabledModelIds(preferences, instance.id)),
     [preferences, instance.id],
   );
-  const enabledCount = group.entries.reduce(
-    (count, entry) => count + Number(!disabledSet.has(entry.modelId)),
-    0,
+  const enabledEntries = group.entries.filter(
+    (entry) => !disabledSet.has(entry.modelId),
   );
+  const enabledCount = enabledEntries.length;
+  const visibleEntries = onlyEnabled ? enabledEntries : group.entries;
 
   const VendorLogo = group.logo;
 
@@ -2164,7 +2174,7 @@ function VendorModelGroup({
       {expanded && (
         <ModelCardList
           instance={instance}
-          entries={group.entries}
+          entries={visibleEntries}
           preferences={preferences}
           onToggleModel={onToggleModel}
           onEditThinking={onEditThinking}
@@ -2228,6 +2238,8 @@ function ModelsSection({
   );
 
   const [searchQuery, setSearchQuery] = useState('');
+  const [modelVisibility, setModelVisibility] =
+    useState<ModelVisibility>('all');
 
   // Group selectable entries by instance
   const allEntries = useMemo(
@@ -2257,6 +2269,9 @@ function ModelsSection({
   const allInstanceModelsDisabled =
     hasInstanceModels &&
     instanceEntries.every((entry) => instanceDisabledSet.has(entry.modelId));
+  const showEnabledOnly = modelVisibility === 'enabled';
+  const isModelEnabled = (entry: ModelSelectorEntry) =>
+    !instanceDisabledSet.has(entry.modelId);
 
   const groupedByInstance = useMemo(() => {
     const groups = new Map<
@@ -2296,7 +2311,10 @@ function ModelsSection({
   }, [groupedByInstance, searchQuery, filterInstanceId]);
 
   const noResults =
-    searchQuery.trim().length > 0 && filteredGroups.length === 0;
+    (searchQuery.trim().length > 0 || showEnabledOnly) &&
+    !filteredGroups.some((group) =>
+      group.entries.some((entry) => !showEnabledOnly || isModelEnabled(entry)),
+    );
 
   // --- Thinking panel state ---
   const [listScrollViewport, setListScrollViewport] =
@@ -2467,13 +2485,22 @@ function ModelsSection({
   useEffect(() => {
     if (!thinkingPanelModelId) return;
     const stillVisible = filteredGroups.some((g) =>
-      g.entries.some((e) => e.modelId === thinkingPanelModelId),
+      g.entries.some(
+        (e) =>
+          e.modelId === thinkingPanelModelId &&
+          (!showEnabledOnly || !instanceDisabledSet.has(e.modelId)),
+      ),
     );
     if (!stillVisible) {
       setThinkingPanelModelId(null);
       setThinkingPanelInstanceId(null);
     }
-  }, [filteredGroups, thinkingPanelModelId]);
+  }, [
+    filteredGroups,
+    thinkingPanelModelId,
+    showEnabledOnly,
+    instanceDisabledSet,
+  ]);
 
   // Close thinking panel on outside click
   useEffect(() => {
@@ -2734,7 +2761,17 @@ function ModelsSection({
 
   return (
     <div className="flex flex-col space-y-3">
-      <div className="flex items-center gap-3">
+      <Tabs
+        value={modelVisibility}
+        onValueChange={(value) => setModelVisibility(value as ModelVisibility)}
+      >
+        <TabsList className="w-auto">
+          <TabsTrigger value="all">All</TabsTrigger>
+          <TabsTrigger value="enabled">Enabled only</TabsTrigger>
+        </TabsList>
+      </Tabs>
+
+      <div className="flex items-center gap-2">
         <Input
           placeholder="Filter models..."
           value={searchQuery}
@@ -2749,36 +2786,34 @@ function ModelsSection({
             Add Model
           </Button>
         )}
+        {!isTrulyCustom && filterInstance && (
+          <Button
+            variant="secondary"
+            size="sm"
+            disabled={isReloading}
+            onClick={() => void handleReloadModels()}
+          >
+            {isReloading ? (
+              <IconLoader6Outline18 className="size-3.5 animate-spin" />
+            ) : (
+              <IconRefreshAnticlockwiseOutline18 className="size-3.5" />
+            )}
+            Reload models
+          </Button>
+        )}
         {filterInstance && (
           <Menu>
             <MenuTrigger>
               <Button
                 variant="secondary"
                 size="icon-sm"
-                aria-label="Model actions"
+                className="rounded-md"
+                aria-label="Bulk model actions"
               >
-                <IconDotsOutline18 className="size-4" />
+                <IconDotsOutline18 className="size-4 rotate-90" />
               </Button>
             </MenuTrigger>
             <MenuContent side="bottom" align="end" size="sm">
-              {!isTrulyCustom && (
-                <>
-                  <MenuItem
-                    disabled={isReloading}
-                    className="data-disabled:opacity-50"
-                    onClick={() => void handleReloadModels()}
-                  >
-                    <IconRefreshAnticlockwiseOutline18
-                      className={cn(
-                        'size-3.5 shrink-0',
-                        isReloading && 'animate-spin',
-                      )}
-                    />
-                    {isReloading ? 'Reloading models...' : 'Reload models'}
-                  </MenuItem>
-                  <MenuSeparator />
-                </>
-              )}
               <MenuItem
                 disabled={!hasInstanceModels || allInstanceModelsEnabled}
                 className="data-disabled:opacity-50"
@@ -2817,6 +2852,9 @@ function ModelsSection({
                 const vendorGroups = groupEntriesByVendor(
                   filteredGroup.entries,
                   filterInstance,
+                )?.filter(
+                  (group) =>
+                    !showEnabledOnly || group.entries.some(isModelEnabled),
                 );
 
                 // Search results are intentionally flat. Outside of search,
@@ -2827,7 +2865,7 @@ function ModelsSection({
                     <div className="space-y-2">
                       {vendorGroups.map((group) => (
                         <VendorModelGroup
-                          key={group.prefix || 'other'}
+                          key={`${modelVisibility}-${group.prefix || 'other'}`}
                           instance={filteredGroup.instance}
                           group={group}
                           preferences={preferences}
@@ -2835,7 +2873,8 @@ function ModelsSection({
                           onEditThinking={handleEditThinking}
                           onEditCustomModel={handleEdit}
                           onDeleteCustomModel={handleDelete}
-                          defaultExpanded={false}
+                          defaultExpanded={showEnabledOnly}
+                          onlyEnabled={showEnabledOnly}
                         />
                       ))}
                     </div>
@@ -2845,7 +2884,11 @@ function ModelsSection({
                 return (
                   <ModelCardList
                     instance={filteredGroup.instance}
-                    entries={filteredGroup.entries}
+                    entries={
+                      showEnabledOnly
+                        ? filteredGroup.entries.filter(isModelEnabled)
+                        : filteredGroup.entries
+                    }
                     preferences={preferences}
                     onToggleModel={handleToggleModel}
                     onEditThinking={handleEditThinking}
@@ -2870,7 +2913,9 @@ function ModelsSection({
           {noResults && (
             <div className="rounded-lg border border-derived-subtle p-4">
               <p className="text-center text-muted-foreground text-sm">
-                No models match your filter.
+                {showEnabledOnly && !searchQuery.trim()
+                  ? 'No models are enabled.'
+                  : 'No models match your filter.'}
               </p>
             </div>
           )}

--- a/apps/browser/src/ui/screens/settings/sections/models-providers-section.tsx
+++ b/apps/browser/src/ui/screens/settings/sections/models-providers-section.tsx
@@ -17,7 +17,6 @@ import {
   DEFAULT_INSTANCE_ID,
   INSTANCE_TYPE_ID_TO_API_SPEC,
   getInstanceDisabledModelIds,
-  getInstanceModelCount,
   getInstanceModelThinkingOverride,
   getInstanceThinkingDefaultOptions,
   getSelectableModelEntries,
@@ -90,6 +89,8 @@ import {
   IconArrowUpRightOutline18,
   IconDotsOutline18,
   IconRefreshAnticlockwiseOutline18,
+  IconCheck2Outline18,
+  IconBanOutline18,
 } from '@stagewise/icons';
 import { Logo } from '@stagewise/stage-ui/components/logo';
 import {
@@ -97,6 +98,7 @@ import {
   MenuTrigger,
   MenuContent,
   MenuItem,
+  MenuSeparator,
 } from '@stagewise/stage-ui/components/menu';
 import { ContextMenu } from '@base-ui/react/context-menu';
 import { Menu as MenuBase } from '@base-ui/react/menu';
@@ -1998,10 +2000,10 @@ function InstanceModelGroup({
 }
 
 // =============================================================================
-// Collapsible Model Section (reusable for enabled/disabled model groups)
+// Model Card List
 // =============================================================================
 
-function CollapsibleModelSection({
+function ModelCardList({
   instance,
   entries,
   preferences,
@@ -2009,9 +2011,7 @@ function CollapsibleModelSection({
   onEditThinking,
   onEditCustomModel,
   onDeleteCustomModel,
-  label = 'Enabled',
-  defaultExpanded = true,
-  emptyMessage,
+  vendorLabelOverride,
 }: {
   instance: ProviderInstance;
   entries: ModelSelectorEntry[];
@@ -2022,17 +2022,25 @@ function CollapsibleModelSection({
     modelId: string,
     event: React.MouseEvent<HTMLElement>,
   ) => void;
-  onEditCustomModel?: (model: CustomModel) => void;
-  onDeleteCustomModel?: (modelId: string) => void;
-  label?: string;
-  defaultExpanded?: boolean;
-  emptyMessage?: string;
+  onEditCustomModel: (model: CustomModel) => void;
+  onDeleteCustomModel: (modelId: string) => void;
+  vendorLabelOverride?: string;
 }) {
-  const [expanded, setExpanded] = useState(defaultExpanded);
   const disabledSet = useMemo(
     () => new Set(getInstanceDisabledModelIds(preferences, instance.id)),
     [preferences, instance.id],
   );
+  const customModelsById = useMemo(() => {
+    const models = preferences.customModels ?? EMPTY_CUSTOM_MODELS;
+    return new Map(
+      models
+        .filter(
+          (model) =>
+            (model.providerInstanceId ?? model.endpointId) === instance.id,
+        )
+        .map((model) => [model.modelId, model]),
+    );
+  }, [preferences.customModels, instance.id]);
 
   const thinkingDefaultOptions = useMemo(
     () => getInstanceThinkingDefaultOptions(instance),
@@ -2046,87 +2054,40 @@ function CollapsibleModelSection({
     [instance.id, onEditThinking],
   );
 
-  if (entries.length === 0) {
-    if (!emptyMessage) return null;
-    return (
-      <div className="space-y-2">
-        <div className="flex items-center gap-2 px-3 py-2">
-          <span className="font-medium text-muted-foreground text-xs">
-            {label}
-          </span>
-          <span className="text-2xs text-muted-foreground/60">0 models</span>
-        </div>
-        <p className="px-3 py-1 text-2xs text-muted-foreground">
-          {emptyMessage}
-        </p>
-      </div>
-    );
-  }
-
-  // Sort enabled entries alphabetically by display name
-  const sortedEntries = [...entries].sort((a, b) =>
-    a.displayName.localeCompare(b.displayName),
-  );
-
   return (
-    <div className="space-y-2">
-      <button
-        type="button"
-        className="group flex w-full cursor-pointer items-center gap-2 rounded-lg px-3 py-2 text-left transition-colors"
-        onClick={() => setExpanded((v) => !v)}
-      >
-        <span className="min-w-0 flex-1 truncate font-medium text-muted-foreground text-xs transition-colors group-hover:text-foreground">
-          {label}
-        </span>
-        <span className="shrink-0 text-2xs text-muted-foreground transition-colors group-hover:text-foreground">
-          {entries.length} models
-        </span>
-        <IconChevronDownOutline18
-          className={cn(
-            'size-3.5 shrink-0 text-muted-foreground transition-colors transition-transform group-hover:text-foreground',
-            !expanded && '-rotate-90',
-          )}
-        />
-      </button>
-      {expanded && (
-        <div className="space-y-2 pl-1">
-          {sortedEntries.map((entry) => {
-            const customModel = preferences.customModels?.find(
-              (model) =>
-                (model.providerInstanceId ?? model.endpointId) ===
-                  instance.id && model.modelId === entry.modelId,
-            );
-            return customModel && onEditCustomModel && onDeleteCustomModel ? (
-              <CustomModelCard
-                key={entry.modelId}
-                model={customModel}
-                endpointName={resolveCustomModelInstanceName(preferences, {
-                  providerInstanceId: customModel.providerInstanceId,
-                  endpointId: customModel.endpointId,
-                })}
-                isEnabled={!disabledSet.has(entry.modelId)}
-                onToggle={() => onToggleModel(instance.id, entry.modelId)}
-                onEdit={() => onEditCustomModel(customModel)}
-                onDelete={() => onDeleteCustomModel(customModel.modelId)}
-              />
-            ) : (
-              <BuiltInModelCard
-                key={entry.modelId}
-                model={entry}
-                isEnabled={!disabledSet.has(entry.modelId)}
-                thinkingDisplay={computeEntryThinkingDisplay(
-                  entry,
-                  instance,
-                  preferences,
-                  thinkingDefaultOptions,
-                )}
-                onToggle={() => onToggleModel(instance.id, entry.modelId)}
-                onEditThinking={(e) => handleEditThinking(entry.modelId, e)}
-              />
-            );
-          })}
-        </div>
-      )}
+    <div className="space-y-2 pl-1">
+      {entries.map((entry) => {
+        const customModel = customModelsById.get(entry.modelId);
+        return customModel ? (
+          <CustomModelCard
+            key={entry.modelId}
+            model={customModel}
+            endpointName={resolveCustomModelInstanceName(preferences, {
+              providerInstanceId: customModel.providerInstanceId,
+              endpointId: customModel.endpointId,
+            })}
+            isEnabled={!disabledSet.has(entry.modelId)}
+            onToggle={() => onToggleModel(instance.id, entry.modelId)}
+            onEdit={() => onEditCustomModel(customModel)}
+            onDelete={() => onDeleteCustomModel(customModel.modelId)}
+          />
+        ) : (
+          <BuiltInModelCard
+            key={entry.modelId}
+            model={entry}
+            isEnabled={!disabledSet.has(entry.modelId)}
+            thinkingDisplay={computeEntryThinkingDisplay(
+              entry,
+              instance,
+              preferences,
+              thinkingDefaultOptions,
+            )}
+            onToggle={() => onToggleModel(instance.id, entry.modelId)}
+            onEditThinking={(e) => handleEditThinking(entry.modelId, e)}
+            vendorLabelOverride={vendorLabelOverride}
+          />
+        );
+      })}
     </div>
   );
 }
@@ -2163,17 +2124,9 @@ function VendorModelGroup({
     () => new Set(getInstanceDisabledModelIds(preferences, instance.id)),
     [preferences, instance.id],
   );
-
-  const thinkingDefaultOptions = useMemo(
-    () => getInstanceThinkingDefaultOptions(instance),
-    [instance],
-  );
-
-  const handleEditThinking = useCallback(
-    (modelId: string, event: React.MouseEvent<HTMLElement>) => {
-      onEditThinking(instance.id, modelId, event);
-    },
-    [instance.id, onEditThinking],
+  const enabledCount = group.entries.reduce(
+    (count, entry) => count + Number(!disabledSet.has(entry.modelId)),
+    0,
   );
 
   const VendorLogo = group.logo;
@@ -2197,7 +2150,7 @@ function VendorModelGroup({
           {group.displayName}
         </span>
         <span className="shrink-0 text-2xs text-muted-foreground transition-colors group-hover:text-foreground">
-          {group.entries.length} models
+          {enabledCount} of {group.entries.length} enabled
         </span>
         <IconChevronDownOutline18
           className={cn(
@@ -2209,44 +2162,16 @@ function VendorModelGroup({
 
       {/* Model list */}
       {expanded && (
-        <div className="space-y-2 pl-1">
-          {group.entries.map((entry) => {
-            const customModel = preferences.customModels?.find(
-              (model) =>
-                (model.providerInstanceId ?? model.endpointId) ===
-                  instance.id && model.modelId === entry.modelId,
-            );
-            return customModel ? (
-              <CustomModelCard
-                key={entry.modelId}
-                model={customModel}
-                endpointName={resolveCustomModelInstanceName(preferences, {
-                  providerInstanceId: customModel.providerInstanceId,
-                  endpointId: customModel.endpointId,
-                })}
-                isEnabled={!disabledSet.has(entry.modelId)}
-                onToggle={() => onToggleModel(instance.id, entry.modelId)}
-                onEdit={() => onEditCustomModel(customModel)}
-                onDelete={() => onDeleteCustomModel(customModel.modelId)}
-              />
-            ) : (
-              <BuiltInModelCard
-                key={entry.modelId}
-                model={entry}
-                isEnabled={!disabledSet.has(entry.modelId)}
-                thinkingDisplay={computeEntryThinkingDisplay(
-                  entry,
-                  instance,
-                  preferences,
-                  thinkingDefaultOptions,
-                )}
-                onToggle={() => onToggleModel(instance.id, entry.modelId)}
-                onEditThinking={(e) => handleEditThinking(entry.modelId, e)}
-                vendorLabelOverride={group.displayName}
-              />
-            );
-          })}
-        </div>
+        <ModelCardList
+          instance={instance}
+          entries={group.entries}
+          preferences={preferences}
+          onToggleModel={onToggleModel}
+          onEditThinking={onEditThinking}
+          onEditCustomModel={onEditCustomModel}
+          onDeleteCustomModel={onDeleteCustomModel}
+          vendorLabelOverride={group.displayName}
+        />
       )}
     </div>
   );
@@ -2309,6 +2234,29 @@ function ModelsSection({
     () => getSelectableModelEntries(preferences, { includeDisabled: true }),
     [preferences],
   );
+  const instanceEntries = useMemo(
+    () =>
+      filterInstanceId
+        ? allEntries.filter((entry) => entry.instanceId === filterInstanceId)
+        : [],
+    [allEntries, filterInstanceId],
+  );
+  const instanceDisabledSet = useMemo(
+    () =>
+      new Set(
+        filterInstanceId
+          ? getInstanceDisabledModelIds(preferences, filterInstanceId)
+          : [],
+      ),
+    [preferences, filterInstanceId],
+  );
+  const hasInstanceModels = instanceEntries.length > 0;
+  const allInstanceModelsEnabled =
+    hasInstanceModels &&
+    instanceEntries.every((entry) => !instanceDisabledSet.has(entry.modelId));
+  const allInstanceModelsDisabled =
+    hasInstanceModels &&
+    instanceEntries.every((entry) => instanceDisabledSet.has(entry.modelId));
 
   const groupedByInstance = useMemo(() => {
     const groups = new Map<
@@ -2615,6 +2563,23 @@ function ModelsSection({
     [preferences, updatePreferences],
   );
 
+  const handleSetAllModelsEnabled = useCallback(
+    async (enabled: boolean) => {
+      if (!filterInstanceId) return;
+      const disabledModelIds = enabled
+        ? []
+        : Array.from(new Set(instanceEntries.map((entry) => entry.modelId)));
+      const [, patches] = produceWithPatches(preferences, (draft) => {
+        const instance = draft.providerInstances.find(
+          (item) => item.id === filterInstanceId,
+        );
+        if (instance) instance.disabledModelIds = disabledModelIds;
+      });
+      await updatePreferences(patches);
+    },
+    [filterInstanceId, instanceEntries, preferences, updatePreferences],
+  );
+
   const resolveThinkingModel = useCallback(
     (instanceId: string, modelId: string): ThinkingPanelModel | undefined => {
       const catalogModel = getAvailableModel(modelId);
@@ -2778,24 +2743,61 @@ function ModelsSection({
           className="flex-1"
           style={{ maxWidth: 'none' }}
         />
-        {isTrulyCustom ? (
+        {isTrulyCustom && (
           <Button variant="secondary" size="sm" onClick={handleAdd}>
             <IconPlusOutline18 className="size-3.5" />
             Add Model
           </Button>
-        ) : filterInstance ? (
-          <Button
-            variant="secondary"
-            size="sm"
-            disabled={isReloading}
-            onClick={() => void handleReloadModels()}
-          >
-            <IconRefreshAnticlockwiseOutline18
-              className={cn('size-3.5', isReloading && 'animate-spin')}
-            />
-            {isReloading ? 'Reloading...' : 'Reload models'}
-          </Button>
-        ) : null}
+        )}
+        {filterInstance && (
+          <Menu>
+            <MenuTrigger>
+              <Button
+                variant="secondary"
+                size="icon-sm"
+                aria-label="Model actions"
+              >
+                <IconDotsOutline18 className="size-4" />
+              </Button>
+            </MenuTrigger>
+            <MenuContent side="bottom" align="end" size="sm">
+              {!isTrulyCustom && (
+                <>
+                  <MenuItem
+                    disabled={isReloading}
+                    className="data-disabled:opacity-50"
+                    onClick={() => void handleReloadModels()}
+                  >
+                    <IconRefreshAnticlockwiseOutline18
+                      className={cn(
+                        'size-3.5 shrink-0',
+                        isReloading && 'animate-spin',
+                      )}
+                    />
+                    {isReloading ? 'Reloading models...' : 'Reload models'}
+                  </MenuItem>
+                  <MenuSeparator />
+                </>
+              )}
+              <MenuItem
+                disabled={!hasInstanceModels || allInstanceModelsEnabled}
+                className="data-disabled:opacity-50"
+                onClick={() => void handleSetAllModelsEnabled(true)}
+              >
+                <IconCheck2Outline18 className="size-3.5 shrink-0" />
+                Enable all models
+              </MenuItem>
+              <MenuItem
+                disabled={!hasInstanceModels || allInstanceModelsDisabled}
+                className="data-disabled:opacity-50"
+                onClick={() => void handleSetAllModelsEnabled(false)}
+              >
+                <IconBanOutline18 className="size-3.5 shrink-0" />
+                Disable all models
+              </MenuItem>
+            </MenuContent>
+          </Menu>
+        )}
       </div>
 
       {reloadError && <TruncatedErrorText text={reloadError} />}
@@ -2811,140 +2813,45 @@ function ModelsSection({
             ? (() => {
                 const filteredGroup = filteredGroups[0];
                 if (!filteredGroup) return null;
-                const disabledIds = new Set(
-                  getInstanceDisabledModelIds(
-                    preferences,
-                    filteredGroup.instance.id,
-                  ),
-                );
-
-                // Keep the enabled/disabled overview consistent across every
-                // provider. While searching, show a flat set of matching
-                // results instead of splitting matches across sections.
                 const hasSearch = searchQuery.trim().length > 0;
-                const useEnabledSplit = !hasSearch;
-
                 const vendorGroups = groupEntriesByVendor(
                   filteredGroup.entries,
                   filterInstance,
                 );
-                if (!vendorGroups) {
-                  // No vendor grouping for this provider type.
-                  if (useEnabledSplit) {
-                    const enabledEntries = filteredGroup.entries.filter(
-                      (e) => !disabledIds.has(e.modelId),
-                    );
-                    return (
-                      <div className="space-y-2">
-                        <CollapsibleModelSection
-                          instance={filteredGroup.instance}
-                          entries={enabledEntries}
-                          preferences={preferences}
-                          onToggleModel={handleToggleModel}
-                          onEditThinking={handleEditThinking}
-                          onEditCustomModel={handleEdit}
-                          onDeleteCustomModel={handleDelete}
-                          emptyMessage="No models enabled — enable models from below."
-                        />
-                        {filteredGroup.entries.length > 0 && (
-                          <CollapsibleModelSection
-                            instance={filteredGroup.instance}
-                            entries={filteredGroup.entries}
-                            preferences={preferences}
-                            onToggleModel={handleToggleModel}
-                            onEditThinking={handleEditThinking}
-                            onEditCustomModel={handleEdit}
-                            onDeleteCustomModel={handleDelete}
-                            label="Other models"
-                            defaultExpanded={false}
-                          />
-                        )}
-                      </div>
-                    );
-                  }
-                  // Fall through to the default InstanceModelGroup path.
-                  return filteredGroups.map(({ instance, entries }) => (
-                    <InstanceModelGroup
-                      key={instance.id}
-                      instance={instance}
-                      entries={entries}
-                      preferences={preferences}
-                      onToggleModel={handleToggleModel}
-                      onEditThinking={handleEditThinking}
-                      onEditCustomModel={handleEdit}
-                      onDeleteCustomModel={handleDelete}
-                    />
-                  ));
-                }
 
-                if (useEnabledSplit) {
-                  const enabledEntries = filteredGroup.entries.filter(
-                    (e) => !disabledIds.has(e.modelId),
-                  );
+                // Search results are intentionally flat. Outside of search,
+                // multi-vendor providers retain their catalog grouping and
+                // every model keeps its original position when toggled.
+                if (!hasSearch && vendorGroups) {
                   return (
                     <div className="space-y-2">
-                      <CollapsibleModelSection
-                        instance={filteredGroup.instance}
-                        entries={enabledEntries}
-                        preferences={preferences}
-                        onToggleModel={handleToggleModel}
-                        onEditThinking={handleEditThinking}
-                        onEditCustomModel={handleEdit}
-                        onDeleteCustomModel={handleDelete}
-                        emptyMessage="No models enabled — enable models from below."
-                      />
-
-                      {/* The enabled section is a summary. Keep every model
-                          available in its regular vendor section as well. */}
-                      {vendorGroups ? (
-                        <div className="space-y-2">
-                          {vendorGroups.map((vg) => (
-                            <VendorModelGroup
-                              key={vg.prefix || 'other'}
-                              instance={filteredGroup.instance}
-                              group={vg}
-                              preferences={preferences}
-                              onToggleModel={handleToggleModel}
-                              onEditThinking={handleEditThinking}
-                              onEditCustomModel={handleEdit}
-                              onDeleteCustomModel={handleDelete}
-                              defaultExpanded={false}
-                            />
-                          ))}
-                        </div>
-                      ) : (
-                        <CollapsibleModelSection
+                      {vendorGroups.map((group) => (
+                        <VendorModelGroup
+                          key={group.prefix || 'other'}
                           instance={filteredGroup.instance}
-                          entries={filteredGroup.entries}
+                          group={group}
                           preferences={preferences}
                           onToggleModel={handleToggleModel}
                           onEditThinking={handleEditThinking}
                           onEditCustomModel={handleEdit}
                           onDeleteCustomModel={handleDelete}
-                          label="Other models"
                           defaultExpanded={false}
                         />
-                      )}
+                      ))}
                     </div>
                   );
                 }
 
-                // Search results stay grouped by vendor when supported.
                 return (
-                  <>
-                    {vendorGroups.map((vg) => (
-                      <VendorModelGroup
-                        key={vg.prefix || 'other'}
-                        instance={filteredGroup.instance}
-                        group={vg}
-                        preferences={preferences}
-                        onToggleModel={handleToggleModel}
-                        onEditThinking={handleEditThinking}
-                        onEditCustomModel={handleEdit}
-                        onDeleteCustomModel={handleDelete}
-                      />
-                    ))}
-                  </>
+                  <ModelCardList
+                    instance={filteredGroup.instance}
+                    entries={filteredGroup.entries}
+                    preferences={preferences}
+                    onToggleModel={handleToggleModel}
+                    onEditThinking={handleEditThinking}
+                    onEditCustomModel={handleEdit}
+                    onDeleteCustomModel={handleDelete}
+                  />
                 );
               })()
             : filteredGroups.map(({ instance, entries }) => (
@@ -3315,6 +3222,22 @@ export function ModelsProvidersSection() {
         (i) => i.id === detailInstanceId,
       )
     : undefined;
+  const detailModelCounts = useMemo(() => {
+    if (!detailInstance) return { enabled: 0, total: 0 };
+    const entries = getSelectableModelEntries(preferences, {
+      includeDisabled: true,
+    }).filter((entry) => entry.instanceId === detailInstance.id);
+    const disabledSet = new Set(
+      getInstanceDisabledModelIds(preferences, detailInstance.id),
+    );
+    return {
+      enabled: entries.reduce(
+        (count, entry) => count + Number(!disabledSet.has(entry.modelId)),
+        0,
+      ),
+      total: entries.length,
+    };
+  }, [detailInstance, preferences]);
 
   // Intercept Escape on the capture phase when a detail page is open.
   // This fires before the global bubble-phase handler in
@@ -3346,7 +3269,7 @@ export function ModelsProvidersSection() {
   if (detailInstance) {
     const displayInfo = getTypeDisplayInfo(detailInstance.typeId);
     const credentialType = displayInfo?.credentialType ?? 'none';
-    const modelCount = getInstanceModelCount(detailInstance, preferences);
+    const modelCount = detailModelCounts.total;
     const canDelete = detailInstance.id !== DEFAULT_INSTANCE_ID;
     const canRename = detailInstance.typeId !== 'stagewise';
 
@@ -3460,8 +3383,12 @@ export function ModelsProvidersSection() {
 
             {/* Models Section */}
             <section className="flex flex-col space-y-6">
-              <div>
+              <div className="flex items-baseline gap-2">
                 <h2 className="font-medium text-foreground text-lg">Models</h2>
+                <span className="text-muted-foreground text-xs">
+                  {detailModelCounts.enabled} of {detailModelCounts.total}{' '}
+                  enabled
+                </span>
               </div>
 
               <ModelsSection

--- a/apps/browser/src/ui/screens/settings/sections/models-providers-section.tsx
+++ b/apps/browser/src/ui/screens/settings/sections/models-providers-section.tsx
@@ -2270,6 +2270,7 @@ function ModelsSection({
     hasInstanceModels &&
     instanceEntries.every((entry) => instanceDisabledSet.has(entry.modelId));
   const showEnabledOnly = modelVisibility === 'enabled';
+  const hasSearch = searchQuery.trim().length > 0;
   const isModelEnabled = (entry: ModelSelectorEntry) =>
     !instanceDisabledSet.has(entry.modelId);
 
@@ -2310,11 +2311,16 @@ function ModelsSection({
       .filter((g) => g.entries.length > 0);
   }, [groupedByInstance, searchQuery, filterInstanceId]);
 
-  const noResults =
-    (searchQuery.trim().length > 0 || showEnabledOnly) &&
-    !filteredGroups.some((group) =>
-      group.entries.some((entry) => !showEnabledOnly || isModelEnabled(entry)),
-    );
+  const noResults = !filteredGroups.some((group) =>
+    group.entries.some((entry) => !showEnabledOnly || isModelEnabled(entry)),
+  );
+  const noResultsMessage = !hasInstanceModels
+    ? 'No models are available for this provider.'
+    : showEnabledOnly
+      ? hasSearch
+        ? 'No enabled models match your search. Switch to All to include disabled models.'
+        : 'No models are enabled. Switch to All to enable models.'
+      : 'No models match your search. Try a different model name or ID.';
 
   // --- Thinking panel state ---
   const [listScrollViewport, setListScrollViewport] =
@@ -2848,7 +2854,6 @@ function ModelsSection({
             ? (() => {
                 const filteredGroup = filteredGroups[0];
                 if (!filteredGroup) return null;
-                const hasSearch = searchQuery.trim().length > 0;
                 const vendorGroups = groupEntriesByVendor(
                   filteredGroup.entries,
                   filterInstance,
@@ -2913,9 +2918,7 @@ function ModelsSection({
           {noResults && (
             <div className="rounded-lg border border-derived-subtle p-4">
               <p className="text-center text-muted-foreground text-sm">
-                {showEnabledOnly && !searchQuery.trim()
-                  ? 'No models are enabled.'
-                  : 'No models match your filter.'}
+                {noResultsMessage}
               </p>
             </div>
           )}

--- a/apps/browser/src/ui/screens/settings/sections/models-providers-section.tsx
+++ b/apps/browser/src/ui/screens/settings/sections/models-providers-section.tsx
@@ -2055,7 +2055,7 @@ function ModelCardList({
   );
 
   return (
-    <div className="space-y-2 pl-1">
+    <div className="space-y-2">
       {entries.map((entry) => {
         const customModel = customModelsById.get(entry.modelId);
         return customModel ? (


### PR DESCRIPTION
## Summary

- replace the duplicated enabled/other model sections with a single stable model list
- preserve catalog order when models are enabled or disabled
- group multi-vendor model catalogs by vendor and show enabled counts per group
- add All and Enabled only views, with enabled vendor groups expanded by default
- keep search results flat and scoped to the selected visibility filter
- keep model reloading as a dedicated action and move bulk enable/disable actions into an overflow menu
- show total and enabled model counts in the provider detail view

Closes #1451

<img width="960" height="967" alt="image" src="https://github.com/user-attachments/assets/2bce7e4e-8223-46bf-b704-84c6e70b173a" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Settings UI and preference patches for `disabledModelIds` only; no auth or inference-path changes, though bulk disable could surprise users if mis-clicked.
> 
> **Overview**
> Reworks **Models** on the provider detail screen so users can manage catalogs without duplicated “enabled vs other” sections.
> 
> **All / Enabled only** tabs filter the list; empty states explain when nothing matches search or when no models are enabled. Multi-vendor catalogs stay grouped by vendor with **X of Y enabled** on each group; in **Enabled only**, groups expand by default and disabled models are hidden. Search uses a flat list and respects the active visibility filter. Toggling enable/disable no longer re-sorts or duplicates rows—each model appears once in catalog order.
> 
> Toolbar changes: **Reload models** keeps a dedicated button with a spinner while loading; **Enable all** / **Disable all** for the current provider move into a overflow menu and update `disabledModelIds` via preferences. The section header shows **enabled of total** counts (replacing reliance on `getInstanceModelCount` for the detail view).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9a818954132ce14f062b64379779e67f4a80553. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->







<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes provider model lists easier to scan with stable ordering, vendor grouping, an “Enabled only” view, and clearer empty/no-results messages. Shows “enabled of total” counts per vendor and provider. Closes #1451.

- **New Features**
  - Add All/Enabled-only tabs; vendor groups show “enabled of total” and hide disabled in Enabled-only; enabled groups expand by default.
  - Keep catalog order and list each model once; search shows a flat list; move “Enable all/Disable all” to an overflow menu; “Reload models” shows a spinner; show enabled/total counts in the provider detail.

- **Bug Fixes**
  - Align model cards with the filter input.
  - Clarify empty/no-results states with helpful guidance; auto-close the thinking panel if its model becomes hidden by filters.

<sup>Written for commit c9a818954132ce14f062b64379779e67f4a80553. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1463?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an **“Enabled only”** tab to filter models.
  * Added bulk **enable/disable** controls for the currently shown provider/model instance.
* **UI Improvements**
  * Refreshed model presentation to a simpler, consistent card list layout.
  * Updated both main and detail screens to show **“X of Y enabled”** and optionally hide disabled models.
* **Bug Fixes**
  * Corrected enabled/disabled counting for both the models overview and the per-provider detail view.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->