### PR TITLE
feat(stagewise): show notification while updates download

### DIFF
--- a/apps/browser/src/backend/services/auto-update.ts
+++ b/apps/browser/src/backend/services/auto-update.ts
@@ -199,6 +199,7 @@ export class AutoUpdateService extends DisposableService {
 
       // Reset downloaded state so the guard in checkForUpdates() allows
       // re-checking against the new channel's update feed.
+      this.dismissUpdateNotification();
       this.updateDownloaded = false;
       this.updateInfo = null;
       this.setAutoUpdateState('idle');
@@ -297,6 +298,14 @@ export class AutoUpdateService extends DisposableService {
       this.logger.debug(`[AutoUpdateService] Error message: ${error.message}`);
       this.logger.debug(`[AutoUpdateService] Error stack: ${error.stack}`);
       this.report(error, 'autoUpdaterError');
+
+      if (this.updateDownloaded) {
+        this.logger.debug(
+          '[AutoUpdateService] Preserving ready update after updater error',
+        );
+        return;
+      }
+
       this.dismissUpdateNotification();
       this.setAutoUpdateState('error', null, error.message);
     });
@@ -318,6 +327,15 @@ export class AutoUpdateService extends DisposableService {
       this.logger.debug(
         '[AutoUpdateService] No update available, app is up to date',
       );
+
+      if (this.updateDownloaded) {
+        this.logger.debug(
+          '[AutoUpdateService] Ignoring stale no-update result because an update is ready',
+        );
+        return;
+      }
+
+      this.dismissUpdateNotification();
       this.setAutoUpdateState('not-available');
     });
 

--- a/apps/browser/src/backend/services/auto-update.ts
+++ b/apps/browser/src/backend/services/auto-update.ts
@@ -297,6 +297,7 @@ export class AutoUpdateService extends DisposableService {
       this.logger.debug(`[AutoUpdateService] Error message: ${error.message}`);
       this.logger.debug(`[AutoUpdateService] Error stack: ${error.stack}`);
       this.report(error, 'autoUpdaterError');
+      this.dismissUpdateNotification();
       this.setAutoUpdateState('error', null, error.message);
     });
 
@@ -309,6 +310,7 @@ export class AutoUpdateService extends DisposableService {
       this.logger.debug(
         '[AutoUpdateService] Update available, download starting automatically',
       );
+      this.showUpdateDownloadingNotification();
       this.setAutoUpdateState('downloading');
     });
 
@@ -360,12 +362,30 @@ export class AutoUpdateService extends DisposableService {
     });
   }
 
+  private dismissUpdateNotification(): void {
+    if (!this.updateNotificationId) return;
+
+    this.notificationService.dismissNotification(this.updateNotificationId);
+    this.updateNotificationId = null;
+  }
+
+  private showUpdateDownloadingNotification(): void {
+    this.dismissUpdateNotification();
+
+    this.updateNotificationId = this.notificationService.showNotification({
+      title: 'Update Available',
+      message: 'A new version is being downloaded.',
+      type: 'info',
+      icon: 'spinner',
+      actions: [],
+    });
+  }
+
   private showUpdateReadyNotification(releaseName: string): void {
     const versionDisplay = releaseName || 'a new version';
 
     // Dismiss any previous update notification before showing a new one
-    if (this.updateNotificationId)
-      this.notificationService.dismissNotification(this.updateNotificationId);
+    this.dismissUpdateNotification();
 
     this.updateNotificationId = this.notificationService.showNotification({
       title: 'Update Ready',

--- a/apps/browser/src/backend/services/auto-update.ts
+++ b/apps/browser/src/backend/services/auto-update.ts
@@ -299,12 +299,8 @@ export class AutoUpdateService extends DisposableService {
       this.logger.debug(`[AutoUpdateService] Error stack: ${error.stack}`);
       this.report(error, 'autoUpdaterError');
 
-      if (this.updateDownloaded) {
-        this.logger.debug(
-          '[AutoUpdateService] Preserving ready update after updater error',
-        );
-        return;
-      }
+      // Keep the ready-to-install update visible.
+      if (this.updateDownloaded) return;
 
       this.dismissUpdateNotification();
       this.setAutoUpdateState('error', null, error.message);
@@ -319,7 +315,14 @@ export class AutoUpdateService extends DisposableService {
       this.logger.debug(
         '[AutoUpdateService] Update available, download starting automatically',
       );
-      this.showUpdateDownloadingNotification();
+      this.dismissUpdateNotification();
+      this.updateNotificationId = this.notificationService.showNotification({
+        title: 'Update Available',
+        message: 'A new version is being downloaded.',
+        type: 'info',
+        icon: 'spinner',
+        actions: [],
+      });
       this.setAutoUpdateState('downloading');
     });
 
@@ -327,14 +330,6 @@ export class AutoUpdateService extends DisposableService {
       this.logger.debug(
         '[AutoUpdateService] No update available, app is up to date',
       );
-
-      if (this.updateDownloaded) {
-        this.logger.debug(
-          '[AutoUpdateService] Ignoring stale no-update result because an update is ready',
-        );
-        return;
-      }
-
       this.dismissUpdateNotification();
       this.setAutoUpdateState('not-available');
     });
@@ -385,18 +380,6 @@ export class AutoUpdateService extends DisposableService {
 
     this.notificationService.dismissNotification(this.updateNotificationId);
     this.updateNotificationId = null;
-  }
-
-  private showUpdateDownloadingNotification(): void {
-    this.dismissUpdateNotification();
-
-    this.updateNotificationId = this.notificationService.showNotification({
-      title: 'Update Available',
-      message: 'A new version is being downloaded.',
-      type: 'info',
-      icon: 'spinner',
-      actions: [],
-    });
   }
 
   private showUpdateReadyNotification(releaseName: string): void {

--- a/apps/browser/src/backend/services/notification.ts
+++ b/apps/browser/src/backend/services/notification.ts
@@ -13,6 +13,7 @@ export interface Notification {
   title: string;
   message: string;
   type: 'info' | 'warning' | 'error';
+  icon?: 'spinner';
   duration?: number; // Duration in milliseconds. Will never auto-dismiss if not set.
   actions: {
     label: string;
@@ -83,6 +84,7 @@ export class NotificationService extends DisposableService {
         title: notification.title,
         message: notification.message,
         type: notification.type,
+        icon: notification.icon,
         duration: notification.duration,
         actions: actionsForState,
       });

--- a/apps/browser/src/shared/karton-contracts/ui/index.ts
+++ b/apps/browser/src/shared/karton-contracts/ui/index.ts
@@ -1162,6 +1162,7 @@ export type AppState = {
     title: string | null;
     message: string | null;
     type: 'info' | 'warning' | 'error';
+    icon?: 'spinner';
     duration?: number; // Duration in milliseconds. Will never auto-dismiss if not set.
     actions: {
       label: string;

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/notification-banners.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/notification-banners.tsx
@@ -5,6 +5,7 @@ import {
   IconTriangleWarningOutline18,
   IconCircleInfoOutline18,
 } from '@stagewise/icons';
+import { LoaderCircleIcon } from 'lucide-react';
 import { SidebarToast } from '../../../_components/sidebar-toast';
 
 export function NotificationBanners() {
@@ -27,7 +28,10 @@ export function NotificationBanners() {
           onDismiss={() => dismissNotification(notification.id)}
         >
           <div className="flex flex-row items-start gap-2 pr-7">
-            <NotificationIcon type={notification.type} />
+            <NotificationIcon
+              type={notification.type}
+              icon={notification.icon}
+            />
             <div className="flex min-w-0 flex-1 flex-col gap-0.5">
               {notification.title && (
                 <p
@@ -72,7 +76,18 @@ export function NotificationBanners() {
   );
 }
 
-function NotificationIcon({ type }: { type: string }) {
+function NotificationIcon({ type, icon }: { type: string; icon?: 'spinner' }) {
+  if (icon === 'spinner') {
+    return (
+      <span
+        className="mt-0.5 size-3.5 shrink-0 animate-spin text-foreground"
+        aria-hidden="true"
+      >
+        <LoaderCircleIcon className="size-full" />
+      </span>
+    );
+  }
+
   switch (type) {
     case 'warning':
     case 'error':

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/notification-banners.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/notification-banners.tsx
@@ -6,13 +6,7 @@ import {
   IconCircleInfoOutline18,
 } from '@stagewise/icons';
 import { LoaderCircleIcon } from 'lucide-react';
-import type { AppState } from '@shared/karton-contracts/ui';
 import { SidebarToast } from '../../../_components/sidebar-toast';
-
-type NotificationIconProps = Pick<
-  AppState['notifications'][number],
-  'type' | 'icon'
->;
 
 export function NotificationBanners() {
   const notifications = useKartonState((s) => s.notifications);
@@ -82,15 +76,13 @@ export function NotificationBanners() {
   );
 }
 
-function NotificationIcon({ type, icon }: NotificationIconProps) {
+function NotificationIcon({ type, icon }: { type: string; icon?: 'spinner' }) {
   if (icon === 'spinner') {
     return (
-      <span
+      <LoaderCircleIcon
         className="mt-0.5 size-3.5 shrink-0 animate-spin text-foreground"
         aria-hidden="true"
-      >
-        <LoaderCircleIcon className="size-full" />
-      </span>
+      />
     );
   }
 

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/notification-banners.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/notification-banners.tsx
@@ -6,7 +6,13 @@ import {
   IconCircleInfoOutline18,
 } from '@stagewise/icons';
 import { LoaderCircleIcon } from 'lucide-react';
+import type { AppState } from '@shared/karton-contracts/ui';
 import { SidebarToast } from '../../../_components/sidebar-toast';
+
+type NotificationIconProps = Pick<
+  AppState['notifications'][number],
+  'type' | 'icon'
+>;
 
 export function NotificationBanners() {
   const notifications = useKartonState((s) => s.notifications);
@@ -76,7 +82,7 @@ export function NotificationBanners() {
   );
 }
 
-function NotificationIcon({ type, icon }: { type: string; icon?: 'spinner' }) {
+function NotificationIcon({ type, icon }: NotificationIconProps) {
   if (icon === 'spinner') {
     return (
       <span


### PR DESCRIPTION
## Summary

- show a dismissible notification when an available update starts downloading automatically
- display a spinner using the existing info notification type
- replace the downloading notification with the existing “Update Ready” notification once the download finishes
- dismiss the downloading notification if the update fails

Closes #1431

<img width="484" height="235" alt="image" src="https://github.com/user-attachments/assets/aad35de7-ca3a-4375-b51d-03c1746b02ff" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized UX around auto-update toasts and a small optional notification icon field; no auth, data, or core agent behavior changes.
> 
> **Overview**
> Adds **in-app feedback while auto-updates download**: when an update is found, users see a dismissible **“Update Available”** info toast with a **spinner**; it is replaced by the existing **“Update Ready”** toast when the download completes.
> 
> Extends notifications with optional **`icon: 'spinner'`** (backend → Karton state → sidebar banners via `LoaderCircleIcon`).
> 
> **Lifecycle cleanup** centralizes dismiss logic in `dismissUpdateNotification()` and clears the downloading toast on **no update**, **errors before download finishes**, and **update channel changes**. Late updater **errors** or stale events after a successful download **no longer hide** the ready-to-install notification.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2cb270010da0952a3862c5e67b9db55f7cab5dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a dismissible “Update Available” toast with a spinner during auto-download, then replaces it with “Update Ready” on completion, with simplified logic to prevent stale or duplicate notifications. Closes #1431.

- **New Features**
  - Show an info toast with a spinner when auto-download starts; user can dismiss.
  - Replace it with “Update Ready” on success; clear it if an error occurs before completion.
  - Add optional `icon?: 'spinner'` to notifications (backend, shared state, UI) and render via `lucide-react`.

- **Bug Fixes**
  - Dismiss the downloading toast on channel changes and when “not available” fires.
  - Keep “Update Ready” visible on late errors.
  - Centralize dismiss logic to consistently clear previous update toasts before showing new ones.

<sup>Written for commit c2cb270010da0952a3862c5e67b9db55f7cab5dd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1466?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a spinner icon option for notifications, used to indicate the update “downloading” phase.
  * Update notifications now present clearer, state-based UI as an update transitions from available to downloading.

* **Bug Fixes**
  * Improved dismissal behavior for update notifications across update events (ready, not-available, and error cases), avoiding incorrect notification loss.
  * Changing the update channel now reliably resets and clears any existing update notification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->