### PR TITLE
fix(stagewise): fix chat input hitbox around stop button

### DIFF
--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/chat-input.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/chat-input.tsx
@@ -234,6 +234,8 @@ export interface ChatInputProps {
   showToolApprovalSelect?: boolean;
   onToolApprovalChange?: () => void;
 
+  onStop?: () => void;
+
   // Context usage ring
   showContextUsageRing?: boolean;
   contextUsedPercentage?: number;
@@ -307,6 +309,8 @@ export const ChatInput = memo(function ChatInput({
 
   showToolApprovalSelect = true,
   onToolApprovalChange,
+
+  onStop,
 
   showContextUsageRing = false,
   contextUsedPercentage = 0,
@@ -857,14 +861,15 @@ export const ChatInput = memo(function ChatInput({
         />
       </div>
 
-      {/* Controls area - only shown when not disabled and has content to show */}
       {!disabled &&
         (showModelSelect ||
           showToolApprovalSelect ||
+          onStop ||
           (showContextUsageRing && contextUsedPercentage > 0)) && (
           <div
             className={cn(
-              'flex shrink-0 flex-row flex-wrap items-center justify-start gap-2 pr-2 pl-1 *:shrink-0',
+              'relative flex shrink-0 flex-wrap items-center gap-2 pl-1 *:shrink-0',
+              onStop ? 'pr-11' : 'pr-1',
             )}
           >
             {showModelSelect && (
@@ -878,20 +883,30 @@ export const ChatInput = memo(function ChatInput({
               />
             )}
             {showToolApprovalSelect && (
-              <>
-                {/*
-                  Invisible flex spacer that eats remaining horizontal space on
-                  the line containing `ToolApprovalSelect`, pushing the select
-                  to the right edge. `!shrink` overrides the parent's
-                  `*:shrink-0` so the spacer can collapse to 0 when the row
-                  wraps — otherwise it would prevent natural wrap behavior and
-                  force `ToolApprovalSelect` onto its own line prematurely.
-                */}
-                <div className="!shrink min-w-0 grow" aria-hidden />
-                <ToolApprovalSelect
-                  onToolApprovalChange={handleToolApprovalChange}
-                />
-              </>
+              <ToolApprovalSelect
+                onToolApprovalChange={handleToolApprovalChange}
+              />
+            )}
+            {onStop && (
+              <Tooltip>
+                <TooltipTrigger>
+                  <Button
+                    onClick={onStop}
+                    aria-label="Stop agent"
+                    variant="secondary"
+                    className="group absolute right-1 bottom-0 z-10 size-8 cursor-pointer rounded-full p-1 opacity-100! shadow-md"
+                  >
+                    <SquareIcon className="size-3 fill-current" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>
+                  <span className="flex items-center gap-1.5">
+                    <span>Stop agent</span>
+                    <HotkeyCombo action={HotkeyActions.STOP_AGENT} size="xs" />
+                    <ShortcutCombo value="Esc" size="xs" />
+                  </span>
+                </TooltipContent>
+              </Tooltip>
             )}
           </div>
         )}
@@ -900,12 +915,6 @@ export const ChatInput = memo(function ChatInput({
 });
 
 export interface ChatInputActionsProps {
-  /** Whether the agent is currently working (used to determine stop/send button visibility) */
-  isAgentWorking?: boolean;
-  /** Whether the agent has a pending user question (hides stop button) */
-  hasPendingQuestion?: boolean;
-  onStop?: () => void;
-
   showElementSelectorButton?: boolean;
   elementSelectionActive?: boolean;
   onToggleElementSelection?: () => void;
@@ -919,10 +928,6 @@ export interface ChatInputActionsProps {
 }
 
 export const ChatInputActions = memo(function ChatInputActions({
-  isAgentWorking = false,
-  hasPendingQuestion = false,
-  onStop,
-
   showElementSelectorButton = true,
   elementSelectionActive = false,
   onToggleElementSelection,
@@ -934,10 +939,6 @@ export const ChatInputActions = memo(function ChatInputActions({
   canSendMessage,
   onSubmit,
 }: ChatInputActionsProps) {
-  // Always show the send button; show stop button alongside it when agent is working
-  const showStopButton = isAgentWorking && !hasPendingQuestion && !!onStop;
-  const showSendButton = true;
-
   return (
     <div className="flex shrink-0 flex-col items-end justify-end gap-1">
       {/* Element selector and image upload - always shown (can add context to queued messages) */}
@@ -1020,46 +1021,20 @@ export const ChatInputActions = memo(function ChatInputActions({
           </Tooltip>
         </>
       )}
-      {/* Stop + Send buttons row — stop is shown to the left when agent is working */}
-      <div className="flex flex-row items-center gap-2">
-        {showStopButton && (
-          <Tooltip>
-            <TooltipTrigger>
-              <Button
-                onClick={onStop}
-                aria-label="Stop agent"
-                variant="secondary"
-                className="group z-10 size-8 shrink-0 cursor-pointer rounded-full p-1 opacity-100! shadow-md"
-              >
-                <SquareIcon className="size-3 fill-current" />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>
-              <span className="flex items-center gap-1.5">
-                <span>Stop agent</span>
-                <HotkeyCombo action={HotkeyActions.STOP_AGENT} size="xs" />
-                <ShortcutCombo value="Esc" size="xs" />
-              </span>
-            </TooltipContent>
-          </Tooltip>
-        )}
-        {showSendButton && (
-          <Tooltip>
-            <TooltipTrigger>
-              <Button
-                disabled={!canSendMessage}
-                onClick={onSubmit}
-                aria-label="Send message"
-                variant="primary"
-                className="z-10 size-8 shrink-0 cursor-pointer rounded-full p-1 shadow-md transition-all disabled:opacity-50"
-              >
-                <ArrowUpIcon className="size-4 stroke-3" />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>Send message</TooltipContent>
-          </Tooltip>
-        )}
-      </div>
+      <Tooltip>
+        <TooltipTrigger>
+          <Button
+            disabled={!canSendMessage}
+            onClick={onSubmit}
+            aria-label="Send message"
+            variant="primary"
+            className="z-10 size-8 shrink-0 cursor-pointer rounded-full p-1 shadow-md transition-all disabled:opacity-50"
+          >
+            <ArrowUpIcon className="size-4 stroke-3" />
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>Send message</TooltipContent>
+      </Tooltip>
     </div>
   );
 });

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/message-user.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/message-user.tsx
@@ -774,7 +774,6 @@ export const MessageUser = memo(
                     {/* Action buttons */}
                     <div className="relative flex shrink-0 flex-col items-center justify-end gap-1">
                       <ChatInputActions
-                        isAgentWorking={false}
                         showElementSelectorButton={hasVisibleBrowsingTab}
                         elementSelectionActive={elementSelectionActive}
                         onToggleElementSelection={handleToggleElementSelection}

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/panel-footer.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/panel-footer.tsx
@@ -721,7 +721,7 @@ export const ChatPanelFooter = memo(function ChatPanelFooter() {
     if (openAgent) await stopAgent(openAgent);
   }, [stopAgent, openAgent, isEarlyAbortEligible]);
 
-  // Stable abort callback for ChatInputActions — avoids memo-busting when
+  // Stable abort callback for ChatInput — avoids memo-busting when
   // abortAgent's reference changes (e.g. openAgent switches).
   const abortAgentRef = useRef(abortAgent);
   abortAgentRef.current = abortAgent;
@@ -795,6 +795,7 @@ export const ChatPanelFooter = memo(function ChatPanelFooter() {
     openAgent ? (s.toolbox[openAgent]?.pendingUserQuestion?.id ?? null) : null,
   );
   const hasPendingQuestion = pendingQuestionId !== null;
+  const canStopAgent = isWorking && !hasPendingQuestion;
   const pendingQuestionIdRef = useRef(pendingQuestionId);
   pendingQuestionIdRef.current = pendingQuestionId;
   const interruptQuestionWithMessage = useKartonProcedure(
@@ -1398,7 +1399,7 @@ export const ChatPanelFooter = memo(function ChatPanelFooter() {
       [shouldPreserveNativeCopy],
     ),
     HotkeyActions.STOP_AGENT,
-    isWorking && !hasPendingQuestion,
+    canStopAgent,
   );
 
   useEventListener(
@@ -1406,7 +1407,7 @@ export const ChatPanelFooter = memo(function ChatPanelFooter() {
     (e: KeyboardEvent) => {
       if (e.code === 'Escape' && chatInputActive) {
         if (e.defaultPrevented) return; // ChatInput's onEscape already handled it
-        if (isWorking && !hasPendingQuestion) {
+        if (canStopAgent) {
           abortAgentRef.current();
           return;
         }
@@ -1860,6 +1861,7 @@ export const ChatPanelFooter = memo(function ChatPanelFooter() {
             attachmentCount={fileAttachments.length}
             showModelSelect
             onModelChange={handleModelChange}
+            onStop={canStopAgent ? stableAbortAgent : undefined}
             showContextUsageRing={
               !!usedTokens && (isVerboseMode || contextUsed > 80)
             }
@@ -1877,9 +1879,6 @@ export const ChatPanelFooter = memo(function ChatPanelFooter() {
             slashCommands={slashCommands}
           />
           <ChatInputActions
-            isAgentWorking={isWorking}
-            hasPendingQuestion={hasPendingQuestion}
-            onStop={stableAbortAgent}
             showElementSelectorButton={hasVisibleBrowsingTab}
             elementSelectionActive={elementSelectionActive}
             onToggleElementSelection={handleToggleElementSelection}


### PR DESCRIPTION
## Summary

- move the stop button into the chat input's bottom controls
- keep the right-side actions column from blocking the text input
- preserve the controls' alignment and responsive wrapping

Closes #1120

<img width="329" height="217" alt="image" src="https://github.com/user-attachments/assets/9532e38a-f53b-4714-b6d6-1deb4a597d6e" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only relocation of the existing stop handler; abort semantics and gating are unchanged.
> 
> **Overview**
> Moves the **Stop agent** control from the right `ChatInputActions` column into `ChatInput`’s bottom controls row (model, context ring, tool approval), so the narrow actions strip no longer intercepts clicks on the text area.
> 
> `ChatInput` gains an optional `onStop` callback and renders the stop button (with existing tooltip/hotkeys) absolutely in that footer when provided. `panel-footer` passes `stableAbortAgent` only when `canStopAgent` (`isWorking && !hasPendingQuestion`); stop hotkey and Escape handling now share that same flag. `ChatInputActions` is send/attach/context-only—agent-working props and the side-by-side stop+send row are removed.
> 
> The tool-approval flex spacer that pushed the select to the right edge is dropped in favor of natural wrap with reserved right padding when stop is visible.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5fb04380054fc4059e2c5439e7791982bc319f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated “Stop agent” button to the chat input when stopping is available.
  * Added tooltip and keyboard shortcut support for stopping the agent.

* **Bug Fixes**
  * Prevented stopping the agent while a pending question requires attention.
  * Aligned Escape-key stopping behavior with the availability of the stop action.
  * Simplified message editing and sending controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->