### PR TITLE
feat(stagewise): wire onboarding provider telemetry

### DIFF
--- a/apps/browser/src/backend/agents/model-provider.test.ts
+++ b/apps/browser/src/backend/agents/model-provider.test.ts
@@ -340,6 +340,7 @@ describe('discovered model routing', () => {
     expect(getModelRequestUrl(result)).toBe(
       'http://ollama.example/v1/chat/completions',
     );
+    expect(result.providerType).toBe('ollama');
     expect(result.reasoningSignatureSource).toMatchObject({
       providerMode: 'custom',
       modelId,
@@ -401,6 +402,7 @@ describe('discovered model routing', () => {
       'https://discovered.example/v1/chat/completions',
     );
     expect(result.providerMode).toBe('custom');
+    expect(result.providerType).toBe('custom-openai-chat');
     expect(
       (service as any).telemetryService.withTracing.mock.calls[0]?.[1]
         .posthogProperties,

--- a/apps/browser/src/backend/agents/model-provider.ts
+++ b/apps/browser/src/backend/agents/model-provider.ts
@@ -98,6 +98,7 @@ export type ModelWithOptions = {
   contextWindowSize: number;
   providerMode: ProviderMode;
   connectedCodingPlanId?: string;
+  providerType?: string;
   reasoningSignatureSource: ReasoningSignatureSource;
   /**
    * When true, the agent must strip the `strict` field from every tool
@@ -804,6 +805,7 @@ export class ModelProviderService {
       }),
       contextWindowSize: modelSettings.modelContextRaw,
       providerMode: type.providerMode,
+      providerType: instance?.typeId ?? type.id,
       ...(resolved.connectedCodingPlanId
         ? { connectedCodingPlanId: resolved.connectedCodingPlanId }
         : {}),
@@ -935,6 +937,7 @@ export class ModelProviderService {
         typeof streamText
       >[0]['providerOptions'],
       contextWindowSize: customModel.contextWindowSize,
+      providerType: instance?.typeId ?? type.id,
       reasoningSignatureSource,
       ...(type.stripStrictFromTools ? { stripStrictFromTools: true } : {}),
     };
@@ -1063,6 +1066,7 @@ export class ModelProviderService {
       providerOptions: resolvedProviderOptions,
       contextWindowSize: contextWindow,
       providerMode: type.providerMode,
+      providerType: instance.typeId,
       reasoningSignatureSource,
       ...(type.stripStrictFromTools ? { stripStrictFromTools: true } : {}),
     };

--- a/apps/browser/src/backend/services/experience.test.ts
+++ b/apps/browser/src/backend/services/experience.test.ts
@@ -19,6 +19,11 @@ import type { TelemetryService } from './telemetry';
 
 const persistedData = new Map<string, unknown>();
 const existingPaths = new Set<string>();
+const procedureHandlers = new Map<
+  string,
+  (...args: unknown[]) => Promise<void>
+>();
+const telemetryCapture = vi.fn();
 
 vi.mock('node:fs/promises', () => ({
   default: {
@@ -131,14 +136,18 @@ function createService(
     }),
     registerStateChangeCallback: vi.fn(),
     unregisterStateChangeCallback: vi.fn(),
-    registerServerProcedureHandler: vi.fn(),
+    registerServerProcedureHandler: vi.fn(
+      (name: string, handler: (...args: unknown[]) => Promise<void>) => {
+        procedureHandlers.set(name, handler);
+      },
+    ),
   } as unknown as KartonService;
   const logger = {
     debug: vi.fn(),
     error: vi.fn(),
   } as unknown as Logger;
   const telemetryService = {
-    capture: vi.fn(),
+    capture: telemetryCapture,
     captureException: vi.fn(),
   } as unknown as TelemetryService;
 
@@ -175,7 +184,66 @@ describe('UserExperienceService recent workspace normalization', () => {
   beforeEach(() => {
     persistedData.clear();
     existingPaths.clear();
+    procedureHandlers.clear();
+    telemetryCapture.mockReset();
     persistedData.set('onboarding-state', { hasSeenOnboardingFlow: false });
+  });
+
+  it('rejects untrusted onboarding completion properties at the procedure boundary', async () => {
+    await createService(createGitService({}));
+    const handler = procedureHandlers.get(
+      'userExperience.setHasSeenOnboardingFlow',
+    );
+
+    await expect(
+      handler?.('client-id', {
+        value: true,
+        summary: {
+          onboarding_run_id: 'run-1',
+          total_duration_ms: 100,
+          connected_provider_keys: ['openai-api'],
+          connected_provider_count: 1,
+          provider_step_skipped: false,
+          personalization_changed: true,
+          skipped: true,
+        },
+      }),
+    ).rejects.toThrow();
+    expect(telemetryCapture).not.toHaveBeenCalled();
+  });
+
+  it('allowlists onboarding completion fields before telemetry capture', async () => {
+    await createService(createGitService({}));
+    const handler = procedureHandlers.get(
+      'userExperience.setHasSeenOnboardingFlow',
+    );
+
+    await handler?.('client-id', {
+      value: true,
+      auth: { auth_method: 'api-keys', provider: 'openai' },
+      summary: {
+        onboarding_run_id: 'run-1',
+        total_duration_ms: 100,
+        connected_provider_keys: ['openai-api'],
+        connected_provider_count: 1,
+        provider_step_skipped: false,
+        personalization_changed: true,
+      },
+    });
+
+    expect(telemetryCapture).toHaveBeenCalledWith('onboarding-completed', {
+      skipped: false,
+      telemetry_level: undefined,
+      auth_method: 'api-keys',
+      provider: 'openai',
+      plan_id: undefined,
+      onboarding_run_id: 'run-1',
+      total_duration_ms: 100,
+      connected_provider_keys: ['openai-api'],
+      connected_provider_count: 1,
+      provider_step_skipped: false,
+      personalization_changed: true,
+    });
   });
 
   it('normalizes linked worktree recents to the main worktree path', async () => {

--- a/apps/browser/src/backend/services/experience.ts
+++ b/apps/browser/src/backend/services/experience.ts
@@ -20,14 +20,18 @@ import {
   type RecentlyOpenedWorkspace,
   type ExperienceSurvey,
   type FounderCallSurvey,
+  type OnboardingCompletionSummary,
 } from '@shared/karton-contracts/ui';
 import type { KartonService } from './karton';
 import type { Logger } from './logger';
 import { DisposableService } from './disposable';
 import { readPersistedData, writePersistedData } from '../utils/persisted-data';
 import type { TelemetryService } from './telemetry';
-import type { ModelProvider } from '@shared/karton-contracts/ui/shared-types';
-import type { CodingPlanId } from '@shared/coding-plans';
+import {
+  modelProviderSchema,
+  type ModelProvider,
+} from '@shared/karton-contracts/ui/shared-types';
+import { codingPlanIds, type CodingPlanId } from '@shared/coding-plan-ids';
 import type { GitRepositoryInfo, GitService } from './git';
 
 export type OnboardingAuthCompletion = {
@@ -35,6 +39,39 @@ export type OnboardingAuthCompletion = {
   provider?: ModelProvider;
   plan_id?: CodingPlanId;
 };
+
+type OnboardingCompletionInput = {
+  value: boolean;
+  auth?: OnboardingAuthCompletion;
+  summary?: OnboardingCompletionSummary;
+};
+
+const onboardingAuthCompletionSchema = z
+  .object({
+    auth_method: z.enum(['stagewise', 'api-keys', 'coding-plan', 'unknown']),
+    provider: modelProviderSchema.optional(),
+    plan_id: z.enum(codingPlanIds).optional(),
+  })
+  .strict();
+
+const onboardingCompletionSummarySchema = z
+  .object({
+    onboarding_run_id: z.string(),
+    total_duration_ms: z.number().nonnegative(),
+    connected_provider_keys: z.array(z.string()),
+    connected_provider_count: z.number().int().nonnegative(),
+    provider_step_skipped: z.boolean(),
+    personalization_changed: z.boolean(),
+  })
+  .strict();
+
+const onboardingCompletionInputSchema = z
+  .object({
+    value: z.boolean(),
+    auth: onboardingAuthCompletionSchema.optional(),
+    summary: onboardingCompletionSummarySchema.optional(),
+  })
+  .strict();
 
 function redactWorkspacePathForTelemetry(workspacePath: string): string {
   return createHash('sha256').update(workspacePath).digest('hex').slice(0, 12);
@@ -212,11 +249,16 @@ export class UserExperienceService extends DisposableService {
       'userExperience.setHasSeenOnboardingFlow',
       async (
         _callingClientId: string,
-        input: boolean | { value: boolean; auth?: OnboardingAuthCompletion },
+        input: boolean | OnboardingCompletionInput,
       ) => {
-        const value = typeof input === 'boolean' ? input : input.value;
-        const auth = typeof input === 'boolean' ? undefined : input.auth;
-        await this.setHasSeenOnboardingFlow(value, auth);
+        if (typeof input === 'boolean') {
+          await this.setHasSeenOnboardingFlow(input);
+          return;
+        }
+
+        const { value, auth, summary } =
+          onboardingCompletionInputSchema.parse(input);
+        await this.setHasSeenOnboardingFlow(value, auth, summary);
       },
     );
     this.uiKarton.registerServerProcedureHandler(
@@ -936,6 +978,7 @@ export class UserExperienceService extends DisposableService {
   public async setHasSeenOnboardingFlow(
     value: boolean,
     auth: OnboardingAuthCompletion = { auth_method: 'unknown' },
+    summary?: OnboardingCompletionSummary,
   ) {
     try {
       await this.writeOnboardingState(value);
@@ -951,7 +994,15 @@ export class UserExperienceService extends DisposableService {
         this.telemetryService.capture('onboarding-completed', {
           skipped: false,
           telemetry_level: this.telemetryService.telemetryLevel,
-          ...auth,
+          auth_method: auth.auth_method,
+          provider: auth.provider,
+          plan_id: auth.plan_id,
+          onboarding_run_id: summary?.onboarding_run_id,
+          total_duration_ms: summary?.total_duration_ms,
+          connected_provider_keys: summary?.connected_provider_keys,
+          connected_provider_count: summary?.connected_provider_count,
+          provider_step_skipped: summary?.provider_step_skipped,
+          personalization_changed: summary?.personalization_changed,
         });
       }
     } catch (error) {

--- a/apps/browser/src/backend/services/global-config.ts
+++ b/apps/browser/src/backend/services/global-config.ts
@@ -18,6 +18,7 @@ export class GlobalConfigService extends DisposableService {
     newConfig: GlobalConfig,
     oldConfig: GlobalConfig | null,
   ) => void)[] = [];
+  private configPatchQueue: Promise<void> = Promise.resolve();
   private readonly logger: Logger;
   private readonly uiKarton: KartonService;
 
@@ -45,10 +46,7 @@ export class GlobalConfigService extends DisposableService {
     this.uiKarton.registerServerProcedureHandler(
       'config.set',
       async (_callingClientId: string, configPatch: Partial<GlobalConfig>) =>
-        this.set({
-          ...this.get(),
-          ...configPatch,
-        }),
+        this.patch(configPatch),
     );
 
     this.logger.debug(
@@ -83,6 +81,17 @@ export class GlobalConfigService extends DisposableService {
       throw new Error('Global config not initialized');
     }
     return structuredClone(this.config);
+  }
+
+  private patch(configPatch: Partial<GlobalConfig>): Promise<void> {
+    const update = this.configPatchQueue.then(() =>
+      this.set({
+        ...this.get(),
+        ...configPatch,
+      }),
+    );
+    this.configPatchQueue = update.catch(() => {});
+    return update;
   }
 
   /**

--- a/apps/browser/src/backend/services/telemetry.test.ts
+++ b/apps/browser/src/backend/services/telemetry.test.ts
@@ -1,5 +1,51 @@
 import { describe, expect, it } from 'vitest';
-import { isUIEventName, parseUIEventProperties } from './telemetry';
+import type {
+  KartonContract,
+  OnboardingCompletionSummary,
+} from '@shared/karton-contracts/ui';
+import type { AuthHandoffProvider } from '@shared/karton-contracts/ui/telemetry';
+import {
+  type BackendEventProperties,
+  isUIEventName,
+  parseUIEventProperties,
+} from './telemetry';
+
+type Assert<T extends true> = T;
+type IsExact<T, U> = [T] extends [U] ? ([U] extends [T] ? true : false) : false;
+type ProviderOf<T> = T extends { provider?: infer P } ? P : never;
+type _AccountProviderContract = Assert<
+  IsExact<
+    ProviderOf<BackendEventProperties['account-auth-method-failed']>,
+    AuthHandoffProvider
+  >
+>;
+type _ChatProviderContract = Assert<
+  IsExact<
+    ProviderOf<BackendEventProperties['chat-auth-method-failed']>,
+    AuthHandoffProvider
+  >
+>;
+type OnboardingCompletionInput = Exclude<
+  Parameters<
+    KartonContract['serverProcedures']['userExperience']['setHasSeenOnboardingFlow']
+  >[0],
+  boolean
+>;
+type _OnboardingSummaryContract = Assert<
+  IsExact<
+    NonNullable<OnboardingCompletionInput['summary']>,
+    OnboardingCompletionSummary
+  >
+>;
+
+const ONBOARDING_COMPLETION_SUMMARY: OnboardingCompletionSummary = {
+  onboarding_run_id: 'run-1',
+  total_duration_ms: 100,
+  connected_provider_keys: ['openai-api'],
+  connected_provider_count: 1,
+  provider_step_skipped: false,
+  personalization_changed: true,
+};
 
 const SOCIAL_AUTH_EVENTS = [
   'onboarding-auth-social-requested',
@@ -30,17 +76,247 @@ const METHOD_FAILURE_EVENTS = [
   'chat-auth-method-failed',
 ] as const;
 
+const EMAIL_HANDOFF_EVENTS = [
+  'onboarding-auth-email-handoff-requested',
+  'onboarding-auth-email-handoff-verified',
+  'account-auth-email-handoff-requested',
+  'account-auth-email-handoff-verified',
+  'chat-auth-email-handoff-requested',
+  'chat-auth-email-handoff-verified',
+] as const;
+
+const ONBOARDING_EVENTS = [
+  'onboarding-started',
+  'onboarding-step-viewed',
+  'onboarding-step-exited',
+  'onboarding-auth-skipped',
+  'onboarding-provider-detail-viewed',
+  'onboarding-provider-connect-attempted',
+  'onboarding-provider-connected',
+  'onboarding-provider-connect-failed',
+  'onboarding-provider-step-completed',
+] as const;
+
+const PROVIDER_IDENTITY = {
+  provider_key: 'openai-api',
+  provider_type: 'openai-api',
+  provider_kind: 'vendor-api',
+} as const;
+
 describe('main UI telemetry schemas', () => {
   it('registers and validates closed-lid sleep toggle events', () => {
     expect(isUIEventName('closed-lid-sleep-toggled')).toBe(true);
     expect(
       parseUIEventProperties('closed-lid-sleep-toggled', { enabled: true }),
     ).toEqual({ enabled: true });
+
     expect(
       parseUIEventProperties('closed-lid-sleep-toggled', { enabled: false }),
     ).toEqual({ enabled: false });
     expect(
       parseUIEventProperties('closed-lid-sleep-toggled', { enabled: 'true' }),
+    ).toBeNull();
+  });
+
+  it('accepts omitted and diagnostic custom-provider abort payloads', () => {
+    expect(
+      parseUIEventProperties('custom-provider-add-aborted', undefined),
+    ).toBeUndefined();
+    expect(
+      parseUIEventProperties('custom-provider-add-aborted', {
+        had_validation_errors: false,
+        any_field_touched: true,
+        api_spec: 'openai',
+      }),
+    ).toEqual({
+      had_validation_errors: false,
+      any_field_touched: true,
+      api_spec: 'openai',
+    });
+    expect(
+      parseUIEventProperties('custom-provider-add-aborted', {
+        had_validation_errors: false,
+        any_field_touched: true,
+      }),
+    ).toBeNull();
+    expect(
+      parseUIEventProperties('custom-provider-add-aborted', {
+        had_validation_errors: false,
+        any_field_touched: true,
+        api_spec: 'openai',
+        api_key: 'secret',
+      }),
+    ).toBeNull();
+  });
+
+  it('accepts every emitted new-agent source and sound loudness value', () => {
+    for (const source of [
+      'sidebar-top',
+      'sidebar-active-agents',
+      'sidebar-workspace-group',
+      'collapsed-titlebar',
+      'hotkey',
+    ] as const) {
+      expect(
+        parseUIEventProperties('chat-new-agent-clicked', { source }),
+      ).toEqual({ source });
+    }
+
+    for (const loudness of ['off', 'subtle', 'default'] as const) {
+      expect(
+        parseUIEventProperties('changed-notification-sound-loudness', {
+          loudness,
+        }),
+      ).toEqual({ loudness });
+    }
+
+    expect(
+      parseUIEventProperties('chat-new-agent-clicked', { source: 'unknown' }),
+    ).toBeNull();
+    expect(
+      parseUIEventProperties('changed-notification-sound-loudness', {
+        loudness: 'loud',
+      }),
+    ).toBeNull();
+  });
+});
+
+describe('onboarding funnel telemetry schemas', () => {
+  it('uses the shared onboarding completion summary contract', () => {
+    expect(ONBOARDING_COMPLETION_SUMMARY.connected_provider_count).toBe(1);
+  });
+  it('registers every funnel event and preserves valid payloads', () => {
+    for (const eventName of ONBOARDING_EVENTS) {
+      expect(isUIEventName(eventName)).toBe(true);
+    }
+
+    const cases = [
+      [
+        'onboarding-started',
+        {
+          onboarding_run_id: 'run-1',
+          already_authenticated: false,
+          connected_provider_count: 0,
+        },
+      ],
+      [
+        'onboarding-step-viewed',
+        {
+          onboarding_run_id: 'run-1',
+          step: 'configure-providers',
+          previous_step: 'login',
+          visit_index: 1,
+          elapsed_ms_since_start: 12.5,
+        },
+      ],
+      [
+        'onboarding-step-exited',
+        {
+          onboarding_run_id: 'run-1',
+          step: 'configure-providers',
+          destination: 'personalization',
+          action: 'next',
+          duration_ms: 30,
+        },
+      ],
+      ['onboarding-auth-skipped', { onboarding_run_id: 'run-1' }],
+      [
+        'onboarding-provider-detail-viewed',
+        {
+          onboarding_run_id: 'run-1',
+          ...PROVIDER_IDENTITY,
+          position: 0,
+          search_active: true,
+          already_connected: false,
+        },
+      ],
+      [
+        'onboarding-provider-connect-attempted',
+        {
+          onboarding_run_id: 'run-1',
+          ...PROVIDER_IDENTITY,
+          attempt_number: 1,
+        },
+      ],
+      [
+        'onboarding-provider-connected',
+        {
+          onboarding_run_id: 'run-1',
+          ...PROVIDER_IDENTITY,
+          attempt_number: 1,
+          duration_ms: 50,
+          discovered_model_count: 4,
+        },
+      ],
+      [
+        'onboarding-provider-connect-failed',
+        {
+          onboarding_run_id: 'run-1',
+          ...PROVIDER_IDENTITY,
+          attempt_number: 2,
+          duration_ms: 25,
+          failure_stage: 'rpc',
+          error_kind: 'network-error',
+        },
+      ],
+      [
+        'onboarding-provider-step-completed',
+        {
+          onboarding_run_id: 'run-1',
+          duration_ms: 100,
+          connected_provider_count: 1,
+          connected_during_step_count: 1,
+          connected_provider_keys: ['openai-api'],
+          viewed_provider_count: 1,
+          connection_attempt_count: 2,
+          connection_failure_count: 1,
+          search_used: true,
+          skipped_without_provider: false,
+        },
+      ],
+    ] as const;
+
+    for (const [eventName, properties] of cases) {
+      expect(parseUIEventProperties(eventName, properties)).toEqual(properties);
+    }
+  });
+
+  it('rejects unknown or sensitive properties and invalid values', () => {
+    expect(
+      parseUIEventProperties('onboarding-provider-connect-attempted', {
+        onboarding_run_id: 'run-1',
+        ...PROVIDER_IDENTITY,
+        attempt_number: 1,
+        api_key: 'secret',
+      }),
+    ).toBeNull();
+    expect(
+      parseUIEventProperties('onboarding-provider-connect-failed', {
+        onboarding_run_id: 'run-1',
+        ...PROVIDER_IDENTITY,
+        attempt_number: 1,
+        duration_ms: 1,
+        failure_stage: 'backend-message',
+        error_kind: 'raw-error',
+      }),
+    ).toBeNull();
+    expect(
+      parseUIEventProperties('onboarding-step-exited', {
+        onboarding_run_id: 'run-1',
+        step: 'login',
+        destination: 'configure-providers',
+        action: 'abandon',
+        duration_ms: -1,
+      }),
+    ).toBeNull();
+    expect(
+      parseUIEventProperties('onboarding-provider-connected', {
+        onboarding_run_id: 'run-1',
+        ...PROVIDER_IDENTITY,
+        attempt_number: 0,
+        duration_ms: Number.POSITIVE_INFINITY,
+        discovered_model_count: -1,
+      }),
     ).toBeNull();
   });
 });
@@ -90,6 +366,16 @@ describe('auth UI telemetry schemas', () => {
     }
   });
 
+  it('registers email handoff events without properties', () => {
+    for (const eventName of EMAIL_HANDOFF_EVENTS) {
+      expect(isUIEventName(eventName)).toBe(true);
+      expect(parseUIEventProperties(eventName, undefined)).toBeUndefined();
+      expect(
+        parseUIEventProperties(eventName, { email: 'secret@example.com' }),
+      ).toBeNull();
+    }
+  });
+
   it('validates OTP failure kinds', () => {
     for (const eventName of OTP_FAILURE_EVENTS) {
       expect(
@@ -100,6 +386,11 @@ describe('auth UI telemetry schemas', () => {
           error_kind: 'turnstile-not-ready',
         }),
       ).toEqual({ error_kind: 'turnstile-not-ready' });
+      expect(
+        parseUIEventProperties(eventName, {
+          error_kind: 'turnstile-solve-failed',
+        }),
+      ).toEqual({ error_kind: 'turnstile-solve-failed' });
       expect(
         parseUIEventProperties(eventName, { error_kind: 'validation-error' }),
       ).toBeNull();
@@ -138,6 +429,17 @@ describe('auth UI telemetry schemas', () => {
       expect(
         parseUIEventProperties(eventName, {
           auth_method: 'stagewise',
+          provider: 'email',
+          error_kind: 'network-error',
+        }),
+      ).toEqual({
+        auth_method: 'stagewise',
+        provider: 'email',
+        error_kind: 'network-error',
+      });
+      expect(
+        parseUIEventProperties(eventName, {
+          auth_method: 'stagewise',
           provider: 'anthropic',
           error_kind: 'network-error',
         }),
@@ -145,7 +447,7 @@ describe('auth UI telemetry schemas', () => {
     }
   });
 
-  it('accepts model and social providers for onboarding method failures', () => {
+  it('accepts model and auth handoff providers for onboarding method failures', () => {
     expect(
       parseUIEventProperties('onboarding-auth-method-failed', {
         auth_method: 'api-keys',
@@ -166,6 +468,17 @@ describe('auth UI telemetry schemas', () => {
     ).toEqual({
       auth_method: 'stagewise',
       provider: 'github',
+      error_kind: 'backend-error',
+    });
+    expect(
+      parseUIEventProperties('onboarding-auth-method-failed', {
+        auth_method: 'stagewise',
+        provider: 'email',
+        error_kind: 'backend-error',
+      }),
+    ).toEqual({
+      auth_method: 'stagewise',
+      provider: 'email',
       error_kind: 'backend-error',
     });
     expect(

--- a/apps/browser/src/backend/services/telemetry.ts
+++ b/apps/browser/src/backend/services/telemetry.ts
@@ -7,6 +7,7 @@ import type { PreferencesService } from './preferences';
 import {
   modelProviderSchema,
   personalizationThemeIdSchema,
+  providerInstanceTypeIds,
   socialAuthProviderSchema,
   type ModelProvider,
   type PersonalizationThemeId,
@@ -14,6 +15,12 @@ import {
   type TelemetryLevel,
   type ToolApprovalMode,
 } from '@shared/karton-contracts/ui/shared-types';
+import type {
+  AuthHandoffProvider,
+  UIEventName,
+  UIEventProperties,
+} from '@shared/karton-contracts/ui/telemetry';
+export type { UIEventName } from '@shared/karton-contracts/ui/telemetry';
 import type { CodingPlanId } from '@shared/coding-plans';
 import type { Logger } from './logger';
 import { DisposableService } from './disposable';
@@ -29,7 +36,8 @@ type OnboardingAuthFailureKind =
 type OnboardingOtpFailureKind =
   | 'backend-error'
   | 'network-error'
-  | 'turnstile-not-ready';
+  | 'turnstile-not-ready'
+  | 'turnstile-solve-failed';
 
 const onboardingAuthMethodSchema = z.enum([
   'stagewise',
@@ -53,9 +61,35 @@ const onboardingOtpFailureKindSchema = z.enum([
   'backend-error',
   'network-error',
   'turnstile-not-ready',
+  'turnstile-solve-failed',
 ]);
 
-export type EventProperties = {
+const authHandoffProviderSchema = z.union([
+  socialAuthProviderSchema,
+  z.literal('email'),
+]);
+const providerInstanceTypeIdSchema = z.enum(providerInstanceTypeIds);
+const onboardingStepSchema = z.enum([
+  'login',
+  'configure-providers',
+  'personalization',
+]);
+const nonNegativeNumberSchema = z.number().nonnegative();
+const nonNegativeIntegerSchema = nonNegativeNumberSchema.int();
+const positiveIntegerSchema = z.number().int().positive();
+const onboardingProviderIdentitySchema = z.object({
+  provider_key: z.string().min(1),
+  provider_type: providerInstanceTypeIdSchema,
+  provider_kind: z.enum([
+    'vendor-api',
+    'coding-plan',
+    'gateway',
+    'self-hosted',
+  ]),
+  plan_id: codingPlanIdSchema.optional(),
+});
+
+export type BackendEventProperties = {
   // Lifecycle
   'app-launched': {
     matched_process_counts: Record<string, number>;
@@ -73,6 +107,12 @@ export type EventProperties = {
     auth_method?: OnboardingAuthCompletionMethod;
     provider?: ModelProvider;
     plan_id?: CodingPlanId;
+    onboarding_run_id?: string;
+    total_duration_ms?: number;
+    connected_provider_keys?: string[];
+    connected_provider_count?: number;
+    provider_step_skipped?: boolean;
+    personalization_changed?: boolean;
   };
   'onboarding-demo-slide-clicked': {
     slide_name: string;
@@ -105,7 +145,7 @@ export type EventProperties = {
   };
   'onboarding-auth-method-failed': {
     auth_method: OnboardingAuthMethod;
-    provider?: ModelProvider | SocialAuthProvider;
+    provider?: ModelProvider | AuthHandoffProvider;
     plan_id?: CodingPlanId;
     error_kind: OnboardingAuthFailureKind;
   };
@@ -123,7 +163,7 @@ export type EventProperties = {
   };
   'account-auth-method-failed': {
     auth_method: 'stagewise';
-    provider?: SocialAuthProvider;
+    provider?: AuthHandoffProvider;
     error_kind: OnboardingAuthFailureKind;
   };
   'chat-auth-social-requested': { provider: SocialAuthProvider };
@@ -135,7 +175,7 @@ export type EventProperties = {
   };
   'chat-auth-method-failed': {
     auth_method: 'stagewise';
-    provider?: SocialAuthProvider;
+    provider?: AuthHandoffProvider;
     error_kind: OnboardingAuthFailureKind;
   };
 
@@ -207,6 +247,7 @@ export type EventProperties = {
     model_id: string;
     provider_mode: string;
     coding_plan_id?: string;
+    provider_type?: string;
     input_tokens: number;
     output_tokens: number;
     tool_call_count: number;
@@ -486,6 +527,9 @@ export type EventProperties = {
   'experience-founder-call-survey-dismissed': undefined;
 };
 
+export type EventProperties = Omit<BackendEventProperties, UIEventName> &
+  UIEventProperties;
+
 export const UI_TELEMETRY_EVENT_NAMES = [
   'account-page-viewed',
   'chat-new-agent-clicked',
@@ -499,6 +543,15 @@ export const UI_TELEMETRY_EVENT_NAMES = [
   'custom-provider-add-started',
   'element-selection-started',
   'element-selection-stopped',
+  'onboarding-started',
+  'onboarding-step-viewed',
+  'onboarding-step-exited',
+  'onboarding-auth-skipped',
+  'onboarding-provider-detail-viewed',
+  'onboarding-provider-connect-attempted',
+  'onboarding-provider-connected',
+  'onboarding-provider-connect-failed',
+  'onboarding-provider-step-completed',
   'onboarding-auth-api-key-input-focused',
   'onboarding-auth-coding-plan-opened',
   'onboarding-auth-method-completed',
@@ -506,6 +559,8 @@ export const UI_TELEMETRY_EVENT_NAMES = [
   'onboarding-auth-mode-switched',
   'onboarding-auth-social-requested',
   'onboarding-auth-social-verified',
+  'onboarding-auth-email-handoff-requested',
+  'onboarding-auth-email-handoff-verified',
   'onboarding-auth-otp-failed',
   'onboarding-auth-otp-requested',
   'onboarding-auth-otp-verified',
@@ -517,12 +572,16 @@ export const UI_TELEMETRY_EVENT_NAMES = [
   'account-auth-otp-verified',
   'account-auth-social-requested',
   'account-auth-social-verified',
+  'account-auth-email-handoff-requested',
+  'account-auth-email-handoff-verified',
   'chat-auth-method-failed',
   'chat-auth-otp-failed',
   'chat-auth-otp-requested',
   'chat-auth-otp-verified',
   'chat-auth-social-requested',
   'chat-auth-social-verified',
+  'chat-auth-email-handoff-requested',
+  'chat-auth-email-handoff-verified',
   'onboarding-demo-slide-clicked',
   'settings-opened',
   'suggestion-clicked',
@@ -539,15 +598,18 @@ export const UI_TELEMETRY_EVENT_NAMES = [
   'experience-survey-feedback-submitted',
   'experience-founder-call-survey-opened',
   'experience-founder-call-survey-dismissed',
-] as const satisfies ReadonlyArray<keyof EventProperties>;
-
-export type UIEventName = (typeof UI_TELEMETRY_EVENT_NAMES)[number];
-export type UIEventProperties = Pick<EventProperties, UIEventName>;
+] as const satisfies ReadonlyArray<UIEventName>;
 
 const UI_TELEMETRY_EVENT_SCHEMAS = {
   'account-page-viewed': z.undefined().optional(),
   'chat-new-agent-clicked': z.object({
-    source: z.enum(['sidebar-top', 'sidebar-active-agents', 'hotkey']),
+    source: z.enum([
+      'sidebar-top',
+      'sidebar-active-agents',
+      'sidebar-workspace-group',
+      'collapsed-titlebar',
+      'hotkey',
+    ]),
   }),
   'chat-sidebar-toggled': z.object({
     new_value: z.enum(['open', 'closed']),
@@ -561,16 +623,19 @@ const UI_TELEMETRY_EVENT_SCHEMAS = {
   }),
   'custom-model-add-finished': z.undefined().optional(),
   'custom-model-add-started': z.undefined().optional(),
-  'custom-provider-add-aborted': z.object({
-    had_validation_errors: z.boolean(),
-    any_field_touched: z.boolean(),
-    api_spec: z.string(),
-    is_local: z.boolean().optional(),
-    base_url: z.string().optional(),
-    aws_auth_mode: z
-      .enum(['access-keys', 'profile', 'default-chain'])
-      .optional(),
-  }),
+  'custom-provider-add-aborted': z
+    .object({
+      had_validation_errors: z.boolean(),
+      any_field_touched: z.boolean(),
+      api_spec: z.string(),
+      is_local: z.boolean().optional(),
+      base_url: z.string().optional(),
+      aws_auth_mode: z
+        .enum(['access-keys', 'profile', 'default-chain'])
+        .optional(),
+    })
+    .strict()
+    .optional(),
   'custom-provider-add-finished': z.object({
     api_spec: z.string(),
     is_local: z.boolean().optional(),
@@ -584,6 +649,83 @@ const UI_TELEMETRY_EVENT_SCHEMAS = {
   'element-selection-stopped': z.object({
     element_selected: z.boolean(),
   }),
+  'onboarding-started': z
+    .object({
+      onboarding_run_id: z.string().min(1),
+      already_authenticated: z.boolean(),
+      connected_provider_count: nonNegativeIntegerSchema,
+    })
+    .strict(),
+  'onboarding-step-viewed': z
+    .object({
+      onboarding_run_id: z.string().min(1),
+      step: onboardingStepSchema,
+      previous_step: onboardingStepSchema.optional(),
+      visit_index: positiveIntegerSchema,
+      elapsed_ms_since_start: nonNegativeNumberSchema,
+    })
+    .strict(),
+  'onboarding-step-exited': z
+    .object({
+      onboarding_run_id: z.string().min(1),
+      step: onboardingStepSchema,
+      destination: z.union([onboardingStepSchema, z.literal('completed')]),
+      action: z.enum(['next', 'back', 'skip', 'finish']),
+      duration_ms: nonNegativeNumberSchema,
+    })
+    .strict(),
+  'onboarding-auth-skipped': z
+    .object({ onboarding_run_id: z.string().min(1) })
+    .strict(),
+  'onboarding-provider-detail-viewed': onboardingProviderIdentitySchema
+    .extend({
+      onboarding_run_id: z.string().min(1),
+      position: nonNegativeIntegerSchema,
+      search_active: z.boolean(),
+      already_connected: z.boolean(),
+    })
+    .strict(),
+  'onboarding-provider-connect-attempted': onboardingProviderIdentitySchema
+    .extend({
+      onboarding_run_id: z.string().min(1),
+      attempt_number: positiveIntegerSchema,
+    })
+    .strict(),
+  'onboarding-provider-connected': onboardingProviderIdentitySchema
+    .extend({
+      onboarding_run_id: z.string().min(1),
+      attempt_number: positiveIntegerSchema,
+      duration_ms: nonNegativeNumberSchema,
+      discovered_model_count: nonNegativeIntegerSchema,
+    })
+    .strict(),
+  'onboarding-provider-connect-failed': onboardingProviderIdentitySchema
+    .extend({
+      onboarding_run_id: z.string().min(1),
+      attempt_number: positiveIntegerSchema,
+      duration_ms: nonNegativeNumberSchema,
+      failure_stage: z.enum(['credential-validation', 'rpc']),
+      error_kind: z.enum([
+        'validation-error',
+        'network-error',
+        'unknown-error',
+      ]),
+    })
+    .strict(),
+  'onboarding-provider-step-completed': z
+    .object({
+      onboarding_run_id: z.string().min(1),
+      duration_ms: nonNegativeNumberSchema,
+      connected_provider_count: nonNegativeIntegerSchema,
+      connected_during_step_count: nonNegativeIntegerSchema,
+      connected_provider_keys: z.array(z.string().min(1)),
+      viewed_provider_count: nonNegativeIntegerSchema,
+      connection_attempt_count: nonNegativeIntegerSchema,
+      connection_failure_count: nonNegativeIntegerSchema,
+      search_used: z.boolean(),
+      skipped_without_provider: z.boolean(),
+    })
+    .strict(),
   'onboarding-auth-api-key-input-focused': z.object({
     provider: modelProviderSchema,
   }),
@@ -599,7 +741,7 @@ const UI_TELEMETRY_EVENT_SCHEMAS = {
   'onboarding-auth-method-failed': z.object({
     auth_method: onboardingAuthMethodSchema,
     provider: z
-      .union([modelProviderSchema, socialAuthProviderSchema])
+      .union([modelProviderSchema, authHandoffProviderSchema])
       .optional(),
     plan_id: codingPlanIdSchema.optional(),
     error_kind: onboardingAuthFailureKindSchema,
@@ -614,6 +756,8 @@ const UI_TELEMETRY_EVENT_SCHEMAS = {
   'onboarding-auth-social-verified': z.object({
     provider: socialAuthProviderSchema,
   }),
+  'onboarding-auth-email-handoff-requested': z.undefined().optional(),
+  'onboarding-auth-email-handoff-verified': z.undefined().optional(),
   'onboarding-auth-otp-failed': z.object({
     error_kind: onboardingOtpFailureKindSchema,
   }),
@@ -633,6 +777,8 @@ const UI_TELEMETRY_EVENT_SCHEMAS = {
   'account-auth-social-verified': z.object({
     provider: socialAuthProviderSchema,
   }),
+  'account-auth-email-handoff-requested': z.undefined().optional(),
+  'account-auth-email-handoff-verified': z.undefined().optional(),
   'account-auth-otp-failed': z.object({
     error_kind: onboardingOtpFailureKindSchema,
   }),
@@ -640,7 +786,7 @@ const UI_TELEMETRY_EVENT_SCHEMAS = {
   'account-auth-otp-verified': z.undefined().optional(),
   'account-auth-method-failed': z.object({
     auth_method: z.literal('stagewise'),
-    provider: socialAuthProviderSchema.optional(),
+    provider: authHandoffProviderSchema.optional(),
     error_kind: onboardingAuthFailureKindSchema,
   }),
   'chat-auth-social-requested': z.object({
@@ -649,6 +795,8 @@ const UI_TELEMETRY_EVENT_SCHEMAS = {
   'chat-auth-social-verified': z.object({
     provider: socialAuthProviderSchema,
   }),
+  'chat-auth-email-handoff-requested': z.undefined().optional(),
+  'chat-auth-email-handoff-verified': z.undefined().optional(),
   'chat-auth-otp-failed': z.object({
     error_kind: onboardingOtpFailureKindSchema,
   }),
@@ -656,7 +804,7 @@ const UI_TELEMETRY_EVENT_SCHEMAS = {
   'chat-auth-otp-verified': z.undefined().optional(),
   'chat-auth-method-failed': z.object({
     auth_method: z.literal('stagewise'),
-    provider: socialAuthProviderSchema.optional(),
+    provider: authHandoffProviderSchema.optional(),
     error_kind: onboardingAuthFailureKindSchema,
   }),
   'onboarding-demo-slide-clicked': z.object({
@@ -686,7 +834,7 @@ const UI_TELEMETRY_EVENT_SCHEMAS = {
     theme: personalizationThemeIdSchema,
   }),
   'changed-notification-sound-loudness': z.object({
-    loudness: z.enum(['off', 'subtle', 'loud']),
+    loudness: z.enum(['off', 'subtle', 'default']),
   }),
   'changed-notification-sound-theme': z.object({
     theme: z.string(),

--- a/apps/browser/src/shared/karton-contracts/ui/index.ts
+++ b/apps/browser/src/shared/karton-contracts/ui/index.ts
@@ -19,6 +19,11 @@ import type { SelectedElement } from '../../selected-elements';
 import type { FileDiff } from './shared-types';
 import type { QuestionField, QuestionAnswerValue } from './agent/tools/types';
 import type { WorktreeSetupScriptVariant } from '@shared/worktree-setup';
+export type {
+  UIEventName,
+  UIEventProperties,
+  TrackUIEvent,
+} from './telemetry';
 import type {
   FilePickerRequest,
   GlobalConfig,
@@ -1283,6 +1288,15 @@ export type AppState = {
   logIngest: { port: number; token: string } | null;
 };
 
+export type OnboardingCompletionSummary = {
+  onboarding_run_id: string;
+  total_duration_ms: number;
+  connected_provider_keys: string[];
+  connected_provider_count: number;
+  provider_step_skipped: boolean;
+  personalization_changed: boolean;
+};
+
 export type AuthStatus =
   | 'authenticated'
   | 'unauthenticated'
@@ -1604,7 +1618,7 @@ export type KartonContract = {
                   | 'minimax-plan'
                   | 'mimo-plan';
               };
-              suggestion?: { id: string; url: string; prompt: string };
+              summary?: OnboardingCompletionSummary;
             },
       ) => Promise<void>;
       clearPendingOnboardingSuggestion: () => Promise<void>;

--- a/apps/browser/src/shared/karton-contracts/ui/telemetry.ts
+++ b/apps/browser/src/shared/karton-contracts/ui/telemetry.ts
@@ -1,0 +1,226 @@
+import type { CodingPlanId } from '@shared/coding-plans';
+import type {
+  ModelProvider,
+  PersonalizationThemeId,
+  ProviderInstanceTypeId,
+  SocialAuthProvider,
+} from './shared-types';
+
+export type OnboardingStep =
+  | 'login'
+  | 'configure-providers'
+  | 'personalization';
+export type OnboardingNavigationAction = 'next' | 'back' | 'skip' | 'finish';
+export type OnboardingProviderKind =
+  | 'vendor-api'
+  | 'coding-plan'
+  | 'gateway'
+  | 'self-hosted';
+export type OnboardingProviderIdentity = {
+  provider_key: string;
+  provider_type: ProviderInstanceTypeId;
+  provider_kind: OnboardingProviderKind;
+  plan_id?: CodingPlanId;
+};
+export type OnboardingAuthMethod = 'stagewise' | 'api-keys' | 'coding-plan';
+export type OnboardingAuthFailureKind =
+  | 'validation-error'
+  | 'backend-error'
+  | 'network-error'
+  | 'unknown-error';
+export type OnboardingOtpFailureKind =
+  | 'backend-error'
+  | 'network-error'
+  | 'turnstile-not-ready'
+  | 'turnstile-solve-failed';
+export type AuthHandoffProvider = SocialAuthProvider | 'email';
+
+export type UIEventProperties = {
+  'account-page-viewed': undefined;
+  'chat-new-agent-clicked': {
+    source:
+      | 'sidebar-top'
+      | 'sidebar-active-agents'
+      | 'sidebar-workspace-group'
+      | 'collapsed-titlebar'
+      | 'hotkey';
+  };
+  'chat-sidebar-toggled': { new_value: 'open' | 'closed' };
+  'closed-lid-sleep-toggled': { enabled: boolean };
+  'custom-model-add-aborted': {
+    had_validation_errors: boolean;
+    any_field_touched: boolean;
+  };
+  'custom-model-add-finished': undefined;
+  'custom-model-add-started': undefined;
+  'custom-provider-add-aborted':
+    | {
+        had_validation_errors: boolean;
+        any_field_touched: boolean;
+        api_spec: string;
+        is_local?: boolean;
+        base_url?: string;
+        aws_auth_mode?: 'access-keys' | 'profile' | 'default-chain';
+      }
+    | undefined;
+  'custom-provider-add-finished': {
+    api_spec: string;
+    is_local?: boolean;
+    base_url?: string;
+    aws_auth_mode?: 'access-keys' | 'profile' | 'default-chain';
+  };
+  'custom-provider-add-started': undefined;
+  'element-selection-started': undefined;
+  'element-selection-stopped': { element_selected: boolean };
+  'onboarding-started': {
+    onboarding_run_id: string;
+    already_authenticated: boolean;
+    connected_provider_count: number;
+  };
+  'onboarding-step-viewed': {
+    onboarding_run_id: string;
+    step: OnboardingStep;
+    previous_step?: OnboardingStep;
+    visit_index: number;
+    elapsed_ms_since_start: number;
+  };
+  'onboarding-step-exited': {
+    onboarding_run_id: string;
+    step: OnboardingStep;
+    destination: OnboardingStep | 'completed';
+    action: OnboardingNavigationAction;
+    duration_ms: number;
+  };
+  'onboarding-auth-skipped': { onboarding_run_id: string };
+  'onboarding-provider-detail-viewed': OnboardingProviderIdentity & {
+    onboarding_run_id: string;
+    position: number;
+    search_active: boolean;
+    already_connected: boolean;
+  };
+  'onboarding-provider-connect-attempted': OnboardingProviderIdentity & {
+    onboarding_run_id: string;
+    attempt_number: number;
+  };
+  'onboarding-provider-connected': OnboardingProviderIdentity & {
+    onboarding_run_id: string;
+    attempt_number: number;
+    duration_ms: number;
+    discovered_model_count: number;
+  };
+  'onboarding-provider-connect-failed': OnboardingProviderIdentity & {
+    onboarding_run_id: string;
+    attempt_number: number;
+    duration_ms: number;
+    failure_stage: 'credential-validation' | 'rpc';
+    error_kind: 'validation-error' | 'network-error' | 'unknown-error';
+  };
+  'onboarding-provider-step-completed': {
+    onboarding_run_id: string;
+    duration_ms: number;
+    connected_provider_count: number;
+    connected_during_step_count: number;
+    connected_provider_keys: string[];
+    viewed_provider_count: number;
+    connection_attempt_count: number;
+    connection_failure_count: number;
+    search_used: boolean;
+    skipped_without_provider: boolean;
+  };
+  'onboarding-auth-api-key-input-focused': { provider: ModelProvider };
+  'onboarding-auth-coding-plan-opened': {
+    plan_id: CodingPlanId;
+    provider: ModelProvider;
+  };
+  'onboarding-auth-method-completed': {
+    auth_method: OnboardingAuthMethod;
+    provider?: ModelProvider;
+    plan_id?: CodingPlanId;
+  };
+  'onboarding-auth-method-failed': {
+    auth_method: OnboardingAuthMethod;
+    provider?: ModelProvider | AuthHandoffProvider;
+    plan_id?: CodingPlanId;
+    error_kind: OnboardingAuthFailureKind;
+  };
+  'onboarding-auth-mode-switched': {
+    from: OnboardingAuthMethod;
+    to: OnboardingAuthMethod;
+  };
+  'onboarding-auth-social-requested': { provider: SocialAuthProvider };
+  'onboarding-auth-social-verified': { provider: SocialAuthProvider };
+  'onboarding-auth-email-handoff-requested': undefined;
+  'onboarding-auth-email-handoff-verified': undefined;
+  'onboarding-auth-otp-failed': { error_kind: OnboardingOtpFailureKind };
+  'onboarding-auth-otp-requested': undefined;
+  'onboarding-auth-otp-verified': undefined;
+  'onboarding-auth-provider-disconnected': {
+    auth_method: 'api-keys' | 'coding-plan';
+    provider: ModelProvider;
+    plan_id?: CodingPlanId;
+  };
+  'onboarding-auth-providers-expanded': { expanded: boolean };
+  'account-auth-social-requested': { provider: SocialAuthProvider };
+  'account-auth-social-verified': { provider: SocialAuthProvider };
+  'account-auth-email-handoff-requested': undefined;
+  'account-auth-email-handoff-verified': undefined;
+  'account-auth-otp-failed': { error_kind: OnboardingOtpFailureKind };
+  'account-auth-otp-requested': undefined;
+  'account-auth-otp-verified': undefined;
+  'account-auth-method-failed': {
+    auth_method: 'stagewise';
+    provider?: AuthHandoffProvider;
+    error_kind: OnboardingAuthFailureKind;
+  };
+  'chat-auth-social-requested': { provider: SocialAuthProvider };
+  'chat-auth-social-verified': { provider: SocialAuthProvider };
+  'chat-auth-email-handoff-requested': undefined;
+  'chat-auth-email-handoff-verified': undefined;
+  'chat-auth-otp-failed': { error_kind: OnboardingOtpFailureKind };
+  'chat-auth-otp-requested': undefined;
+  'chat-auth-otp-verified': undefined;
+  'chat-auth-method-failed': {
+    auth_method: 'stagewise';
+    provider?: AuthHandoffProvider;
+    error_kind: OnboardingAuthFailureKind;
+  };
+  'onboarding-demo-slide-clicked': { slide_name: string };
+  'settings-opened': undefined;
+  'suggestion-clicked': {
+    suggestion_id: string;
+    context: 'onboarding' | 'empty-chat';
+  };
+  'suggestion-dismissed': {
+    suggestion_id: string;
+    context: 'onboarding' | 'empty-chat';
+  };
+  'tabs-cleaned': { closed_count: number };
+  'workspace-connect-aborted': {
+    reason: 'picker-closed' | 'suggestions-dismissed';
+  };
+  'workspace-connect-failed': { source: 'picker' | 'recent-workspace' };
+  'workspace-connect-finished': undefined;
+  'workspace-connect-started': undefined;
+  'changed-theme': { theme: PersonalizationThemeId };
+  'changed-notification-sound-loudness': {
+    loudness: 'default' | 'off' | 'subtle';
+  };
+  'changed-notification-sound-theme': { theme: string };
+  'experience-survey-answered': { answer: 'yes' | 'no' };
+  'experience-survey-feedback-submitted': {
+    feedback: string;
+    feedback_length: number;
+  };
+  'experience-founder-call-survey-opened': undefined;
+  'experience-founder-call-survey-dismissed': undefined;
+};
+
+export type UIEventName = keyof UIEventProperties;
+export type TrackUIEvent = <T extends string>(
+  eventName: T,
+  ...args: T extends UIEventName
+    ? undefined extends UIEventProperties[T]
+      ? [properties?: UIEventProperties[T]]
+      : [properties: UIEventProperties[T]]
+    : [properties?: Record<string, unknown>]
+) => Promise<void>;

--- a/apps/browser/src/ui/components/auth/sign-in-options-panel.tsx
+++ b/apps/browser/src/ui/components/auth/sign-in-options-panel.tsx
@@ -9,15 +9,13 @@ import { IconEnvelopeOutline18, IconKey2Outline18 } from '@stagewise/icons';
 import { Loader2Icon } from 'lucide-react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { cn } from '@stagewise/stage-ui/lib/utils';
+import type { TrackUIEvent } from '@shared/karton-contracts/ui';
 import type { SocialAuthProvider } from '@shared/karton-contracts/ui/shared-types';
 export type SignInMethod = SocialAuthProvider | 'email';
 
 type AuthPhase = 'options' | 'email' | 'otp' | 'social';
 type TrackingPrefix = 'onboarding-auth' | 'account-auth' | 'chat-auth';
-type TrackEvent = (
-  eventName: string,
-  properties?: Record<string, unknown>,
-) => void | Promise<void>;
+type TrackEvent = TrackUIEvent;
 
 // This component is shared by both Electron renderer hosts: the main UI
 // preload exposes `window.electron`, while internal pages expose

--- a/apps/browser/src/ui/hooks/personalization-change-handlers.test.tsx
+++ b/apps/browser/src/ui/hooks/personalization-change-handlers.test.tsx
@@ -1,0 +1,187 @@
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  state: {
+    globalConfig: {
+      personalizationThemeId: 'default',
+      notificationSoundLoudness: 'subtle',
+      notificationSoundPack: 'bubble-pops',
+    },
+    notificationSoundPacks: {
+      available: ['bubble-pops', 'chimes'],
+      displayNames: {},
+    },
+  },
+  setGlobalConfig: vi.fn(),
+  previewSoundPack: vi.fn(),
+  track: vi.fn(),
+}));
+
+vi.mock('@ui/hooks/use-karton', () => ({
+  useKartonState: (selector: (state: typeof mocks.state) => unknown) =>
+    selector(mocks.state),
+  useKartonProcedure: (selector: (procedures: unknown) => unknown) =>
+    selector({
+      config: {
+        set: mocks.setGlobalConfig,
+        previewSoundPack: mocks.previewSoundPack,
+      },
+    }),
+}));
+vi.mock('@ui/hooks/use-track', () => ({ useTrack: () => mocks.track }));
+
+import { useSoundSettings } from './use-sound-settings';
+import { useThemeSelection } from './use-theme-selection';
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+describe('personalization change handlers', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    mocks.setGlobalConfig.mockReset().mockResolvedValue(undefined);
+    mocks.previewSoundPack.mockReset().mockResolvedValue(undefined);
+    mocks.track.mockReset().mockResolvedValue(undefined);
+  });
+
+  it('reports only distinct successfully persisted theme changes', async () => {
+    const { result } = renderHook(() => useThemeSelection());
+
+    await expect(result.current.handleThemeChange('default')).resolves.toBe(
+      false,
+    );
+    expect(mocks.setGlobalConfig).not.toHaveBeenCalled();
+
+    let changed = false;
+    await act(async () => {
+      changed = await result.current.handleThemeChange('fire');
+    });
+    expect(changed).toBe(true);
+    expect(mocks.setGlobalConfig).toHaveBeenCalledWith({
+      personalizationThemeId: 'fire',
+    });
+
+    mocks.setGlobalConfig.mockRejectedValueOnce(new Error('save failed'));
+    await act(async () => {
+      changed = await result.current.handleThemeChange('forest');
+    });
+    expect(changed).toBe(false);
+
+    mocks.track.mockRejectedValueOnce(new Error('tracking failed'));
+    await act(async () => {
+      changed = await result.current.handleThemeChange('forest');
+    });
+    expect(changed).toBe(true);
+  });
+
+  it('serializes theme saves and reports only the latest request', async () => {
+    const firstSave = deferred();
+    mocks.setGlobalConfig
+      .mockImplementationOnce(() => firstSave.promise)
+      .mockResolvedValueOnce(undefined);
+    const { result } = renderHook(() => useThemeSelection());
+
+    let firstResult!: boolean;
+    let secondResult!: boolean;
+    await act(async () => {
+      const first = result.current
+        .handleThemeChange('fire')
+        .then((value) => (firstResult = value));
+      const second = result.current
+        .handleThemeChange('forest')
+        .then((value) => (secondResult = value));
+
+      await vi.waitFor(() =>
+        expect(mocks.setGlobalConfig).toHaveBeenCalledTimes(1),
+      );
+      firstSave.resolve();
+      await Promise.all([first, second]);
+    });
+
+    expect(mocks.setGlobalConfig.mock.calls).toEqual([
+      [{ personalizationThemeId: 'fire' }],
+      [{ personalizationThemeId: 'forest' }],
+    ]);
+    expect(firstResult).toBe(false);
+    expect(secondResult).toBe(true);
+    expect(mocks.track).toHaveBeenCalledOnce();
+    expect(mocks.track).toHaveBeenCalledWith('changed-theme', {
+      theme: 'forest',
+    });
+  });
+
+  it('reports only distinct successfully persisted sound changes', async () => {
+    const { result } = renderHook(() => useSoundSettings());
+
+    await expect(result.current.handleLoudnessChange(1)).resolves.toBe(false);
+    await expect(
+      result.current.handleSoundPackChange('bubble-pops'),
+    ).resolves.toBe(false);
+    expect(mocks.setGlobalConfig).not.toHaveBeenCalled();
+
+    await expect(result.current.handleLoudnessChange(2)).resolves.toBe(true);
+    await expect(result.current.handleSoundPackChange('chimes')).resolves.toBe(
+      true,
+    );
+
+    mocks.setGlobalConfig.mockRejectedValueOnce(new Error('save failed'));
+    await act(async () => {
+      await expect(result.current.handleLoudnessChange(0)).resolves.toBe(false);
+    });
+
+    mocks.track.mockRejectedValueOnce(new Error('tracking failed'));
+    await act(async () => {
+      await expect(result.current.handleLoudnessChange(0)).resolves.toBe(true);
+    });
+
+    mocks.track.mockRejectedValueOnce(new Error('tracking failed'));
+    await act(async () => {
+      await expect(
+        result.current.handleSoundPackChange('chimes'),
+      ).resolves.toBe(true);
+    });
+  });
+
+  it('serializes sound saves and reports only the latest field request', async () => {
+    const firstSave = deferred();
+    mocks.setGlobalConfig
+      .mockImplementationOnce(() => firstSave.promise)
+      .mockResolvedValueOnce(undefined);
+    const { result } = renderHook(() => useSoundSettings());
+
+    let firstResult!: boolean;
+    let secondResult!: boolean;
+    await act(async () => {
+      const first = result.current
+        .handleLoudnessChange(2)
+        .then((value) => (firstResult = value));
+      const second = result.current
+        .handleLoudnessChange(0)
+        .then((value) => (secondResult = value));
+
+      await vi.waitFor(() =>
+        expect(mocks.setGlobalConfig).toHaveBeenCalledTimes(1),
+      );
+      firstSave.resolve();
+      await Promise.all([first, second]);
+    });
+
+    expect(mocks.setGlobalConfig.mock.calls).toEqual([
+      [{ notificationSoundLoudness: 'default' }],
+      [{ notificationSoundLoudness: 'off' }],
+    ]);
+    expect(firstResult).toBe(false);
+    expect(secondResult).toBe(true);
+    expect(mocks.track).toHaveBeenCalledOnce();
+    expect(mocks.track).toHaveBeenCalledWith(
+      'changed-notification-sound-loudness',
+      { loudness: 'off' },
+    );
+  });
+});

--- a/apps/browser/src/ui/hooks/use-sound-settings.ts
+++ b/apps/browser/src/ui/hooks/use-sound-settings.ts
@@ -1,3 +1,4 @@
+import { useRef } from 'react';
 import { useKartonState, useKartonProcedure } from '@ui/hooks/use-karton';
 import { useTrack } from '@ui/hooks/use-track';
 
@@ -27,6 +28,9 @@ export function useSoundSettings() {
   const setGlobalConfig = useKartonProcedure((p) => p.config.set);
   const previewSoundPack = useKartonProcedure((p) => p.config.previewSoundPack);
   const track = useTrack();
+  const saveQueueRef = useRef<Promise<void>>(Promise.resolve());
+  const latestLoudnessRequestIdRef = useRef(0);
+  const latestSoundPackRequestIdRef = useRef(0);
 
   const soundLoudness: SoundLoudness =
     globalConfig.notificationSoundLoudness ?? 'subtle';
@@ -66,34 +70,68 @@ export function useSoundSettings() {
     );
     const notificationSoundLoudness =
       NOTIFICATION_LOUDNESS_OPTIONS[index]?.value ?? 'subtle';
+    if (notificationSoundLoudness === soundLoudness) return false;
 
     previewSound(currentPack, notificationSoundLoudness);
+    const requestId = latestLoudnessRequestIdRef.current + 1;
+    latestLoudnessRequestIdRef.current = requestId;
+    const save = saveQueueRef.current.then(() =>
+      setGlobalConfig({
+        notificationSoundLoudness,
+      }),
+    );
+    saveQueueRef.current = save.catch(() => {});
 
     try {
-      await setGlobalConfig({
-        notificationSoundLoudness,
-      });
-      track('changed-notification-sound-loudness', {
-        loudness: notificationSoundLoudness,
-      });
+      await save;
     } catch (error) {
       console.error('Failed to save sound loudness', error);
+      return false;
     }
+
+    if (latestLoudnessRequestIdRef.current !== requestId) return false;
+
+    void track('changed-notification-sound-loudness', {
+      loudness: notificationSoundLoudness,
+    }).catch((error) => {
+      console.error('Failed to track sound loudness change', error);
+    });
+    return true;
   };
 
   const handleSoundPackChange = async (value: unknown) => {
-    if (typeof value !== 'string' || !packOptions.includes(value)) return;
+    if (
+      typeof value !== 'string' ||
+      !packOptions.includes(value) ||
+      value === currentPack
+    ) {
+      return false;
+    }
     previewSound(value, soundLoudness);
-    try {
-      await setGlobalConfig({
+    const requestId = latestSoundPackRequestIdRef.current + 1;
+    latestSoundPackRequestIdRef.current = requestId;
+    const save = saveQueueRef.current.then(() =>
+      setGlobalConfig({
         notificationSoundPack: value,
-      });
-      track('changed-notification-sound-theme', {
-        theme: value === DEFAULT_SOUND_PACK ? value : 'custom',
-      });
+      }),
+    );
+    saveQueueRef.current = save.catch(() => {});
+
+    try {
+      await save;
     } catch (error) {
       console.error('Failed to save sound pack', error);
+      return false;
     }
+
+    if (latestSoundPackRequestIdRef.current !== requestId) return false;
+
+    void track('changed-notification-sound-theme', {
+      theme: value === DEFAULT_SOUND_PACK ? value : 'custom',
+    }).catch((error) => {
+      console.error('Failed to track sound pack change', error);
+    });
+    return true;
   };
 
   return {

--- a/apps/browser/src/ui/hooks/use-theme-selection.ts
+++ b/apps/browser/src/ui/hooks/use-theme-selection.ts
@@ -17,6 +17,7 @@ export function useThemeSelection() {
   const setGlobalConfig = useKartonProcedure((p) => p.config.set);
   const track = useTrack();
   const latestSaveRequestIdRef = useRef(0);
+  const saveQueueRef = useRef<Promise<void>>(Promise.resolve());
   const latestRequestedThemeIdRef = useRef<PersonalizationThemeId | undefined>(
     undefined,
   );
@@ -49,14 +50,14 @@ export function useThemeSelection() {
       typeof value !== 'string' ||
       !PERSONALIZATION_THEMES.some((theme) => theme.id === value)
     ) {
-      return;
+      return false;
     }
 
     const nextThemeId = value as PersonalizationThemeId;
     const previousThemeId = currentThemeIdRef.current;
 
     if (nextThemeId === previousThemeId) {
-      return;
+      return false;
     }
 
     const saveRequestId = latestSaveRequestIdRef.current + 1;
@@ -66,14 +67,18 @@ export function useThemeSelection() {
     setCurrentTheme(nextThemeId);
     applyPersonalizationThemeToRoot(nextThemeId, { transition: true });
 
-    try {
-      await setGlobalConfig({
+    const save = saveQueueRef.current.then(() =>
+      setGlobalConfig({
         personalizationThemeId: nextThemeId,
-      });
-      track('changed-theme', { theme: nextThemeId });
+      }),
+    );
+    saveQueueRef.current = save.catch(() => {});
+
+    try {
+      await save;
     } catch (error) {
       if (latestSaveRequestIdRef.current !== saveRequestId) {
-        return;
+        return false;
       }
 
       latestRequestedThemeIdRef.current = undefined;
@@ -81,7 +86,15 @@ export function useThemeSelection() {
       setCurrentTheme(groundTruth);
       applyPersonalizationThemeToRoot(groundTruth, { transition: true });
       console.error('Failed to save personalization theme', error);
+      return false;
     }
+
+    if (latestSaveRequestIdRef.current !== saveRequestId) return false;
+
+    void track('changed-theme', { theme: nextThemeId }).catch((error) => {
+      console.error('Failed to track personalization theme change', error);
+    });
+    return true;
   };
 
   return {

--- a/apps/browser/src/ui/hooks/use-track.ts
+++ b/apps/browser/src/ui/hooks/use-track.ts
@@ -1,5 +1,8 @@
+import type { TrackUIEvent } from '@shared/karton-contracts/ui';
 import { useKartonProcedure } from './use-karton';
 
-export function useTrack() {
-  return useKartonProcedure((p) => p.telemetry.capture);
+export function useTrack(): TrackUIEvent {
+  return useKartonProcedure(
+    (p) => p.telemetry.capture,
+  ) as unknown as TrackUIEvent;
 }

--- a/apps/browser/src/ui/screens/onboarding/index.test.tsx
+++ b/apps/browser/src/ui/screens/onboarding/index.test.tsx
@@ -1,0 +1,247 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  track: vi.fn(),
+  setHasSeenOnboardingFlow: vi.fn(),
+  state: {
+    userAccount: { status: 'unauthenticated' },
+    preferences: { providerInstances: [] as unknown[] },
+  },
+}));
+
+vi.mock('@ui/hooks/use-track', () => ({ useTrack: () => mocks.track }));
+vi.mock('@ui/hooks/use-karton', () => ({
+  useKartonState: vi.fn((selector) => selector(mocks.state)),
+  useKartonProcedure: vi.fn((selector) =>
+    selector({
+      userExperience: {
+        setHasSeenOnboardingFlow: mocks.setHasSeenOnboardingFlow,
+      },
+    }),
+  ),
+}));
+vi.mock('./steps/01-login', () => ({
+  StepLogin: ({ onSkip, onAuthenticated }: any) => (
+    <div>
+      <button type="button" onClick={onSkip}>
+        Skip login
+      </button>
+      <button
+        type="button"
+        onClick={() => onAuthenticated({ auth_method: 'stagewise' })}
+      >
+        Authenticate
+      </button>
+    </div>
+  ),
+}));
+vi.mock('./steps/06-configure-providers', () => ({
+  StepConfigureProviders: ({ onNext, onBack, onSummary }: any) => (
+    <div>
+      <button type="button" onClick={onBack}>
+        Provider back
+      </button>
+      <button
+        type="button"
+        onClick={() => {
+          onSummary({
+            connected_provider_count: 1,
+            connected_provider_keys: ['openai-api'],
+            provider_step_skipped: false,
+          });
+          onNext();
+        }}
+      >
+        Provider next
+      </button>
+      <button
+        type="button"
+        onClick={() => {
+          onSummary({
+            connected_provider_count: 1,
+            connected_provider_keys: ['openai-api'],
+            provider_step_skipped: true,
+          });
+          onNext();
+        }}
+      >
+        Provider next skipped
+      </button>
+    </div>
+  ),
+}));
+vi.mock('./steps/07-theme', () => ({
+  StepTheme: ({ onNext, onBack, onPersonalizationChanged }: any) => (
+    <div>
+      <button type="button" onClick={onBack}>
+        Theme back
+      </button>
+      <button type="button" onClick={onPersonalizationChanged}>
+        Change theme
+      </button>
+      <button type="button" onClick={onNext}>
+        Finish
+      </button>
+    </div>
+  ),
+}));
+
+import { OnboardingWizard } from './index';
+
+function callsFor(eventName: string) {
+  return mocks.track.mock.calls.filter(([name]) => name === eventName);
+}
+
+describe('OnboardingWizard telemetry', () => {
+  beforeEach(() => {
+    mocks.track.mockReset();
+    mocks.track.mockResolvedValue(undefined);
+    mocks.setHasSeenOnboardingFlow.mockReset();
+    mocks.state.userAccount.status = 'unauthenticated';
+    mocks.state.preferences.providerInstances = [];
+    vi.spyOn(globalThis.crypto, 'randomUUID').mockReturnValue(
+      '00000000-0000-4000-8000-000000000001',
+    );
+  });
+
+  it('emits one view per logical navigation and classifies skip/back', async () => {
+    render(<OnboardingWizard />);
+
+    await waitFor(() => expect(callsFor('onboarding-started')).toHaveLength(1));
+    expect(callsFor('onboarding-step-viewed')).toHaveLength(1);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Skip login' }));
+    await screen.findByRole('button', { name: 'Provider back' });
+    fireEvent.click(screen.getByRole('button', { name: 'Provider back' }));
+    await screen.findByRole('button', { name: 'Skip login' });
+
+    await waitFor(() =>
+      expect(callsFor('onboarding-step-viewed')).toHaveLength(3),
+    );
+    expect(callsFor('onboarding-started')).toHaveLength(1);
+    expect(callsFor('onboarding-step-exited')).toEqual([
+      [
+        'onboarding-step-exited',
+        expect.objectContaining({
+          step: 'login',
+          destination: 'configure-providers',
+          action: 'skip',
+        }),
+      ],
+      [
+        'onboarding-step-exited',
+        expect.objectContaining({
+          step: 'configure-providers',
+          destination: 'login',
+          action: 'back',
+        }),
+      ],
+    ]);
+  });
+
+  it('keeps onboarding-started as one immutable start snapshot', async () => {
+    const { rerender } = render(<OnboardingWizard />);
+
+    await waitFor(() => expect(callsFor('onboarding-started')).toHaveLength(1));
+    const initialCall = callsFor('onboarding-started')[0];
+
+    mocks.state.userAccount.status = 'authenticated';
+    mocks.state.preferences.providerInstances = [
+      { id: 'provider-1', typeId: 'openai-api', config: {} },
+    ];
+    rerender(<OnboardingWizard />);
+
+    expect(callsFor('onboarding-started')).toEqual([initialCall]);
+    expect(initialCall).toEqual([
+      'onboarding-started',
+      expect.objectContaining({
+        already_authenticated: false,
+        connected_provider_count: 0,
+      }),
+    ]);
+  });
+
+  it('passes the final aggregate summary to durable completion', async () => {
+    render(<OnboardingWizard />);
+    await screen.findByRole('button', { name: 'Authenticate' });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Authenticate' }));
+    await screen.findByRole('button', { name: 'Provider next' });
+    fireEvent.click(screen.getByRole('button', { name: 'Provider next' }));
+    await screen.findByRole('button', { name: 'Change theme' });
+    fireEvent.click(screen.getByRole('button', { name: 'Change theme' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Finish' }));
+
+    expect(mocks.setHasSeenOnboardingFlow).toHaveBeenCalledOnce();
+    expect(mocks.setHasSeenOnboardingFlow).toHaveBeenCalledWith({
+      value: true,
+      auth: { auth_method: 'stagewise' },
+      summary: expect.objectContaining({
+        onboarding_run_id: '00000000-0000-4000-8000-000000000001',
+        connected_provider_keys: ['openai-api'],
+        connected_provider_count: 1,
+        provider_step_skipped: false,
+        personalization_changed: true,
+      }),
+    });
+    expect(callsFor('onboarding-step-exited').at(-1)).toEqual([
+      'onboarding-step-exited',
+      expect.objectContaining({
+        step: 'personalization',
+        destination: 'completed',
+        action: 'finish',
+      }),
+    ]);
+  });
+
+  it('preserves a provider connection across repeated step visits', async () => {
+    render(<OnboardingWizard />);
+
+    fireEvent.click(
+      await screen.findByRole('button', { name: 'Authenticate' }),
+    );
+    fireEvent.click(
+      await screen.findByRole('button', { name: 'Provider next' }),
+    );
+    fireEvent.click(await screen.findByRole('button', { name: 'Theme back' }));
+    fireEvent.click(
+      await screen.findByRole('button', { name: 'Provider next skipped' }),
+    );
+    fireEvent.click(await screen.findByRole('button', { name: 'Finish' }));
+
+    expect(mocks.setHasSeenOnboardingFlow).toHaveBeenCalledWith(
+      expect.objectContaining({
+        summary: expect.objectContaining({
+          connected_provider_count: 1,
+          connected_provider_keys: ['openai-api'],
+          provider_step_skipped: false,
+        }),
+      }),
+    );
+  });
+
+  it('preserves run-local skip attribution with existing providers', async () => {
+    mocks.state.preferences.providerInstances = [
+      { id: 'existing', typeId: 'openai-api', config: {} },
+    ];
+    render(<OnboardingWizard />);
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Skip login' }));
+    await screen.findByRole('button', { name: 'Provider next skipped' });
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Provider next skipped' }),
+    );
+    fireEvent.click(await screen.findByRole('button', { name: 'Finish' }));
+
+    expect(mocks.setHasSeenOnboardingFlow).toHaveBeenCalledWith(
+      expect.objectContaining({
+        summary: expect.objectContaining({
+          connected_provider_count: 1,
+          connected_provider_keys: ['openai-api'],
+          provider_step_skipped: true,
+        }),
+      }),
+    );
+  });
+});

--- a/apps/browser/src/ui/screens/onboarding/index.tsx
+++ b/apps/browser/src/ui/screens/onboarding/index.tsx
@@ -1,4 +1,10 @@
-import { useState, useCallback, type ReactNode } from 'react';
+import {
+  useState,
+  useCallback,
+  useEffect,
+  useRef,
+  type ReactNode,
+} from 'react';
 import { Button } from '@stagewise/stage-ui/components/button';
 import {
   Tooltip,
@@ -6,37 +12,114 @@ import {
   TooltipContent,
 } from '@stagewise/stage-ui/components/tooltip';
 import { IconArrowLeftFill18, IconArrowRightFill18 } from '@stagewise/icons';
-import { useKartonProcedure } from '@ui/hooks/use-karton';
+import { useKartonProcedure, useKartonState } from '@ui/hooks/use-karton';
+import { useTrack } from '@ui/hooks/use-track';
 import { cn } from '@ui/utils';
 import { StepLogin } from './steps/01-login';
 import type { OnboardingAuthCompletion } from './steps/01-login';
-import { StepConfigureProviders } from './steps/06-configure-providers';
+import {
+  StepConfigureProviders,
+  type ProviderStepSummary,
+} from './steps/06-configure-providers';
 import { StepTheme } from './steps/07-theme';
 
-type ScreenId = 'login' | 'configure-providers' | 'theme';
+type ScreenId = 'login' | 'configure-providers' | 'personalization';
+type NavigationAction = 'next' | 'back' | 'skip' | 'finish';
 
 export function OnboardingWizard() {
   const [screen, setScreen] = useState<ScreenId>('login');
-  const [prevScreen, setPrevScreen] = useState<ScreenId>('configure-providers');
+  const [onboardingRunId] = useState(() => crypto.randomUUID());
   const [authCompletion, setAuthCompletion] =
     useState<OnboardingAuthCompletion | null>(null);
+  const providerSummaryRef = useRef<ProviderStepSummary | null>(null);
+  const personalizationChangedRef = useRef(false);
+  const track = useTrack();
+  const authStatus = useKartonState((s) => s.userAccount.status);
+  const connectedProviderCount = useKartonState(
+    (s) => s.preferences.providerInstances?.length ?? 0,
+  );
+  const runStartedAtRef = useRef(performance.now());
+  const stepEnteredAtRef = useRef(runStartedAtRef.current);
+  const currentStepRef = useRef<ScreenId>('login');
+  const previousStepRef = useRef<ScreenId | undefined>(undefined);
+  const visitCountsRef = useRef<Record<ScreenId, number>>({
+    login: 0,
+    'configure-providers': 0,
+    personalization: 0,
+  });
+  const startedTrackedRef = useRef(false);
+  const lastViewedStepRef = useRef<ScreenId | null>(null);
   const setHasSeenOnboardingFlow = useKartonProcedure(
     (p) => p.userExperience.setHasSeenOnboardingFlow,
   );
 
-  const navigate = useCallback((next: ScreenId) => {
-    setScreen((current) => {
-      setPrevScreen(current);
-      return next;
+  useEffect(() => {
+    if (!startedTrackedRef.current) {
+      startedTrackedRef.current = true;
+      void track('onboarding-started', {
+        onboarding_run_id: onboardingRunId,
+        already_authenticated:
+          authStatus === 'authenticated' || authStatus === 'server_unreachable',
+        connected_provider_count: connectedProviderCount,
+      });
+    }
+
+    if (lastViewedStepRef.current === screen) return;
+
+    const now = performance.now();
+    visitCountsRef.current[screen] += 1;
+    stepEnteredAtRef.current = now;
+    currentStepRef.current = screen;
+    lastViewedStepRef.current = screen;
+    void track('onboarding-step-viewed', {
+      onboarding_run_id: onboardingRunId,
+      step: screen,
+      previous_step: previousStepRef.current,
+      visit_index: visitCountsRef.current[screen],
+      elapsed_ms_since_start: now - runStartedAtRef.current,
     });
-  }, []);
+  }, [authStatus, connectedProviderCount, onboardingRunId, screen, track]);
+
+  const navigate = useCallback(
+    (next: ScreenId, action: NavigationAction) => {
+      const current = currentStepRef.current;
+      void track('onboarding-step-exited', {
+        onboarding_run_id: onboardingRunId,
+        step: current,
+        destination: next,
+        action,
+        duration_ms: performance.now() - stepEnteredAtRef.current,
+      });
+      previousStepRef.current = current;
+      setScreen(next);
+    },
+    [onboardingRunId, track],
+  );
 
   const complete = useCallback(() => {
+    const current = currentStepRef.current;
+    void track('onboarding-step-exited', {
+      onboarding_run_id: onboardingRunId,
+      step: current,
+      destination: 'completed',
+      action: 'finish',
+      duration_ms: performance.now() - stepEnteredAtRef.current,
+    });
+    const providerSummary = providerSummaryRef.current;
     setHasSeenOnboardingFlow({
       value: true,
       auth: authCompletion ?? { auth_method: 'unknown' },
+      summary: {
+        onboarding_run_id: onboardingRunId,
+        total_duration_ms: performance.now() - runStartedAtRef.current,
+        connected_provider_keys: providerSummary?.connected_provider_keys ?? [],
+        connected_provider_count:
+          providerSummary?.connected_provider_count ?? 0,
+        provider_step_skipped: providerSummary?.provider_step_skipped ?? true,
+        personalization_changed: personalizationChangedRef.current,
+      },
     });
-  }, [authCompletion, setHasSeenOnboardingFlow]);
+  }, [authCompletion, onboardingRunId, setHasSeenOnboardingFlow, track]);
 
   return (
     <div
@@ -51,21 +134,38 @@ export function OnboardingWizard() {
       <div className="flex flex-1 flex-col overflow-hidden">
         {screen === 'login' && (
           <StepLogin
-            onSkip={() => navigate('configure-providers')}
+            onboardingRunId={onboardingRunId}
+            onSkip={() => navigate('configure-providers', 'skip')}
             onAuthenticated={(completion) => {
               setAuthCompletion(completion);
-              navigate('configure-providers');
+              navigate('configure-providers', 'next');
             }}
           />
         )}
         {screen === 'configure-providers' && (
           <StepConfigureProviders
-            onNext={() => navigate('theme')}
-            onBack={() => navigate('login')}
+            onboardingRunId={onboardingRunId}
+            onSummary={(summary) => {
+              const previousSummary = providerSummaryRef.current;
+              providerSummaryRef.current = {
+                ...summary,
+                provider_step_skipped:
+                  (previousSummary?.provider_step_skipped ?? true) &&
+                  summary.provider_step_skipped,
+              };
+            }}
+            onNext={() => navigate('personalization', 'next')}
+            onBack={() => navigate('login', 'back')}
           />
         )}
-        {screen === 'theme' && (
-          <StepTheme onNext={complete} onBack={() => navigate(prevScreen)} />
+        {screen === 'personalization' && (
+          <StepTheme
+            onNext={complete}
+            onBack={() => navigate('configure-providers', 'back')}
+            onPersonalizationChanged={() => {
+              personalizationChangedRef.current = true;
+            }}
+          />
         )}
       </div>
     </div>

--- a/apps/browser/src/ui/screens/onboarding/steps/01-login.tsx
+++ b/apps/browser/src/ui/screens/onboarding/steps/01-login.tsx
@@ -14,7 +14,7 @@ import { OnboardingBottomNav } from '../index';
 import type { TelemetryLevel } from '@shared/karton-contracts/ui/shared-types';
 
 export type OnboardingAuthCompletion = {
-  auth_method: 'stagewise' | 'api-keys' | 'coding-plan' | 'unknown';
+  auth_method: 'stagewise' | 'api-keys' | 'coding-plan';
   provider?: import('@shared/karton-contracts/ui/shared-types').ModelProvider;
   plan_id?: import('@shared/coding-plan-ids').CodingPlanId;
 };
@@ -22,8 +22,10 @@ export type OnboardingAuthCompletion = {
 export function StepLogin({
   onSkip,
   onAuthenticated,
+  onboardingRunId,
 }: {
   onSkip: () => void;
+  onboardingRunId: string;
   onAuthenticated: (completion: OnboardingAuthCompletion) => void;
 }) {
   const sendOtp = useKartonProcedure((p) => p.userAccount.sendOtp);
@@ -167,7 +169,12 @@ export function StepLogin({
           <Button
             variant="ghost"
             size="sm"
-            onClick={onSkip}
+            onClick={() => {
+              void track('onboarding-auth-skipped', {
+                onboarding_run_id: onboardingRunId,
+              });
+              onSkip();
+            }}
             className={cn('text-muted-foreground hover:text-foreground')}
           >
             Continue without account

--- a/apps/browser/src/ui/screens/onboarding/steps/06-configure-providers.test.tsx
+++ b/apps/browser/src/ui/screens/onboarding/steps/06-configure-providers.test.tsx
@@ -1,13 +1,64 @@
-import { fireEvent, render, screen } from '@testing-library/react';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ProviderInstance } from '@shared/karton-contracts/ui/shared-types';
+import type { ProviderEntry } from './06-configure-providers';
+
+const mocks = vi.hoisted(() => ({
+  addProviderInstance: vi.fn(),
+  openExternalUrl: vi.fn(),
+  track: vi.fn(),
+}));
 
 vi.mock('@ui/hooks/use-karton', () => ({
   useKartonState: vi.fn(),
-  useKartonProcedure: vi.fn(),
+  useKartonProcedure: vi.fn((selector) =>
+    selector({
+      preferences: { addProviderInstance: mocks.addProviderInstance },
+      openExternalUrl: mocks.openExternalUrl,
+    }),
+  ),
 }));
-vi.mock('@ui/hooks/use-track', () => ({ useTrack: vi.fn() }));
+vi.mock('@ui/hooks/use-track', () => ({ useTrack: () => mocks.track }));
 
-import { TruncatedErrorText } from './06-configure-providers';
+import {
+  ConnectionDetailView,
+  createProviderStepSummary,
+  summarizeProviderInstances,
+  TruncatedErrorText,
+} from './06-configure-providers';
+
+const ENTRY: ProviderEntry = {
+  key: 'openai-api',
+  displayName: 'OpenAI',
+  tagline: 'OpenAI API',
+  kind: 'vendor-api',
+  typeId: 'openai-api',
+};
+
+function renderConnectionView(
+  getNextAttemptNumber = vi.fn().mockReturnValue(1),
+  onConnectionResult = vi.fn(),
+) {
+  const onBack = vi.fn();
+  render(
+    <ConnectionDetailView
+      entry={ENTRY}
+      onBack={onBack}
+      onboardingRunId="run-1"
+      getNextAttemptNumber={getNextAttemptNumber}
+      onConnectionResult={onConnectionResult}
+    />,
+  );
+  return { getNextAttemptNumber, onConnectionResult, onBack };
+}
+
+async function connectWithSecret(secret = 'sk-sensitive') {
+  fireEvent.change(screen.getByPlaceholderText('Enter API key...'), {
+    target: { value: secret },
+  });
+  fireEvent.click(screen.getByRole('button', { name: 'Connect' }));
+  await waitFor(() => expect(mocks.addProviderInstance).toHaveBeenCalled());
+}
 
 describe('TruncatedErrorText', () => {
   afterEach(() => {
@@ -47,5 +98,202 @@ describe('TruncatedErrorText', () => {
     render(<TruncatedErrorText text="Connection failed" />);
 
     expect(screen.getByRole('button').getAttribute('tabindex')).toBe('-1');
+  });
+});
+
+describe('provider completion summary', () => {
+  it('counts custom, cloud, duplicate, and coding-plan instances safely', () => {
+    const instances = [
+      {
+        id: 'sensitive-custom-id',
+        typeId: 'custom-openai-chat',
+        name: 'Private endpoint',
+        config: {
+          baseUrl: 'https://sensitive.example.com',
+          encryptedApiKey: 'encrypted-secret',
+        },
+      },
+      {
+        id: 'sensitive-azure-id',
+        typeId: 'azure',
+        name: 'Private Azure',
+        config: {
+          resourceName: 'sensitive-resource',
+          deploymentName: 'sensitive-deployment',
+          encryptedApiKey: 'encrypted-secret',
+        },
+      },
+      {
+        id: 'first-openai-id',
+        typeId: 'openai-api',
+        name: 'First OpenAI',
+        config: { encryptedApiKey: 'encrypted-secret' },
+      },
+      {
+        id: 'second-openai-id',
+        typeId: 'openai-api',
+        name: 'Second OpenAI',
+        config: { encryptedApiKey: 'encrypted-secret' },
+      },
+      {
+        id: 'coding-plan-id',
+        typeId: 'coding-plan',
+        name: 'Sensitive plan label',
+        config: {
+          planId: 'claude-code',
+          encryptedApiKey: 'encrypted-secret',
+        },
+      },
+    ] as ProviderInstance[];
+
+    const summary = summarizeProviderInstances(instances);
+
+    expect(summary).toEqual({
+      connected_provider_count: 5,
+      connected_provider_keys: [
+        'custom-openai-chat',
+        'azure',
+        'openai-api',
+        'openai-api',
+        'plan:claude-code',
+      ],
+    });
+    const serialized = JSON.stringify(summary);
+    expect(serialized).not.toContain('sensitive');
+    expect(serialized).not.toContain('encrypted-secret');
+  });
+
+  it('reports an empty final provider configuration', () => {
+    expect(summarizeProviderInstances([])).toEqual({
+      connected_provider_count: 0,
+      connected_provider_keys: [],
+    });
+  });
+
+  it('classifies skip from run-local connections, not final providers', () => {
+    const existingProvider = {
+      id: 'existing-id',
+      typeId: 'openai-api',
+      name: 'Existing OpenAI',
+      config: { encryptedApiKey: 'encrypted-secret' },
+    } as ProviderInstance;
+
+    expect(createProviderStepSummary([existingProvider], 0)).toEqual({
+      connected_provider_count: 1,
+      connected_provider_keys: ['openai-api'],
+      provider_step_skipped: true,
+    });
+    expect(createProviderStepSummary([existingProvider], 1)).toEqual({
+      connected_provider_count: 1,
+      connected_provider_keys: ['openai-api'],
+      provider_step_skipped: false,
+    });
+  });
+});
+
+describe('ConnectionDetailView telemetry', () => {
+  beforeEach(() => {
+    mocks.addProviderInstance.mockReset();
+    mocks.openExternalUrl.mockReset();
+    mocks.track.mockReset();
+  });
+
+  it('tracks an attempt and successful result without leaking the secret', async () => {
+    mocks.addProviderInstance.mockResolvedValue({
+      success: true,
+      discoveredModels: [{ modelId: 'gpt-5' }, { modelId: 'gpt-5-mini' }],
+    });
+    const callbacks = renderConnectionView();
+
+    await connectWithSecret();
+
+    await waitFor(() => expect(callbacks.onBack).toHaveBeenCalledOnce());
+    expect(mocks.track).toHaveBeenCalledWith(
+      'onboarding-provider-connect-attempted',
+      expect.objectContaining({
+        onboarding_run_id: 'run-1',
+        provider_key: 'openai-api',
+        provider_type: 'openai-api',
+        provider_kind: 'vendor-api',
+        attempt_number: 1,
+      }),
+    );
+    expect(mocks.track).toHaveBeenCalledWith(
+      'onboarding-provider-connected',
+      expect.objectContaining({
+        attempt_number: 1,
+        discovered_model_count: 2,
+      }),
+    );
+    expect(callbacks.onConnectionResult).toHaveBeenCalledWith({
+      entry: ENTRY,
+      success: true,
+    });
+    expect(JSON.stringify(mocks.track.mock.calls)).not.toContain(
+      'sk-sensitive',
+    );
+  });
+
+  it('tracks structured validation failures and increments retries', async () => {
+    mocks.addProviderInstance
+      .mockResolvedValueOnce({ success: false, error: 'raw backend secret' })
+      .mockResolvedValueOnce({ success: true, discoveredModels: [] });
+    const nextAttempt = vi.fn().mockReturnValueOnce(1).mockReturnValueOnce(2);
+    const callbacks = renderConnectionView(nextAttempt);
+
+    await connectWithSecret();
+    await waitFor(() =>
+      expect(screen.getByText('raw backend secret')).toBeTruthy(),
+    );
+    fireEvent.change(screen.getByPlaceholderText('Enter API key...'), {
+      target: { value: 'sk-second-secret' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Connect' }));
+
+    await waitFor(() => expect(callbacks.onBack).toHaveBeenCalledOnce());
+    expect(mocks.track).toHaveBeenCalledWith(
+      'onboarding-provider-connect-failed',
+      expect.objectContaining({
+        attempt_number: 1,
+        failure_stage: 'credential-validation',
+        error_kind: 'validation-error',
+      }),
+    );
+    expect(mocks.track).toHaveBeenCalledWith(
+      'onboarding-provider-connected',
+      expect.objectContaining({ attempt_number: 2 }),
+    );
+    const serializedTelemetry = JSON.stringify(mocks.track.mock.calls);
+    expect(serializedTelemetry).not.toContain('raw backend secret');
+    expect(serializedTelemetry).not.toContain('sk-second-secret');
+  });
+
+  it('tracks RPC exceptions without leaking raw errors', async () => {
+    mocks.addProviderInstance.mockRejectedValue(
+      new Error('network failed with sensitive URL'),
+    );
+    const callbacks = renderConnectionView();
+
+    await connectWithSecret();
+
+    await waitFor(() =>
+      expect(
+        screen.getByText('Connection failed. Please try again.'),
+      ).toBeTruthy(),
+    );
+    expect(mocks.track).toHaveBeenCalledWith(
+      'onboarding-provider-connect-failed',
+      expect.objectContaining({
+        failure_stage: 'rpc',
+        error_kind: 'unknown-error',
+      }),
+    );
+    expect(callbacks.onConnectionResult).toHaveBeenCalledWith({
+      entry: ENTRY,
+      success: false,
+    });
+    expect(JSON.stringify(mocks.track.mock.calls)).not.toContain(
+      'network failed with sensitive URL',
+    );
   });
 });

--- a/apps/browser/src/ui/screens/onboarding/steps/06-configure-providers.tsx
+++ b/apps/browser/src/ui/screens/onboarding/steps/06-configure-providers.tsx
@@ -17,7 +17,14 @@ import {
   IconCheck2Outline18,
   IconArrowUpRightOutline18,
 } from '@stagewise/icons';
-import type { ProviderInstanceTypeId } from '@shared/karton-contracts/ui/shared-types';
+import type {
+  OnboardingProviderIdentity,
+  UIEventProperties,
+} from '@shared/karton-contracts/ui/telemetry';
+import type {
+  ProviderInstance,
+  ProviderInstanceTypeId,
+} from '@shared/karton-contracts/ui/shared-types';
 import { getTypeDisplayInfo } from '@shared/provider-instance-helpers';
 import { CODING_PLANS, type CodingPlanId } from '@shared/coding-plans';
 import { ProviderLogo } from '@ui/components/provider-logos';
@@ -30,7 +37,7 @@ const consoleUrl =
 
 // ─── Unified Provider Entries ──────────────────────────────────────────────
 
-type ProviderEntry = {
+export type ProviderEntry = {
   key: string;
   kind: 'vendor-api' | 'coding-plan' | 'gateway' | 'self-hosted';
   typeId: ProviderInstanceTypeId;
@@ -124,6 +131,59 @@ function buildUnifiedEntries(): ProviderEntry[] {
 }
 
 const UNIFIED_ENTRIES = buildUnifiedEntries();
+
+function getTelemetryIdentity(
+  entry: ProviderEntry,
+): OnboardingProviderIdentity {
+  return {
+    provider_key: entry.key,
+    provider_type: entry.kind === 'coding-plan' ? 'coding-plan' : entry.typeId,
+    provider_kind: entry.kind,
+    ...(entry.planId ? { plan_id: entry.planId } : {}),
+  };
+}
+
+export type ProviderStepSummary = Pick<
+  UIEventProperties['onboarding-provider-step-completed'],
+  'connected_provider_count' | 'connected_provider_keys'
+> & {
+  provider_step_skipped: boolean;
+};
+
+export function getProviderInstanceTelemetryKey(
+  instance: ProviderInstance,
+): string {
+  if (instance.typeId === 'coding-plan') {
+    const planId = instance.config.planId;
+    if (planId) return `plan:${planId}`;
+  }
+  return instance.typeId;
+}
+
+export function summarizeProviderInstances(
+  instances: ProviderInstance[],
+): Omit<ProviderStepSummary, 'provider_step_skipped'> {
+  const connectedProviderKeys = instances.map(getProviderInstanceTelemetryKey);
+  return {
+    connected_provider_count: connectedProviderKeys.length,
+    connected_provider_keys: connectedProviderKeys,
+  };
+}
+
+export function createProviderStepSummary(
+  instances: ProviderInstance[],
+  connectedDuringStepCount: number,
+): ProviderStepSummary {
+  return {
+    ...summarizeProviderInstances(instances),
+    provider_step_skipped: connectedDuringStepCount === 0,
+  };
+}
+
+type ProviderConnectionResult = {
+  entry: ProviderEntry;
+  success: boolean;
+};
 const VENDOR_ENTRIES = UNIFIED_ENTRIES.filter((e) => e.kind === 'vendor-api');
 const CODING_PLAN_ENTRIES = UNIFIED_ENTRIES.filter(
   (e) => e.kind === 'coding-plan',
@@ -320,12 +380,18 @@ function ProviderListCard({
 
 // ─── Connection Detail View ─────────────────────────────────────────────────
 
-function ConnectionDetailView({
+export function ConnectionDetailView({
   entry,
   onBack,
+  onboardingRunId,
+  getNextAttemptNumber,
+  onConnectionResult,
 }: {
   entry: ProviderEntry;
   onBack: () => void;
+  onboardingRunId: string;
+  getNextAttemptNumber: (entry: ProviderEntry) => number;
+  onConnectionResult: (result: ProviderConnectionResult) => void;
 }) {
   const addProviderInstance = useKartonProcedure(
     (p) => p.preferences.addProviderInstance,
@@ -343,7 +409,16 @@ function ConnectionDetailView({
     if (!apiKey.trim()) return;
     setIsConnecting(true);
     setError(null);
+    const attemptNumber = getNextAttemptNumber(entry);
+    const startedAt = performance.now();
+    const identity = getTelemetryIdentity(entry);
+    void track('onboarding-provider-connect-attempted', {
+      onboarding_run_id: onboardingRunId,
+      ...identity,
+      attempt_number: attemptNumber,
+    });
     try {
+      let discoveredModelCount = 0;
       if (entry.kind === 'vendor-api' || entry.kind === 'gateway') {
         const result = await addProviderInstance({
           typeId: entry.typeId,
@@ -353,11 +428,17 @@ function ConnectionDetailView({
         if (!result.success) {
           setError(result.error);
           void track('onboarding-provider-connect-failed', {
-            key: entry.key,
+            onboarding_run_id: onboardingRunId,
+            ...identity,
+            attempt_number: attemptNumber,
+            duration_ms: performance.now() - startedAt,
+            failure_stage: 'credential-validation',
             error_kind: 'validation-error',
           });
+          onConnectionResult({ entry, success: false });
           return;
         }
+        discoveredModelCount = result.discoveredModels.length;
       } else if (entry.kind === 'self-hosted') {
         const result = await addProviderInstance({
           typeId: entry.typeId,
@@ -366,11 +447,17 @@ function ConnectionDetailView({
         if (!result.success) {
           setError(result.error);
           void track('onboarding-provider-connect-failed', {
-            key: entry.key,
+            onboarding_run_id: onboardingRunId,
+            ...identity,
+            attempt_number: attemptNumber,
+            duration_ms: performance.now() - startedAt,
+            failure_stage: 'credential-validation',
             error_kind: 'validation-error',
           });
+          onConnectionResult({ entry, success: false });
           return;
         }
+        discoveredModelCount = result.discoveredModels.length;
       } else if (entry.planId) {
         const plan = CODING_PLANS[entry.planId];
         const result = await addProviderInstance({
@@ -381,24 +468,51 @@ function ConnectionDetailView({
         if (!result.success) {
           setError(result.error);
           void track('onboarding-provider-connect-failed', {
-            key: entry.key,
+            onboarding_run_id: onboardingRunId,
+            ...identity,
+            attempt_number: attemptNumber,
+            duration_ms: performance.now() - startedAt,
+            failure_stage: 'credential-validation',
             error_kind: 'validation-error',
           });
+          onConnectionResult({ entry, success: false });
           return;
         }
+        discoveredModelCount = result.discoveredModels.length;
       }
-      void track('onboarding-provider-connected', { key: entry.key });
+      void track('onboarding-provider-connected', {
+        onboarding_run_id: onboardingRunId,
+        ...identity,
+        attempt_number: attemptNumber,
+        duration_ms: performance.now() - startedAt,
+        discovered_model_count: discoveredModelCount,
+      });
+      onConnectionResult({ entry, success: true });
       onBack();
     } catch {
       setError('Connection failed. Please try again.');
       void track('onboarding-provider-connect-failed', {
-        key: entry.key,
-        error_kind: 'network-error',
+        onboarding_run_id: onboardingRunId,
+        ...identity,
+        attempt_number: attemptNumber,
+        duration_ms: performance.now() - startedAt,
+        failure_stage: 'rpc',
+        error_kind: 'unknown-error',
       });
+      onConnectionResult({ entry, success: false });
     } finally {
       setIsConnecting(false);
     }
-  }, [apiKey, entry, addProviderInstance, track, onBack]);
+  }, [
+    apiKey,
+    entry,
+    addProviderInstance,
+    getNextAttemptNumber,
+    onBack,
+    onConnectionResult,
+    onboardingRunId,
+    track,
+  ]);
 
   return (
     <div className="space-y-4">
@@ -728,17 +842,29 @@ function ScrollableProviderList({
 export function StepConfigureProviders({
   onNext,
   onBack,
+  onboardingRunId,
+  onSummary,
 }: {
   onNext: () => void;
   onBack: () => void;
+  onboardingRunId: string;
+  onSummary: (summary: ProviderStepSummary) => void;
 }) {
   const preferences = useKartonState((s) => s.preferences);
   const authStatus = useKartonState((s) => s.userAccount.status);
+  const track = useTrack();
 
   const [selectedEntry, setSelectedEntry] = useState<ProviderEntry | null>(
     null,
   );
   const [searchQuery, setSearchQuery] = useState('');
+  const stepStartedAtRef = useRef(performance.now());
+  const viewedProviderKeysRef = useRef(new Set<string>());
+  const connectedDuringStepKeysRef = useRef(new Set<string>());
+  const attemptCountsRef = useRef(new Map<string, number>());
+  const connectionAttemptCountRef = useRef(0);
+  const connectionFailureCountRef = useRef(0);
+  const searchUsedRef = useRef(false);
 
   const isStagewiseConnected =
     authStatus === 'authenticated' || authStatus === 'server_unreachable';
@@ -775,6 +901,65 @@ export function StepConfigureProviders({
     setSearchQuery('');
   }, []);
 
+  const getNextAttemptNumber = useCallback((entry: ProviderEntry) => {
+    const next = (attemptCountsRef.current.get(entry.key) ?? 0) + 1;
+    attemptCountsRef.current.set(entry.key, next);
+    connectionAttemptCountRef.current += 1;
+    return next;
+  }, []);
+
+  const handleConnectionResult = useCallback(
+    ({ entry, success }: ProviderConnectionResult) => {
+      if (success) connectedDuringStepKeysRef.current.add(entry.key);
+      else connectionFailureCountRef.current += 1;
+    },
+    [],
+  );
+
+  const handleSelectEntry = useCallback(
+    (entry: ProviderEntry) => {
+      const position = UNIFIED_ENTRIES.findIndex(
+        (candidate) => candidate.key === entry.key,
+      );
+      viewedProviderKeysRef.current.add(entry.key);
+      void track('onboarding-provider-detail-viewed', {
+        onboarding_run_id: onboardingRunId,
+        ...getTelemetryIdentity(entry),
+        position: Math.max(position, 0),
+        search_active: searchQuery.trim().length > 0,
+        already_connected: isEntryConnected(entry),
+      });
+      setSelectedEntry(entry);
+    },
+    [isEntryConnected, onboardingRunId, searchQuery, track],
+  );
+
+  const handleSearchChange = useCallback((value: string) => {
+    if (value.trim()) searchUsedRef.current = true;
+    setSearchQuery(value);
+  }, []);
+
+  const handleNext = useCallback(() => {
+    const summary = createProviderStepSummary(
+      preferences.providerInstances ?? [],
+      connectedDuringStepKeysRef.current.size,
+    );
+    void track('onboarding-provider-step-completed', {
+      onboarding_run_id: onboardingRunId,
+      duration_ms: performance.now() - stepStartedAtRef.current,
+      connected_provider_count: summary.connected_provider_count,
+      connected_provider_keys: summary.connected_provider_keys,
+      skipped_without_provider: summary.provider_step_skipped,
+      connected_during_step_count: connectedDuringStepKeysRef.current.size,
+      viewed_provider_count: viewedProviderKeysRef.current.size,
+      connection_attempt_count: connectionAttemptCountRef.current,
+      connection_failure_count: connectionFailureCountRef.current,
+      search_used: searchUsedRef.current,
+    });
+    onSummary(summary);
+    onNext();
+  }, [onNext, onSummary, onboardingRunId, preferences, track]);
+
   return (
     <>
       <div className="app-no-drag flex flex-1 flex-col items-center justify-center overflow-hidden">
@@ -801,7 +986,7 @@ export function StepConfigureProviders({
                 type="text"
                 placeholder="Search providers..."
                 value={searchQuery}
-                onValueChange={setSearchQuery}
+                onValueChange={handleSearchChange}
                 className="w-full"
               />
             )}
@@ -810,7 +995,13 @@ export function StepConfigureProviders({
           {selectedEntry ? (
             /* Connection detail view */
             <div className="min-h-0 pb-4">
-              <ConnectionDetailView entry={selectedEntry} onBack={handleBack} />
+              <ConnectionDetailView
+                entry={selectedEntry}
+                onBack={handleBack}
+                onboardingRunId={onboardingRunId}
+                getNextAttemptNumber={getNextAttemptNumber}
+                onConnectionResult={handleConnectionResult}
+              />
             </div>
           ) : (
             /* Scrollable provider list with groups */
@@ -818,7 +1009,7 @@ export function StepConfigureProviders({
               isStagewiseConnected={isStagewiseConnected}
               searchQuery={searchQuery}
               isEntryConnected={isEntryConnected}
-              onSelectEntry={setSelectedEntry}
+              onSelectEntry={handleSelectEntry}
               onBack={onBack}
             />
           )}
@@ -833,7 +1024,7 @@ export function StepConfigureProviders({
       ) : (
         <OnboardingBottomNav
           left={<BackButton onClick={onBack} />}
-          right={<NextButton onClick={onNext} label="Next" />}
+          right={<NextButton onClick={handleNext} label="Next" />}
         />
       )}
     </>

--- a/apps/browser/src/ui/screens/onboarding/steps/07-theme.test.tsx
+++ b/apps/browser/src/ui/screens/onboarding/steps/07-theme.test.tsx
@@ -1,0 +1,135 @@
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  handleThemeChange: vi.fn(),
+  handleSoundPackChange: vi.fn(),
+  handleLoudnessChange: vi.fn(),
+}));
+
+vi.mock('@ui/hooks/use-karton', () => ({
+  useKartonState: vi.fn(),
+  useKartonProcedure: vi.fn(),
+}));
+vi.mock('@ui/hooks/use-track', () => ({ useTrack: () => vi.fn() }));
+vi.mock('@ui/utils', () => ({
+  cn: (...values: unknown[]) => values.filter(Boolean).join(' '),
+}));
+vi.mock('@ui/hooks/use-theme-selection', () => ({
+  useThemeSelection: () => ({
+    currentThemeId: 'default',
+    handleThemeChange: mocks.handleThemeChange,
+  }),
+}));
+vi.mock('@ui/hooks/use-sound-settings', () => ({
+  NOTIFICATION_LOUDNESS_OPTIONS: [
+    { value: 'off', label: 'Off' },
+    { value: 'subtle', label: 'Subtle' },
+    { value: 'full', label: 'Full' },
+  ],
+  useSoundSettings: () => ({
+    soundLoudness: 'subtle',
+    currentPack: 'bubble-pops',
+    soundPackItems: [
+      { value: 'bubble-pops', label: 'Bubble Pops' },
+      { value: 'chimes', label: 'Chimes' },
+    ],
+    loudnessIndex: 1,
+    previewSound: vi.fn(),
+    handleLoudnessChange: mocks.handleLoudnessChange,
+    handleSoundPackChange: mocks.handleSoundPackChange,
+  }),
+}));
+vi.mock('@ui/components/theme-badge', () => ({
+  ThemeBadge: ({ name }: { name: string }) => <span>{name}</span>,
+}));
+vi.mock('@shared/personalization-themes', () => ({
+  PERSONALIZATION_THEMES: [
+    { id: 'default', name: 'Default' },
+    { id: 'fire', name: 'Fire' },
+  ],
+}));
+vi.mock('@stagewise/stage-ui/components/overlay-scrollbar', () => ({
+  OverlayScrollbar: ({ children }: { children: React.ReactNode }) => children,
+}));
+vi.mock('@stagewise/stage-ui/components/select', () => ({
+  Select: ({ onValueChange }: { onValueChange: (value: string) => void }) => (
+    <button type="button" onClick={() => onValueChange('chimes')}>
+      Change sound pack
+    </button>
+  ),
+}));
+vi.mock('@stagewise/stage-ui/components/slider', () => ({
+  Slider: ({ onValueChange }: { onValueChange: (value: number) => void }) => (
+    <button type="button" onClick={() => onValueChange(2)}>
+      Change loudness
+    </button>
+  ),
+}));
+
+import { StepTheme } from './07-theme';
+
+function deferredBoolean() {
+  let resolve!: (value: boolean) => void;
+  const promise = new Promise<boolean>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+function renderStep() {
+  const onNext = vi.fn();
+  const onPersonalizationChanged = vi.fn();
+  render(
+    <StepTheme
+      onNext={onNext}
+      onBack={vi.fn()}
+      onPersonalizationChanged={onPersonalizationChanged}
+    />,
+  );
+  return { onNext, onPersonalizationChanged };
+}
+
+describe('StepTheme completion gating', () => {
+  beforeEach(() => {
+    mocks.handleThemeChange.mockReset().mockResolvedValue(false);
+    mocks.handleSoundPackChange.mockReset().mockResolvedValue(false);
+    mocks.handleLoudnessChange.mockReset().mockResolvedValue(false);
+  });
+
+  it('blocks Finish until a successful theme write settles', async () => {
+    const mutation = deferredBoolean();
+    mocks.handleThemeChange.mockReturnValue(mutation.promise);
+    const callbacks = renderStep();
+
+    fireEvent.click(screen.getByRole('radio', { name: 'Use Fire theme' }));
+    const finish = screen.getByRole('button', { name: 'Finish' });
+    expect(finish.hasAttribute('disabled')).toBe(true);
+    fireEvent.click(finish);
+    expect(callbacks.onNext).not.toHaveBeenCalled();
+
+    await act(async () => mutation.resolve(true));
+
+    expect(finish.hasAttribute('disabled')).toBe(false);
+    expect(callbacks.onPersonalizationChanged).toHaveBeenCalledOnce();
+    fireEvent.click(finish);
+    expect(callbacks.onNext).toHaveBeenCalledOnce();
+  });
+
+  it('gates sound writes without marking failed or no-op changes', async () => {
+    const mutation = deferredBoolean();
+    mocks.handleSoundPackChange.mockReturnValue(mutation.promise);
+    const callbacks = renderStep();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Change sound pack' }));
+    expect(
+      screen.getByRole('button', { name: 'Finish' }).hasAttribute('disabled'),
+    ).toBe(true);
+    await act(async () => mutation.resolve(false));
+
+    expect(callbacks.onPersonalizationChanged).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByRole('button', { name: 'Change loudness' }));
+    await act(async () => {});
+    expect(callbacks.onPersonalizationChanged).not.toHaveBeenCalled();
+  });
+});

--- a/apps/browser/src/ui/screens/onboarding/steps/07-theme.tsx
+++ b/apps/browser/src/ui/screens/onboarding/steps/07-theme.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useState } from 'react';
 import { Select } from '@stagewise/stage-ui/components/select';
 import { Slider } from '@stagewise/stage-ui/components/slider';
 import { Button } from '@stagewise/stage-ui/components/button';
@@ -16,10 +16,31 @@ import { PlayIcon } from 'lucide-react';
 export function StepTheme({
   onNext,
   onBack,
+  onPersonalizationChanged,
 }: {
   onNext: () => void;
   onBack: () => void;
+  onPersonalizationChanged: () => void;
 }) {
+  const [pendingMutationCount, setPendingMutationCount] = useState(0);
+  const isPersonalizationPending = pendingMutationCount > 0;
+
+  const persistPersonalizationChange = useCallback(
+    async (mutation: () => Promise<boolean>) => {
+      setPendingMutationCount((count) => count + 1);
+      try {
+        if (await mutation()) onPersonalizationChanged();
+      } finally {
+        setPendingMutationCount((count) => count - 1);
+      }
+    },
+    [onPersonalizationChanged],
+  );
+
+  const handleFinish = useCallback(() => {
+    if (!isPersonalizationPending) onNext();
+  }, [isPersonalizationPending, onNext]);
+
   return (
     <>
       <div className="app-no-drag flex flex-1 flex-col items-center overflow-hidden px-8 py-8">
@@ -37,19 +58,33 @@ export function StepTheme({
             </p>
           </div>
 
-          <ThemeSelection />
-          <SoundSelection />
+          <ThemeSelection onChange={persistPersonalizationChange} />
+          <SoundSelection onChange={persistPersonalizationChange} />
         </OverlayScrollbar>
       </div>
       <OnboardingBottomNav
         left={<BackButton onClick={onBack} />}
-        right={<NextButton onClick={onNext} label="Finish" />}
+        right={
+          <NextButton
+            onClick={handleFinish}
+            label="Finish"
+            disabled={isPersonalizationPending}
+          />
+        }
       />
     </>
   );
 }
 
-function ThemeSelection() {
+type PersonalizationChangeHandler = (
+  mutation: () => Promise<boolean>,
+) => Promise<void>;
+
+function ThemeSelection({
+  onChange,
+}: {
+  onChange: PersonalizationChangeHandler;
+}) {
   const { currentThemeId, handleThemeChange } = useThemeSelection();
 
   const themeIds = PERSONALIZATION_THEMES.map((t) => t.id);
@@ -72,7 +107,7 @@ function ThemeSelection() {
       if (nextIndex !== null) {
         e.preventDefault();
         const nextId = themeIds[nextIndex]!;
-        void handleThemeChange(nextId);
+        void onChange(() => handleThemeChange(nextId));
         // Move focus to the newly-selected radio
         const container = e.currentTarget.parentElement;
         if (container) {
@@ -82,7 +117,7 @@ function ThemeSelection() {
         }
       }
     },
-    [themeIds, handleThemeChange],
+    [themeIds, handleThemeChange, onChange],
   );
 
   return (
@@ -98,7 +133,9 @@ function ThemeSelection() {
             key={theme.id}
             type="button"
             className="group rounded-lg"
-            onClick={() => handleThemeChange(theme.id)}
+            onClick={() => {
+              void onChange(() => handleThemeChange(theme.id));
+            }}
             onKeyDown={(e) => handleThemeKeyDown(e, index)}
             aria-checked={active}
             aria-label={`Use ${theme.name} theme`}
@@ -114,7 +151,11 @@ function ThemeSelection() {
   );
 }
 
-function SoundSelection() {
+function SoundSelection({
+  onChange,
+}: {
+  onChange: PersonalizationChangeHandler;
+}) {
   const {
     soundLoudness,
     currentPack,
@@ -132,7 +173,9 @@ function SoundSelection() {
         <div className="flex items-center gap-1">
           <Select
             value={currentPack}
-            onValueChange={handleSoundPackChange}
+            onValueChange={(value) => {
+              void onChange(() => handleSoundPackChange(value));
+            }}
             items={soundPackItems}
             size="sm"
             triggerClassName="w-40"
@@ -161,7 +204,9 @@ function SoundSelection() {
             step={1}
             ariaLabel="Notification sound loudness"
             thickness="default"
-            onValueChange={handleLoudnessChange}
+            onValueChange={(value) => {
+              void onChange(() => handleLoudnessChange(value));
+            }}
           />
           <div className="relative h-3 text-[11px] text-muted-foreground">
             {NOTIFICATION_LOUDNESS_OPTIONS.map((option, index) => (

--- a/packages/agent-core/src/agents/base-agent-provider-metadata.test.ts
+++ b/packages/agent-core/src/agents/base-agent-provider-metadata.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { ModelWithOptions } from '../host/models';
+import { ChatAgent } from './chat/chat';
+
+type Deferred<T> = {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (reason: unknown) => void;
+};
+
+type RunStepInternals = {
+  _stepGeneration: number;
+  _stepProviderMode: string;
+  _stepCodingPlanId: string | undefined;
+  _stepProviderType: string | undefined;
+  runStep: () => Promise<void>;
+  applyStepProviderMetadataIfCurrent: (
+    modelWithOptions: ModelWithOptions,
+    stepGeneration: number,
+  ) => void;
+  host: {
+    models: { getWithOptions: () => Promise<ModelWithOptions> };
+    logger: {
+      error: ReturnType<typeof vi.fn>;
+      warn: ReturnType<typeof vi.fn>;
+      debug: ReturnType<typeof vi.fn>;
+    };
+  };
+  state: {
+    get: ReturnType<typeof vi.fn>;
+    commands: {
+      beginStep: ReturnType<typeof vi.fn>;
+      recordStepError: ReturnType<typeof vi.fn>;
+    };
+  };
+  [key: string]: any;
+};
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+function providerMetadata(
+  providerMode: string,
+  connectedCodingPlanId: string | undefined,
+  providerType: string | undefined,
+): ModelWithOptions {
+  return {
+    providerMode,
+    connectedCodingPlanId,
+    providerType,
+  } as ModelWithOptions;
+}
+
+function createStubAgent(
+  getWithOptions: () => Promise<ModelWithOptions>,
+): RunStepInternals {
+  const agent = Object.create(ChatAgent.prototype) as RunStepInternals;
+  agent._stepGeneration = 0;
+  agent._stepProviderMode = 'current-mode';
+  agent._stepCodingPlanId = 'current-plan';
+  agent._stepProviderType = 'current-provider';
+  agent.canRunStep = vi.fn().mockReturnValue(true);
+  agent.generateContextForNewStep = vi.fn();
+  agent.getToolsForStep = vi.fn();
+  agent.getModelSettings = vi.fn();
+  agent.report = vi.fn();
+  agent.emitNotificationEvent = vi.fn();
+  agent.scheduleMemorySnapshotWrite = vi.fn();
+  agent.state = {
+    get: vi.fn().mockReturnValue({
+      activeModelId: 'test-model',
+      activeProviderInstanceId: 'test-provider',
+      history: [],
+    }),
+    commands: {
+      beginStep: vi.fn().mockReturnValue({ queueFlushIndex: undefined }),
+      recordStepError: vi.fn(),
+    },
+  };
+  agent.host = {
+    models: { getWithOptions },
+    logger: {
+      error: vi.fn(),
+      warn: vi.fn(),
+      debug: vi.fn(),
+    },
+  };
+  return agent;
+}
+
+describe('BaseAgent step provider metadata', () => {
+  it('ignores metadata resolved for a superseded step generation', () => {
+    const agent = createStubAgent(vi.fn());
+    agent._stepGeneration = 2;
+
+    agent.applyStepProviderMetadataIfCurrent(
+      providerMetadata('stale-mode', 'stale-plan', 'stale-provider'),
+      1,
+    );
+
+    expect(agent._stepProviderMode).toBe('current-mode');
+    expect(agent._stepCodingPlanId).toBe('current-plan');
+    expect(agent._stepProviderType).toBe('current-provider');
+  });
+
+  it('updates the complete metadata tuple for the current generation', () => {
+    const agent = createStubAgent(vi.fn());
+    agent._stepGeneration = 2;
+
+    agent.applyStepProviderMetadataIfCurrent(
+      providerMetadata('next-mode', undefined, 'next-provider'),
+      2,
+    );
+
+    expect(agent._stepProviderMode).toBe('next-mode');
+    expect(agent._stepCodingPlanId).toBeUndefined();
+    expect(agent._stepProviderType).toBe('next-provider');
+  });
+});
+
+describe('BaseAgent stale step preparation', () => {
+  it('stops after a model lookup resolves for a superseded generation', async () => {
+    const lookup = deferred<ModelWithOptions>();
+    const agent = createStubAgent(() => lookup.promise);
+
+    const run = agent.runStep();
+    agent._stepGeneration += 1;
+    lookup.resolve(providerMetadata('stale', undefined, 'stale-provider'));
+    await run;
+
+    expect(agent.generateContextForNewStep).not.toHaveBeenCalled();
+  });
+
+  it('silently ignores a model lookup rejection after supersession', async () => {
+    const lookup = deferred<ModelWithOptions>();
+    const agent = createStubAgent(() => lookup.promise);
+
+    const run = agent.runStep();
+    agent._stepGeneration += 1;
+    lookup.reject(new Error('stale lookup failure'));
+    await run;
+
+    expect(agent.host.logger.error).not.toHaveBeenCalled();
+    expect(agent.report).not.toHaveBeenCalled();
+    expect(agent.state.commands.recordStepError).not.toHaveBeenCalled();
+  });
+
+  it('stops after context generation when the generation is superseded', async () => {
+    const context = deferred<never[]>();
+    const agent = createStubAgent(() =>
+      Promise.resolve(providerMetadata('official', undefined, 'openai-api')),
+    );
+    agent.generateContextForNewStep = vi.fn(() => context.promise);
+
+    const run = agent.runStep();
+    await vi.waitFor(() =>
+      expect(agent.generateContextForNewStep).toHaveBeenCalledOnce(),
+    );
+    agent._stepGeneration += 1;
+    context.resolve([]);
+    await run;
+
+    expect(agent.getToolsForStep).not.toHaveBeenCalled();
+    expect(agent.getModelSettings).not.toHaveBeenCalled();
+    expect(agent.stepAbortController).toBeUndefined();
+  });
+});

--- a/packages/agent-core/src/agents/base-agent.ts
+++ b/packages/agent-core/src/agents/base-agent.ts
@@ -593,6 +593,7 @@ export abstract class BaseAgent<
   private _stepStartTime = 0;
   private _stepProviderMode = '';
   private _stepCodingPlanId: string | undefined;
+  private _stepProviderType: string | undefined;
   private _toolCallDurations = new Map<string, number>();
   private _memoryWriter: AgentMemoryWriter | null = null;
   private _memoryWriteTimer: ReturnType<typeof setTimeout> | null = null;
@@ -1636,9 +1637,10 @@ export abstract class BaseAgent<
           [PROVIDER_INSTANCE_ID_METADATA_KEY]: stepProviderInstanceId,
         },
       );
-      this._stepProviderMode = modelWithOptions.providerMode;
-      this._stepCodingPlanId = modelWithOptions.connectedCodingPlanId;
+      this.applyStepProviderMetadataIfCurrent(modelWithOptions, stepGen);
+      if (this._stepGeneration !== stepGen) return;
     } catch (error) {
+      if (this._stepGeneration !== stepGen) return;
       const err = error as Error;
       this.host.logger.error(
         `[BaseAgent:${this.instanceId}] Failed to resolve model "${stepModelId}": ${err.message}`,
@@ -1666,18 +1668,23 @@ export abstract class BaseAgent<
         queueFlushIndex >= 0 ? queueFlushIndex : undefined,
         modelWithOptions.reasoningSignatureSource,
       );
+      if (this._stepGeneration !== stepGen) return;
       tools = await this.getToolsForStep();
+      if (this._stepGeneration !== stepGen) return;
       this._toolCallDurations.clear();
       tools = this.wrapToolsWithTiming(tools);
       tools = this.wrapToolsWithOutputBudget(tools);
       if (modelWithOptions.stripStrictFromTools) {
         tools = this.stripStrictFromTools(tools);
       }
+      const modelSettings = await this.getModelSettings(this.messages);
+      if (this._stepGeneration !== stepGen) return;
       resolvedConfig = {
         ...this.config,
-        ...(await this.getModelSettings(this.messages)),
+        ...modelSettings,
       };
     } catch (e) {
+      if (this._stepGeneration !== stepGen) return;
       const error = e as Error;
       this.host.logger.error(
         `[BaseAgent:${this.instanceId}] Failed to prepare step context: ${this.formatError(error)}`,
@@ -1695,6 +1702,8 @@ export abstract class BaseAgent<
       return;
     }
 
+    if (this._stepGeneration !== stepGen) return;
+
     if (isApprovalContinuation)
       modelMessages = this.ensureToolApprovalResponseIsLast(modelMessages);
 
@@ -1703,8 +1712,10 @@ export abstract class BaseAgent<
 
     this.host.logger.debug(`[BaseAgent:${this.instanceId}] Running step`);
 
+    if (this._stepGeneration !== stepGen) return;
     this.stepAbortController = new AbortController();
 
+    if (this._stepGeneration !== stepGen) return;
     const stream = streamText({
       model: modelWithOptions.model,
       providerOptions: modelWithOptions.providerOptions,
@@ -2442,6 +2453,7 @@ export abstract class BaseAgent<
       model_id: this.state.get().activeModelId,
       provider_mode: this._stepProviderMode,
       coding_plan_id: this._stepCodingPlanId,
+      provider_type: this._stepProviderType,
       input_tokens: result.usage.inputTokens ?? 0,
       output_tokens: result.usage.outputTokens ?? 0,
       tool_call_count: result.toolCalls.length,
@@ -2911,6 +2923,17 @@ export abstract class BaseAgent<
         },
       });
     }
+  }
+
+  private applyStepProviderMetadataIfCurrent(
+    modelWithOptions: ModelWithOptions,
+    stepGeneration: number,
+  ): void {
+    if (this._stepGeneration !== stepGeneration) return;
+
+    this._stepProviderMode = modelWithOptions.providerMode;
+    this._stepCodingPlanId = modelWithOptions.connectedCodingPlanId;
+    this._stepProviderType = modelWithOptions.providerType;
   }
 
   private async internalStop(

--- a/packages/agent-core/src/host/models.ts
+++ b/packages/agent-core/src/host/models.ts
@@ -65,6 +65,8 @@ export interface ModelWithOptions {
    * telemetry.
    */
   connectedCodingPlanId?: string;
+  /** Stable host-defined provider type used for aggregate telemetry. */
+  providerType?: string;
   /**
    * Semantic owner of any signed `reasoning_details` this route produces.
    * Threaded through the step so capture tags the metadata and conversion


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches telemetry contracts, onboarding completion RPC validation, and agent step concurrency; mistakes could drop events or mis-tag provider types, but changes are heavily schema-tested and avoid logging secrets.
> 
> **Overview**
> Adds a shared **`@shared/karton-contracts/ui/telemetry`** contract and wires **`useTrack`** / auth UI to typed **`TrackUIEvent`**, with strict Zod schemas for onboarding funnel events, email handoff, and expanded UI payloads.
> 
> The **onboarding wizard** now emits step view/exit timing (with `onboarding_run_id`), auth skip, and provider browse/connect attempt/success/failure events using **`OnboardingProviderIdentity`**; completion passes a validated **`OnboardingCompletionSummary`** through **`setHasSeenOnboardingFlow`** (replacing the old suggestion field) with backend allowlisting so extra client fields never reach PostHog.
> 
> **`providerType`** is set on **`ModelWithOptions`** and included on **`agent-step-completed`**; agents ignore provider metadata and async prep work from superseded steps. Theme/sound hooks serialize config patches, return booleans for persisted changes, and the personalization step blocks **Finish** until writes settle.
> 
> **`GlobalConfigService`** queues concurrent **`config.set`** patches; OTP telemetry gains **`turnstile-solve-failed`** and **`email`** as an auth handoff provider.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da7a4f6859396799d07afeaba3e01f6b4ba99ce5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wired end-to-end onboarding telemetry with a typed tracker, step timings/actions, provider browse/connect outcomes, and a validated completion summary persisted via `setHasSeenOnboardingFlow`. Threaded a stable `providerType` into models/agents, tightened backend allowlists, and serialized `config.set` patches to keep personalization saves reliable and data secret-free.

- **New Features**
  - Added `@shared/karton-contracts/ui/telemetry` exporting `UIEventName`, `UIEventProperties`, `TrackUIEvent`; re-exported from `@shared/karton-contracts/ui`. `useTrack` and auth UI now use the typed tracker.
  - Implemented the onboarding funnel with `onboarding_run_id`: step view/exit events, auth skip, and provider browse/connect attempt/success/failure using `OnboardingProviderIdentity`; completion passes typed `OnboardingCompletionSummary` through `setHasSeenOnboardingFlow` with strict backend validation of provider instance types and coding plan IDs.
  - Added `providerType` to `ModelWithOptions` and threaded it to agent step telemetry.
  - Serialized `config.set` patches; theme/sound handlers return booleans, the theme step blocks Finish while writes are pending, and only marks personalization changed after persisted updates.

- **Bug Fixes**
  - Agents ignore late async work from superseded steps when applying provider metadata to avoid mis-tagged `provider_type`.
  - Better auth/connection failure classification and no secret logging; added OTP failure kind `turnstile-solve-failed`.

<sup>Written for commit da7a4f6859396799d07afeaba3e01f6b4ba99ce5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1472?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added enriched onboarding analytics with stable onboarding run IDs, step view/exit timing and actions, and durable completion summaries (including connected providers and personalization).
  * Added “continue without account” tracking and gated onboarding completion until personalization/theme/sound updates finish persisting.
  * Expanded telemetry coverage for onboarding funnel, email handoff, and added OTP failure kind `turnstile-solve-failed`.
* **Bug Fixes**
  * Improved telemetry correctness and validation while preventing sensitive/secret error leakage; onboarding completion now supports an optional summary payload.
* **Tests**
  * Expanded onboarding, provider connection, onboarding telemetry schema/fixtures, and discovered-model routing assertions (updated provider-type expectations).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->