### PR TITLE
feat(stagewise): add device emulation toolbar

### DIFF
--- a/apps/browser/src/backend/services/window-layout/browsing-tab-controller.ts
+++ b/apps/browser/src/backend/services/window-layout/browsing-tab-controller.ts
@@ -200,6 +200,7 @@ export class BrowsingTabController extends EventEmitter<TabControllerEventMap> {
     scale: number;
     zoom: number;
   } | null = null;
+  private deviceEmulationFitScale = 1;
 
   // Viewport tracking
   private viewportTrackingInterval: NodeJS.Timeout | null = null;
@@ -852,6 +853,7 @@ export class BrowsingTabController extends EventEmitter<TabControllerEventMap> {
 
   private applyDeviceEmulation(emulation: DeviceEmulation | null) {
     const wc = this.webContentsView.webContents;
+    this.deviceEmulationFitScale = emulation?.fitScale ?? 1;
 
     if (!emulation) {
       wc.disableDeviceEmulation();
@@ -1156,7 +1158,7 @@ export class BrowsingTabController extends EventEmitter<TabControllerEventMap> {
     // both interpret their inputs as page CSS pixels.
     //
     // Two multiplicative contractions can be in play:
-    //   - scale: DevTools device-emulation scale (1 outside device mode)
+    //   - scale: DevTools or custom device-emulation scale
     //   - zoom:  Chromium page zoom (user Cmd+-/+, persisted per origin)
     //
     // UI px = page px * zoom * scale, so page px = UI px / (zoom * scale).
@@ -1164,7 +1166,9 @@ export class BrowsingTabController extends EventEmitter<TabControllerEventMap> {
     // that scales with the cursor's distance from the origin whenever page zoom
     // was not 100% (e.g. ~30px offset at 90% zoom, ~2x that at 50%).
 
-    const scale = this.currentViewportSize?.scale || 1;
+    const scale = this.webContentsView.webContents.isDevToolsOpened()
+      ? this.currentViewportSize?.scale || 1
+      : this.deviceEmulationFitScale;
     const zoom = this.currentViewportLayout?.zoom || 1;
     const factor = scale * zoom;
     const adjustedX = Math.floor(x / factor);
@@ -1203,7 +1207,9 @@ export class BrowsingTabController extends EventEmitter<TabControllerEventMap> {
   }) {
     // Same coordinate-space conversion as setContextSelectionMouseCoordinates:
     // UI px -> page px by dividing out both device-emulation scale and page zoom.
-    const scale = this.currentViewportSize?.scale || 1;
+    const scale = this.webContentsView.webContents.isDevToolsOpened()
+      ? this.currentViewportSize?.scale || 1
+      : this.deviceEmulationFitScale;
     const zoom = this.currentViewportLayout?.zoom || 1;
     const factor = scale * zoom;
     const adjustedX = Math.floor(event.x / factor);
@@ -1899,13 +1905,12 @@ export class BrowsingTabController extends EventEmitter<TabControllerEventMap> {
       await this.updateViewportSizeFromDevTools();
     } else {
       // When DevTools are closed, use full visualViewport dimensions
-      // Scale is always 1 in non-devtools mode
       const viewportSize = {
         width: visualViewport.clientWidth,
         height: visualViewport.clientHeight,
         top: 0,
         left: 0,
-        scale: 1,
+        scale: this.deviceEmulationFitScale,
         fitScale: 1,
         appliedDeviceScaleFactor: 1,
       };

--- a/apps/browser/src/backend/services/window-layout/browsing-tab-controller.ts
+++ b/apps/browser/src/backend/services/window-layout/browsing-tab-controller.ts
@@ -20,7 +20,7 @@ import {
   type TabKartonContract,
   type SerializableKeyboardEvent,
 } from '@shared/karton-contracts/web-contents-preload';
-import type { ColorScheme } from '@shared/karton-contracts/ui';
+import type { ColorScheme, DeviceEmulation } from '@shared/karton-contracts/ui';
 import type { SelectedElement } from '@shared/selected-elements';
 import { SelectedElementTracker } from './selected-element-tracker';
 import { electronInputToDomKeyboardEvent } from '@/utils/electron-input-to-dom-keyboard-event';
@@ -65,6 +65,7 @@ export interface TabState {
   isPlayingAudio: boolean;
   isMuted: boolean;
   colorScheme: ColorScheme;
+  deviceEmulation: DeviceEmulation | null;
   error: {
     code: number;
     message?: string;
@@ -378,6 +379,7 @@ export class BrowsingTabController extends EventEmitter<TabControllerEventMap> {
       isPlayingAudio: this.webContentsView.webContents.isCurrentlyAudible(),
       isMuted: this.webContentsView.webContents.audioMuted,
       colorScheme: 'system',
+      deviceEmulation: null,
       error: null,
       navigationHistory: {
         canGoBack: false,
@@ -835,6 +837,36 @@ export class BrowsingTabController extends EventEmitter<TabControllerEventMap> {
         new_value: nextScheme,
       });
     }
+  }
+
+  public setDeviceEmulation(
+    emulation: DeviceEmulation | null,
+    transient = false,
+  ) {
+    const wc = this.webContentsView.webContents;
+    if (wc.isDestroyed()) return;
+
+    if (!transient) this.updateState({ deviceEmulation: emulation });
+    if (!wc.isDevToolsOpened()) this.applyDeviceEmulation(emulation);
+  }
+
+  private applyDeviceEmulation(emulation: DeviceEmulation | null) {
+    const wc = this.webContentsView.webContents;
+
+    if (!emulation) {
+      wc.disableDeviceEmulation();
+      return;
+    }
+
+    const viewSize = { width: emulation.width, height: emulation.height };
+    wc.enableDeviceEmulation({
+      screenPosition: emulation.mobile ? 'mobile' : 'desktop',
+      screenSize: viewSize,
+      viewPosition: { x: 0, y: 0 },
+      deviceScaleFactor: emulation.deviceScaleFactor,
+      viewSize,
+      scale: emulation.scale,
+    });
   }
 
   public focus() {
@@ -1528,6 +1560,7 @@ export class BrowsingTabController extends EventEmitter<TabControllerEventMap> {
         devTools: { open: this.currentState.devTools.open, chromeOpen: false },
       });
       this.detachDevToolsDebugger();
+      this.applyDeviceEmulation(this.currentState.deviceEmulation);
       // Immediately update viewport size when DevTools close
       // to transition back to regular viewport tracking (full size)
       try {
@@ -1540,6 +1573,7 @@ export class BrowsingTabController extends EventEmitter<TabControllerEventMap> {
     });
 
     wc.on('devtools-opened', () => {
+      wc.disableDeviceEmulation();
       this.emit('devtoolsOpened', this.id);
       this.updateState({
         devTools: { open: this.currentState.devTools.open, chromeOpen: true },

--- a/apps/browser/src/backend/services/window-layout/browsing-tab-controller.ts
+++ b/apps/browser/src/backend/services/window-layout/browsing-tab-controller.ts
@@ -1002,8 +1002,14 @@ export class BrowsingTabController extends EventEmitter<TabControllerEventMap> {
         return null;
       }
 
-      // Calculate capture rect with padding, accounting for scroll position
-      const scale = viewportLayout?.scale ?? 1;
+      // Convert page CSS pixels to capture-surface pixels. Custom device
+      // emulation scales the rendered surface without changing DOM rects.
+      const scale =
+        (viewportLayout?.scale ?? 1) *
+        (wc.isDevToolsOpened()
+          ? 1
+          : (viewportLayout?.zoom ?? 1) *
+            (this.currentState.deviceEmulation?.scale ?? 1));
 
       // For iframe elements, transform coordinates to main frame
       let effectiveBoundingRect = boundingRect;

--- a/apps/browser/src/backend/services/window-layout/index.ts
+++ b/apps/browser/src/backend/services/window-layout/index.ts
@@ -30,6 +30,7 @@ import { ChatStateController } from './chat-state-controller';
 import {
   type ColorScheme,
   type ConfigurablePermissionType,
+  type DeviceEmulation,
   PermissionSetting,
   configurablePermissionTypes,
   getFileTabDefaults,
@@ -1196,6 +1197,7 @@ export class WindowLayoutService extends DisposableService {
     this.uiController.on('toggleAudioMuted', this.handleToggleAudioMuted);
     this.uiController.on('setColorScheme', this.handleSetColorScheme);
     this.uiController.on('cycleColorScheme', this.handleCycleColorScheme);
+    this.uiController.on('setDeviceEmulation', this.handleSetDeviceEmulation);
     this.uiController.on('setZoomPercentage', this.handleSetZoomPercentage);
     this.uiController.on('setTabAgentInstance', this.handleSetTabAgentInstance);
     this.uiController.on('setLastOpenAgentId', this.handleSetLastOpenAgentId);
@@ -2280,6 +2282,15 @@ export class WindowLayoutService extends DisposableService {
   private handleCycleColorScheme = async (tabId?: string) => {
     const tab = tabId ? this.tabs[tabId] : this.activeTab;
     await tab?.cycleColorScheme();
+  };
+
+  private handleSetDeviceEmulation = async (
+    emulation: DeviceEmulation | null,
+    tabId?: string,
+    transient?: boolean,
+  ) => {
+    const tab = tabId ? this.tabs[tabId] : this.activeTab;
+    tab?.setDeviceEmulation(emulation, transient);
   };
 
   private handleSetZoomPercentage = async (

--- a/apps/browser/src/backend/services/window-layout/ui-controller.ts
+++ b/apps/browser/src/backend/services/window-layout/ui-controller.ts
@@ -8,7 +8,7 @@ import type { TelemetryService } from '../telemetry';
 import { EventEmitter } from 'node:events';
 import { KartonService } from '../karton';
 import type { SerializableKeyboardEvent } from '@shared/karton-contracts/web-contents-preload';
-import type { ColorScheme } from '@shared/karton-contracts/ui';
+import type { ColorScheme, DeviceEmulation } from '@shared/karton-contracts/ui';
 import type { PageTransition } from '@shared/karton-contracts/pages-api/types';
 import type { SelectedElement } from '@shared/selected-elements';
 import type { SettingsRoute } from '@shared/settings-route';
@@ -178,6 +178,11 @@ export interface UIControllerEventMap {
   toggleAudioMuted: [tabId?: string];
   setColorScheme: [scheme: ColorScheme, tabId?: string];
   cycleColorScheme: [tabId?: string];
+  setDeviceEmulation: [
+    emulation: DeviceEmulation | null,
+    tabId?: string,
+    transient?: boolean,
+  ];
   setZoomPercentage: [percentage: number, tabId?: string];
   setTabAgentInstance: [tabId: string, agentInstanceId: string | null];
   setLastOpenAgentId: [agentInstanceId: string | null];
@@ -876,6 +881,17 @@ export class UIController extends EventEmitter<UIControllerEventMap> {
       },
     );
     this.uiKarton.registerServerProcedureHandler(
+      'browser.setDeviceEmulation',
+      async (
+        _callingClientId: string,
+        emulation: DeviceEmulation | null,
+        tabId?: string,
+        transient?: boolean,
+      ) => {
+        this.emit('setDeviceEmulation', emulation, tabId, transient);
+      },
+    );
+    this.uiKarton.registerServerProcedureHandler(
       'browser.setZoomPercentage',
       async (_callingClientId: string, percentage: number, tabId?: string) => {
         this.emit('setZoomPercentage', percentage, tabId);
@@ -1234,6 +1250,7 @@ export class UIController extends EventEmitter<UIControllerEventMap> {
     this.uiKarton.removeServerProcedureHandler('browser.toggleAudioMuted');
     this.uiKarton.removeServerProcedureHandler('browser.setColorScheme');
     this.uiKarton.removeServerProcedureHandler('browser.cycleColorScheme');
+    this.uiKarton.removeServerProcedureHandler('browser.setDeviceEmulation');
     this.uiKarton.removeServerProcedureHandler('browser.setZoomPercentage');
     this.uiKarton.removeServerProcedureHandler('browser.setTabAgentInstance');
     this.uiKarton.removeServerProcedureHandler(

--- a/apps/browser/src/shared/karton-contracts/ui/index.ts
+++ b/apps/browser/src/shared/karton-contracts/ui/index.ts
@@ -764,6 +764,7 @@ export type DeviceEmulation = {
   deviceScaleFactor: number;
   mobile: boolean;
   scale: number;
+  fitScale: number;
 };
 
 export type TabState = {

--- a/apps/browser/src/shared/karton-contracts/ui/index.ts
+++ b/apps/browser/src/shared/karton-contracts/ui/index.ts
@@ -757,6 +757,15 @@ export type FileTreeOperationResult = {
   relativePath?: string;
 };
 
+export type DeviceEmulation = {
+  presetId: string;
+  width: number;
+  height: number;
+  deviceScaleFactor: number;
+  mobile: boolean;
+  scale: number;
+};
+
 export type TabState = {
   id: string;
   /** Discriminator: 'browser' for web-content tabs, 'terminal' for PTY tabs, 'file' for workspace file previews. */
@@ -771,6 +780,8 @@ export type TabState = {
   isPlayingAudio: boolean;
   isMuted: boolean;
   colorScheme: ColorScheme;
+  /** Per-tab device viewport emulation. `null` means the normal browser viewport. */
+  deviceEmulation: DeviceEmulation | null;
   error: {
     code: number;
     message?: string;
@@ -833,6 +844,7 @@ export function getTerminalTabDefaults(): Omit<
     isPlayingAudio: false,
     isMuted: false,
     colorScheme: 'system' as TabState['colorScheme'],
+    deviceEmulation: null,
     error: null,
     navigationHistory: { canGoBack: false, canGoForward: false },
     devTools: { open: false, chromeOpen: false },
@@ -866,6 +878,7 @@ export function getFileTabDefaults(): Omit<
     isPlayingAudio: false,
     isMuted: false,
     colorScheme: 'system' as TabState['colorScheme'],
+    deviceEmulation: null,
     error: null,
     navigationHistory: { canGoBack: false, canGoForward: false },
     devTools: { open: false, chromeOpen: false },
@@ -1767,6 +1780,11 @@ export type KartonContract = {
       toggleAudioMuted: (tabId?: string) => Promise<void>;
       setColorScheme: (scheme: ColorScheme, tabId?: string) => Promise<void>;
       cycleColorScheme: (tabId?: string) => Promise<void>;
+      setDeviceEmulation: (
+        emulation: DeviceEmulation | null,
+        tabId?: string,
+        transient?: boolean,
+      ) => Promise<void>;
       setZoomPercentage: (percentage: number, tabId?: string) => Promise<void>;
       /** Set the agent instance ID this tab is attached to (null = globally visible) */
       setTabAgentInstance: (

--- a/apps/browser/src/ui/screens/main/content/_components/control-buttons/device-emulation.tsx
+++ b/apps/browser/src/ui/screens/main/content/_components/control-buttons/device-emulation.tsx
@@ -1,0 +1,41 @@
+import type { TabState } from '@shared/karton-contracts/ui';
+import { Button } from '@stagewise/stage-ui/components/button';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@stagewise/stage-ui/components/tooltip';
+import { useKartonProcedure } from '@ui/hooks/use-karton';
+import { MonitorSmartphoneIcon } from 'lucide-react';
+import { DEFAULT_DEVICE_EMULATION } from '../device-emulation-presets';
+
+export function DeviceEmulationWidget({ tab }: { tab: TabState }) {
+  const setDeviceEmulation = useKartonProcedure(
+    (procedures) => procedures.browser.setDeviceEmulation,
+  );
+  const isEnabled = tab.deviceEmulation !== null;
+  const label = isEnabled ? 'Hide device toolbar' : 'Show device toolbar';
+
+  return (
+    <Tooltip>
+      <TooltipTrigger>
+        <Button
+          variant="ghost"
+          size="icon-sm"
+          aria-label={label}
+          onClick={() =>
+            setDeviceEmulation(
+              isEnabled ? null : DEFAULT_DEVICE_EMULATION,
+              tab.id,
+            )
+          }
+          className="text-muted-foreground data-[active=true]:text-primary-solid data-[active=true]:hover:text-primary-solid"
+          data-active={isEnabled ? 'true' : 'false'}
+        >
+          <MonitorSmartphoneIcon className="size-4" />
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent>{label}</TooltipContent>
+    </Tooltip>
+  );
+}

--- a/apps/browser/src/ui/screens/main/content/_components/control-buttons/zoom-bar.tsx
+++ b/apps/browser/src/ui/screens/main/content/_components/control-buttons/zoom-bar.tsx
@@ -136,7 +136,12 @@ export function ZoomBar({ tabId }: ZoomBarProps) {
         </Tooltip>
         <Tooltip>
           <TooltipTrigger>
-            <Button variant="ghost" size="xs" onClick={resetZoom}>
+            <Button
+              variant="ghost"
+              size="xs"
+              className="w-12 px-0 tabular-nums"
+              onClick={resetZoom}
+            >
               {zoomPercentage}%
             </Button>
           </TooltipTrigger>

--- a/apps/browser/src/ui/screens/main/content/_components/device-emulation-frame.tsx
+++ b/apps/browser/src/ui/screens/main/content/_components/device-emulation-frame.tsx
@@ -1,0 +1,390 @@
+import type { DeviceEmulation, TabState } from '@shared/karton-contracts/ui';
+import { Button } from '@stagewise/stage-ui/components/button';
+import { Input } from '@stagewise/stage-ui/components/input';
+import { Select } from '@stagewise/stage-ui/components/select';
+import { IconReuseOutline18 } from '@stagewise/icons';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@stagewise/stage-ui/components/tooltip';
+import { useKartonProcedure, useKartonState } from '@ui/hooks/use-karton';
+import { XIcon } from 'lucide-react';
+import type {
+  PointerEvent as ReactPointerEvent,
+  ReactNode,
+  RefObject,
+} from 'react';
+import { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { DEVICE_PRESETS, getPresetConfig } from './device-emulation-presets';
+
+const MIN_VIEWPORT_WIDTH = 240;
+const MIN_VIEWPORT_HEIGHT = 160;
+const CANVAS_PADDING = 32;
+const DEVICE_PRESET_ITEMS = DEVICE_PRESETS.map((preset) => ({
+  value: preset.presetId,
+  label: preset.label,
+  description: `${preset.width} × ${preset.height}`,
+}));
+const ZOOM_ITEMS = [50, 75, 100, 125, 150, 200].map((zoom) => ({
+  value: String(zoom),
+  label: `${zoom}%`,
+}));
+
+const RESIZE_HANDLES = [
+  ['left', 'top-0 -left-4 h-full w-4 cursor-ew-resize', 'h-10 w-0.5'],
+  ['right', 'top-0 -right-4 h-full w-4 cursor-ew-resize', 'h-10 w-0.5'],
+  ['bottom', '-bottom-4 left-0 h-4 w-full cursor-ns-resize', 'h-0.5 w-10'],
+  [
+    'bottom-left',
+    '-bottom-4 -left-4 size-4 cursor-nesw-resize',
+    'size-2 rounded-sm',
+  ],
+  [
+    'bottom-right',
+    '-right-4 -bottom-4 size-4 cursor-nwse-resize',
+    'size-2 rounded-sm',
+  ],
+] as const;
+type ResizeEdge = (typeof RESIZE_HANDLES)[number][0];
+
+type DeviceEmulationFrameProps = {
+  tab: TabState;
+  containerRef: RefObject<HTMLDivElement | null>;
+  children: ReactNode;
+};
+
+export function DeviceEmulationFrame({
+  tab,
+  containerRef,
+  children,
+}: DeviceEmulationFrameProps) {
+  const emulation = tab.deviceEmulation;
+
+  if (!emulation || tab.devTools.chromeOpen) {
+    return (
+      <div
+        ref={containerRef}
+        id={`dev-app-preview-container-${tab.id}`}
+        className="relative flex size-full flex-col items-center justify-center overflow-hidden rounded-lg"
+      >
+        {children}
+      </div>
+    );
+  }
+
+  return (
+    <EnabledDeviceEmulationFrame
+      tab={tab}
+      emulation={emulation}
+      containerRef={containerRef}
+    >
+      {children}
+    </EnabledDeviceEmulationFrame>
+  );
+}
+
+function EnabledDeviceEmulationFrame({
+  tab,
+  emulation: initialEmulation,
+  containerRef,
+  children,
+}: DeviceEmulationFrameProps & { emulation: DeviceEmulation }) {
+  const setDeviceEmulation = useKartonProcedure(
+    (procedures) => procedures.browser.setDeviceEmulation,
+  );
+  const setZoomPercentage = useKartonProcedure(
+    (procedures) => procedures.browser.setZoomPercentage,
+  );
+  const uiZoomPercentage = useKartonState(
+    (state) => state.preferences.general.uiZoomPercentage,
+  );
+  const canvasRef = useRef<HTMLDivElement>(null);
+  const dragRef = useRef<{
+    edge: ResizeEdge;
+    startX: number;
+    startY: number;
+    startWidth: number;
+    startHeight: number;
+    scale: number;
+  } | null>(null);
+  const dragFrameRef = useRef<number | null>(null);
+  const pendingDragSizeRef = useRef<{
+    width: number;
+    height: number;
+  } | null>(null);
+  const [canvasSize, setCanvasSize] = useState({ width: 0, height: 0 });
+  const [emulation, setEmulation] = useState(initialEmulation);
+  const viewportSize = {
+    width: emulation.width,
+    height: emulation.height,
+  };
+
+  useLayoutEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+
+    const updateSize = () => {
+      setCanvasSize({
+        width: canvas.clientWidth,
+        height: canvas.clientHeight,
+      });
+    };
+
+    updateSize();
+    const observer = new ResizeObserver(updateSize);
+    observer.observe(canvas);
+    return () => observer.disconnect();
+  }, []);
+
+  const fitScale =
+    canvasSize.width && canvasSize.height
+      ? Math.max(
+          0.1,
+          Math.min(
+            1,
+            (canvasSize.width - CANVAS_PADDING) / viewportSize.width,
+            (canvasSize.height - CANVAS_PADDING) / viewportSize.height,
+          ),
+        )
+      : 1;
+  const appliedScale = fitScale * (uiZoomPercentage / 100);
+
+  useEffect(() => {
+    setDeviceEmulation.fire(
+      {
+        ...emulation,
+        scale: appliedScale,
+      },
+      tab.id,
+      dragRef.current !== null,
+    );
+  }, [emulation, appliedScale, setDeviceEmulation, tab.id]);
+
+  useEffect(
+    () => () => {
+      if (dragFrameRef.current !== null) {
+        cancelAnimationFrame(dragFrameRef.current);
+      }
+    },
+    [],
+  );
+
+  const canResize = emulation.presetId === 'responsive';
+  const frameWidth = Math.round(viewportSize.width * fitScale);
+  const frameHeight = Math.round(viewportSize.height * fitScale);
+
+  const updateEmulation = (updates: Partial<DeviceEmulation>) => {
+    setEmulation((current) => ({
+      ...current,
+      ...updates,
+    }));
+  };
+
+  const handlePresetChange = (presetId: string) => {
+    const preset = DEVICE_PRESETS.find((item) => item.presetId === presetId);
+    if (!preset) return;
+    updateEmulation(getPresetConfig(preset));
+  };
+
+  const updateDimension = (dimension: 'width' | 'height', value: string) => {
+    const number = Number(value);
+    if (!number) return;
+    const min =
+      dimension === 'width' ? MIN_VIEWPORT_WIDTH : MIN_VIEWPORT_HEIGHT;
+    updateEmulation({
+      presetId: 'responsive',
+      deviceScaleFactor: 1,
+      mobile: false,
+      [dimension]: Math.max(number, min),
+    });
+  };
+
+  const handlePointerDown = (
+    event: ReactPointerEvent<HTMLDivElement>,
+    edge: ResizeEdge,
+  ) => {
+    event.preventDefault();
+    event.currentTarget.setPointerCapture(event.pointerId);
+    dragRef.current = {
+      edge,
+      startX: event.clientX,
+      startY: event.clientY,
+      startWidth: viewportSize.width,
+      startHeight: viewportSize.height,
+      scale: fitScale,
+    };
+  };
+
+  const handlePointerMove = (event: ReactPointerEvent<HTMLDivElement>) => {
+    const drag = dragRef.current;
+    if (!drag) return;
+
+    const deltaX = (event.clientX - drag.startX) / drag.scale;
+    const deltaY = (event.clientY - drag.startY) / drag.scale;
+    let width = drag.startWidth;
+    let height = drag.startHeight;
+
+    if (drag.edge.includes('left')) width -= deltaX * 2;
+    if (drag.edge.includes('right')) width += deltaX * 2;
+    if (drag.edge.includes('bottom')) height += deltaY;
+
+    pendingDragSizeRef.current = {
+      width: Math.max(Math.round(width), MIN_VIEWPORT_WIDTH),
+      height: Math.max(Math.round(height), MIN_VIEWPORT_HEIGHT),
+    };
+    if (dragFrameRef.current !== null) return;
+
+    dragFrameRef.current = requestAnimationFrame(() => {
+      dragFrameRef.current = null;
+      const size = pendingDragSizeRef.current;
+      pendingDragSizeRef.current = null;
+      if (size) setEmulation((current) => ({ ...current, ...size }));
+    });
+  };
+
+  const handlePointerUp = (event: ReactPointerEvent<HTMLDivElement>) => {
+    const drag = dragRef.current;
+    if (!drag) return;
+    event.currentTarget.releasePointerCapture(event.pointerId);
+
+    if (dragFrameRef.current !== null) {
+      cancelAnimationFrame(dragFrameRef.current);
+      dragFrameRef.current = null;
+    }
+    const finalSize = pendingDragSizeRef.current;
+    pendingDragSizeRef.current = null;
+    dragRef.current = null;
+    setEmulation((current) =>
+      finalSize ? { ...current, ...finalSize } : { ...current },
+    );
+  };
+
+  return (
+    <div className="flex size-full min-h-0 flex-col overflow-hidden">
+      <div className="relative z-40 flex h-9 shrink-0 items-center gap-2 border-derived border-b bg-background pr-1 pl-2">
+        <Select
+          items={DEVICE_PRESET_ITEMS}
+          value={emulation.presetId}
+          onValueChange={(value) => handlePresetChange(value)}
+          renderValue={(presetId) => (
+            <span className="flex min-w-0 items-center gap-1.5">
+              <span className="shrink-0 text-muted-foreground">
+                Dimensions:
+              </span>
+              <span className="truncate text-foreground">
+                {
+                  DEVICE_PRESET_ITEMS.find((item) => item.value === presetId)
+                    ?.label
+                }
+              </span>
+            </span>
+          )}
+          size="sm"
+          triggerVariant="ghost"
+          triggerClassName="w-56 justify-between"
+        />
+        <div className="flex items-center gap-1">
+          <Input
+            type="number"
+            aria-label="Viewport width"
+            value={viewportSize.width}
+            debounce={250}
+            onValueChange={(value) => updateDimension('width', value)}
+            size="xs"
+            className="w-16 px-1 text-center text-sm tabular-nums"
+          />
+          <span className="text-muted-foreground text-sm">×</span>
+          <Input
+            type="number"
+            aria-label="Viewport height"
+            value={viewportSize.height}
+            debounce={250}
+            onValueChange={(value) => updateDimension('height', value)}
+            size="xs"
+            className="w-16 px-1 text-center text-sm tabular-nums"
+          />
+        </div>
+        <Tooltip>
+          <TooltipTrigger>
+            <Button
+              variant="ghost"
+              size="icon-sm"
+              aria-label="Rotate viewport"
+              onClick={() =>
+                updateEmulation({
+                  width: viewportSize.height,
+                  height: viewportSize.width,
+                })
+              }
+            >
+              <IconReuseOutline18 className="size-4" aria-hidden="true" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>Rotate viewport</TooltipContent>
+        </Tooltip>
+        <Select
+          items={ZOOM_ITEMS}
+          value={String(tab.zoomPercentage)}
+          onValueChange={(value) => setZoomPercentage(Number(value), tab.id)}
+          renderValue={() => `${tab.zoomPercentage}%`}
+          size="sm"
+          triggerVariant="ghost"
+          triggerClassName="w-20 justify-between tabular-nums"
+          align="end"
+        />
+        <div className="ml-auto">
+          <Tooltip>
+            <TooltipTrigger>
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                aria-label="Hide device toolbar"
+                onClick={() => setDeviceEmulation(null, tab.id)}
+              >
+                <XIcon className="size-4" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>Hide device toolbar</TooltipContent>
+          </Tooltip>
+        </div>
+      </div>
+
+      <div
+        ref={canvasRef}
+        className="relative flex min-h-0 flex-1 items-start justify-center overflow-hidden p-4"
+      >
+        <div
+          className="relative shrink-0 shadow-[0_0_0_100vmax_var(--color-surface-2)] ring-1 ring-border"
+          style={{ width: frameWidth, height: frameHeight }}
+        >
+          <div
+            ref={containerRef}
+            id={`dev-app-preview-container-${tab.id}`}
+            className="absolute inset-0 overflow-hidden"
+          >
+            {children}
+          </div>
+
+          {canResize
+            ? RESIZE_HANDLES.map(([edge, className, indicatorClassName]) => (
+                <div
+                  key={edge}
+                  aria-hidden="true"
+                  onPointerDown={(event) => handlePointerDown(event, edge)}
+                  onPointerMove={handlePointerMove}
+                  onPointerUp={handlePointerUp}
+                  onPointerCancel={handlePointerUp}
+                  className={`group absolute z-50 flex touch-none items-center justify-center text-muted-foreground ${className}`}
+                >
+                  <span
+                    className={`rounded-full bg-muted-foreground/60 transition-colors group-hover:bg-foreground ${indicatorClassName}`}
+                  />
+                </div>
+              ))
+            : null}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/browser/src/ui/screens/main/content/_components/device-emulation-frame.tsx
+++ b/apps/browser/src/ui/screens/main/content/_components/device-emulation-frame.tsx
@@ -26,10 +26,6 @@ const DEVICE_PRESET_ITEMS = DEVICE_PRESETS.map((preset) => ({
   label: preset.label,
   description: `${preset.width} × ${preset.height}`,
 }));
-const ZOOM_ITEMS = [50, 75, 100, 125, 150, 200].map((zoom) => ({
-  value: String(zoom),
-  label: `${zoom}%`,
-}));
 
 const RESIZE_HANDLES = [
   ['left', 'top-0 -left-4 h-full w-4 cursor-ew-resize', 'h-10 w-0.5'],
@@ -93,9 +89,6 @@ function EnabledDeviceEmulationFrame({
   const setDeviceEmulation = useKartonProcedure(
     (procedures) => procedures.browser.setDeviceEmulation,
   );
-  const setZoomPercentage = useKartonProcedure(
-    (procedures) => procedures.browser.setZoomPercentage,
-  );
   const uiZoomPercentage = useKartonState(
     (state) => state.preferences.general.uiZoomPercentage,
   );
@@ -155,11 +148,12 @@ function EnabledDeviceEmulationFrame({
       {
         ...emulation,
         scale: appliedScale,
+        fitScale,
       },
       tab.id,
       dragRef.current !== null,
     );
-  }, [emulation, appliedScale, setDeviceEmulation, tab.id]);
+  }, [emulation, appliedScale, fitScale, setDeviceEmulation, tab.id]);
 
   useEffect(
     () => () => {
@@ -323,16 +317,6 @@ function EnabledDeviceEmulationFrame({
           </TooltipTrigger>
           <TooltipContent>Rotate viewport</TooltipContent>
         </Tooltip>
-        <Select
-          items={ZOOM_ITEMS}
-          value={String(tab.zoomPercentage)}
-          onValueChange={(value) => setZoomPercentage(Number(value), tab.id)}
-          renderValue={() => `${tab.zoomPercentage}%`}
-          size="sm"
-          triggerVariant="ghost"
-          triggerClassName="w-20 justify-between tabular-nums"
-          align="end"
-        />
         <div className="ml-auto">
           <Tooltip>
             <TooltipTrigger>

--- a/apps/browser/src/ui/screens/main/content/_components/device-emulation-presets.ts
+++ b/apps/browser/src/ui/screens/main/content/_components/device-emulation-presets.ts
@@ -1,6 +1,6 @@
 import type { DeviceEmulation } from '@shared/karton-contracts/ui';
 
-export type DevicePreset = Omit<DeviceEmulation, 'scale'> & {
+export type DevicePreset = Omit<DeviceEmulation, 'scale' | 'fitScale'> & {
   label: string;
 };
 
@@ -39,4 +39,5 @@ export const getPresetConfig = ({ label: _label, ...config }: DevicePreset) =>
 export const DEFAULT_DEVICE_EMULATION: DeviceEmulation = {
   ...getPresetConfig(DEVICE_PRESETS[0]!),
   scale: 1,
+  fitScale: 1,
 };

--- a/apps/browser/src/ui/screens/main/content/_components/device-emulation-presets.ts
+++ b/apps/browser/src/ui/screens/main/content/_components/device-emulation-presets.ts
@@ -1,0 +1,42 @@
+import type { DeviceEmulation } from '@shared/karton-contracts/ui';
+
+export type DevicePreset = Omit<DeviceEmulation, 'scale'> & {
+  label: string;
+};
+
+const preset = (
+  presetId: string,
+  label: string,
+  width: number,
+  height: number,
+  deviceScaleFactor = 1,
+  mobile = true,
+): DevicePreset => ({
+  presetId,
+  label,
+  width,
+  height,
+  deviceScaleFactor,
+  mobile,
+});
+
+export const DEVICE_PRESETS = [
+  preset('responsive', 'Responsive', 1280, 720, 1, false),
+  preset('iphone-17', 'iPhone 17', 402, 874, 3),
+  preset('iphone-air', 'iPhone Air', 420, 912, 3),
+  preset('iphone-17-pro-max', 'iPhone 17 Pro Max', 440, 956, 3),
+  preset('iphone-16e', 'iPhone 16e', 390, 844, 3),
+  preset('pixel-10', 'Pixel 10', 412, 924, 2.625),
+  preset('galaxy-s26-ultra', 'Galaxy S26 Ultra', 412, 892, 3.5),
+  preset('ipad-pro-11', 'iPad Pro 11"', 834, 1210, 2),
+  preset('ipad-mini', 'iPad mini', 744, 1133, 2),
+  preset('laptop', 'Laptop', 1440, 900, 1, false),
+];
+
+export const getPresetConfig = ({ label: _label, ...config }: DevicePreset) =>
+  config;
+
+export const DEFAULT_DEVICE_EMULATION: DeviceEmulation = {
+  ...getPresetConfig(DEVICE_PRESETS[0]!),
+  scale: 1,
+};

--- a/apps/browser/src/ui/screens/main/content/_components/per-tab-content.tsx
+++ b/apps/browser/src/ui/screens/main/content/_components/per-tab-content.tsx
@@ -11,7 +11,9 @@ import { WebContentsOverlay } from '@ui/components/web-contents-overlay';
 import { WebContentsOverlayProvider } from '@ui/contexts';
 import { BasicAuthDialog } from './basic-auth-dialog';
 import { ColorSchemeWidget } from './control-buttons/color-scheme';
+import { DeviceEmulationWidget } from './control-buttons/device-emulation';
 import { ChromeDevToolsWidget } from './control-buttons/chrome-devtools';
+import { DeviceEmulationFrame } from './device-emulation-frame';
 import { PerTerminalContent } from '../../terminal-panel/_components/per-terminal-content';
 import { FilePreviewTabContent } from '../../file-tree/file-preview-tab-content';
 
@@ -76,16 +78,16 @@ export const PerTabContent = forwardRef<PerTabContentRef, PerTabContentProps>(
           )}
           <div className="flex flex-row items-center gap-0.5">
             {tab && <ColorSchemeWidget tab={tab} />}
+            {tab && <DeviceEmulationWidget tab={tab} />}
             {tab && <ChromeDevToolsWidget tab={tab} />}
           </div>
         </div>
         {/* Content area - wrapped with WebContentsOverlayProvider for overlay access */}
         <WebContentsOverlayProvider>
-          <div className="flex size-full flex-col items-center justify-center overflow-hidden">
-            <div
-              ref={devAppPreviewContainerRef}
-              id={`dev-app-preview-container-${tabId}`}
-              className="relative flex size-full flex-col items-center justify-center overflow-hidden rounded-lg"
+          {tab ? (
+            <DeviceEmulationFrame
+              tab={tab}
+              containerRef={devAppPreviewContainerRef}
             >
               {/* Unified web contents overlay for devtools and DOM selection */}
               {!isInternalPage && <WebContentsOverlay />}
@@ -97,8 +99,8 @@ export const PerTabContent = forwardRef<PerTabContentRef, PerTabContentProps>(
                   container={devAppPreviewContainerRef}
                 />
               )}
-            </div>
-          </div>
+            </DeviceEmulationFrame>
+          ) : null}
         </WebContentsOverlayProvider>
       </div>
     );

--- a/packages/icons/src/nucleo/ui-outline-18/IconReuseOutline18.tsx
+++ b/packages/icons/src/nucleo/ui-outline-18/IconReuseOutline18.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { Icon, type IconProps } from './Icon';
+
+interface IconReuseOutline18Props extends IconProps {
+  strokeWidth?: number;
+}
+
+export const IconReuseOutline18: React.FC<IconReuseOutline18Props> = ({
+  strokeWidth = 1.5,
+  ...props
+}) => {
+  return (
+    <Icon size="18px" {...props}>
+      <path
+        d="M7 13.25 5 15.25 7 17.25"
+        stroke="currentColor"
+        strokeWidth={strokeWidth}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        data-color="color-2"
+        fill="none"
+      />
+      <path
+        d="M11 4.75 13 2.75 11 .75"
+        stroke="currentColor"
+        strokeWidth={strokeWidth}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        fill="none"
+      />
+      <path
+        d="M5.25 15.25h8c1.105 0 2-.9 2-2v-8.5"
+        stroke="currentColor"
+        strokeWidth={strokeWidth}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        data-color="color-2"
+        fill="none"
+      />
+      <path
+        d="M12.75 2.75h-8c-1.105 0-2 .9-2 2v8.5"
+        stroke="currentColor"
+        strokeWidth={strokeWidth}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        fill="none"
+      />
+    </Icon>
+  );
+};

--- a/packages/icons/src/nucleo/ui-outline-18/index.ts
+++ b/packages/icons/src/nucleo/ui-outline-18/index.ts
@@ -86,6 +86,7 @@ export { IconPresentationScreenVideoOutline18 } from './IconPresentationScreenVi
 export { IconPuzzlePieceOutline18 } from './IconPuzzlePieceOutline18';
 export { IconRedoOutline18 } from './IconRedoOutline18';
 export { IconRefreshAnticlockwiseOutline18 } from './IconRefreshAnticlockwiseOutline18';
+export { IconReuseOutline18 } from './IconReuseOutline18';
 export { IconSearchContentOutline18 } from './IconSearchContentOutline18';
 export { IconServerOutline18 } from './IconServerOutline18';
 export { IconSideProfileSparkleOutline18 } from './IconSideProfileSparkleOutline18';


### PR DESCRIPTION
## Summary

- add a per-tab device emulation toolbar
- support responsive resizing, viewport dimensions, rotation, and page zoom
- add current iPhone, Pixel, Galaxy, iPad, and laptop presets
- fit emulated viewports into the available browser area
- temporarily disable emulation while Chrome DevTools are open and restore it afterward
- add the reuse icon to `@stagewise/icons`

<img width="895" height="577" alt="image" src="https://github.com/user-attachments/assets/5d404c1f-37a2-4932-9706-56cebd4efe3e" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches input coordinate mapping, screenshots, and Electron device emulation alongside DevTools lifecycle—bugs could misalign selection or break emulation restore, but scope is tab preview UX rather than auth or data.
> 
> **Overview**
> Adds **per-tab responsive device emulation** so browser tabs can preview pages at fixed viewports (phones, tablets, laptop) without relying on Chrome DevTools device mode.
> 
> **Backend & contracts:** Introduces `DeviceEmulation` on tab state and wires `browser.setDeviceEmulation` through Karton/UI → `BrowsingTabController`, which applies Electron `enableDeviceEmulation` / `disableDeviceEmulation`. Emulation is skipped while Chrome DevTools is open and **re-applied on close**. A `transient` flag avoids persisting state during live resize drags.
> 
> **UI:** New toolbar toggle, `DeviceEmulationFrame` (presets, W×H inputs, rotate, responsive resize handles, auto fit-scale), and tab content wrapped in that frame when emulation is on.
> 
> **Coordinate fixes:** Pointer/wheel passthrough and element screenshots now account for custom emulation **fit scale** and page zoom (not only DevTools scale), so DOM context selection stays aligned outside DevTools.
> 
> Minor: zoom percentage button width styling; new `IconReuseOutline18` in icons.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca89277e6e56c2696ee919445a9d8b014edf474f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-tab device emulation with phone, tablet, laptop, and responsive presets.
  * Added an emulation toolbar and resizable/rotatable emulation frame with width/height inputs and a hide-emulation toggle.
  * Kept emulation settings synced and consistent with DevTools viewport behavior.
* **Bug Fixes**
  * Improved input and screenshot scaling accuracy when emulation is active.
* **Style**
  * Refined the “Reset zoom” button styling.
* **UI Assets**
  * Added a new 18px outline icon component.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a per-tab device emulation toolbar so users can preview pages at phone, tablet, and laptop sizes. It supports responsive resizing, rotation, zoom, and auto-fit; emulation pauses while Chrome DevTools is open and resumes when closed.

- New Features
  - Toolbar toggle with `DeviceEmulationFrame`: presets (iPhone, Pixel, Galaxy, iPad, laptop, Responsive), width/height inputs, rotate, drag-resize, zoom selector.
  - Auto-fit scales to available space and UI zoom; transient updates while resizing.
  - Per-tab state via `DeviceEmulation` and Karton procedure `browser.setDeviceEmulation`; backend applies Electron `enableDeviceEmulation`/`disableDeviceEmulation`.
  - Adds a reuse icon to `@stagewise/icons`.

- Bug Fixes
  - Corrects pointer/selection coordinate mapping outside DevTools by accounting for page zoom and emulation fit scale.
  - Fixes element screenshot capture to include page zoom and emulation scale when DevTools are closed.

<sup>Written for commit ca89277e6e56c2696ee919445a9d8b014edf474f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1478?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

