### PR TITLE
feat(stagewise): add terminals to command center

### DIFF
--- a/apps/browser/src/shared/karton-contracts/ui/index.ts
+++ b/apps/browser/src/shared/karton-contracts/ui/index.ts
@@ -7,7 +7,7 @@ import type {
   MountPermission,
   MentionFileCandidate,
   AttachmentMetadata,
-  ShellSessionSnapshot,
+  ShellSnapshot,
 } from './agent/metadata';
 import type {
   MountEntry,
@@ -1059,7 +1059,7 @@ export type AppState = {
       /** Maps toolCallId → sessionId for in-flight shell commands. */
       pendingShellSessionIds?: Record<string, string>;
       /** Live shell session manifest — pushed eagerly on lifecycle events. */
-      shells?: { sessions: ShellSessionSnapshot[] };
+      shells?: ShellSnapshot;
 
       activeApp?: {
         appId: string;

--- a/apps/browser/src/ui/screens/main/_components/local-servers-popover.tsx
+++ b/apps/browser/src/ui/screens/main/_components/local-servers-popover.tsx
@@ -1,10 +1,8 @@
 import type {
-  MountEntry,
   RunningServer,
   RunningServerOwner,
 } from '@shared/karton-contracts/ui';
 import type { FaviconBitmapResult } from '@shared/karton-contracts/pages-api/types';
-import { getBaseName, normalizePath } from '@shared/path-utils';
 import {
   IconArrowUpRightOutline18,
   IconCodeBranchOutline18,
@@ -39,6 +37,7 @@ import {
 import { useTabUIState } from '@ui/hooks/use-tab-ui-state';
 import { Globe2 } from 'lucide-react';
 import { type ReactNode, useEffect, useRef, useState } from 'react';
+import { getWorkspaceLocation } from '../_lib/workspace-location';
 
 const REFRESH_INTERVAL_MS = 5_000;
 
@@ -48,41 +47,6 @@ type ServerGroup = {
   agentId: string | null;
   servers: RunningServer[];
 };
-
-type ServerLocation = {
-  isGit: boolean;
-  name: string;
-  detail: string | null;
-};
-
-function getServerLocation(cwd: string, mounts: MountEntry[]): ServerLocation {
-  const normalizedCwd = normalizePath(cwd).replace(/\/$/, '');
-  let closestMount: MountEntry | undefined;
-
-  for (const mount of mounts) {
-    const mountPath = normalizePath(mount.path).replace(/\/$/, '');
-    if (
-      (normalizedCwd === mountPath ||
-        normalizedCwd.startsWith(`${mountPath}/`)) &&
-      (!closestMount || mountPath.length > closestMount.path.length)
-    ) {
-      closestMount = mount;
-    }
-  }
-
-  if (!closestMount?.git) {
-    return { isGit: false, name: cwd, detail: null };
-  }
-
-  const repoPath =
-    closestMount.git.mainWorktreePath ?? closestMount.git.repoRoot;
-  return {
-    isGit: true,
-    name: getBaseName(repoPath) || repoPath,
-    detail:
-      closestMount.git.branch ?? closestMount.git.headSha?.slice(0, 7) ?? null,
-  };
-}
 
 function getServerId(owner: RunningServerOwner): string {
   return owner.type === 'agent' ? owner.sessionId : owner.terminalId;
@@ -404,7 +368,7 @@ export function LocalServersPopover({
                   <div className="flex flex-col gap-1.5">
                     {group.servers.map((server) => {
                       const isAgent = server.owner.type === 'agent';
-                      const location = getServerLocation(
+                      const location = getWorkspaceLocation(
                         server.cwd,
                         workspaceMounts,
                       );

--- a/apps/browser/src/ui/screens/main/_lib/workspace-location.ts
+++ b/apps/browser/src/ui/screens/main/_lib/workspace-location.ts
@@ -1,0 +1,31 @@
+import type { MountEntry } from '@shared/karton-contracts/ui';
+import { getBaseName, normalizePath } from '@shared/path-utils';
+
+export function getWorkspaceLocation(cwd: string, mounts: MountEntry[]) {
+  const normalizedCwd = normalizePath(cwd).replace(/\/$/, '');
+  let closestMount: MountEntry | undefined;
+
+  for (const mount of mounts) {
+    const mountPath = normalizePath(mount.path).replace(/\/$/, '');
+    if (
+      (normalizedCwd === mountPath ||
+        normalizedCwd.startsWith(`${mountPath}/`)) &&
+      (!closestMount || mountPath.length > closestMount.path.length)
+    ) {
+      closestMount = mount;
+    }
+  }
+
+  if (!closestMount?.git) {
+    return { isGit: false, name: cwd, detail: null };
+  }
+
+  const repoPath =
+    closestMount.git.mainWorktreePath ?? closestMount.git.repoRoot;
+  return {
+    isGit: true,
+    name: getBaseName(repoPath) || repoPath,
+    detail:
+      closestMount.git.branch ?? closestMount.git.headSha?.slice(0, 7) ?? null,
+  };
+}

--- a/apps/browser/src/ui/screens/main/command-center/_components/command-center-input.tsx
+++ b/apps/browser/src/ui/screens/main/command-center/_components/command-center-input.tsx
@@ -30,7 +30,9 @@ export const CommandCenterInput = forwardRef<
         onPointerUp={(event) => onSelectionChange(event.currentTarget)}
         onSelect={(event) => onSelectionChange(event.currentTarget)}
         placeholder={
-          mode === 'files' ? 'Search files…' : 'Search agents, tabs, settings…'
+          mode === 'files'
+            ? 'Search files…'
+            : 'Search agents, tabs, terminals, settings…'
         }
         className="min-w-0 flex-1 bg-transparent text-foreground text-sm outline-none placeholder:text-subtle-foreground"
       />

--- a/apps/browser/src/ui/screens/main/command-center/_components/command-center-mode-toggle.tsx
+++ b/apps/browser/src/ui/screens/main/command-center/_components/command-center-mode-toggle.tsx
@@ -3,6 +3,7 @@ import {
   IconFolder5Outline18,
   IconGear3Outline18,
   IconMsgWritingOutline18,
+  IconSquareTerminalOutline18,
 } from '@stagewise/icons';
 import type { ComponentType } from 'react';
 import { ShortcutKey } from '@stagewise/stage-ui/components/shortcut-key';
@@ -19,6 +20,11 @@ const modes: ModeDefinition[] = [
   { mode: 'global', label: 'All' },
   { mode: 'agents', label: 'Agents', Icon: IconMsgWritingOutline18 },
   { mode: 'browser', label: 'Browser', Icon: IconEarthSearchOutline18 },
+  {
+    mode: 'terminals',
+    label: 'Terminals',
+    Icon: IconSquareTerminalOutline18,
+  },
   { mode: 'files', label: 'Files', Icon: IconFolder5Outline18 },
   { mode: 'settings', label: 'Settings', Icon: IconGear3Outline18 },
 ];

--- a/apps/browser/src/ui/screens/main/command-center/command-center-model.ts
+++ b/apps/browser/src/ui/screens/main/command-center/command-center-model.ts
@@ -1,11 +1,13 @@
 import type { HotkeyActions } from '@shared/hotkeys';
 import type { ReactNode } from 'react';
+import type { RunningServerOwner } from '@shared/karton-contracts/ui';
 import type { SettingsRoute } from '@shared/settings-route';
 
 export type CommandCenterMode =
   | 'global'
   | 'agents'
   | 'browser'
+  | 'terminals'
   | 'settings'
   | 'files';
 
@@ -13,6 +15,7 @@ export const COMMAND_CENTER_MODES: CommandCenterMode[] = [
   'global',
   'agents',
   'browser',
+  'terminals',
   'files',
   'settings',
 ];
@@ -20,6 +23,7 @@ export const COMMAND_CENTER_MODES: CommandCenterMode[] = [
 export type CommandCenterItemKind =
   | 'agent'
   | 'tab'
+  | 'terminal'
   | 'setting'
   | 'action'
   | 'file';
@@ -69,6 +73,14 @@ export type TabCommandItem = CommandCenterItemBase & {
   lastFocusedAt: number;
 };
 
+export type TerminalCommandItem = CommandCenterItemBase & {
+  kind: 'terminal';
+  mode: 'terminals';
+  owner: RunningServerOwner;
+  isActive: boolean;
+  lastFocusedAt: number;
+};
+
 export type SettingCommandItem = CommandCenterItemBase & {
   kind: 'setting';
   mode: 'settings';
@@ -100,6 +112,7 @@ export type ActionCommandItem = CommandCenterItemBase & {
 export type CommandCenterItem =
   | AgentCommandItem
   | TabCommandItem
+  | TerminalCommandItem
   | SettingCommandItem
   | FileCommandItem
   | ActionCommandItem;

--- a/apps/browser/src/ui/screens/main/command-center/command-center-rows.ts
+++ b/apps/browser/src/ui/screens/main/command-center/command-center-rows.ts
@@ -80,6 +80,11 @@ function buildGlobalRows(items: CommandCenterItem[]): CommandCenterRenderRow[] {
   );
   pushSection(
     rows,
+    'Terminals',
+    indexedItems.filter(({ item }) => item.kind === 'terminal'),
+  );
+  pushSection(
+    rows,
     'Files',
     indexedItems.filter(({ item }) => item.kind === 'file'),
   );
@@ -136,9 +141,11 @@ export function buildGroupedRows(
   const label =
     mode === 'browser'
       ? 'Browser'
-      : mode === 'files'
-        ? (options?.filesLabel ?? 'Files')
-        : 'Settings';
+      : mode === 'terminals'
+        ? 'Terminals'
+        : mode === 'files'
+          ? (options?.filesLabel ?? 'Files')
+          : 'Settings';
 
   return [
     {

--- a/apps/browser/src/ui/screens/main/command-center/command-center-search.ts
+++ b/apps/browser/src/ui/screens/main/command-center/command-center-search.ts
@@ -19,7 +19,8 @@ function getSearchableUrl(item: CommandCenterItem) {
 
 function getRecency(item: CommandCenterItem) {
   if (item.kind === 'agent') return item.lastMessageAt;
-  if (item.kind === 'tab') return item.lastFocusedAt;
+  if (item.kind === 'tab' || item.kind === 'terminal')
+    return item.lastFocusedAt;
   return 0;
 }
 

--- a/apps/browser/src/ui/screens/main/command-center/command-center.tsx
+++ b/apps/browser/src/ui/screens/main/command-center/command-center.tsx
@@ -386,16 +386,19 @@ export function CommandCenter() {
         void switchTab(item.tabId);
       } else if (item.kind === 'terminal') {
         const agentInstanceId = item.owner.agentInstanceId;
-        if (agentInstanceId) {
-          setOpenAgent(agentInstanceId);
-          void setLastOpenAgentId(agentInstanceId);
-        }
         if (item.owner.type === 'terminal') {
           const { terminalId } = item.owner;
           setContentCollapsed(false);
-          void switchTab(terminalId).then(() =>
-            requestTerminalFocus(terminalId),
-          );
+          void switchTab(terminalId).then(() => {
+            if (agentInstanceId) {
+              setOpenAgent(agentInstanceId);
+              void setLastOpenAgentId(agentInstanceId);
+            }
+            requestTerminalFocus(terminalId);
+          });
+        } else {
+          setOpenAgent(agentInstanceId);
+          void setLastOpenAgentId(agentInstanceId);
         }
       } else if (item.kind === 'setting') {
         if (item.settingsRoute) {

--- a/apps/browser/src/ui/screens/main/command-center/command-center.tsx
+++ b/apps/browser/src/ui/screens/main/command-center/command-center.tsx
@@ -21,6 +21,7 @@ import {
 import { useOpenAgent } from '@ui/hooks/use-open-chat';
 import { useTabUIState } from '@ui/hooks/use-tab-ui-state';
 import { usePendingRemovals } from '@ui/hooks/use-pending-agent-removals';
+import { useContentCollapsed } from '../_components/content-collapsed-context';
 import {
   COMMAND_CENTER_MODES,
   type AgentCommandItem,
@@ -127,6 +128,7 @@ export function CommandCenter() {
     activeTabId ? (s.contentTabs.tabs[activeTabId] ?? null) : null,
   );
   const [openAgent, setOpenAgent] = useOpenAgent();
+  const { setCollapsed: setContentCollapsed } = useContentCollapsed();
   const resumeAgent = useKartonProcedure((p) => p.agents.resume);
   const openFileTab = useKartonProcedure((p) => p.fileTree.openFileTab);
   const setFileTreeVisible = useKartonProcedure((p) => p.fileTree.setVisible);
@@ -382,6 +384,19 @@ export function CommandCenter() {
           );
         }
         void switchTab(item.tabId);
+      } else if (item.kind === 'terminal') {
+        const agentInstanceId = item.owner.agentInstanceId;
+        if (agentInstanceId) {
+          setOpenAgent(agentInstanceId);
+          void setLastOpenAgentId(agentInstanceId);
+        }
+        if (item.owner.type === 'terminal') {
+          const { terminalId } = item.owner;
+          setContentCollapsed(false);
+          void switchTab(terminalId).then(() =>
+            requestTerminalFocus(terminalId),
+          );
+        }
       } else if (item.kind === 'setting') {
         if (item.settingsRoute) {
           void openSettings(item.settingsRoute);
@@ -400,10 +415,12 @@ export function CommandCenter() {
       resumeAgent,
       setLastOpenAgentId,
       setOpenAgent,
+      setContentCollapsed,
       switchTab,
       setFileTreeVisible,
       setFileTreeActiveWorkspace,
       setDirectoryExpanded,
+      requestTerminalFocus,
     ],
   );
 

--- a/apps/browser/src/ui/screens/main/command-center/sources/use-command-center-items.ts
+++ b/apps/browser/src/ui/screens/main/command-center/sources/use-command-center-items.ts
@@ -6,6 +6,7 @@ import type {
 import { useAgentCommandItems } from './use-agent-command-items';
 import { useSettingsCommandItems } from './use-settings-command-items';
 import { useTabCommandItems } from './use-tab-command-items';
+import { useTerminalCommandItems } from './use-terminal-command-items';
 import { useFileSearchCommandItems } from './use-file-command-items';
 import type { FileSearchFilterState as FileFilterState } from './use-file-command-items';
 
@@ -39,6 +40,7 @@ export function useCommandCenterItems({
     enabled: mode === 'global' || mode === 'agents',
   });
   const tabs = useTabCommandItems(query);
+  const terminals = useTerminalCommandItems(query);
   const settings = useSettingsCommandItems(query);
   // File search runs in both "files" mode and the "all" (global) mode. In
   // global mode we always search across every connected workspace (empty
@@ -63,16 +65,29 @@ export function useCommandCenterItems({
   const items = useMemo<CommandCenterItem[]>(() => {
     if (mode === 'agents') return agents.items;
     if (mode === 'browser') return tabs.items;
+    if (mode === 'terminals') return terminals.items;
     if (mode === 'files') return fileItems;
     if (mode === 'settings') return settings.items;
 
-    const ranked = [...agents.items, ...tabs.items, ...settings.items]
+    const ranked = [
+      ...agents.items,
+      ...tabs.items,
+      ...terminals.items,
+      ...settings.items,
+    ]
       .sort((a, b) => (b.score ?? 0) - (a.score ?? 0))
       .slice(0, GLOBAL_LIMIT);
     // Append file results after the ranked list so they always surface in the
     // "all" view rather than being cut by the global limit.
     return [...ranked, ...fileItems];
-  }, [agents.items, fileItems, mode, settings.items, tabs.items]);
+  }, [
+    agents.items,
+    fileItems,
+    mode,
+    settings.items,
+    tabs.items,
+    terminals.items,
+  ]);
 
   return {
     items,

--- a/apps/browser/src/ui/screens/main/command-center/sources/use-tab-command-items.tsx
+++ b/apps/browser/src/ui/screens/main/command-center/sources/use-tab-command-items.tsx
@@ -39,8 +39,7 @@ export function useTabCommandItems(query: string) {
       const activeTabId = s.contentTabs.activeTabId;
       return (
         Object.values(s.contentTabs.tabs)
-          // Browser mode intentionally lists web tabs only. Terminal tab
-          // search/switching will be added later as its own command source.
+          // Terminals are provided by their own command source and mode.
           .filter((tab) => tab.type === undefined || tab.type === 'browser')
           .map((tab) => {
             const title = tabTitle(tab);

--- a/apps/browser/src/ui/screens/main/command-center/sources/use-terminal-command-items.tsx
+++ b/apps/browser/src/ui/screens/main/command-center/sources/use-terminal-command-items.tsx
@@ -1,0 +1,120 @@
+import { IconSquareTerminalOutline18 } from '@stagewise/icons';
+import { useComparingSelector, useKartonState } from '@ui/hooks/use-karton';
+import { normalizePath } from '@shared/path-utils';
+import { getWorkspaceLocation } from '../../_lib/workspace-location';
+import type { TerminalCommandItem } from '../command-center-model';
+import { filterAndRankCommandCenterItems } from '../command-center-search';
+
+const terminalIcon = <IconSquareTerminalOutline18 className="size-4" />;
+
+function shellTitle(type?: string) {
+  if (!type) return 'Shell';
+  if (type === 'powershell') return 'PowerShell';
+  return type.charAt(0).toUpperCase() + type.slice(1);
+}
+
+function terminalItemsEqual(
+  a: TerminalCommandItem[],
+  b: TerminalCommandItem[],
+) {
+  return (
+    a.length === b.length &&
+    a.every((item, index) => {
+      const other = b[index];
+      return (
+        other &&
+        item.id === other.id &&
+        item.owner.agentInstanceId === other.owner.agentInstanceId &&
+        item.title === other.title &&
+        item.subtitle === other.subtitle &&
+        item.isActive === other.isActive &&
+        item.lastFocusedAt === other.lastFocusedAt &&
+        item.keywords?.[2] === other.keywords?.[2]
+      );
+    })
+  );
+}
+
+export function useTerminalCommandItems(query: string) {
+  const terminals = useKartonState(
+    useComparingSelector((state): TerminalCommandItem[] => {
+      const mounts = Object.values(state.toolbox).flatMap(
+        (toolbox) => toolbox.workspace.mounts,
+      );
+      const agentTitle = (agentId: string | null) =>
+        agentId
+          ? state.agents.instances[agentId]?.state.title || 'Agent chat'
+          : 'Global';
+      const description = (
+        cwd: string,
+        agentId: string | null,
+        source: 'Agent' | 'Manual',
+      ) => {
+        const path = normalizePath(cwd);
+        const appsPath = agentId && `/agents/${agentId}/apps`;
+        const location =
+          !appsPath ||
+          (!path.endsWith(appsPath) && !path.includes(`${appsPath}/`))
+            ? getWorkspaceLocation(cwd, mounts)
+            : null;
+        const workspace = location?.detail
+          ? `${location.name} (${location.detail})`
+          : location?.name;
+        return [workspace, source].filter(Boolean).join(' · ');
+      };
+
+      const items: TerminalCommandItem[] = Object.values(state.contentTabs.tabs)
+        .filter((tab) => tab.type === 'terminal')
+        .map((tab) => ({
+          id: `terminal-tab:${tab.id}`,
+          kind: 'terminal',
+          mode: 'terminals',
+          title: `${tab.title.trim() || 'Terminal'} · ${agentTitle(tab.agentInstanceId)}`,
+          subtitle: description(tab.cwd, tab.agentInstanceId, 'Manual'),
+          keywords: ['terminal', 'manual', tab.cwd],
+          icon: terminalIcon,
+          owner: {
+            type: 'terminal',
+            terminalId: tab.id,
+            agentInstanceId: tab.agentInstanceId,
+          },
+          isActive: tab.id === state.contentTabs.activeTabId,
+          lastFocusedAt: tab.lastFocusedAt,
+        }));
+
+      for (const [agentInstanceId, toolbox] of Object.entries(state.toolbox)) {
+        for (const session of toolbox.shells?.sessions ?? []) {
+          if (session.exited) continue;
+          items.push({
+            id: `agent-shell:${session.id}`,
+            kind: 'terminal',
+            mode: 'terminals',
+            title: `${shellTitle(toolbox.shells?.shellType)} · ${agentTitle(agentInstanceId)}`,
+            subtitle: description(session.cwd, agentInstanceId, 'Agent'),
+            keywords: ['terminal', 'agent', session.cwd],
+            icon: terminalIcon,
+            owner: {
+              type: 'agent',
+              agentInstanceId,
+              sessionId: session.id,
+            },
+            isActive: false,
+            lastFocusedAt: session.createdAt,
+          });
+        }
+      }
+
+      return items;
+    }, terminalItemsEqual),
+  );
+
+  const items = filterAndRankCommandCenterItems(terminals, query).sort(
+    (a, b) => {
+      if (a.isActive !== b.isActive) return a.isActive ? -1 : 1;
+      if (b.score !== a.score) return (b.score ?? 0) - (a.score ?? 0);
+      return b.lastFocusedAt - a.lastFocusedAt;
+    },
+  );
+
+  return { items };
+}

--- a/packages/agent-shell/src/engine/shell-service.ts
+++ b/packages/agent-shell/src/engine/shell-service.ts
@@ -357,6 +357,7 @@ export class ShellService extends DisposableService {
     const sessions = this.sessionManager.getSessionsForAgent(agentInstanceId);
     const TAIL_CHARS = 400;
     const snapshot: ShellSnapshot = {
+      shellType: this.shell?.type,
       sessions: sessions.map((s) => {
         const lineCount = s.logger?.lineCount ?? 0;
         const logPath = s.logger

--- a/packages/agent-shell/src/schemas/index.ts
+++ b/packages/agent-shell/src/schemas/index.ts
@@ -200,6 +200,7 @@ export const shellSessionSnapshotSchema = z.object({
 export type ShellSessionSnapshot = z.infer<typeof shellSessionSnapshotSchema>;
 
 export const shellSnapshotSchema = z.object({
+  shellType: z.string().optional(),
   sessions: z.array(shellSessionSnapshotSchema),
 });
 export type ShellSnapshot = z.infer<typeof shellSnapshotSchema>;


### PR DESCRIPTION
## Summary

- list manual terminal tabs and active agent shell sessions in Cmd+K
- add a dedicated Terminals filter with shell, chat, repository, branch, and ownership context
- open and focus manual terminal tabs while routing agent shells to their associated chat
- reuse workspace location metadata from the local servers popover

Closes #1220

<img width="742" height="294" alt="image" src="https://github.com/user-attachments/assets/400d0592-1033-451d-ae06-67f33037f4f8" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly UI and navigation in the command center; the only contract tweak is optional `shellType` on shell snapshots, with no auth or data-handling changes.
> 
> **Overview**
> Adds **terminal discovery** to Cmd+K: a new **Terminals** filter (and a **Terminals** section in All) lists manual terminal tabs and active agent shell sessions, with labels for shell type, agent chat, workspace repo/branch, and Manual vs Agent ownership.
> 
> Selecting a **manual terminal** expands the content panel, switches to that tab, and focuses the PTY (opening the linked agent chat when present). Selecting an **agent shell** opens the associated agent chat. Browser tab search no longer includes terminal tabs.
> 
> Workspace display logic is **extracted** to shared `getWorkspaceLocation` and reused by the local servers popover and terminal results. `toolbox.shells` is typed as `ShellSnapshot`, and shell snapshots now optionally include **`shellType`** for friendlier titles in the command center.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c11e4cf4f439a561148431a744e3d8aea0d6d487. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated **Terminals** mode to the command center.
  * Command center search now includes open terminals and active shell sessions.
  * Selecting a terminal opens the relevant workspace and focuses the terminal (and keeps the view expanded when appropriate).
  * Workspace details now show Git repository and branch information when available.

* **Improvements**
  * Terminal results are ranked by activity and recent focus.
  * Shell snapshots now include the shell type.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds terminal discovery and navigation to the Command Center (Cmd+K) so you can find and open terminal tabs and active agent shells fast. Implements #1220 with a new Terminals mode and correct focus when opening terminals.

- **New Features**
  - Added a Terminals mode; terminals also surface in the All view. Updated search placeholder.
  - Results include manual terminal tabs and non-exited agent shell sessions. Labels show shell type (optional `shellType` on `ShellSnapshot`) and workspace repo/branch (via shared `getWorkspaceLocation`).
  - Selecting a manual terminal opens its tab first, expands content, and focuses the PTY; if linked to an agent, the agent chat opens after. Selecting an agent shell opens its associated agent chat.
  - Ranking prioritizes active and recent items; browser tab search no longer includes terminals.

<sup>Written for commit c11e4cf4f439a561148431a744e3d8aea0d6d487. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1477?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

