### PR TITLE
feat(stagewise): add app data reset option

### DIFF
--- a/apps/browser/src/backend/index.ts
+++ b/apps/browser/src/backend/index.ts
@@ -5,6 +5,7 @@ import { app, protocol } from 'electron';
 import started from 'electron-squirrel-startup';
 import path from 'node:path';
 import { installStartupOpenUrlListener } from './startup-url-events';
+import { applyPendingAppDataReset } from './utils/app-data-reset';
 
 // CRITICAL: `main` is imported dynamically (below in the 'ready' handler)
 // instead of statically. On Windows machines without the VC++ redistributable
@@ -61,6 +62,12 @@ installStartupOpenUrlListener();
 // We keep userData where it is, but we will put session data into a sub-folder called "session"
 app.setPath('userData', path.join(app.getPath('appData'), appBaseName));
 app.setPath('sessionData', path.join(app.getPath('userData'), 'session'));
+
+try {
+  applyPendingAppDataReset(app.getPath('userData'));
+} catch (error) {
+  console.error('[AppDataReset] Failed to reset app data', error);
+}
 
 // Register custom protocols as privileged (must happen before app.ready)
 protocol.registerSchemesAsPrivileged([

--- a/apps/browser/src/backend/index.ts
+++ b/apps/browser/src/backend/index.ts
@@ -63,12 +63,6 @@ installStartupOpenUrlListener();
 app.setPath('userData', path.join(app.getPath('appData'), appBaseName));
 app.setPath('sessionData', path.join(app.getPath('userData'), 'session'));
 
-try {
-  applyPendingAppDataReset(app.getPath('userData'));
-} catch (error) {
-  console.error('[AppDataReset] Failed to reset app data', error);
-}
-
 // Register custom protocols as privileged (must happen before app.ready)
 protocol.registerSchemesAsPrivileged([
   {
@@ -129,6 +123,12 @@ const singleInstanceLock = app.requestSingleInstanceLock();
 
 if (!singleInstanceLock) {
   app.quit();
+} else if (!started) {
+  try {
+    applyPendingAppDataReset(app.getPath('userData'));
+  } catch (error) {
+    console.error('[AppDataReset] Failed to reset app data', error);
+  }
 }
 
 // This method will be called when Electron has finished

--- a/apps/browser/src/backend/main.ts
+++ b/apps/browser/src/backend/main.ts
@@ -24,6 +24,7 @@ import { NotificationService } from './services/notification';
 import { PagesService } from './services/pages';
 import { NotificationSoundsService } from './services/notification-sounds';
 import { WindowLayoutService } from './services/window-layout';
+import { revealPathInFileManager } from './services/window-layout/protocol-utils';
 import { HistoryService } from './services/history';
 import { FaviconService } from './services/favicon';
 import { WebDataService } from './services/webdata';
@@ -71,6 +72,7 @@ import { AssetCacheService } from './services/asset-cache';
 import { detectShell, resolveShellEnv } from '@stagewise/agent-shell';
 import path from 'node:path';
 import { registerStartupUrlHandler } from './startup-url-events';
+import { requestAppDataReset } from './utils/app-data-reset';
 import { AgentPowerSaveBlockerService } from './services/agent-power-save-blocker';
 import { AgentRuntimeRecoveryService } from './services/agent-runtime-recovery';
 import { MacOSClosedLidSleepService } from './services/macos-closed-lid-sleep';
@@ -455,6 +457,17 @@ export async function main({ launchOptions: { verbose } }: MainParameters) {
       telemetryService.capture(eventName, parsedProperties);
     },
   );
+
+  uiKarton.registerServerProcedureHandler('appData.openFolder', async () =>
+    revealPathInFileManager(app.getPath('userData')),
+  );
+
+  uiKarton.registerServerProcedureHandler('appData.reset', async () => {
+    requestAppDataReset(app.getPath('userData'));
+    telemetryService.capture('app-data-reset');
+    if (app.isPackaged) app.relaunch();
+    app.quit();
+  });
 
   // Start remaining services that are irrelevant to non-regular operation of the app.
   const filePickerService = await FilePickerService.create(logger, uiKarton);

--- a/apps/browser/src/backend/services/telemetry.ts
+++ b/apps/browser/src/backend/services/telemetry.ts
@@ -65,6 +65,7 @@ export type EventProperties = {
     matched_process_counts: Record<string, number>;
     total_matched_processes: number;
   };
+  'app-data-reset': undefined;
   'telemetry-level-changed': { from: TelemetryLevel; to: TelemetryLevel };
   'onboarding-completed': {
     skipped: boolean;

--- a/apps/browser/src/backend/utils/app-data-reset.test.ts
+++ b/apps/browser/src/backend/utils/app-data-reset.test.ts
@@ -1,13 +1,19 @@
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
   applyPendingAppDataReset,
   requestAppDataReset,
 } from './app-data-reset';
 
 let userDataDirectory: string;
+const tempDirectoryPrefix = path.join(os.tmpdir(), 'stagewise-reset-');
+
+beforeEach(() => {
+  userDataDirectory = fs.mkdtempSync(tempDirectoryPrefix);
+  fs.mkdirSync(path.join(userDataDirectory, 'stagewise'));
+});
 
 afterEach(() => {
   fs.rmSync(userDataDirectory, { recursive: true, force: true });
@@ -15,18 +21,15 @@ afterEach(() => {
 
 describe('app data reset', () => {
   it('deletes user data while preserving identity.json', () => {
-    userDataDirectory = fs.mkdtempSync(
-      path.join(os.tmpdir(), 'stagewise-reset-'),
-    );
     const dataRoot = path.join(userDataDirectory, 'stagewise');
     const identityPath = path.join(dataRoot, 'identity.json');
     const identity = '{"machineId":"00000000-0000-4000-8000-000000000001"}';
 
-    fs.mkdirSync(path.join(userDataDirectory, 'session'), { recursive: true });
-    fs.mkdirSync(dataRoot, { recursive: true });
+    fs.mkdirSync(path.join(userDataDirectory, 'session'));
     fs.writeFileSync(identityPath, identity);
     fs.writeFileSync(path.join(dataRoot, 'preferences.json'), '{}');
     fs.writeFileSync(path.join(userDataDirectory, 'session', 'Cookies'), 'x');
+    fs.writeFileSync(path.join(userDataDirectory, 'SingletonLock'), 'lock');
 
     requestAppDataReset(userDataDirectory);
 
@@ -34,15 +37,17 @@ describe('app data reset', () => {
     expect(fs.readFileSync(identityPath, 'utf8')).toBe(identity);
     expect(fs.existsSync(path.join(dataRoot, 'preferences.json'))).toBe(false);
     expect(fs.existsSync(path.join(userDataDirectory, 'session'))).toBe(false);
+    expect(fs.existsSync(path.join(userDataDirectory, 'SingletonLock'))).toBe(
+      true,
+    );
   });
 
   it('deletes user data without an identity.json', () => {
-    userDataDirectory = fs.mkdtempSync(
-      path.join(os.tmpdir(), 'stagewise-reset-'),
-    );
+    const dataRoot = path.join(userDataDirectory, 'stagewise');
+    fs.writeFileSync(path.join(dataRoot, 'preferences.json'), '{}');
     requestAppDataReset(userDataDirectory);
 
     applyPendingAppDataReset(userDataDirectory);
-    expect(fs.existsSync(userDataDirectory)).toBe(false);
+    expect(fs.readdirSync(dataRoot)).toEqual([]);
   });
 });

--- a/apps/browser/src/backend/utils/app-data-reset.test.ts
+++ b/apps/browser/src/backend/utils/app-data-reset.test.ts
@@ -1,0 +1,38 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  applyPendingAppDataReset,
+  requestAppDataReset,
+} from './app-data-reset';
+
+let userDataDirectory: string;
+
+afterEach(() => {
+  fs.rmSync(userDataDirectory, { recursive: true, force: true });
+});
+
+describe('app data reset', () => {
+  it('deletes user data while preserving identity.json', () => {
+    userDataDirectory = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'stagewise-reset-'),
+    );
+    const dataRoot = path.join(userDataDirectory, 'stagewise');
+    const identityPath = path.join(dataRoot, 'identity.json');
+    const identity = '{"machineId":"00000000-0000-4000-8000-000000000001"}';
+
+    fs.mkdirSync(path.join(userDataDirectory, 'session'), { recursive: true });
+    fs.mkdirSync(dataRoot, { recursive: true });
+    fs.writeFileSync(identityPath, identity);
+    fs.writeFileSync(path.join(dataRoot, 'preferences.json'), '{}');
+    fs.writeFileSync(path.join(userDataDirectory, 'session', 'Cookies'), 'x');
+
+    requestAppDataReset(userDataDirectory);
+
+    applyPendingAppDataReset(userDataDirectory);
+    expect(fs.readFileSync(identityPath, 'utf8')).toBe(identity);
+    expect(fs.existsSync(path.join(dataRoot, 'preferences.json'))).toBe(false);
+    expect(fs.existsSync(path.join(userDataDirectory, 'session'))).toBe(false);
+  });
+});

--- a/apps/browser/src/backend/utils/app-data-reset.test.ts
+++ b/apps/browser/src/backend/utils/app-data-reset.test.ts
@@ -35,4 +35,14 @@ describe('app data reset', () => {
     expect(fs.existsSync(path.join(dataRoot, 'preferences.json'))).toBe(false);
     expect(fs.existsSync(path.join(userDataDirectory, 'session'))).toBe(false);
   });
+
+  it('deletes user data without an identity.json', () => {
+    userDataDirectory = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'stagewise-reset-'),
+    );
+    requestAppDataReset(userDataDirectory);
+
+    applyPendingAppDataReset(userDataDirectory);
+    expect(fs.existsSync(userDataDirectory)).toBe(false);
+  });
 });

--- a/apps/browser/src/backend/utils/app-data-reset.ts
+++ b/apps/browser/src/backend/utils/app-data-reset.ts
@@ -1,0 +1,24 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const RESET_MARKER = '.reset-app-data';
+
+export function requestAppDataReset(userDataDirectory: string): void {
+  fs.writeFileSync(path.join(userDataDirectory, RESET_MARKER), '');
+}
+
+export function applyPendingAppDataReset(userDataDirectory: string): void {
+  const markerPath = path.join(userDataDirectory, RESET_MARKER);
+  if (!fs.existsSync(markerPath)) return;
+
+  const identityPath = path.join(
+    userDataDirectory,
+    'stagewise',
+    'identity.json',
+  );
+  const identity = fs.readFileSync(identityPath);
+
+  fs.rmSync(userDataDirectory, { recursive: true, force: true });
+  fs.mkdirSync(path.dirname(identityPath), { recursive: true });
+  fs.writeFileSync(identityPath, identity);
+}

--- a/apps/browser/src/backend/utils/app-data-reset.ts
+++ b/apps/browser/src/backend/utils/app-data-reset.ts
@@ -16,9 +16,13 @@ export function applyPendingAppDataReset(userDataDirectory: string): void {
     'stagewise',
     'identity.json',
   );
-  const identity = fs.readFileSync(identityPath);
+  const identity = fs.existsSync(identityPath)
+    ? fs.readFileSync(identityPath)
+    : undefined;
 
   fs.rmSync(userDataDirectory, { recursive: true, force: true });
-  fs.mkdirSync(path.dirname(identityPath), { recursive: true });
-  fs.writeFileSync(identityPath, identity);
+  if (identity) {
+    fs.mkdirSync(path.dirname(identityPath), { recursive: true });
+    fs.writeFileSync(identityPath, identity);
+  }
 }

--- a/apps/browser/src/backend/utils/app-data-reset.ts
+++ b/apps/browser/src/backend/utils/app-data-reset.ts
@@ -10,19 +10,24 @@ export function requestAppDataReset(userDataDirectory: string): void {
 export function applyPendingAppDataReset(userDataDirectory: string): void {
   const markerPath = path.join(userDataDirectory, RESET_MARKER);
   if (!fs.existsSync(markerPath)) return;
+  const removeOptions = { recursive: true, force: true };
 
-  const identityPath = path.join(
-    userDataDirectory,
-    'stagewise',
-    'identity.json',
-  );
-  const identity = fs.existsSync(identityPath)
-    ? fs.readFileSync(identityPath)
-    : undefined;
-
-  fs.rmSync(userDataDirectory, { recursive: true, force: true });
-  if (identity) {
-    fs.mkdirSync(path.dirname(identityPath), { recursive: true });
-    fs.writeFileSync(identityPath, identity);
+  for (const entry of fs.readdirSync(userDataDirectory)) {
+    if (
+      entry === RESET_MARKER ||
+      entry === 'stagewise' ||
+      entry.startsWith('Singleton')
+    )
+      continue;
+    fs.rmSync(path.join(userDataDirectory, entry), removeOptions);
   }
+
+  const dataRoot = path.join(userDataDirectory, 'stagewise');
+  if (fs.existsSync(dataRoot))
+    for (const entry of fs.readdirSync(dataRoot)) {
+      if (entry !== 'identity.json')
+        fs.rmSync(path.join(dataRoot, entry), removeOptions);
+    }
+
+  fs.rmSync(markerPath);
 }

--- a/apps/browser/src/shared/karton-contracts/ui/index.ts
+++ b/apps/browser/src/shared/karton-contracts/ui/index.ts
@@ -1634,6 +1634,12 @@ export type KartonContract = {
       /** Quit the app and install the downloaded update */
       quitAndInstall: () => Promise<void>;
     };
+    appData: {
+      /** Open the OS-specific Electron userData directory. */
+      openFolder: () => Promise<void>;
+      /** Delete app data on restart while retaining the installation ID. */
+      reset: () => Promise<void>;
+    };
     config: {
       set: (config: Partial<GlobalConfig>) => Promise<void>;
       previewSoundPack: (

--- a/apps/browser/src/ui/screens/settings/sections/about-section.tsx
+++ b/apps/browser/src/ui/screens/settings/sections/about-section.tsx
@@ -417,6 +417,42 @@ function OpenSourceLicenses() {
   );
 }
 
+function AppDataManagement() {
+  const openFolder = useKartonProcedure((p) => p.appData.openFolder);
+  const resetAppData = useKartonProcedure((p) => p.appData.reset);
+
+  return (
+    <div className="flex items-start justify-between gap-4">
+      <div className="flex flex-col gap-1">
+        <h3 className="font-medium text-base text-foreground">App Data</h3>
+        <p className="text-muted-foreground text-sm">
+          Open the data folder for troubleshooting or reset stagewise to a clean
+          setup.
+        </p>
+      </div>
+      <div className="flex shrink-0 items-center gap-2">
+        <Button variant="secondary" size="sm" onClick={() => openFolder()}>
+          Open Folder
+        </Button>
+        <Button
+          variant="destructive"
+          size="sm"
+          onClick={() => {
+            if (
+              window.confirm(
+                'Delete all app data and restart? This cannot be undone. Your installation identifier will be retained.',
+              )
+            )
+              resetAppData();
+          }}
+        >
+          Delete App Data
+        </Button>
+      </div>
+    </div>
+  );
+}
+
 export function AboutSection() {
   const appInfo = useKartonState((s) => s.appInfo);
   const [appLicenseOpen, setAppLicenseOpen] = useState(false);
@@ -575,6 +611,12 @@ export function AboutSection() {
               </div>
             </div>
           </div>
+
+          {/* Divider */}
+          <hr className="border-border/30" />
+
+          {/* App Data Management */}
+          <AppDataManagement />
 
           {/* Divider */}
           <hr className="border-border/30" />


### PR DESCRIPTION
## Summary

- add app data management controls to the About section
- allow opening the Electron user data directory in Finder or Explorer
- add a destructive reset action with confirmation
- delete app data on the next launch while preserving `identity.json`
- restart packaged builds automatically and record the reset event

Closes #1425

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Destructive filesystem deletes on startup if the marker is present; wrong paths or races could cause data loss, though scope is limited to userData and identity is explicitly preserved.
> 
> **Overview**
> Adds **App Data** controls under Settings → About so users can open the Electron `userData` folder or wipe local state after confirmation.
> 
> The reset is **deferred**: confirming writes a `.reset-app-data` marker, quits (and **relaunches** when packaged), then on the next startup `applyPendingAppDataReset` runs early in `index.ts` (before `main` loads) to delete almost everything under `userData` while keeping `stagewise/identity.json` and Electron `Singleton*` lock files. Failures are logged and do not block launch. Backend exposes `appData.openFolder` / `appData.reset` on the Karton contract and records an `app-data-reset` telemetry event.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7b4eafa7cf51105a48842119c0af39c7f42a9e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds App Data management in the About section: open the Electron `userData` folder and perform a destructive reset with confirmation.

- **New Features**
  - Added About > App Data actions: Open Folder and Delete App Data.
  - Exposed UI contracts `appData.openFolder` and `appData.reset`; emits `'app-data-reset'`.
  - Reset flow: write `.reset-app-data`, then on next launch wipe `userData`, keeping `stagewise/identity.json` if present; packaged builds relaunch.

- **Bug Fixes**
  - Run pending reset early during startup and log failures without blocking launch.
  - Handle missing `identity.json` by deleting all data without failing.
  - Preserve Electron `Singleton*` lock files during reset to avoid startup issues.

<sup>Written for commit d7b4eafa7cf51105a48842119c0af39c7f42a9e7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1469?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an App Data Management section in Settings with “Open Folder” and a destructive “Delete App Data” action that preserves the installation identity and restarts to complete the reset.
* **Bug Fixes**
  * Enhanced startup to automatically apply any pending app-data reset after single-instance lock acquisition; errors are logged without interrupting launch.
* **Tests**
  * Added coverage to ensure identity is preserved during reset and that user data is cleared appropriately when the identity file is missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->