### PR TITLE
fix(stagewise): simplify auto-scroll with Virtuoso followOutput

### DIFF
--- a/apps/browser/src/ui/hooks/use-auto-scroll.test.tsx
+++ b/apps/browser/src/ui/hooks/use-auto-scroll.test.tsx
@@ -1,0 +1,108 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useAutoScroll } from './use-auto-scroll';
+
+describe('useAutoScroll', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) =>
+      window.setTimeout(() => callback(0), 0),
+    );
+    vi.stubGlobal('cancelAnimationFrame', window.clearTimeout);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  const flushScroll = () => act(() => vi.runAllTimers());
+
+  const createViewport = (height = 1_000) => {
+    const viewport = document.createElement('div');
+    let scrollHeight = height;
+    Object.defineProperty(viewport, 'scrollHeight', {
+      get: () => scrollHeight,
+    });
+    return {
+      viewport,
+      setHeight: (nextHeight: number) => {
+        scrollHeight = nextHeight;
+      },
+    };
+  };
+
+  it('uses Virtuoso native output following', () => {
+    const { result } = renderHook(() => useAutoScroll({ mode: 'virtuoso' }));
+
+    expect(result.current.followOutput).toBe('auto');
+  });
+
+  it('pauses on wheel-up and resumes at the bottom', () => {
+    const { result } = renderHook(() => useAutoScroll({ mode: 'virtuoso' }));
+    const { viewport, setHeight } = createViewport();
+
+    act(() => result.current.scrollerRef(viewport));
+    flushScroll();
+    viewport.scrollTop = 400;
+    act(() => viewport.dispatchEvent(new WheelEvent('wheel', { deltaY: -1 })));
+
+    expect(result.current.isAutoScrollEnabled()).toBe(false);
+
+    setHeight(1_500);
+    act(result.current.forceEnableAutoScroll);
+    flushScroll();
+    expect(viewport.scrollTop).toBe(1_500);
+    expect(result.current.isAutoScrollEnabled()).toBe(true);
+  });
+
+  it('pauses when the scrollbar thumb moves upward', () => {
+    const { result } = renderHook(() => useAutoScroll({ mode: 'virtuoso' }));
+    const { viewport } = createViewport();
+
+    act(() => result.current.scrollerRef(viewport));
+    flushScroll();
+    viewport.scrollTop = 500;
+    act(() => viewport.dispatchEvent(new Event('scroll')));
+    viewport.scrollTop = 400;
+    act(() => viewport.dispatchEvent(new Event('scroll')));
+
+    expect(result.current.isAutoScrollEnabled()).toBe(false);
+
+    viewport.scrollTop = 1_000;
+    act(() => viewport.dispatchEvent(new Event('scroll')));
+    act(() => viewport.dispatchEvent(new Event('scrollend')));
+    expect(result.current.isAutoScrollEnabled()).toBe(true);
+  });
+
+  it('starts following when Virtuoso mounts a new scroller', () => {
+    const { result } = renderHook(() => useAutoScroll({ mode: 'virtuoso' }));
+    const first = createViewport();
+    const second = createViewport(2_000);
+
+    act(() => result.current.scrollerRef(first.viewport));
+    flushScroll();
+    act(result.current.disableAutoScroll);
+    act(() => result.current.scrollerRef(second.viewport));
+    flushScroll();
+
+    expect(second.viewport.scrollTop).toBe(2_000);
+  });
+
+  it('follows mutations in a regular scroll container', async () => {
+    const { result } = renderHook(() =>
+      useAutoScroll({ initializeAtBottom: false }),
+    );
+    const { viewport, setHeight } = createViewport();
+
+    act(() => result.current.scrollerRef(viewport));
+    setHeight(1_500);
+    await act(async () => {
+      viewport.append(document.createElement('div'));
+      await Promise.resolve();
+    });
+    flushScroll();
+
+    expect(viewport.scrollTop).toBe(1_500);
+  });
+});

--- a/apps/browser/src/ui/hooks/use-auto-scroll.test.tsx
+++ b/apps/browser/src/ui/hooks/use-auto-scroll.test.tsx
@@ -32,44 +32,46 @@ describe('useAutoScroll', () => {
     };
   };
 
-  it('uses Virtuoso native output following', () => {
-    const { result } = renderHook(() => useAutoScroll({ mode: 'virtuoso' }));
-
-    expect(result.current.followOutput).toBe('auto');
-  });
-
   it('pauses on wheel-up and resumes at the bottom', () => {
     const { result } = renderHook(() => useAutoScroll({ mode: 'virtuoso' }));
     const { viewport, setHeight } = createViewport();
 
     act(() => result.current.scrollerRef(viewport));
     flushScroll();
+    expect(result.current.followOutput).toBe('auto');
+
     viewport.scrollTop = 400;
     act(() => viewport.dispatchEvent(new WheelEvent('wheel', { deltaY: -1 })));
 
     expect(result.current.isAutoScrollEnabled()).toBe(false);
+    expect(result.current.followOutput).toBe(false);
 
     setHeight(1_500);
     act(result.current.forceEnableAutoScroll);
     flushScroll();
     expect(viewport.scrollTop).toBe(1_500);
     expect(result.current.isAutoScrollEnabled()).toBe(true);
+    expect(result.current.followOutput).toBe('auto');
   });
 
-  it('pauses when the scrollbar thumb moves upward', () => {
+  it('follows content growth but pauses when scrolling upward', () => {
     const { result } = renderHook(() => useAutoScroll({ mode: 'virtuoso' }));
-    const { viewport } = createViewport();
+    const { viewport, setHeight } = createViewport();
 
     act(() => result.current.scrollerRef(viewport));
     flushScroll();
-    viewport.scrollTop = 500;
     act(() => viewport.dispatchEvent(new Event('scroll')));
+
+    setHeight(1_500);
+    viewport.scrollTop = 1_100;
+    act(() => viewport.dispatchEvent(new Event('scroll')));
+    expect(result.current.followOutput).toBe('auto');
+
     viewport.scrollTop = 400;
     act(() => viewport.dispatchEvent(new Event('scroll')));
-
     expect(result.current.isAutoScrollEnabled()).toBe(false);
 
-    viewport.scrollTop = 1_000;
+    viewport.scrollTop = 1_500;
     act(() => viewport.dispatchEvent(new Event('scroll')));
     act(() => viewport.dispatchEvent(new Event('scrollend')));
     expect(result.current.isAutoScrollEnabled()).toBe(true);

--- a/apps/browser/src/ui/hooks/use-auto-scroll.ts
+++ b/apps/browser/src/ui/hooks/use-auto-scroll.ts
@@ -17,6 +17,13 @@ export function useAutoScroll({
   const shouldFollowRef = useRef(true);
   const scrollFrameRef = useRef<number | null>(null);
   const [scroller, setScroller] = useState<HTMLElement | null>(null);
+  const [followOutput, setFollowOutput] = useState<'auto' | false>('auto');
+
+  const setShouldFollow = useCallback((shouldFollow: boolean) => {
+    if (shouldFollowRef.current === shouldFollow) return;
+    shouldFollowRef.current = shouldFollow;
+    setFollowOutput(shouldFollow ? 'auto' : false);
+  }, []);
 
   const scrollToBottom = useCallback(() => {
     if (scrollFrameRef.current !== null)
@@ -30,40 +37,43 @@ export function useAutoScroll({
     });
   }, []);
 
-  const scrollerRef = useCallback((element: HTMLElement | Window | null) => {
-    const viewport = element instanceof HTMLElement ? element : null;
-    viewportRef.current = viewport;
-    shouldFollowRef.current = viewport !== null;
-    setScroller(viewport);
-  }, []);
+  const scrollerRef = useCallback(
+    (element: HTMLElement | Window | null) => {
+      const viewport = element instanceof HTMLElement ? element : null;
+      viewportRef.current = viewport;
+      if (viewport) setShouldFollow(true);
+      else shouldFollowRef.current = false;
+      setScroller(viewport);
+    },
+    [setShouldFollow],
+  );
 
   const forceEnableAutoScroll = useCallback(() => {
-    shouldFollowRef.current = true;
+    setShouldFollow(true);
     scrollToBottom();
-  }, [scrollToBottom]);
+  }, [scrollToBottom, setShouldFollow]);
 
   const disableAutoScroll = useCallback(() => {
-    shouldFollowRef.current = false;
-  }, []);
+    setShouldFollow(false);
+  }, [setShouldFollow]);
 
   const isAutoScrollEnabled = useCallback(() => shouldFollowRef.current, []);
 
   useEffect(() => {
     if (!scroller || !enabled) return;
 
+    let previousScrollTop = scroller.scrollTop;
     const handleScroll = () => {
-      const distanceFromBottom =
-        scroller.scrollHeight - (scroller.scrollTop + scroller.clientHeight);
-      if (distanceFromBottom > 1) shouldFollowRef.current = false;
+      if (scroller.scrollTop < previousScrollTop) setShouldFollow(false);
+      previousScrollTop = scroller.scrollTop;
     };
     const handleScrollEnd = () => {
       const distanceFromBottom =
         scroller.scrollHeight - (scroller.scrollTop + scroller.clientHeight);
-      if (distanceFromBottom <= scrollEndThreshold)
-        shouldFollowRef.current = true;
+      if (distanceFromBottom <= scrollEndThreshold) setShouldFollow(true);
     };
     const handleWheel = (event: WheelEvent) => {
-      if (event.deltaY < 0) shouldFollowRef.current = false;
+      if (event.deltaY < 0) setShouldFollow(false);
     };
 
     scroller.addEventListener('wheel', handleWheel, { passive: true });
@@ -98,6 +108,7 @@ export function useAutoScroll({
     scrollEndThreshold,
     scroller,
     scrollToBottom,
+    setShouldFollow,
   ]);
 
   return {
@@ -106,6 +117,6 @@ export function useAutoScroll({
     forceEnableAutoScroll,
     disableAutoScroll,
     isAutoScrollEnabled,
-    followOutput: 'auto' as const,
+    followOutput,
   };
 }

--- a/apps/browser/src/ui/hooks/use-auto-scroll.ts
+++ b/apps/browser/src/ui/hooks/use-auto-scroll.ts
@@ -1,260 +1,111 @@
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
-export interface UseAutoScrollOptions {
-  /**
-   * Threshold in pixels from bottom to consider "at bottom" for opt-in.
-   * @default 80
-   */
-  scrollEndThreshold?: number;
-  /**
-   * Whether auto-scroll is enabled. When false, MutationObserver and
-   * listeners are not attached. Useful for collapsible containers.
-   * @default true
-   */
+type UseAutoScrollOptions = {
   enabled?: boolean;
-  /**
-   * Wether to initialize the scroll position to the bottom when the hook is mounted.
-   * @default true
-   */
   initializeAtBottom?: boolean;
-}
+  mode?: 'dom' | 'virtuoso';
+  scrollEndThreshold?: number;
+};
 
-export interface UseAutoScrollReturn {
-  /**
-   * Callback ref to pass to scrollable element or Virtuoso's scrollerRef.
-   * Call with the HTMLElement when it becomes available.
-   */
-  scrollerRef: (element: HTMLElement | Window | null) => void;
-  /** Manually scroll to the bottom of the container */
-  scrollToBottom: () => void;
-  /** Force enable auto-scroll (e.g., when user sends a message) */
-  forceEnableAutoScroll: () => void;
-  /** Check if auto-scroll is currently enabled */
-  isAutoScrollEnabled: () => boolean;
-}
-
-/**
- * Hook for managing auto-scroll behavior in scrollable containers.
- *
- * Features:
- * - Auto-scrolls to bottom when content changes (via MutationObserver)
- * - Wheel up: immediately opts out of auto-scroll
- * - Wheel down + scrollend: opts back in if near bottom
- * - Exposes `forceEnableAutoScroll` for external triggers (e.g., sending a message)
- *
- * @example
- * ```tsx
- * const { scrollerRef, forceEnableAutoScroll } = useAutoScroll();
- *
- * // When user sends a message:
- * forceEnableAutoScroll();
- *
- * // With Virtuoso:
- * return <Virtuoso scrollerRef={scrollerRef} ... />;
- *
- * // Or with a regular scrollable div:
- * return <div ref={scrollerRef}>...</div>;
- * ```
- */
-export function useAutoScroll(
-  options: UseAutoScrollOptions = {},
-): UseAutoScrollReturn {
-  const {
-    scrollEndThreshold = 80,
-    enabled = true,
-    initializeAtBottom = true,
-  } = options;
-
-  // Store the viewport element directly
+export function useAutoScroll({
+  enabled = true,
+  initializeAtBottom = true,
+  mode = 'dom',
+  scrollEndThreshold = 80,
+}: UseAutoScrollOptions = {}) {
   const viewportRef = useRef<HTMLElement | null>(null);
-  const isAutoScrollLockedRef = useRef(true);
-  const observerRef = useRef<MutationObserver | null>(null);
-  // Guards against the `scroll` listener misinterpreting our own
-  // programmatic scrolls as user-initiated upward movement.
-  const isProgrammaticScrollRef = useRef(false);
-  const prevScrollTopRef = useRef<number | null>(null);
+  const shouldFollowRef = useRef(true);
+  const scrollFrameRef = useRef<number | null>(null);
+  const [scroller, setScroller] = useState<HTMLElement | null>(null);
 
-  // Scroll to the very bottom
   const scrollToBottom = useCallback(() => {
-    const viewport = viewportRef.current;
-    if (!viewport) return;
-    // Flag so the `scroll` listener ignores this movement
-    isProgrammaticScrollRef.current = true;
-    viewport.scrollTop = viewport.scrollHeight;
-    // Clear after the browser dispatches the resulting `scroll` event
-    requestAnimationFrame(() => {
-      isProgrammaticScrollRef.current = false;
+    if (scrollFrameRef.current !== null)
+      cancelAnimationFrame(scrollFrameRef.current);
+
+    scrollFrameRef.current = requestAnimationFrame(() => {
+      scrollFrameRef.current = null;
+      const viewport = viewportRef.current;
+      if (!viewport || !shouldFollowRef.current) return;
+      viewport.scrollTop = viewport.scrollHeight;
     });
   }, []);
 
-  // Force enable auto-scroll (for external triggers like sending a message)
-  // NOTE: Does NOT scroll immediately - just enables auto-scroll.
-  // The MutationObserver will scroll when content actually changes.
-  // This prevents a "double scroll" where we scroll before new content exists.
+  const scrollerRef = useCallback((element: HTMLElement | Window | null) => {
+    const viewport = element instanceof HTMLElement ? element : null;
+    viewportRef.current = viewport;
+    shouldFollowRef.current = viewport !== null;
+    setScroller(viewport);
+  }, []);
+
   const forceEnableAutoScroll = useCallback(() => {
-    isAutoScrollLockedRef.current = true;
-    // Don't call scrollToBottom() here - let MutationObserver handle it
+    shouldFollowRef.current = true;
+    scrollToBottom();
+  }, [scrollToBottom]);
+
+  const disableAutoScroll = useCallback(() => {
+    shouldFollowRef.current = false;
   }, []);
 
-  // Check if auto-scroll is currently enabled
-  const isAutoScrollEnabled = useCallback(() => {
-    return isAutoScrollLockedRef.current;
-  }, []);
+  const isAutoScrollEnabled = useCallback(() => shouldFollowRef.current, []);
 
-  // Handle wheel events for immediate opt-out (fires before `scroll`)
-  const handleWheel = useCallback((e: WheelEvent) => {
-    if (e.deltaY < 0) {
-      // Scrolling UP → immediate opt-out
-      isAutoScrollLockedRef.current = false;
-    }
-  }, []);
+  useEffect(() => {
+    if (!scroller || !enabled) return;
 
-  // Handle scroll events for thumb / keyboard / touch opt-out.
-  // Compares scrollTop against the previous value to detect upward movement.
-  const handleScroll = useCallback(() => {
-    const viewport = viewportRef.current;
-    if (!viewport) return;
-    const current = viewport.scrollTop;
-    // Always keep prevScrollTopRef warm — even during programmatic scrolls —
-    // so the first real user scroll event has an accurate baseline.
-    if (isProgrammaticScrollRef.current) {
-      prevScrollTopRef.current = current;
-      return;
-    }
-    const prev = prevScrollTopRef.current;
-    if (prev !== null && current < prev) {
-      // User scrolled up via a non-wheel input → opt out
-      isAutoScrollLockedRef.current = false;
-    }
-    prevScrollTopRef.current = current;
-  }, []);
+    const handleScroll = () => {
+      const distanceFromBottom =
+        scroller.scrollHeight - (scroller.scrollTop + scroller.clientHeight);
+      if (distanceFromBottom > 1) shouldFollowRef.current = false;
+    };
+    const handleScrollEnd = () => {
+      const distanceFromBottom =
+        scroller.scrollHeight - (scroller.scrollTop + scroller.clientHeight);
+      if (distanceFromBottom <= scrollEndThreshold)
+        shouldFollowRef.current = true;
+    };
+    const handleWheel = (event: WheelEvent) => {
+      if (event.deltaY < 0) shouldFollowRef.current = false;
+    };
 
-  // Handle scrollend event — re-enable auto-scroll if the user has
-  // scrolled back near the bottom (works for wheel, thumb, keyboard, etc.)
-  const handleScrollEnd = useCallback(() => {
-    if (isProgrammaticScrollRef.current) return;
-    const viewport = viewportRef.current;
-    if (!viewport) return;
+    scroller.addEventListener('wheel', handleWheel, { passive: true });
+    scroller.addEventListener('scroll', handleScroll, { passive: true });
+    scroller.addEventListener('scrollend', handleScrollEnd);
 
-    const distanceFromBottom =
-      viewport.scrollHeight - (viewport.scrollTop + viewport.clientHeight);
-    if (distanceFromBottom <= scrollEndThreshold) {
-      isAutoScrollLockedRef.current = true;
-    }
-  }, [scrollEndThreshold]);
-
-  // Callback ref that sets up everything when the element is attached
-  const scrollerRef = useCallback(
-    (element: HTMLElement | Window | null) => {
-      // Cleanup previous element
-      const prevViewport = viewportRef.current;
-      if (prevViewport) {
-        prevViewport.removeEventListener('wheel', handleWheel);
-        prevViewport.removeEventListener('scroll', handleScroll);
-        prevViewport.removeEventListener('scrollend', handleScrollEnd);
-        observerRef.current?.disconnect();
-        observerRef.current = null;
-      }
-
-      // Store new element (ignore Window, only accept HTMLElement)
-      if (element instanceof HTMLElement) {
-        viewportRef.current = element;
-      } else {
-        viewportRef.current = null;
-        return;
-      }
-
-      if (!enabled) return;
-
-      const viewport = viewportRef.current;
-
-      // Attach event listeners
-      viewport.addEventListener('wheel', handleWheel, { passive: true });
-      viewport.addEventListener('scroll', handleScroll, { passive: true });
-      viewport.addEventListener('scrollend', handleScrollEnd);
-
-      // Seed prevScrollTop so the first `scroll` event has a baseline
-      prevScrollTopRef.current = viewport.scrollTop;
-
-      // Setup MutationObserver for auto-scroll on content changes
-      // Use requestAnimationFrame to defer scroll, allowing spacer height
-      // updates to complete first (prevents flicker where content appears
-      // at wrong position for one frame)
-      let pendingScrollFrame: number | null = null;
-      const observer = new MutationObserver(() => {
-        if (!isAutoScrollLockedRef.current) return;
-        // Cancel any pending scroll and schedule a new one
-        // This batches multiple rapid mutations into a single scroll
-        if (pendingScrollFrame !== null)
-          cancelAnimationFrame(pendingScrollFrame);
-
-        pendingScrollFrame = requestAnimationFrame(() => {
-          pendingScrollFrame = null;
-          if (!isAutoScrollLockedRef.current) return;
-          scrollToBottom();
-        });
-      });
-      observer.observe(viewport, {
+    let observer: MutationObserver | undefined;
+    if (mode === 'dom') {
+      observer = new MutationObserver(scrollToBottom);
+      observer.observe(scroller, {
         childList: true,
         subtree: true,
         characterData: true,
       });
-      observerRef.current = observer;
-
-      // Initialize scroll position to bottom
-      if (initializeAtBottom) {
-        // Use rAF to ensure content is rendered
-        requestAnimationFrame(() => {
-          scrollToBottom();
-          isAutoScrollLockedRef.current = true;
-        });
-      }
-    },
-    [
-      enabled,
-      initializeAtBottom,
-      handleWheel,
-      handleScroll,
-      handleScrollEnd,
-      scrollToBottom,
-    ],
-  );
-
-  // Sync observer and listeners when `enabled` changes.
-  // The scrollerRef callback is only re-invoked when the DOM element changes,
-  // not when `enabled` changes, so we need this effect for both teardown
-  // (enabled → false) and re-attachment (enabled → true).
-  useEffect(() => {
-    if (enabled && viewportRef.current) scrollerRef(viewportRef.current);
-    else {
-      const viewport = viewportRef.current;
-      if (viewport) {
-        viewport.removeEventListener('wheel', handleWheel);
-        viewport.removeEventListener('scroll', handleScroll);
-        viewport.removeEventListener('scrollend', handleScrollEnd);
-      }
-      observerRef.current?.disconnect();
-      observerRef.current = null;
     }
-  }, [enabled, scrollerRef, handleWheel, handleScroll, handleScrollEnd]);
 
-  // Cleanup on unmount
-  useEffect(() => {
+    if (initializeAtBottom) forceEnableAutoScroll();
+
     return () => {
-      const viewport = viewportRef.current;
-      if (viewport) {
-        viewport.removeEventListener('wheel', handleWheel);
-        viewport.removeEventListener('scroll', handleScroll);
-        viewport.removeEventListener('scrollend', handleScrollEnd);
-      }
-      observerRef.current?.disconnect();
+      scroller.removeEventListener('wheel', handleWheel);
+      scroller.removeEventListener('scroll', handleScroll);
+      scroller.removeEventListener('scrollend', handleScrollEnd);
+      observer?.disconnect();
+      if (scrollFrameRef.current !== null)
+        cancelAnimationFrame(scrollFrameRef.current);
     };
-  }, [handleWheel, handleScroll, handleScrollEnd]);
+  }, [
+    enabled,
+    forceEnableAutoScroll,
+    initializeAtBottom,
+    mode,
+    scrollEndThreshold,
+    scroller,
+    scrollToBottom,
+  ]);
 
   return {
+    scroller,
     scrollerRef,
-    scrollToBottom,
     forceEnableAutoScroll,
+    disableAutoScroll,
     isAutoScrollEnabled,
+    followOutput: 'auto' as const,
   };
 }

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/chat-history.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/chat-history.tsx
@@ -252,38 +252,27 @@ export const ChatHistory = () => {
     [updateSpacerHeight],
   );
 
-  // Auto-scroll hook
+  // Virtuoso-specific auto-scroll controller. Virtuoso reports measured list
+  // height changes, so streaming and other layout growth do not need a DOM
+  // MutationObserver.
   const {
-    scrollerRef: autoScrollRef,
-    isAutoScrollEnabled,
-    scrollToBottom,
+    scroller,
+    scrollerRef,
     forceEnableAutoScroll,
-  } = useAutoScroll({
-    scrollEndThreshold: 100,
-  });
+    disableAutoScroll,
+    isAutoScrollEnabled,
+    followOutput,
+  } = useAutoScroll({ mode: 'virtuoso', scrollEndThreshold: 100 });
 
-  // Track scroller element for spacerHeight calculation
-  const [scroller, setScroller] = useState<HTMLElement | null>(null);
   // Track scroll offset to drive the top fade overlay. We only need an
   // approximate value (used to fade between 0 and 16px) so no throttling.
   const [scrollTop, setScrollTop] = useState(0);
-  const scrollerRef = useCallback(
-    (element: HTMLElement | Window | null) => {
-      // Chain to auto-scroll hook
-      autoScrollRef(element);
-      // Store element for local use (spacerHeight, etc.)
-      if (element instanceof HTMLElement) {
-        setScroller(element);
-      } else {
-        setScroller(null);
-      }
-    },
-    [autoScrollRef],
-  );
 
   const scrollChatHistoryByPage = useCallback(
     (direction: ChatHistoryScrollDirection) => {
       if (!scroller) return;
+
+      if (direction === 'up') disableAutoScroll();
 
       const amount = Math.max(
         CHAT_PAGE_SCROLL_MIN,
@@ -294,7 +283,7 @@ export const ChatHistory = () => {
         behavior: 'smooth',
       });
     },
-    [scroller],
+    [disableAutoScroll, scroller],
   );
 
   useEffect(() => {
@@ -400,7 +389,7 @@ export const ChatHistory = () => {
       cancelAnimationFrame(rafId);
       disconnectResizeObserver?.();
     };
-  }, [isAutoScrollEnabled, scrollToBottom, scroller]);
+  }, [isAutoScrollEnabled, scroller, updateSpacerHeight]);
 
   const handleRemoveSuggestion = (id: string) => {
     // State update first — telemetry is fire-and-forget and must never be
@@ -717,9 +706,6 @@ export const ChatHistory = () => {
 
   // Calculate average estimated height for defaultItemHeight
 
-  // Track when user sends a message - we'll enable auto-scroll once the message is in DOM
-  const pendingAutoScrollRef = useRef(false);
-  const prevMessagesLengthRef = useRef(filteredMessages.length);
   const serverUserMessageCountRef = useRef(0);
   serverUserMessageCountRef.current = serverMessages.filter(
     (message) => message.role === 'user',
@@ -740,7 +726,7 @@ export const ChatHistory = () => {
             serverUserMessageCountRef.current + prev.length,
         },
       ]);
-      pendingAutoScrollRef.current = true;
+      forceEnableAutoScroll();
       pendingWorkingRef.current = true;
     };
 
@@ -787,7 +773,7 @@ export const ChatHistory = () => {
         _replacedMessageId: replaceId,
       };
       setOptimisticMessages((prev) => [...prev, optimisticMsg]);
-      pendingAutoScrollRef.current = true;
+      forceEnableAutoScroll();
       pendingWorkingRef.current = true;
     };
 
@@ -815,43 +801,14 @@ export const ChatHistory = () => {
       );
       window.removeEventListener('chat-message-edited', handleMessageEdited);
     };
-  }, []);
-
-  // Enable auto-scroll ONLY when new message is actually in the DOM
-  useLayoutEffect(() => {
-    const prevLength = prevMessagesLengthRef.current;
-    const currentLength = filteredMessages.length;
-    prevMessagesLengthRef.current = currentLength;
-
-    // Trigger auto-scroll when:
-    // 1. Messages increased (new message added) AND we were waiting to auto-scroll
-    // 2. OR we're in edit mode (replacedMessageId set) AND pending scroll
-    //    (edit mode may decrease length but we still want to scroll)
-    const shouldTrigger =
-      pendingAutoScrollRef.current &&
-      (currentLength > prevLength || replacedMessageId !== null);
-
-    if (shouldTrigger) {
-      pendingAutoScrollRef.current = false;
-      forceEnableAutoScroll();
-      // Also scroll immediately - the MutationObserver may have already fired
-      // while auto-scroll was disabled, so we need to scroll manually
-      scrollToBottom();
-    }
-  }, [
-    filteredMessages.length,
-    replacedMessageId,
-    forceEnableAutoScroll,
-    scrollToBottom,
-  ]);
+  }, [forceEnableAutoScroll]);
 
   // Scroll to bottom when an error appears so it's always visible
   useEffect(() => {
     if (error) {
       forceEnableAutoScroll();
-      scrollToBottom();
     }
-  }, [error, forceEnableAutoScroll, scrollToBottom]);
+  }, [error, forceEnableAutoScroll]);
 
   // Clear pending-working bridge once isWorking catches up.
   useEffect(() => {
@@ -1335,7 +1292,8 @@ export const ChatHistory = () => {
             increaseViewportBy={{ top: 400, bottom: 400 }} // Render items above and below viewport
             heightEstimates={estimatedHeights}
             itemContent={itemContent}
-            followOutput={false} // We use our own auto-scroll logic
+            atBottomThreshold={100}
+            followOutput={followOutput}
             computeItemKey={(_, message) => message.id}
             totalCount={filteredMessages.length}
           />


### PR DESCRIPTION
## Summary

- use Virtuoso's native `followOutput` behavior for the chat history
- keep DOM-based auto-scrolling for non-Virtuoso containers
- preserve manual scroll-up behavior without forcing users back to the bottom
- simplify the shared auto-scroll implementation

Fixes #1444

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core chat scrolling during streaming and optimistic sends; behavior change is intentional but regressions (double-scroll, stuck-at-top) are possible in edge cases.
> 
> **Overview**
> Refactors **`useAutoScroll`** so Virtuoso chat uses native **`followOutput`** (`'auto'` / `false`) instead of a DOM **`MutationObserver`** and manual bottom scrolling. A new **`mode: 'dom' | 'virtuoso'`** keeps **`MutationObserver`** only for non-Virtuoso containers; **`virtuoso`** mode drives follow state via wheel/scroll/`scrollend` and exposes **`followOutput`**, **`disableAutoScroll`**, and **`scroller`** from the hook.
> 
> **`chat-history`** wires **`followOutput`** and **`atBottomThreshold={100}`**, drops the chained scroller ref and **`pendingAutoScrollRef`** / **`useLayoutEffect`** deferral, and calls **`forceEnableAutoScroll`** when sending or editing messages. Page-up navigation calls **`disableAutoScroll`** so smooth scroll-up does not snap back to the bottom.
> 
> Adds **`use-auto-scroll.test.tsx`** covering pause/resume, scroller remount, and DOM mutation follow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dfd7168ca6de9eaccadd2ab9cbe43e7ddf8ce1ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplifies chat auto-scroll by using `Virtuoso`’s native `followOutput` and keeping a lightweight DOM mode for non-`Virtuoso` containers. Respects manual scrolling and fixes #1444.

- **Refactors**
  - Use `followOutput="auto"` in chat history with `atBottomThreshold={100}`.
  - Expose `followOutput` and `scroller` from `useAutoScroll`; keep `scrollerRef`, `forceEnableAutoScroll`, `disableAutoScroll`, `isAutoScrollEnabled`.
  - Added unit tests for `Virtuoso` and DOM containers.

- **Bug Fixes**
  - Pauses auto-scroll on any upward manual scroll (wheel, drag, page-up); resumes when back at bottom.
  - Removes double-scroll/snap when sending messages or during streaming.
  - Initializes at bottom and handles scroller remounts without flicker.

<sup>Written for commit dfd7168ca6de9eaccadd2ab9cbe43e7ddf8ce1ac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1467?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat auto-scrolling when new messages arrive or content changes.
  * Auto-scroll now pauses when users scroll upward and resumes when they return near the bottom.
  * Improved scrolling behavior when the chat view is remounted or messages are edited.

* **Tests**
  * Added coverage for auto-scroll behavior across standard and virtualized scrolling containers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->