### PR TITLE
feat(stagewise): reset sidebar width on handle double-click

### DIFF
--- a/apps/browser/src/ui/screens/main/index.tsx
+++ b/apps/browser/src/ui/screens/main/index.tsx
@@ -334,8 +334,6 @@ function DefaultLayoutInner({ show }: { show: boolean }) {
             <>
               <Sidebar />
 
-              {!sidebarCollapsed && <ResizableHandle />}
-
               <ResizablePanel
                 id="content-panel"
                 order={1}

--- a/apps/browser/src/ui/screens/main/sidebar/index.tsx
+++ b/apps/browser/src/ui/screens/main/sidebar/index.tsx
@@ -100,7 +100,9 @@ export function Sidebar() {
         )}
       </ResizablePanel>
 
-      {!collapsed && <ResizableHandle onDoubleClick={reset} />}
+      {!collapsed && (
+        <ResizableHandle className="after:w-2.5" onDoubleClick={reset} />
+      )}
     </>
   );
 }

--- a/apps/browser/src/ui/screens/main/sidebar/index.tsx
+++ b/apps/browser/src/ui/screens/main/sidebar/index.tsx
@@ -1,4 +1,5 @@
 import {
+  ResizableHandle,
   ResizablePanel,
   type ImperativePanelHandle,
 } from '@stagewise/stage-ui/components/resizable';
@@ -27,7 +28,7 @@ import {
 
 // Read the persisted collapsed state *once* at module eval so we can seed
 // `defaultSize` on first render. Without this the panel mounts expanded
-// (`defaultSize={12}`) and then collapses via effect on the next frame,
+// at its default size and then collapses via effect on the next frame,
 // producing a visible flash when the user last left the sidebar collapsed.
 const INITIAL_COLLAPSED = readInitialSidebarCollapsed();
 export function Sidebar() {
@@ -61,39 +62,45 @@ export function Sidebar() {
     }
   }, [collapsed]);
 
+  const reset = () => panelRef.current?.resize(DEFAULT_EXPANDED_SIDEBAR_SIZE);
+
   return (
-    <ResizablePanel
-      ref={panelRef}
-      id={SIDEBAR_PANEL_ID}
-      order={SIDEBAR_PANEL_ORDER}
-      defaultSize={INITIAL_COLLAPSED ? 0 : DEFAULT_EXPANDED_SIDEBAR_SIZE}
-      minSize={SIDEBAR_PANEL_MIN_SIZE}
-      maxSize={SIDEBAR_PANEL_MAX_SIZE}
-      collapsible
-      collapsedSize={0}
-      onCollapse={() => setCollapsed(true)}
-      onExpand={() => setCollapsed(false)}
-      data-tutorial="sidebar-panel"
-      className={`${SIDEBAR_PANEL_CLASS_NAME} data-[panel-size='0.0']:min-w-0`}
-    >
-      <SidebarTitlebarRow absolute />
-      {!collapsed && (
-        <div
-          className="flex h-full flex-col items-stretch p-2"
-          style={{ paddingTop: (TITLEBAR_HEIGHT + 8) * counterScale }}
-        >
-          <AgentsList />
+    <>
+      <ResizablePanel
+        ref={panelRef}
+        id={SIDEBAR_PANEL_ID}
+        order={SIDEBAR_PANEL_ORDER}
+        defaultSize={INITIAL_COLLAPSED ? 0 : DEFAULT_EXPANDED_SIDEBAR_SIZE}
+        minSize={SIDEBAR_PANEL_MIN_SIZE}
+        maxSize={SIDEBAR_PANEL_MAX_SIZE}
+        collapsible
+        collapsedSize={0}
+        onCollapse={() => setCollapsed(true)}
+        onExpand={() => setCollapsed(false)}
+        data-tutorial="sidebar-panel"
+        className={`${SIDEBAR_PANEL_CLASS_NAME} data-[panel-size='0.0']:min-w-0`}
+      >
+        <SidebarTitlebarRow absolute />
+        {!collapsed && (
+          <div
+            className="flex h-full flex-col items-stretch p-2"
+            style={{ paddingTop: (TITLEBAR_HEIGHT + 8) * counterScale }}
+          >
+            <AgentsList />
 
-          <div className="mt-8 flex shrink-0 flex-col gap-2">
-            <SidebarExperienceSurvey />
-            <NotificationBanners />
-            <UsageWarningBadge />
-            <WorktreeCleanupBadge />
+            <div className="mt-8 flex shrink-0 flex-col gap-2">
+              <SidebarExperienceSurvey />
+              <NotificationBanners />
+              <UsageWarningBadge />
+              <WorktreeCleanupBadge />
+            </div>
+
+            <SidebarAuthFooter />
           </div>
+        )}
+      </ResizablePanel>
 
-          <SidebarAuthFooter />
-        </div>
-      )}
-    </ResizablePanel>
+      {!collapsed && <ResizableHandle onDoubleClick={reset} />}
+    </>
   );
 }


### PR DESCRIPTION
## Summary

- Reset the sidebar to its default width by double-clicking the resize handle
- Align the visible handle and double-click area with the default resize hit area

## Context

The initial sidebar width requested in #1271 has already been increased separately. This PR adds the missing way to reset a persisted sidebar width back to that default, after which the issue can be closed.

Closes #1271

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only layout/resize behavior with no auth, data, or API changes.
> 
> **Overview**
> **Double-clicking the sidebar resize handle** now resets the panel to `DEFAULT_EXPANDED_SIDEBAR_SIZE`, so users can undo a persisted custom width without digging through settings.
> 
> The **resize handle moves from the main layout into `Sidebar`**, rendered only while the sidebar is expanded, with a wider hit area (`after:w-2.5`) and `onDoubleClick` wired to `panel.resize(...)`. The duplicate handle between sidebar and content in `index.tsx` is removed.
> 
> A small comment tweak drops a hardcoded size reference in the collapse-flash note.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb97a6ad7df6f0354ced11c9e8c8597c97ce07c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Double-clicking the sidebar resize handle now resets the sidebar to its default width, making it easy to undo a custom size. This completes the reset behavior requested in #1271.

- New Features
  - Double-click on the resize handle resets to `DEFAULT_EXPANDED_SIDEBAR_SIZE`.
  - Moved the handle into `Sidebar` and render it only when expanded; widened hit area for easier targeting.
  - Removed the duplicate handle from the main layout.

<sup>Written for commit fb97a6ad7df6f0354ced11c9e8c8597c97ce07c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1468?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a resizable divider between the sidebar and main content.
  - Double-clicking the divider restores the sidebar to its default expanded width.

- **Bug Fixes**
  - Improved sidebar initialization to prevent visual flashing during loading.
  - Updated main content styling for a consistent background and layout appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->