### PR TITLE
fix(stagewise): mount the full global agents directory

### DIFF
--- a/apps/browser/src/backend/env-domains/host-environment-sources.ts
+++ b/apps/browser/src/backend/env-domains/host-environment-sources.ts
@@ -10,7 +10,7 @@
  *   from the Karton preferences tree, keyed by absolute workspace
  *   path so `AgentsMdProvider` can correlate with `MountManager`.
  * - `getGlobalSkillsMounts` — returns the static global-skills mount
- *   descriptors (`~/.stagewise/skills`, `~/.agents/skills`) with a
+ *   descriptors (`~/.stagewise/skills`, `~/.agents`) with a
  *   live `exists` flag computed against disk.
  *
  * This adapter stays thin on purpose — the orchestrator invokes it on

--- a/apps/browser/src/backend/services/toolbox/global-skills.test.ts
+++ b/apps/browser/src/backend/services/toolbox/global-skills.test.ts
@@ -30,8 +30,11 @@ describe('getGlobalSkillsMounts', () => {
   it('resolves paths under the home directory', () => {
     const home = homedir();
     const mounts = getGlobalSkillsMounts();
-    const sw = mounts.find((m) => m.prefix === 'globalskills-codex');
-    expect(sw?.absolutePath).toBe(path.resolve(home, '.codex', 'skills'));
+    const codex = mounts.find((m) => m.prefix === 'globalskills-codex');
+    const agents = mounts.find((m) => m.prefix === 'globalskills-agents');
+    expect(codex?.absolutePath).toBe(path.resolve(home, '.codex', 'skills'));
+    expect(agents?.absolutePath).toBe(path.resolve(home, '.agents'));
+    expect(agents?.skillsPath).toBe(path.resolve(home, '.agents', 'skills'));
   });
 });
 

--- a/apps/browser/src/backend/services/toolbox/global-skills.ts
+++ b/apps/browser/src/backend/services/toolbox/global-skills.ts
@@ -11,6 +11,7 @@ import { ALWAYS_ENABLED_GLOBAL_SKILL_PREFIXES } from '@shared/global-skill-prefi
 export function getGlobalSkillsMounts(): Array<{
   prefix: string;
   absolutePath: string;
+  skillsPath?: string;
 }> {
   const home = homedir();
   return [
@@ -20,7 +21,8 @@ export function getGlobalSkillsMounts(): Array<{
     },
     {
       prefix: 'globalskills-agents',
-      absolutePath: path.resolve(home, '.agents', 'skills'),
+      absolutePath: path.resolve(home, '.agents'),
+      skillsPath: path.resolve(home, '.agents', 'skills'),
     },
     {
       prefix: 'globalskills-codex',
@@ -45,7 +47,7 @@ export function getGlobalSkillsMounts(): Array<{
  */
 export function getEnabledGlobalSkillsMounts(
   enabledGlobalSkillDirs: readonly string[],
-): Array<{ prefix: string; absolutePath: string }> {
+): Array<{ prefix: string; absolutePath: string; skillsPath?: string }> {
   const enabled = new Set(enabledGlobalSkillDirs);
   return getGlobalSkillsMounts().filter(
     (m) =>

--- a/apps/browser/src/backend/services/toolbox/index.ts
+++ b/apps/browser/src/backend/services/toolbox/index.ts
@@ -1093,9 +1093,7 @@ export class ToolboxService
     const perMount = await Promise.all(
       mounts.map(async (m) => ({
         mount: m,
-        skills: existsSync(m.absolutePath)
-          ? await discoverSkills(m.absolutePath)
-          : [],
+        skills: await discoverSkills(m.skillsPath ?? m.absolutePath),
       })),
     );
     if (gen !== this.globalSkillsRebuildGeneration) return;
@@ -1184,7 +1182,9 @@ export class ToolboxService
       this.uiKarton.state.preferences?.agent?.enabledGlobalSkillDirs ?? [],
     );
     for (const mount of enabledGlobalMounts) {
-      const skills = await discoverSkills(mount.absolutePath);
+      const skills = await discoverSkills(
+        mount.skillsPath ?? mount.absolutePath,
+      );
       for (const skill of skills) {
         if (allDisabled.has(skill.name) || disabledGlobalSkills.has(skill.name))
           continue;
@@ -1813,7 +1813,7 @@ export class ToolboxService
     };
 
     for (const mount of getGlobalSkillsMounts()) {
-      const parentDir = path.dirname(mount.absolutePath);
+      const parentDir = path.dirname(mount.skillsPath ?? mount.absolutePath);
       if (!existsSync(parentDir)) continue;
 
       const watcher = chokidar.watch(parentDir, {

--- a/packages/agent-core/src/env/adapters/enabled-skills.prompt.md
+++ b/packages/agent-core/src/env/adapters/enabled-skills.prompt.md
@@ -9,7 +9,7 @@ Each skill is a folder with a `SKILL.md` file and optional supporting files.
 1. **`plugins/{id}/SKILL.md`** — Core intrinsic knowledge. Always prefer.
 2. **`globalskills-sw/*`** — User-level skills from `~/.stagewise/skills/`. Personal defaults across all workspaces.
 3. **`{WORKSPACE}/.stagewise/skills/*`** — Workspace-specific, created for you. Overrides general skills.
-4. **`globalskills-agents/*`** — Cross-agent user-level skills from `~/.agents/skills/`.
+4. **`globalskills-agents/skills/*`** — Cross-agent user-level skills from `~/.agents/skills/`.
 5. **`{WORKSPACE}/.agents/skills/*`** — General skills shared with other agents.
 
 ### Workflow

--- a/packages/agent-core/src/env/adapters/workspace.prompt.md
+++ b/packages/agent-core/src/env/adapters/workspace.prompt.md
@@ -16,7 +16,7 @@ The working directory consists of symlinks to folders on the user's machine.
 | `apps/` | Agent-owned scratch space for richer per-agent outputs | Read/write. Contents are internal and not shown to the user |
 | `plugins/` | Built-in plugin skills | **Intrinsic knowledge** — highest priority. Internal, not visible to the user |
 | `globalskills-sw/` | User-level global skills from `~/.stagewise/skills/` | Read-only. Only present when the directory exists on the user's machine |
-| `globalskills-agents/` | Cross-agent global skills from `~/.agents/skills/` | Read-only. Only present when the directory exists on the user's machine |
+| `globalskills-agents/` | Cross-agent files from `~/.agents/`; skills are in `skills/` | Read-only. Only present when the directory exists on the user's machine |
 | `w{4_CHAR_ID}/` | Mounted workspaces the user gave the agent access to | The 4-char id is a stable alias derived from the original path. Originals appear in the `<symlinks>` table |
 
 Hosts may expose additional symlinks (e.g. `shells/`, `logs/`, `plans/`); their domain sections below explain those.

--- a/packages/agent-core/src/host/environment-sources.ts
+++ b/packages/agent-core/src/host/environment-sources.ts
@@ -43,7 +43,7 @@ export interface WorkspaceAgentSettingsEntry {
 export interface GlobalSkillsMount {
   /** Mount prefix used in the agent-facing workspace list. */
   prefix: string;
-  /** Absolute directory containing this mount's skill directories. */
+  /** Absolute directory exposed to the agent by this mount. */
   absolutePath: string;
   /** `true` when the absolute path exists on disk right now. */
   exists: boolean;
@@ -75,7 +75,7 @@ export interface HostEnvironmentSources {
 
   /**
    * Static global-skills mounts exposed in the workspace snapshot
-   * (e.g. `~/.stagewise/skills`, `~/.agents/skills`). The host is
+   * (e.g. `~/.stagewise/skills`, `~/.agents`). The host is
    * responsible for filtering out entries that do not exist on disk
    * (`exists: false` entries are still emitted so callers can log or
    * diagnose).


### PR DESCRIPTION
## Summary

- Mount `~/.agents` instead of only `~/.agents/skills`.
- Keep automatic skill discovery scoped to `~/.agents/skills`.
- Allow skills to access shared files elsewhere inside `~/.agents`.
- Update agent-facing paths and documentation for the new mount structure.

Closes #1371

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Expands read-only agent exposure from a skills subfolder to all of `~/.agents` and changes mount paths in prompts and skill indexing; behavior is intentional but affects every agent using global agents skills.
> 
> **Overview**
> **`globalskills-agents` now symlinks to `~/.agents` instead of only `~/.agents/skills`**, so agents can read shared files anywhere under that tree while skill discovery stays on `~/.agents/skills`.
> 
> Mount descriptors gain an optional **`skillsPath`** (used for the agents mount). **`ToolboxService`** discovers skills via `skillsPath ?? absolutePath`, still mounts sandboxes/runtimes at `absolutePath`, and builds agent-facing **`skillPath`** values relative to the mount root (e.g. `globalskills-agents/skills/...`). Global-skills file watching keys off the parent of that discovery path.
> 
> **Agent-core** docs and **`GlobalSkillsMount`** comments are updated so prompts describe `globalskills-agents/` as the full `~/.agents` mount with skills under `skills/`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fdf601548a6e897a84093e404a582d7a7f0a625a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Mount the full `~/.agents` directory instead of just `~/.agents/skills` so global skills can access shared files, while keeping auto-discovery limited to `skills/`. Aligns with #1371.

- **Bug Fixes**
  - Global mount now targets `~/.agents` and adds an optional `skillsPath` for discovery.
  - Discovery, rebuilds, and watchers prefer `skillsPath` when set.
  - Tests and workspace docs updated to reflect `globalskills-agents/` exposing `~/.agents` and skills under `globalskills-agents/skills/`.
  - Host environment comments and descriptors updated from `~/.agents/skills` to `~/.agents`.

- **Migration**
  - If you reference agent-visible paths directly, use `globalskills-agents/skills/*` for skills; place shared files alongside in `globalskills-agents/`.

<sup>Written for commit fdf601548a6e897a84093e404a582d7a7f0a625a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1470?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved support for global skills stored under the shared `~/.agents/skills/` directory.
  - Global skill discovery and live updates now correctly target the skills subdirectory.

- **Bug Fixes**
  - Corrected global skill path resolution so skills are consistently indexed and available to agents.

- **Documentation**
  - Updated guidance and path descriptions to clarify the location and structure of shared global skills.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->