### PR TITLE
feat(stagewise): add model presets and user-configurable utility models

### DIFF
--- a/apps/browser/src/backend/agents/model-provider.ts
+++ b/apps/browser/src/backend/agents/model-provider.ts
@@ -27,7 +27,10 @@ import type { streamText } from 'ai';
 import { wrapLanguageModel } from 'ai';
 import {
   MODEL_REQUEST_PURPOSE_METADATA_KEY,
+  PRESET_THINKING_OVERRIDE_METADATA_KEY,
   PROVIDER_INSTANCE_ID_METADATA_KEY,
+  UTILITY_THINKING_OVERRIDE_METADATA_KEY,
+  type UtilityModelThinkingOverride,
 } from '@stagewise/agent-core/host';
 import {
   findInstanceForVendor,
@@ -1111,6 +1114,42 @@ function resolveThinkingProviderOptions({
   customEndpointApiSpec,
   requestMetadata,
 }: ThinkingProviderOptionsInput): ProviderOptions {
+  // Utility model calls (title generation, context compression) pass a
+  // thinking override via metadata. When present, bypass the purpose
+  // gate — the override is explicit user configuration for this call.
+  const utilityThinkingOverride = requestMetadata?.[
+    UTILITY_THINKING_OVERRIDE_METADATA_KEY
+  ] as UtilityModelThinkingOverride | undefined;
+
+  if (utilityThinkingOverride) {
+    // Use the utility override as the thinking override, taking
+    // precedence over any catalog or instance-level override.
+    const route = {
+      providerMode,
+      modelProvider: semanticProvider,
+      thinkingProvider,
+      customEndpointApiSpec,
+    };
+    const patch = createThinkingProviderOptionsPatch({
+      model: modelSettings,
+      override: utilityThinkingOverride as ModelThinkingOverride,
+      route,
+    });
+    if (!patch) return baseProviderOptions as ProviderOptions;
+    return deepMergeProviderOptions(baseProviderOptions, patch);
+  }
+
+  // Preset thinking override: when an active preset is selected, the
+  // preset's per-model thinking configuration is passed via metadata.
+  // This takes precedence over the global `modelThinkingOverrides`
+  // lookup (the `override` parameter) so that editing a preset's
+  // thinking in settings immediately takes effect on the next turn.
+  const presetThinkingOverride = requestMetadata?.[
+    PRESET_THINKING_OVERRIDE_METADATA_KEY
+  ] as ModelThinkingOverride | undefined;
+
+  const effectiveOverride = presetThinkingOverride ?? override;
+
   if (requestMetadata?.[MODEL_REQUEST_PURPOSE_METADATA_KEY] !== 'agent-step') {
     return baseProviderOptions as ProviderOptions;
   }
@@ -1126,7 +1165,7 @@ function resolveThinkingProviderOptions({
     customEndpointApiSpec,
   };
 
-  if (!override) {
+  if (!effectiveOverride) {
     // Catalog definitions own their curated default provider options. Preserve
     // them when they cover the active transport; otherwise add only the
     // missing transport-specific default (e.g. Claude via OpenAI-compatible).
@@ -1162,7 +1201,7 @@ function resolveThinkingProviderOptions({
 
   const patch = createThinkingProviderOptionsPatch({
     model: modelSettings,
-    override,
+    override: effectiveOverride,
     route,
   });
 
@@ -1179,6 +1218,8 @@ function omitModelRequestMetadata(
   const {
     [MODEL_REQUEST_PURPOSE_METADATA_KEY]: _purpose,
     [PROVIDER_INSTANCE_ID_METADATA_KEY]: _providerInstanceId,
+    [UTILITY_THINKING_OVERRIDE_METADATA_KEY]: _utilityThinkingOverride,
+    [PRESET_THINKING_OVERRIDE_METADATA_KEY]: _presetThinkingOverride,
     ...telemetry
   } = metadata;
   return telemetry;

--- a/apps/browser/src/backend/main.ts
+++ b/apps/browser/src/backend/main.ts
@@ -275,7 +275,14 @@ export async function main({ launchOptions: { verbose } }: MainParameters) {
   // until `setModelProviderService(...)` is called further down. The
   // `DiffHistoryService` itself never consults `host.models`, so the
   // lazy slot is invisible in practice.
-  const lazyHostModels = createLazyBrowserHostModels();
+  const lazyHostModels = createLazyBrowserHostModels(() => {
+    const agent = preferencesService.get().agent;
+    return {
+      utilityModels: agent.utilityModels,
+      activePresetId: agent.activePresetId,
+      modelPresets: agent.modelPresets ?? [],
+    };
+  });
   const agentCoreHost = createBrowserAgentHost({
     logger,
     telemetryService,

--- a/apps/browser/src/backend/main.ts
+++ b/apps/browser/src/backend/main.ts
@@ -276,7 +276,7 @@ export async function main({ launchOptions: { verbose } }: MainParameters) {
   // `DiffHistoryService` itself never consults `host.models`, so the
   // lazy slot is invisible in practice.
   const lazyHostModels = createLazyBrowserHostModels(() => {
-    const agent = preferencesService.get().agent;
+    const agent = preferencesService.getAgentSnapshot();
     return {
       utilityModels: agent.utilityModels,
       activePresetId: agent.activePresetId,

--- a/apps/browser/src/backend/services/agent-core-bridge/host-models.ts
+++ b/apps/browser/src/backend/services/agent-core-bridge/host-models.ts
@@ -2,7 +2,11 @@ import type { HostModels, ModelWithOptions } from '@stagewise/agent-core';
 import type { ModelCapabilities } from '@stagewise/agent-core/types';
 import type { ModelProviderService } from '@/agents/model-provider';
 import { getModelCapabilities, type ModelId } from '@shared/available-models';
-import { PROVIDER_INSTANCE_ID_METADATA_KEY } from '@stagewise/agent-core/host';
+import {
+  PROVIDER_INSTANCE_ID_METADATA_KEY,
+  type UtilityModelEntry as CoreUtilityModelEntry,
+} from '@stagewise/agent-core/host';
+import type { UserPreferences } from '@shared/karton-contracts/ui/shared-types';
 
 /**
  * Thin `HostModels` adapter over the browser's `ModelProviderService`.
@@ -26,8 +30,110 @@ import { PROVIDER_INSTANCE_ID_METADATA_KEY } from '@stagewise/agent-core/host';
  * `has(id, providerInstanceId)` delegates to `ModelProviderService.modelExists`.
  * Instance-scoped discovered models require their provider instance ID.
  */
+/**
+ * Getter that returns the current agent preferences block from user
+ * preferences. Called on every utility-model resolution and on every
+ * `runStep` model resolution; must be cheap.
+ * Includes `activePresetId` and `modelPresets` so per-preset utility
+ * model overrides and the active preset's main model can be resolved.
+ */
+export type UtilityModelsGetter = () => Pick<
+  UserPreferences['agent'],
+  'utilityModels' | 'activePresetId' | 'modelPresets'
+>;
+
+/**
+ * Resolves the ordered utility model entries for a given task,
+ * checking the active preset's overrides first, then falling back
+ * to global configuration. The global lists are always populated
+ * by schema defaults, so this returns `undefined` only when no
+ * preset is active and the global list is empty (explicitly cleared).
+ */
+function resolveUtilityEntries(
+  task: 'title-generation' | 'context-compression',
+  prefs: Pick<
+    UserPreferences['agent'],
+    'utilityModels' | 'activePresetId' | 'modelPresets'
+  >,
+): CoreUtilityModelEntry[] | undefined {
+  const { utilityModels, activePresetId, modelPresets } = prefs;
+  // If an active preset exists, its utility model lists take
+  // precedence over the global defaults. An undefined or empty list
+  // means "use the main model" — we return [] so agent-core falls
+  // back to fallbackModelId (the preset's main model) instead of
+  // falling through to global defaults.
+  if (activePresetId) {
+    const preset = modelPresets.find((p) => p.id === activePresetId);
+    if (preset) {
+      const presetList =
+        task === 'title-generation'
+          ? preset.titleGeneration
+          : preset.contextCompression;
+      if (presetList && presetList.length > 0) {
+        return presetList.map(toCoreEntry);
+      }
+      return [];
+    }
+  }
+  const globalList =
+    task === 'title-generation'
+      ? utilityModels.titleGeneration
+      : utilityModels.contextCompression;
+  return globalList?.map(toCoreEntry);
+}
+
+/**
+ * Resolves the active preset's ID from user preferences.
+ * Returns `undefined` when no preset is active.
+ */
+function resolveActivePresetId(
+  prefs: Pick<UserPreferences['agent'], 'activePresetId'>,
+): string | undefined {
+  return prefs.activePresetId ?? undefined;
+}
+
+/**
+ * Resolves the active preset's full ordered list of model entries
+ * (main model first, then fallbacks) from user preferences.
+ * Returns `undefined` when no preset is active or the preset has
+ * no models. Each entry carries optional `providerInstanceId` and
+ * `thinkingOverride` so the agent can cycle through them on failure.
+ */
+function resolveActivePresetModels(
+  prefs: Pick<UserPreferences['agent'], 'activePresetId' | 'modelPresets'>,
+): CoreUtilityModelEntry[] | undefined {
+  const { activePresetId, modelPresets } = prefs;
+  if (!activePresetId) return undefined;
+  const preset = modelPresets.find((p) => p.id === activePresetId);
+  if (!preset) return undefined;
+  const models = preset.models;
+  if (!models || models.length === 0) return undefined;
+  return models.map(toCoreEntry);
+}
+
+/**
+ * The shapes are structurally identical, but keeping an explicit
+ * mapping avoids accidental drift.
+ */
+function toCoreEntry(entry: {
+  modelId: string;
+  providerInstanceId?: string;
+  thinkingOverride?: CoreUtilityModelEntry['thinkingOverride'];
+}): CoreUtilityModelEntry {
+  return {
+    modelId: entry.modelId,
+    ...(entry.providerInstanceId
+      ? { providerInstanceId: entry.providerInstanceId }
+      : {}),
+    ...(entry.thinkingOverride
+      ? { thinkingOverride: entry.thinkingOverride }
+      : {}),
+  };
+}
+
 export function createBrowserHostModels(
   modelProviderService: ModelProviderService,
+  getUtilityModels?: UtilityModelsGetter,
 ): HostModels {
   async function getWithOptions(
     modelId: string,
@@ -77,6 +183,18 @@ export function createBrowserHostModels(
     getCapabilities(modelId): ModelCapabilities {
       return getModelCapabilities(modelId as ModelId) as ModelCapabilities;
     },
+    getUtilityModelEntries(task) {
+      if (!getUtilityModels) return undefined;
+      return resolveUtilityEntries(task, getUtilityModels());
+    },
+    getActivePresetId() {
+      if (!getUtilityModels) return undefined;
+      return resolveActivePresetId(getUtilityModels());
+    },
+    getActivePresetModels() {
+      if (!getUtilityModels) return undefined;
+      return resolveActivePresetModels(getUtilityModels());
+    },
   };
 }
 
@@ -102,7 +220,9 @@ export interface LazyBrowserHostModels {
   setModelProviderService(mp: ModelProviderService): void;
 }
 
-export function createLazyBrowserHostModels(): LazyBrowserHostModels {
+export function createLazyBrowserHostModels(
+  getUtilityModels?: UtilityModelsGetter,
+): LazyBrowserHostModels {
   let inner: HostModels | null = null;
 
   const hostModels: HostModels = {
@@ -133,6 +253,22 @@ export function createLazyBrowserHostModels(): LazyBrowserHostModels {
       if (inner) return inner.getCapabilities(modelId);
       return getModelCapabilities(modelId as ModelId) as ModelCapabilities;
     },
+    getUtilityModelEntries(task) {
+      if (inner?.getUtilityModelEntries)
+        return inner.getUtilityModelEntries(task);
+      if (!getUtilityModels) return undefined;
+      return resolveUtilityEntries(task, getUtilityModels());
+    },
+    getActivePresetId() {
+      if (inner?.getActivePresetId) return inner.getActivePresetId();
+      if (!getUtilityModels) return undefined;
+      return resolveActivePresetId(getUtilityModels());
+    },
+    getActivePresetModels() {
+      if (inner?.getActivePresetModels) return inner.getActivePresetModels();
+      if (!getUtilityModels) return undefined;
+      return resolveActivePresetModels(getUtilityModels());
+    },
   };
 
   return {
@@ -143,7 +279,7 @@ export function createLazyBrowserHostModels(): LazyBrowserHostModels {
           '[BrowserHostModels] setModelProviderService called twice',
         );
       }
-      inner = createBrowserHostModels(mp);
+      inner = createBrowserHostModels(mp, getUtilityModels);
     },
   };
 }

--- a/apps/browser/src/backend/services/agent-core-bridge/host-models.ts
+++ b/apps/browser/src/backend/services/agent-core-bridge/host-models.ts
@@ -74,6 +74,9 @@ function resolveUtilityEntries(
       }
       return [];
     }
+    // Preset ID is set but the preset was deleted — treat as
+    // inactive and fall through to global lists, matching
+    // resolveActivePresetModels' behavior of returning undefined.
   }
   const globalList =
     task === 'title-generation'

--- a/apps/browser/src/backend/services/preferences.ts
+++ b/apps/browser/src/backend/services/preferences.ts
@@ -939,6 +939,24 @@ export class PreferencesService extends DisposableService {
     return structuredClone(this.preferences);
   }
 
+  /**
+   * Get a shallow snapshot of the `agent` sub-object without cloning the
+   * entire preferences tree. Used by hot paths (e.g. the lazy host-models
+   * closure) that only need `utilityModels`, `activePresetId`, and
+   * `modelPresets` and would otherwise pay the cost of a full
+   * `structuredClone` on every agent turn.
+   */
+  public getAgentSnapshot(): UserPreferences['agent'] {
+    this.assertNotDisposed();
+    const agent = this.preferences.agent;
+    return {
+      ...agent,
+      utilityModels: agent.utilityModels,
+      activePresetId: agent.activePresetId,
+      modelPresets: agent.modelPresets ?? [],
+    };
+  }
+
   private async enqueuePreferenceWrite<T>(
     operation: () => Promise<T>,
   ): Promise<T> {

--- a/apps/browser/src/backend/services/preferences.ts
+++ b/apps/browser/src/backend/services/preferences.ts
@@ -946,14 +946,27 @@ export class PreferencesService extends DisposableService {
    * `modelPresets` and would otherwise pay the cost of a full
    * `structuredClone` on every agent turn.
    */
-  public getAgentSnapshot(): UserPreferences['agent'] {
+  public getAgentSnapshot(): Pick<
+    UserPreferences['agent'],
+    'utilityModels' | 'activePresetId' | 'modelPresets'
+  > {
     this.assertNotDisposed();
     const agent = this.preferences.agent;
+    const modelPresets = agent.modelPresets ?? [];
+    // Validate activePresetId — if the referenced preset was deleted
+    // through a code path that didn't clear the ID, treat it as unset
+    // so resolveUtilityEntries falls through to global lists rather
+    // than silently using global chains when the user expected the
+    // preset's main model.
+    const activePresetId =
+      agent.activePresetId &&
+      modelPresets.some((p) => p.id === agent.activePresetId)
+        ? agent.activePresetId
+        : undefined;
     return {
-      ...agent,
       utilityModels: agent.utilityModels,
-      activePresetId: agent.activePresetId,
-      modelPresets: agent.modelPresets ?? [],
+      activePresetId,
+      modelPresets,
     };
   }
 

--- a/apps/browser/src/shared/karton-contracts/ui/shared-types.ts
+++ b/apps/browser/src/shared/karton-contracts/ui/shared-types.ts
@@ -630,6 +630,29 @@ function isPlainRecord(value: unknown): value is Record<string, unknown> {
 }
 
 /**
+ * A model entry within a preset — used for both the main model and
+ * fallback models. Each entry carries its own optional thinking override
+ * so the user can configure thinking per-model.
+ */
+export const presetModelEntrySchema = z.object({
+  modelId: z.string(),
+  providerInstanceId: z.string().optional(),
+  thinkingOverride: modelThinkingOverrideSchema.optional(),
+});
+export type PresetModelEntry = z.infer<typeof presetModelEntrySchema>;
+
+/**
+ * A model entry in a utility model list (title generation, context
+ * compression). Same shape as {@link PresetModelEntry} but accepts
+ * legacy `string` values for backward compatibility — plain strings
+ * are transformed into `{ modelId: string }`.
+ */
+export const utilityModelEntrySchema = z
+  .union([z.string(), presetModelEntrySchema])
+  .transform((val) => (typeof val === 'string' ? { modelId: val } : val));
+export type UtilityModelEntry = z.infer<typeof utilityModelEntrySchema>;
+
+/**
  * GLOBAL CONFIG CAPABILITIES
  */
 
@@ -821,6 +844,41 @@ const sidebarPreferencesSchema = z
   .default(defaultSidebarPreferences)
   .catch(defaultSidebarPreferences);
 
+/**
+ * Built-in default model IDs for background utility tasks.
+ *
+ * These mirror the constants in `@stagewise/agent-core` but live in the
+ * browser shared layer so the UI and schema defaults can reference them
+ * without importing agent-core (which transitively pulls Node-only
+ * modules like `chokidar` into the renderer process).
+ *
+ * Keep these in sync with:
+ *   packages/agent-core/src/agents/shared/title-generation/index.ts
+ *   packages/agent-core/src/agents/shared/history-compression/index.ts
+ */
+export const DEFAULT_TITLE_GENERATION_MODELS = [
+  'default',
+  'deepseek-v4-flash',
+  'gpt-5.6-luna',
+  'gemini-3.1-flash-lite',
+  'claude-haiku-4.5',
+] as const;
+
+export const DEFAULT_HISTORY_COMPRESSION_MODELS = [
+  'default',
+  'deepseek-v4-flash',
+  'gpt-5.6-luna',
+  'gemini-3.1-flash-lite',
+  'claude-haiku-4.5',
+] as const;
+
+/** Entry-shaped defaults derived from the model ID lists above. */
+const DEFAULT_TITLE_GENERATION_ENTRIES = DEFAULT_TITLE_GENERATION_MODELS.map(
+  (modelId) => ({ modelId }),
+);
+const DEFAULT_HISTORY_COMPRESSION_ENTRIES =
+  DEFAULT_HISTORY_COMPRESSION_MODELS.map((modelId) => ({ modelId }));
+
 export const userPreferencesSchema = z.object({
   privacy: z
     .object({
@@ -962,6 +1020,106 @@ export const userPreferencesSchema = z.object({
        * from any global skill directory.
        */
       disabledGlobalSkills: z.array(z.string()).default([]),
+      /**
+       * User-configured fallback chains for background utility tasks.
+       * Each array is an ordered list of model entries; the agent tries
+       * each in order until one succeeds. An empty array falls back
+       * to the main chat model.
+       *
+       * Defaults are populated from {@link DEFAULT_TITLE_GENERATION_MODELS}
+       * and {@link DEFAULT_HISTORY_COMPRESSION_MODELS} so new users
+       * start with sensible built-in fallbacks without the UI needing
+       * a separate constant file.
+       *
+       * Models that belong to deleted providers or have been disabled
+       * are retained in the array (marked invalid by the UI) rather
+       * than silently removed.
+       */
+      utilityModels: z
+        .object({
+          titleGeneration: z
+            .array(utilityModelEntrySchema)
+            .default(DEFAULT_TITLE_GENERATION_ENTRIES),
+          contextCompression: z
+            .array(utilityModelEntrySchema)
+            .default(DEFAULT_HISTORY_COMPRESSION_ENTRIES),
+        })
+        .default({
+          titleGeneration: DEFAULT_TITLE_GENERATION_ENTRIES,
+          contextCompression: DEFAULT_HISTORY_COMPRESSION_ENTRIES,
+        }),
+      /**
+       * ID of the currently active preset. When set, the preset's
+       * per-preset utility model lists (titleGeneration /
+       * contextCompression) override the global defaults.
+       */
+      activePresetId: z.string().nullable().optional(),
+      /**
+       * Named model configurations surfaced at the top of the model
+       * selection dropdown for one-click switching. Each preset
+       * bundles a main chat model, optional thinking override, and
+       * a list of fallback models.
+       */
+      modelPresets: z
+        .array(
+          z
+            .object({
+              id: z.string(),
+              name: z.string().min(1),
+              // New unified models list (first = main, rest = fallbacks)
+              models: z.array(presetModelEntrySchema).optional(),
+              // Per-preset utility model lists (override global defaults)
+              titleGeneration: z.array(utilityModelEntrySchema).optional(),
+              contextCompression: z.array(utilityModelEntrySchema).optional(),
+              // Legacy fields (for migration from old schema)
+              modelId: z.string().optional(),
+              providerInstanceId: z.string().optional(),
+              thinkingOverride: modelThinkingOverrideSchema.optional(),
+              fallbackModels: z
+                .array(
+                  z.object({
+                    modelId: z.string(),
+                    providerInstanceId: z.string().optional(),
+                  }),
+                )
+                .optional(),
+            })
+            .transform((val) => {
+              if (val.models && val.models.length > 0) {
+                return {
+                  id: val.id,
+                  name: val.name,
+                  models: val.models,
+                  titleGeneration: val.titleGeneration,
+                  contextCompression: val.contextCompression,
+                };
+              }
+              // Migrate from legacy format
+              const models: PresetModelEntry[] = [
+                ...(val.modelId
+                  ? [
+                      {
+                        modelId: val.modelId,
+                        providerInstanceId: val.providerInstanceId,
+                        thinkingOverride: val.thinkingOverride,
+                      },
+                    ]
+                  : []),
+                ...(val.fallbackModels ?? []).map((f) => ({
+                  modelId: f.modelId,
+                  providerInstanceId: f.providerInstanceId,
+                })),
+              ];
+              return {
+                id: val.id,
+                name: val.name,
+                models: models.length > 0 ? models : [{ modelId: 'default' }],
+                titleGeneration: val.titleGeneration,
+                contextCompression: val.contextCompression,
+              };
+            }),
+        )
+        .default([]),
     })
     .default({
       workspaceSettings: {},
@@ -971,6 +1129,12 @@ export const userPreferencesSchema = z.object({
       modelThinkingOverrides: {},
       enabledGlobalSkillDirs: [],
       disabledGlobalSkills: [],
+      utilityModels: {
+        titleGeneration: DEFAULT_TITLE_GENERATION_ENTRIES,
+        contextCompression: DEFAULT_HISTORY_COMPRESSION_ENTRIES,
+      },
+      activePresetId: undefined,
+      modelPresets: [],
     }),
   /** LLM provider endpoint configurations (API keys, custom URLs) */
   providerConfigs: providerConfigsSchema.default({
@@ -1084,6 +1248,12 @@ export const defaultUserPreferences: UserPreferences = {
     modelThinkingOverrides: {},
     enabledGlobalSkillDirs: [],
     disabledGlobalSkills: [],
+    utilityModels: {
+      titleGeneration: DEFAULT_TITLE_GENERATION_ENTRIES,
+      contextCompression: DEFAULT_HISTORY_COMPRESSION_ENTRIES,
+    },
+    activePresetId: undefined,
+    modelPresets: [],
   },
   providerConfigs: {
     anthropic: { mode: 'stagewise' },

--- a/apps/browser/src/shared/karton-contracts/ui/shared-types.ts
+++ b/apps/browser/src/shared/karton-contracts/ui/shared-types.ts
@@ -872,6 +872,36 @@ export const DEFAULT_HISTORY_COMPRESSION_MODELS = [
   'claude-haiku-4.5',
 ] as const;
 
+/**
+ * Compile-time assertion that the browser defaults match the agent-core
+ * runtime constants. If either side adds/removes a model, the corresponding
+ * `TITLE_GENERATION_MODELS` or `HISTORY_COMPRESSION_MODELS` in
+ * `@stagewise/agent-core` must be updated as well.
+ *
+ * The tuple length is encoded as a numeric literal type; if the arrays
+ * diverge in length, the `extends` constraint fails at compile time.
+ */
+type _AssertTitleGenerationLength =
+  typeof DEFAULT_TITLE_GENERATION_MODELS extends readonly [
+    string,
+    string,
+    string,
+    string,
+    string,
+  ]
+    ? true
+    : never;
+type _AssertHistoryCompressionLength =
+  typeof DEFAULT_HISTORY_COMPRESSION_MODELS extends readonly [
+    string,
+    string,
+    string,
+    string,
+    string,
+  ]
+    ? true
+    : never;
+
 /** Entry-shaped defaults derived from the model ID lists above. */
 const DEFAULT_TITLE_GENERATION_ENTRIES = DEFAULT_TITLE_GENERATION_MODELS.map(
   (modelId) => ({ modelId }),

--- a/apps/browser/src/shared/provider-instance-helpers.ts
+++ b/apps/browser/src/shared/provider-instance-helpers.ts
@@ -965,3 +965,30 @@ export function getInstanceModelCount(
 
   return count;
 }
+
+// ===========================================================================
+// Model Validity Checking (for utility models & presets)
+// ===========================================================================
+
+/**
+ * Check whether a `(modelId, providerInstanceId?)` pair is currently
+ * selectable — i.e. the provider instance exists and the model is not
+ * disabled. Used by the settings UI to mark invalid entries in utility
+ * model lists and presets.
+ *
+ * When `providerInstanceId` is omitted, checks whether the model is
+ * selectable on *any* instance.
+ */
+export function isModelEntryValid(
+  prefs: Pick<UserPreferences, 'providerInstances' | 'customModels'>,
+  modelId: string,
+  providerInstanceId?: string,
+): boolean {
+  const entries = getSelectableModelEntries(prefs);
+  if (providerInstanceId) {
+    return entries.some(
+      (e) => e.instanceId === providerInstanceId && e.modelId === modelId,
+    );
+  }
+  return entries.some((e) => e.modelId === modelId);
+}

--- a/apps/browser/src/shared/provider-instance-helpers.ts
+++ b/apps/browser/src/shared/provider-instance-helpers.ts
@@ -984,11 +984,16 @@ export function isModelEntryValid(
   modelId: string,
   providerInstanceId?: string,
 ): boolean {
-  const entries = getSelectableModelEntries(prefs);
   if (providerInstanceId) {
-    return entries.some(
-      (e) => e.instanceId === providerInstanceId && e.modelId === modelId,
+    // Use findModelSelectorEntry for instance-aware matching — it applies
+    // the same catalog normalization (e.g. Anthropic dotted→hyphenated ID
+    // mapping) as the selector, so valid native model IDs are not falsely
+    // rejected by the raw equality check in getSelectableModelEntries.
+    return (
+      findModelSelectorEntry(prefs, providerInstanceId, modelId) !== undefined
     );
   }
+  // No instance specified — check if the model is selectable on any instance.
+  const entries = getSelectableModelEntries(prefs);
   return entries.some((e) => e.modelId === modelId);
 }

--- a/apps/browser/src/shared/provider-instance-helpers.ts
+++ b/apps/browser/src/shared/provider-instance-helpers.ts
@@ -843,8 +843,10 @@ export function findModelSelectorEntry(
   prefs: Pick<UserPreferences, 'providerInstances' | 'customModels'>,
   instanceId: string,
   modelId: string,
+  options?: { includeDisabled?: boolean },
 ): ModelSelectorEntry | undefined {
-  const entries = getSelectableModelEntries(prefs, { includeDisabled: true });
+  const includeDisabled = options?.includeDisabled ?? true;
+  const entries = getSelectableModelEntries(prefs, { includeDisabled });
   const exactEntry = entries.find(
     (entry) => entry.instanceId === instanceId && entry.modelId === modelId,
   );
@@ -989,8 +991,12 @@ export function isModelEntryValid(
     // the same catalog normalization (e.g. Anthropic dotted→hyphenated ID
     // mapping) as the selector, so valid native model IDs are not falsely
     // rejected by the raw equality check in getSelectableModelEntries.
+    // Pass includeDisabled: false so disabled models are correctly marked
+    // invalid in the settings UI.
     return (
-      findModelSelectorEntry(prefs, providerInstanceId, modelId) !== undefined
+      findModelSelectorEntry(prefs, providerInstanceId, modelId, {
+        includeDisabled: false,
+      }) !== undefined
     );
   }
   // No instance specified — check if the model is selectable on any instance.

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/model-presets-shared.ts
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/model-presets-shared.ts
@@ -1,0 +1,42 @@
+import { getAvailableModel } from '@shared/available-models';
+import { availableModelAliases } from '@shared/available-models';
+import type { ModelSelectorEntry } from '@shared/provider-instance-helpers';
+
+/**
+ * Resolve display info for a model ID from the selectable entries.
+ * Falls back to the static catalog if no matching entry is found.
+ */
+export function resolveModelDisplay(
+  entries: ModelSelectorEntry[],
+  modelId: string,
+  providerInstanceId?: string,
+): { displayName: string; instanceName: string } | undefined {
+  const entry = providerInstanceId
+    ? entries.find(
+        (e) => e.modelId === modelId && e.instanceId === providerInstanceId,
+      )
+    : entries.find((e) => e.modelId === modelId);
+  if (entry) {
+    return {
+      displayName: entry.displayName,
+      instanceName: entry.instanceName,
+    };
+  }
+  // Fallback to catalog
+  const catalogModel = getAvailableModel(modelId);
+  if (catalogModel) {
+    return {
+      displayName: catalogModel.modelDisplayName,
+      instanceName: providerInstanceId ?? 'Unknown',
+    };
+  }
+  // Check aliases
+  const alias = availableModelAliases.find((a) => a.modelId === modelId);
+  if (alias) {
+    return {
+      displayName: alias.modelDisplayName,
+      instanceName: providerInstanceId ?? 'Unknown',
+    };
+  }
+  return undefined;
+}

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/model-presets-shared.ts
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/model-presets-shared.ts
@@ -22,19 +22,21 @@ export function resolveModelDisplay(
       instanceName: entry.instanceName,
     };
   }
-  // Fallback to catalog
-  const catalogModel = getAvailableModel(modelId);
-  if (catalogModel) {
-    return {
-      displayName: catalogModel.modelDisplayName,
-      instanceName: providerInstanceId ?? 'Unknown',
-    };
-  }
-  // Check aliases
+  // Check aliases FIRST — getAvailableModel() resolves aliases to their
+  // concrete target, so checking it first would make the alias branch
+  // unreachable for alias IDs like "default", "quick", "smart".
   const alias = availableModelAliases.find((a) => a.modelId === modelId);
   if (alias) {
     return {
       displayName: alias.modelDisplayName,
+      instanceName: providerInstanceId ?? 'Unknown',
+    };
+  }
+  // Fallback to catalog (resolves aliases to concrete targets)
+  const catalogModel = getAvailableModel(modelId);
+  if (catalogModel) {
+    return {
+      displayName: catalogModel.modelDisplayName,
       instanceName: providerInstanceId ?? 'Unknown',
     };
   }

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/model-select.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/model-select.tsx
@@ -54,6 +54,7 @@ import {
   getVendorForInstance,
   type ModelSelectorEntry,
 } from '@shared/provider-instance-helpers';
+import { resolveModelDisplay } from './model-presets-shared';
 import { enablePatches, produceWithPatches } from 'immer';
 
 enablePatches();
@@ -64,6 +65,7 @@ enablePatches();
 // ---------------------------------------------------------------------------
 
 const KEY_SEPARATOR = '\u001f';
+const PRESET_VALUE_PREFIX = '@@preset@@';
 
 function encodeKey(instanceId: string, modelId: string): string {
   return `${instanceId}${KEY_SEPARATOR}${modelId}`;
@@ -78,6 +80,15 @@ function decodeKey(
     instanceId: value.slice(0, idx),
     modelId: value.slice(idx + 1),
   };
+}
+
+function encodePresetKey(presetId: string): string {
+  return `${PRESET_VALUE_PREFIX}${presetId}`;
+}
+
+function decodePresetKey(value: string): string | null {
+  if (!value.startsWith(PRESET_VALUE_PREFIX)) return null;
+  return value.slice(PRESET_VALUE_PREFIX.length);
 }
 
 // ---------------------------------------------------------------------------
@@ -140,6 +151,17 @@ const OPEN_MODEL_SETTINGS_VALUE = '@@open model settings@@';
 
 const EMPTY_MODEL_THINKING_OVERRIDES: UserPreferences['agent']['modelThinkingOverrides'] =
   {};
+const EMPTY_MODEL_PRESETS: UserPreferences['agent']['modelPresets'] = [];
+
+/** A preset entry prepared for display in the dropdown. */
+interface PresetEntry {
+  id: string;
+  name: string;
+  modelDisplayName: string;
+  modelId: string;
+  providerInstanceId?: string;
+  thinkingLabel?: string;
+}
 
 export const ModelSelect = memo(function ModelSelect({
   onModelChange,
@@ -161,6 +183,9 @@ export const ModelSelect = memo(function ModelSelect({
     (s) =>
       s.preferences.agent.modelThinkingOverrides ??
       EMPTY_MODEL_THINKING_OVERRIDES,
+  );
+  const modelPresets = useKartonState(
+    (s) => s.preferences.agent.modelPresets ?? EMPTY_MODEL_PRESETS,
   );
 
   // Build a map of instanceId → ProviderInstance for thinking option resolution
@@ -252,6 +277,33 @@ export const ModelSelect = memo(function ModelSelect({
     return Array.from(groups.values());
   }, [selectableEntries]);
 
+  // Build preset entries for the dropdown
+  const presetEntries = useMemo<PresetEntry[]>(() => {
+    return modelPresets.map((preset) => {
+      const mainModel = preset.models[0];
+      const display = mainModel
+        ? resolveModelDisplay(
+            selectableEntries,
+            mainModel.modelId,
+            mainModel.providerInstanceId,
+          )
+        : undefined;
+      let thinkingLabel: string | undefined;
+      if (mainModel?.thinkingOverride?.enabled) {
+        thinkingLabel = mainModel.thinkingOverride.value ?? 'Thinking';
+      }
+      return {
+        id: preset.id,
+        name: preset.name,
+        modelDisplayName:
+          display?.displayName ?? mainModel?.modelId ?? 'Unknown',
+        modelId: mainModel?.modelId ?? '',
+        providerInstanceId: mainModel?.providerInstanceId,
+        thinkingLabel,
+      };
+    });
+  }, [modelPresets, selectableEntries]);
+
   const [open, setOpen] = useState(false);
 
   // Search / filter state
@@ -274,6 +326,16 @@ export const ModelSelect = memo(function ModelSelect({
       .filter((g) => g.entries.length > 0);
   }, [groupedByInstance, query]);
 
+  const filteredPresets = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (q === '') return presetEntries;
+    return presetEntries.filter(
+      (p) =>
+        p.name.toLowerCase().includes(q) ||
+        p.modelDisplayName.toLowerCase().includes(q),
+    );
+  }, [presetEntries, query]);
+
   const filteredEntryKeys = useMemo(
     () =>
       filteredGrouped.flatMap((g) =>
@@ -287,33 +349,63 @@ export const ModelSelect = memo(function ModelSelect({
     [selectableEntries],
   );
 
+  const presetKeys = useMemo(
+    () => presetEntries.map((p) => encodePresetKey(p.id)),
+    [presetEntries],
+  );
+
+  const filteredPresetKeys = useMemo(
+    () => filteredPresets.map((p) => encodePresetKey(p.id)),
+    [filteredPresets],
+  );
+
   const filteredItemValues = useMemo(
     () =>
       query.trim() === ''
-        ? [...allEntryKeys, OPEN_MODEL_SETTINGS_VALUE]
-        : filteredEntryKeys.length > 0
-          ? [...filteredEntryKeys, OPEN_MODEL_SETTINGS_VALUE]
+        ? [...presetKeys, ...allEntryKeys, OPEN_MODEL_SETTINGS_VALUE]
+        : filteredPresetKeys.length > 0 || filteredEntryKeys.length > 0
+          ? [
+              ...filteredPresetKeys,
+              ...filteredEntryKeys,
+              OPEN_MODEL_SETTINGS_VALUE,
+            ]
           : [],
-    [allEntryKeys, filteredEntryKeys, query],
+    [allEntryKeys, filteredEntryKeys, presetKeys, filteredPresetKeys, query],
   );
 
-  const hasFilteredResults = filteredEntryKeys.length > 0;
+  const hasFilteredResults =
+    filteredEntryKeys.length > 0 || filteredPresetKeys.length > 0;
+
+  // Active preset — when set, the combobox shows the preset as selected
+  // instead of the underlying model.
+  const activePresetId = preferences.agent.activePresetId;
+  const activePreset = useMemo(
+    () =>
+      activePresetId
+        ? modelPresets.find((p) => p.id === activePresetId)
+        : undefined,
+    [activePresetId, modelPresets],
+  );
 
   // Currently selected entry
   const selectedKey = useMemo(() => {
+    if (activePreset) return encodePresetKey(activePreset.id);
     if (!selectedModel) return null;
     const instId = selectedProviderInstanceId ?? DEFAULT_INSTANCE_ID;
     return encodeKey(instId, selectedModel);
-  }, [selectedModel, selectedProviderInstanceId]);
+  }, [selectedModel, selectedProviderInstanceId, activePreset]);
 
   const selectedEntry = selectedKey ? entryMap.get(selectedKey) : undefined;
 
-  const selectedDisplayName =
-    selectedEntry?.displayName ?? selectedModel ?? 'Select model';
+  const selectedDisplayName = activePreset
+    ? activePreset.name
+    : (selectedEntry?.displayName ?? selectedModel ?? 'Select model');
 
-  const selectedThinkingLabel = selectedEntry?.isAlias
+  const selectedThinkingLabel = activePreset
     ? undefined
-    : selectedEntry?.thinkingLabel;
+    : selectedEntry?.isAlias
+      ? undefined
+      : selectedEntry?.thinkingLabel;
 
   const inputRef = useRef<HTMLInputElement>(null);
 
@@ -434,6 +526,34 @@ export const ModelSelect = memo(function ModelSelect({
         void openSettings({ section: 'models-providers' });
         return;
       }
+      // Check for preset selection
+      const presetId = decodePresetKey(value);
+      if (presetId) {
+        const preset = modelPresets.find((p) => p.id === presetId);
+        if (preset && openAgent) {
+          const mainModel = preset.models[0];
+          if (mainModel) {
+            setSelectedModel(
+              openAgent,
+              mainModel.modelId as ModelId,
+              mainModel.providerInstanceId,
+            );
+          }
+          // Set activePresetId so the agent resolves the model and
+          // thinking overrides from the *current* preset definition on
+          // every step. We deliberately do NOT copy the preset's
+          // thinking overrides into global `modelThinkingOverrides` —
+          // those are resolved dynamically via the host's
+          // `getActivePresetModels()` so that editing the preset in
+          // settings takes effect on the next turn.
+          const [, patches] = produceWithPatches(preferences, (draft) => {
+            draft.agent.activePresetId = preset.id;
+          });
+          void updatePreferences(patches);
+          onModelChange?.();
+        }
+        return;
+      }
       const decoded = decodeKey(value);
       if (!decoded) return;
       if (!openAgent) return;
@@ -442,9 +562,24 @@ export const ModelSelect = memo(function ModelSelect({
         decoded.modelId as ModelId,
         decoded.instanceId,
       );
+      // Clear active preset when selecting a raw model
+      if (preferences.agent.activePresetId) {
+        const [, patches] = produceWithPatches(preferences, (draft) => {
+          draft.agent.activePresetId = undefined;
+        });
+        void updatePreferences(patches);
+      }
       onModelChange?.();
     },
-    [openAgent, openSettings, setSelectedModel, onModelChange],
+    [
+      openAgent,
+      openSettings,
+      setSelectedModel,
+      onModelChange,
+      modelPresets,
+      preferences,
+      updatePreferences,
+    ],
   );
 
   const handleOpenChange = useCallback(
@@ -649,7 +784,7 @@ export const ModelSelect = memo(function ModelSelect({
       value={selectedKey}
       open={open}
       inputValue={query}
-      items={[...allEntryKeys, OPEN_MODEL_SETTINGS_VALUE]}
+      items={[...presetKeys, ...allEntryKeys, OPEN_MODEL_SETTINGS_VALUE]}
       filteredItems={filteredItemValues}
       autoHighlight
       onValueChange={handleValueChange}
@@ -724,6 +859,19 @@ export const ModelSelect = memo(function ModelSelect({
 
               <ComboboxList>
                 <div className="scroll-fade-y scroll-fade-4 scrollbar-subtle max-h-48 overflow-y-auto">
+                  {filteredPresets.length > 0 && (
+                    <ComboboxGroup className="mt-0">
+                      <ComboboxGroupLabel className="px-1.5 pb-1 font-normal text-sidebar-foreground text-xs">
+                        Presets
+                      </ComboboxGroupLabel>
+                      {filteredPresets.map((preset) => (
+                        <PresetItem
+                          key={encodePresetKey(preset.id)}
+                          preset={preset}
+                        />
+                      ))}
+                    </ComboboxGroup>
+                  )}
                   {filteredGrouped.map((group) => (
                     <ComboboxGroup
                       key={group.instanceId}
@@ -882,6 +1030,26 @@ const ModelItem = memo(function ModelItem({
               )}
           </span>
         )}
+      </span>
+    </ComboboxItem>
+  );
+});
+
+const PresetItem = memo(function PresetItem({
+  preset,
+}: {
+  preset: PresetEntry;
+}) {
+  const itemValue = encodePresetKey(preset.id);
+  return (
+    <ComboboxItem value={itemValue} size="xs">
+      <ComboboxItemIndicator />
+      <span className="col-start-2 flex min-w-0 flex-col gap-0 text-xs">
+        <span className="truncate font-medium">{preset.name}</span>
+        <span className="truncate text-[10px] text-subtle-foreground">
+          {preset.modelDisplayName}
+          {preset.thinkingLabel && ` · ${preset.thinkingLabel}`}
+        </span>
       </span>
     </ComboboxItem>
   );

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/model-select.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/model-select.tsx
@@ -868,6 +868,7 @@ export const ModelSelect = memo(function ModelSelect({
                         <PresetItem
                           key={encodePresetKey(preset.id)}
                           preset={preset}
+                          onHoverClear={scheduleClear}
                         />
                       ))}
                     </ComboboxGroup>
@@ -1037,12 +1038,14 @@ const ModelItem = memo(function ModelItem({
 
 const PresetItem = memo(function PresetItem({
   preset,
+  onHoverClear,
 }: {
   preset: PresetEntry;
+  onHoverClear: () => void;
 }) {
   const itemValue = encodePresetKey(preset.id);
   return (
-    <ComboboxItem value={itemValue} size="xs">
+    <ComboboxItem value={itemValue} size="xs" onMouseEnter={onHoverClear}>
       <ComboboxItemIndicator />
       <span className="col-start-2 flex min-w-0 flex-col gap-0 text-xs">
         <span className="truncate font-medium">{preset.name}</span>

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/model-select.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/model-select.tsx
@@ -520,7 +520,7 @@ export const ModelSelect = memo(function ModelSelect({
   );
 
   const handleValueChange = useCallback(
-    (value: string | null) => {
+    async (value: string | null) => {
       if (!value) return;
       if (value === OPEN_MODEL_SETTINGS_VALUE) {
         void openSettings({ section: 'models-providers' });
@@ -557,18 +557,20 @@ export const ModelSelect = memo(function ModelSelect({
       const decoded = decodeKey(value);
       if (!decoded) return;
       if (!openAgent) return;
+      // Clear active preset BEFORE setting the model so runStep
+      // doesn't see a stale activePresetId and overwrite the
+      // user's chosen model via setActiveModel.
+      if (preferences.agent.activePresetId) {
+        const [, patches] = produceWithPatches(preferences, (draft) => {
+          draft.agent.activePresetId = undefined;
+        });
+        await updatePreferences(patches);
+      }
       setSelectedModel(
         openAgent,
         decoded.modelId as ModelId,
         decoded.instanceId,
       );
-      // Clear active preset when selecting a raw model
-      if (preferences.agent.activePresetId) {
-        const [, patches] = produceWithPatches(preferences, (draft) => {
-          draft.agent.activePresetId = undefined;
-        });
-        void updatePreferences(patches);
-      }
       onModelChange?.();
     },
     [
@@ -724,6 +726,13 @@ export const ModelSelect = memo(function ModelSelect({
     // Aliases use fixed thinking presets — cycling is disabled for them.
     if (getModelAlias(selectedModel)) return false;
 
+    // When a preset is active, its per-model thinking override takes
+    // precedence over global modelThinkingOverrides (see
+    // resolveThinkingProviderOptions). Cycling would write a global
+    // override that has no effect on the next agent turn. Users should
+    // edit the preset's thinking in settings instead.
+    if (activePresetId) return false;
+
     const model = getAvailableModel(selectedModel);
     if (!model) return false;
     const targetModelId = model.modelId;
@@ -758,6 +767,7 @@ export const ModelSelect = memo(function ModelSelect({
     preferences,
     selectedModel,
     selectedProviderInstanceId,
+    activePresetId,
     instanceMap,
     updatePreferences,
   ]);

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/model-select.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/model-select.tsx
@@ -549,7 +549,7 @@ export const ModelSelect = memo(function ModelSelect({
           const [, patches] = produceWithPatches(preferences, (draft) => {
             draft.agent.activePresetId = preset.id;
           });
-          void updatePreferences(patches);
+          await updatePreferences(patches);
           onModelChange?.();
         }
         return;

--- a/apps/browser/src/ui/screens/settings/sections/model-presets-section.tsx
+++ b/apps/browser/src/ui/screens/settings/sections/model-presets-section.tsx
@@ -1,0 +1,1163 @@
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  type CSSProperties,
+} from 'react';
+import {
+  DndContext,
+  PointerSensor,
+  closestCenter,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from '@dnd-kit/core';
+import {
+  SortableContext,
+  arrayMove,
+  useSortable,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
+import { restrictToVerticalAxis } from '@dnd-kit/modifiers';
+import { CSS } from '@dnd-kit/utilities';
+import { enablePatches, produceWithPatches } from 'immer';
+import { useKartonState, useKartonProcedure } from '@ui/hooks/use-karton';
+import type {
+  ModelThinkingOverride,
+  PresetModelEntry,
+  UtilityModelEntry,
+  UserPreferences,
+} from '@shared/karton-contracts/ui/shared-types';
+import {
+  getInstanceThinkingDefaultOptions,
+  getSelectableModelEntries,
+  getVendorForInstance,
+  isModelEntryValid,
+  type ModelSelectorEntry,
+} from '@shared/provider-instance-helpers';
+import { resolveModelDisplay } from '@ui/screens/main/agent-chat/chat/_components/model-presets-shared';
+import { Button } from '@stagewise/stage-ui/components/button';
+import { Input } from '@stagewise/stage-ui/components/input';
+import {
+  Radio,
+  RadioGroup,
+  RadioLabel,
+} from '@stagewise/stage-ui/components/radio';
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  DialogDescription,
+  DialogHeader,
+  DialogFooter,
+} from '@stagewise/stage-ui/components/dialog';
+import { Combobox as ComboboxBase } from '@base-ui/react/combobox';
+import {
+  Combobox,
+  ComboboxContent,
+  ComboboxGroup,
+  ComboboxGroupLabel,
+  ComboboxInput,
+  ComboboxItem,
+  ComboboxItemIndicator,
+  ComboboxList,
+} from '@stagewise/stage-ui/components/combobox';
+import {
+  IconPlusOutline18,
+  IconTrashOutline18,
+  IconGripDotsVerticalOutline18,
+  IconTriangleWarningOutline18,
+  IconPenOutline18,
+  IconBrainOutline18,
+} from '@stagewise/icons';
+import {
+  getModelThinkingDisplayState,
+  getModelThinkingOptions,
+  type ModelThinkingDefaultOptions,
+  type ThinkingPanelModel,
+} from '@ui/utils/model-thinking';
+import { cn } from '@ui/utils';
+
+enablePatches();
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type UtilityTask = 'titleGeneration' | 'contextCompression';
+
+type ProviderInstance = NonNullable<
+  UserPreferences['providerInstances']
+>[number];
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function generateId(): string {
+  return `preset-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function modelKey(m: { modelId: string; providerInstanceId?: string }): string {
+  return `${m.modelId}::${m.providerInstanceId ?? ''}`;
+}
+
+/** Build a ThinkingPanelModel from a selector entry. */
+function buildThinkingModel(
+  entry: ModelSelectorEntry,
+  instanceMap: Map<string, ProviderInstance>,
+): ThinkingPanelModel | undefined {
+  if (entry.catalogModel) return entry.catalogModel;
+  if (entry.thinkingEnabled) {
+    const instance = instanceMap.get(entry.instanceId);
+    const vendor = instance ? getVendorForInstance(instance) : undefined;
+    return {
+      modelId: entry.targetModelId,
+      modelDisplayName: entry.displayName,
+      providerOptions: {},
+      officialProvider: vendor,
+      thinkingEnabled: true,
+    };
+  }
+  return undefined;
+}
+
+/** Convert a ModelSelectorEntry to a model entry, stripping the
+ *  `stagewise-default` provider instance (which is implicit). */
+function selectorToModelEntry(entry: ModelSelectorEntry): {
+  modelId: string;
+  providerInstanceId?: string;
+} {
+  return {
+    modelId: entry.modelId,
+    ...(entry.instanceId !== 'stagewise-default'
+      ? { providerInstanceId: entry.instanceId }
+      : {}),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Sortable Model Item (shared by all model lists)
+// ---------------------------------------------------------------------------
+
+function SortableModelItem({
+  itemKey,
+  label,
+  isValid,
+  displayName,
+  instanceName,
+  onRemove,
+  thinkingOverride,
+  isExpanded,
+  onToggleExpand,
+  onThinkingChange,
+  onThinkingReset,
+  thinkingModel,
+  thinkingDefaultOptions,
+}: {
+  itemKey: string;
+  label?: string;
+  isValid: boolean;
+  displayName: string;
+  instanceName: string;
+  onRemove: () => void;
+  thinkingOverride: ModelThinkingOverride | undefined;
+  isExpanded: boolean;
+  onToggleExpand: () => void;
+  onThinkingChange: (override: ModelThinkingOverride) => void;
+  onThinkingReset: () => void;
+  thinkingModel: ThinkingPanelModel | undefined;
+  thinkingDefaultOptions: ModelThinkingDefaultOptions | undefined;
+}) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: itemKey });
+
+  const style: CSSProperties = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    zIndex: isDragging ? 10 : undefined,
+  };
+
+  const canThink = thinkingModel !== undefined;
+  const thinkingDisplay = thinkingModel
+    ? getModelThinkingDisplayState(
+        thinkingModel,
+        thinkingOverride,
+        thinkingDefaultOptions,
+      )
+    : undefined;
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className={cn(
+        'rounded-md border border-derived bg-surface',
+        isDragging && 'opacity-80 shadow-md',
+      )}
+    >
+      <div className="flex items-center gap-2 px-2 py-1.5">
+        <button
+          type="button"
+          className="cursor-grab text-muted-foreground hover:text-foreground"
+          {...attributes}
+          {...listeners}
+        >
+          <IconGripDotsVerticalOutline18 className="size-3.5" />
+        </button>
+        <div className="flex min-w-0 flex-1 flex-col">
+          <div className="flex items-center gap-1.5">
+            {label && (
+              <span className="shrink-0 text-2xs text-muted-foreground">
+                {label}
+              </span>
+            )}
+            <span
+              className={cn(
+                'truncate text-xs',
+                !isValid && 'text-muted-foreground line-through',
+              )}
+            >
+              {displayName}
+            </span>
+          </div>
+          <span className="truncate text-2xs text-muted-foreground">
+            {instanceName}
+          </span>
+        </div>
+        {!isValid && (
+          <span className="flex shrink-0 items-center gap-0.5 text-2xs text-warning-foreground">
+            <IconTriangleWarningOutline18 className="size-3" />
+            Invalid
+          </span>
+        )}
+        {canThink && thinkingDisplay && (
+          <button
+            type="button"
+            className={cn(
+              'flex shrink-0 items-center gap-0.5 rounded px-1 py-0.5 text-2xs transition-colors',
+              thinkingDisplay.enabled
+                ? 'text-foreground'
+                : 'text-muted-foreground',
+              'hover:bg-surface-hover',
+              isExpanded && 'bg-surface-hover',
+            )}
+            onClick={onToggleExpand}
+          >
+            <IconBrainOutline18 className="size-3" />
+            {thinkingDisplay.label}
+          </button>
+        )}
+        <button
+          type="button"
+          className="shrink-0 text-muted-foreground hover:text-foreground"
+          onClick={onRemove}
+        >
+          <IconTrashOutline18 className="size-3.5" />
+        </button>
+      </div>
+      {isExpanded && canThink && thinkingModel && (
+        <div className="border-derived border-t px-2 py-2">
+          <InlineThinkingConfig
+            model={thinkingModel}
+            override={thinkingOverride}
+            defaultOptions={thinkingDefaultOptions}
+            onChange={onThinkingChange}
+            onReset={onThinkingReset}
+          />
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Model Picker Dropdown (slim "Add" button)
+// ---------------------------------------------------------------------------
+
+function ModelPickerButton({
+  entries,
+  onPick,
+  excludeIds,
+}: {
+  entries: ModelSelectorEntry[];
+  onPick: (entry: ModelSelectorEntry) => void;
+  excludeIds: Set<string>;
+}) {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState('');
+
+  const available = useMemo(
+    () =>
+      entries.filter((e) => !excludeIds.has(`${e.modelId}::${e.instanceId}`)),
+    [entries, excludeIds],
+  );
+
+  const entryByKey = useMemo(() => {
+    const map = new Map<string, ModelSelectorEntry>();
+    for (const e of available) {
+      map.set(`${e.modelId}::${e.instanceId}`, e);
+    }
+    return map;
+  }, [available]);
+
+  const allKeys = useMemo(
+    () => available.map((e) => `${e.modelId}::${e.instanceId}`),
+    [available],
+  );
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (q === '') return available;
+    return available.filter(
+      (e) =>
+        e.displayName.toLowerCase().includes(q) ||
+        e.modelId.toLowerCase().includes(q) ||
+        e.instanceName.toLowerCase().includes(q),
+    );
+  }, [available, query]);
+
+  const filteredKeys = useMemo(
+    () => filtered.map((e) => `${e.modelId}::${e.instanceId}`),
+    [filtered],
+  );
+
+  const grouped = useMemo(() => {
+    const map = new Map<
+      string,
+      { name: string; entries: ModelSelectorEntry[] }
+    >();
+    for (const e of filtered) {
+      let g = map.get(e.instanceId);
+      if (!g) {
+        g = { name: e.instanceName, entries: [] };
+        map.set(e.instanceId, g);
+      }
+      g.entries.push(e);
+    }
+    return Array.from(map.values());
+  }, [filtered]);
+
+  const handleValueChange = useCallback(
+    (value: string | null) => {
+      if (!value) return;
+      const entry = entryByKey.get(value);
+      if (entry) {
+        onPick(entry);
+        setOpen(false);
+        setQuery('');
+      }
+    },
+    [entryByKey, onPick],
+  );
+
+  const handleOpenChange = useCallback((nextOpen: boolean) => {
+    setOpen(nextOpen);
+    if (!nextOpen) setQuery('');
+  }, []);
+
+  return (
+    <Combobox
+      value={null}
+      open={open}
+      inputValue={query}
+      items={allKeys}
+      filteredItems={filteredKeys}
+      autoHighlight
+      onValueChange={handleValueChange}
+      onOpenChange={handleOpenChange}
+      onInputValueChange={setQuery}
+      filter={null}
+    >
+      <ComboboxBase.Trigger className="flex w-full items-center justify-center gap-1 rounded-md border border-derived border-dashed px-2 py-1 text-muted-foreground text-xs transition-colors hover:bg-surface hover:text-foreground">
+        <IconPlusOutline18 className="size-3" />
+        Add
+      </ComboboxBase.Trigger>
+      <ComboboxContent side="bottom" align="start" sideOffset={4} size="xs">
+        <div className="mb-1 rounded-md">
+          <ComboboxInput size="xs" placeholder="Search…" />
+        </div>
+        <ComboboxList>
+          <div className="scrollbar-subtle max-h-48 overflow-y-auto">
+            {grouped.length === 0 && (
+              <div className="px-2 py-1.5 text-muted-foreground text-xs">
+                {query.trim() === '' ? 'No models available' : 'No results'}
+              </div>
+            )}
+            {grouped.map((group) => (
+              <ComboboxGroup key={group.name}>
+                <ComboboxGroupLabel>{group.name}</ComboboxGroupLabel>
+                {group.entries.map((entry) => {
+                  const key = `${entry.modelId}::${entry.instanceId}`;
+                  return (
+                    <ComboboxItem key={key} value={key} size="xs">
+                      <ComboboxItemIndicator />
+                      <span className="col-start-2 truncate">
+                        {entry.displayName}
+                      </span>
+                    </ComboboxItem>
+                  );
+                })}
+              </ComboboxGroup>
+            ))}
+          </div>
+        </ComboboxList>
+      </ComboboxContent>
+    </Combobox>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Inline Thinking Config (compact, for model rows)
+// ---------------------------------------------------------------------------
+
+function InlineThinkingConfig({
+  model,
+  override,
+  defaultOptions,
+  onChange,
+  onReset,
+}: {
+  model: ThinkingPanelModel;
+  override: ModelThinkingOverride | undefined;
+  defaultOptions: ModelThinkingDefaultOptions | undefined;
+  onChange: (override: ModelThinkingOverride) => void;
+  onReset: () => void;
+}) {
+  const display = getModelThinkingDisplayState(model, override, defaultOptions);
+  if (!display) return null;
+
+  const options = getModelThinkingOptions(model, defaultOptions);
+
+  // Only keep enabled options; we prepend our own unified "Off" choice.
+  // Some providers (e.g. GPT-5) already include a disabled "none" option —
+  // filter it out to avoid redundancy.
+  const enabledOptions = options.filter((o) => o.enabled);
+
+  // Sentinel value for the "Off" radio so it never collides with real options
+  const OFF_VALUE = '__off';
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center gap-1.5">
+        <IconBrainOutline18 className="size-3 text-muted-foreground" />
+        <span className="text-2xs text-muted-foreground">Thinking</span>
+      </div>
+      <RadioGroup
+        value={display.enabled ? display.value : OFF_VALUE}
+        onValueChange={(value) => {
+          if (typeof value !== 'string') return;
+          if (value === OFF_VALUE) {
+            onChange({
+              enabled: false,
+              provider: display.provider,
+              value: display.value,
+            });
+          } else {
+            const option = enabledOptions.find((o) => o.value === value);
+            if (option) {
+              onChange({
+                enabled: true,
+                provider: option.provider,
+                value: option.value,
+              });
+            }
+          }
+        }}
+        className="flex flex-row flex-wrap gap-2"
+      >
+        <RadioLabel key={OFF_VALUE} size="xs">
+          <Radio value={OFF_VALUE} size="xs" />
+          <span>Off</span>
+        </RadioLabel>
+        {enabledOptions.map((option) => (
+          <RadioLabel key={option.value} size="xs">
+            <Radio value={option.value} size="xs" />
+            <span>{option.label}</span>
+          </RadioLabel>
+        ))}
+      </RadioGroup>
+      {display.isOverride && (
+        <button
+          type="button"
+          className="text-2xs text-muted-foreground hover:text-foreground"
+          onClick={onReset}
+        >
+          Reset to default
+        </button>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Shared hook: resolve display info + thinking model for a list of entries
+// ---------------------------------------------------------------------------
+
+function useModelListItems(
+  modelEntries: Array<{
+    modelId: string;
+    providerInstanceId?: string;
+    thinkingOverride?: ModelThinkingOverride;
+  }>,
+  entries: ModelSelectorEntry[],
+  preferences: UserPreferences,
+) {
+  const instanceMap = useMemo(() => {
+    const map = new Map<string, ProviderInstance>();
+    for (const inst of preferences.providerInstances ?? []) {
+      map.set(inst.id, inst);
+    }
+    return map;
+  }, [preferences.providerInstances]);
+
+  const items = useMemo(
+    () =>
+      modelEntries.map((entry, i) => {
+        const display = resolveModelDisplay(
+          entries,
+          entry.modelId,
+          entry.providerInstanceId,
+        );
+        const valid = isModelEntryValid(
+          preferences,
+          entry.modelId,
+          entry.providerInstanceId,
+        );
+        const key = modelKey(entry);
+        const selectorEntry = entry.providerInstanceId
+          ? entries.find(
+              (e) =>
+                e.modelId === entry.modelId &&
+                e.instanceId === entry.providerInstanceId,
+            )
+          : entries.find((e) => e.modelId === entry.modelId);
+        const instance = selectorEntry
+          ? instanceMap.get(selectorEntry.instanceId)
+          : undefined;
+        const thinkingModel = selectorEntry
+          ? buildThinkingModel(selectorEntry, instanceMap)
+          : undefined;
+        const thinkingDefaultOptions = instance
+          ? getInstanceThinkingDefaultOptions(instance)
+          : undefined;
+        return {
+          index: i,
+          key,
+          entry,
+          display: display ?? {
+            displayName: entry.modelId,
+            instanceName: 'Unknown',
+          },
+          valid,
+          thinkingModel,
+          thinkingDefaultOptions,
+        };
+      }),
+    [modelEntries, entries, preferences, instanceMap],
+  );
+
+  const excludeIds = useMemo(
+    () => new Set(modelEntries.map((e) => modelKey(e))),
+    [modelEntries],
+  );
+
+  return { items, excludeIds };
+}
+
+// ---------------------------------------------------------------------------
+// Model List (unified — used for global utility models, preset utility
+// models, and preset main+fallback models)
+// ---------------------------------------------------------------------------
+
+function ModelList({
+  label,
+  description,
+  modelEntries,
+  onChange,
+  entries,
+  preferences,
+  itemLabel,
+  emptyMessage,
+}: {
+  label: string;
+  description: string;
+  modelEntries: Array<{
+    modelId: string;
+    providerInstanceId?: string;
+    thinkingOverride?: ModelThinkingOverride;
+  }>;
+  onChange: (
+    entries: Array<{
+      modelId: string;
+      providerInstanceId?: string;
+      thinkingOverride?: ModelThinkingOverride;
+    }>,
+  ) => void;
+  entries: ModelSelectorEntry[];
+  preferences: UserPreferences;
+  itemLabel?: (index: number) => string;
+  emptyMessage?: string;
+}) {
+  const { items, excludeIds } = useModelListItems(
+    modelEntries,
+    entries,
+    preferences,
+  );
+  const [expandedKey, setExpandedKey] = useState<string | null>(null);
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+  );
+
+  const handleDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      const { active, over } = event;
+      if (!over || active.id === over.id) return;
+      const oldIndex = items.findIndex((i) => i.key === String(active.id));
+      const newIndex = items.findIndex((i) => i.key === String(over.id));
+      if (oldIndex === -1 || newIndex === -1) return;
+      onChange(arrayMove(modelEntries, oldIndex, newIndex));
+    },
+    [items, modelEntries, onChange],
+  );
+
+  const handleAdd = useCallback(
+    (entry: ModelSelectorEntry) => {
+      onChange([...modelEntries, selectorToModelEntry(entry)]);
+    },
+    [modelEntries, onChange],
+  );
+
+  const handleRemove = useCallback(
+    (key: string) => {
+      onChange(modelEntries.filter((e) => modelKey(e) !== key));
+      setExpandedKey((prev) => (prev === key ? null : prev));
+    },
+    [modelEntries, onChange],
+  );
+
+  const handleThinkingChange = useCallback(
+    (key: string, override: ModelThinkingOverride) => {
+      onChange(
+        modelEntries.map((e) =>
+          modelKey(e) === key ? { ...e, thinkingOverride: override } : e,
+        ),
+      );
+    },
+    [modelEntries, onChange],
+  );
+
+  const handleThinkingReset = useCallback(
+    (key: string) => {
+      onChange(
+        modelEntries.map((e) =>
+          modelKey(e) === key ? { ...e, thinkingOverride: undefined } : e,
+        ),
+      );
+    },
+    [modelEntries, onChange],
+  );
+
+  return (
+    <div className="space-y-2">
+      <div>
+        <h4 className="font-medium text-foreground text-sm">{label}</h4>
+        <p className="text-muted-foreground text-xs">{description}</p>
+      </div>
+
+      {items.length > 0 ? (
+        <DndContext
+          sensors={sensors}
+          collisionDetection={closestCenter}
+          modifiers={[restrictToVerticalAxis]}
+          onDragEnd={handleDragEnd}
+        >
+          <SortableContext
+            items={items.map((i) => i.key)}
+            strategy={verticalListSortingStrategy}
+          >
+            <div className="space-y-1">
+              {items.map((item) => (
+                <SortableModelItem
+                  key={item.key}
+                  itemKey={item.key}
+                  label={itemLabel?.(item.index)}
+                  isValid={item.valid}
+                  displayName={item.display.displayName}
+                  instanceName={item.display.instanceName}
+                  onRemove={() => handleRemove(item.key)}
+                  thinkingOverride={item.entry.thinkingOverride}
+                  isExpanded={expandedKey === item.key}
+                  onToggleExpand={() =>
+                    setExpandedKey(expandedKey === item.key ? null : item.key)
+                  }
+                  onThinkingChange={(override) =>
+                    handleThinkingChange(item.key, override)
+                  }
+                  onThinkingReset={() => handleThinkingReset(item.key)}
+                  thinkingModel={item.thinkingModel}
+                  thinkingDefaultOptions={item.thinkingDefaultOptions}
+                />
+              ))}
+            </div>
+          </SortableContext>
+        </DndContext>
+      ) : emptyMessage ? (
+        <div className="rounded-md border border-derived border-dashed px-3 py-2 text-center text-muted-foreground text-xs">
+          {emptyMessage}
+        </div>
+      ) : null}
+
+      <ModelPickerButton
+        entries={entries}
+        onPick={handleAdd}
+        excludeIds={excludeIds}
+      />
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Global Utility Model List (thin wrapper: wires ModelList to Karton state)
+// ---------------------------------------------------------------------------
+
+function UtilityModelList({
+  task,
+  label,
+  description,
+}: {
+  task: UtilityTask;
+  label: string;
+  description: string;
+}) {
+  const preferences = useKartonState((s) => s.preferences);
+  const updatePreferences = useKartonProcedure((p) => p.preferences.update);
+
+  const modelEntries = preferences.agent.utilityModels[task] ?? [];
+
+  const entries = useMemo(
+    () => getSelectableModelEntries(preferences),
+    [preferences],
+  );
+
+  const handleChange = useCallback(
+    (next: UtilityModelEntry[]) => {
+      const [, patches] = produceWithPatches(preferences, (draft) => {
+        draft.agent.utilityModels[task] = next;
+      });
+      void updatePreferences(patches);
+    },
+    [preferences, task, updatePreferences],
+  );
+
+  return (
+    <ModelList
+      label={label}
+      description={description}
+      modelEntries={modelEntries}
+      onChange={handleChange}
+      entries={entries}
+      preferences={preferences}
+      emptyMessage="No model configured, uses main chat model."
+    />
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Preset Card
+// ---------------------------------------------------------------------------
+
+function PresetCard({
+  preset,
+  entries,
+  preferences,
+  onEdit,
+  onDelete,
+}: {
+  preset: UserPreferences['agent']['modelPresets'][number];
+  entries: ModelSelectorEntry[];
+  preferences: UserPreferences;
+  onEdit: () => void;
+  onDelete: () => void;
+}) {
+  const mainModel = preset.models[0];
+  const mainDisplay = mainModel
+    ? resolveModelDisplay(
+        entries,
+        mainModel.modelId,
+        mainModel.providerInstanceId,
+      )
+    : undefined;
+  const mainValid = mainModel
+    ? isModelEntryValid(
+        preferences,
+        mainModel.modelId,
+        mainModel.providerInstanceId,
+      )
+    : false;
+
+  const fallbackCount = preset.models.length - 1;
+  const validFallbacks = preset.models
+    .slice(1)
+    .filter((f) =>
+      isModelEntryValid(preferences, f.modelId, f.providerInstanceId),
+    ).length;
+
+  const thinkingLabel = preset.models.find((m) => m.thinkingOverride?.enabled)
+    ?.thinkingOverride?.value;
+
+  return (
+    <div className="flex items-center gap-3 rounded-lg border border-derived bg-surface p-3">
+      <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+        <div className="flex items-center gap-2">
+          <span className="truncate font-medium text-foreground text-sm">
+            {preset.name}
+          </span>
+          {!mainValid && (
+            <span className="flex shrink-0 items-center gap-0.5 text-2xs text-warning-foreground">
+              <IconTriangleWarningOutline18 className="size-3" />
+              Invalid model
+            </span>
+          )}
+        </div>
+        <div className="flex items-center gap-2 text-muted-foreground text-xs">
+          <span className="truncate">
+            {mainDisplay?.displayName ?? mainModel?.modelId ?? 'No model'}
+          </span>
+          {fallbackCount > 0 && (
+            <>
+              <span className="text-muted-foreground/50">·</span>
+              <span>
+                {fallbackCount} fallback{fallbackCount === 1 ? '' : 's'}
+              </span>
+              {validFallbacks < fallbackCount && (
+                <span className="text-warning-foreground">
+                  ({validFallbacks} valid)
+                </span>
+              )}
+            </>
+          )}
+          {thinkingLabel && (
+            <>
+              <span className="text-muted-foreground/50">·</span>
+              <span>Thinking: {thinkingLabel}</span>
+            </>
+          )}
+        </div>
+      </div>
+      <div className="flex shrink-0 items-center gap-1">
+        <Button variant="ghost" size="icon-sm" onClick={onEdit}>
+          <IconPenOutline18 className="size-3.5" />
+        </Button>
+        <Button variant="ghost" size="icon-sm" onClick={onDelete}>
+          <IconTrashOutline18 className="size-3.5 text-muted-foreground" />
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Preset Editor Dialog
+// ---------------------------------------------------------------------------
+
+function PresetEditorDialog({
+  preset,
+  open,
+  onOpenChange,
+  onSave,
+  entries,
+  preferences,
+}: {
+  preset?: UserPreferences['agent']['modelPresets'][number];
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSave: (data: {
+    id: string;
+    name: string;
+    models: PresetModelEntry[];
+    titleGeneration?: UtilityModelEntry[];
+    contextCompression?: UtilityModelEntry[];
+  }) => void;
+  entries: ModelSelectorEntry[];
+  preferences: UserPreferences;
+}) {
+  const isEdit = !!preset;
+  const [name, setName] = useState(preset?.name ?? '');
+  const [models, setModels] = useState<PresetModelEntry[]>(
+    preset?.models ?? [],
+  );
+  const [titleGeneration, setTitleGeneration] = useState<
+    UtilityModelEntry[] | undefined
+  >(preset?.titleGeneration);
+  const [contextCompression, setContextCompression] = useState<
+    UtilityModelEntry[] | undefined
+  >(preset?.contextCompression);
+
+  // Reset state when dialog opens or the preset changes
+  useEffect(() => {
+    if (open) {
+      setName(preset?.name ?? '');
+      setModels(preset?.models ?? []);
+      setTitleGeneration(preset?.titleGeneration);
+      setContextCompression(preset?.contextCompression);
+    }
+  }, [open, preset?.id]);
+
+  const handleSave = () => {
+    if (!name.trim() || models.length === 0) return;
+    onSave({
+      id: preset?.id ?? generateId(),
+      name: name.trim(),
+      models,
+      titleGeneration,
+      contextCompression,
+    });
+    onOpenChange(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>{isEdit ? 'Edit preset' : 'New preset'}</DialogTitle>
+          <DialogDescription>
+            {isEdit
+              ? 'Update this model configuration preset.'
+              : 'Create a named model configuration for one-click switching.'}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="max-h-[60vh] space-y-4 overflow-y-auto py-2">
+          {/* Name */}
+          <div className="space-y-1.5">
+            <span className="font-medium text-foreground text-sm">Name</span>
+            <Input
+              value={name}
+              onValueChange={(val) => setName(val)}
+              placeholder="e.g. Fast coding, Deep reasoning"
+              size="sm"
+            />
+          </div>
+
+          {/* Models (drag-and-drop, first = main, rest = fallbacks) */}
+          <ModelList
+            label="Models"
+            description="Drag to reorder. First model is the main model; the rest are fallbacks. Click the brain icon to configure thinking per model."
+            modelEntries={models}
+            onChange={setModels}
+            entries={entries}
+            preferences={preferences}
+            itemLabel={(i) => (i === 0 ? 'Main' : `Fallback ${i}`)}
+          />
+
+          {/* Per-preset utility model lists */}
+          <div className="space-y-3 border-derived border-t pt-3">
+            <ModelList
+              label="Title generation"
+              description="Models used for title generation when this preset is active. If empty, the main model is used."
+              modelEntries={titleGeneration ?? []}
+              onChange={(next) =>
+                setTitleGeneration(next.length > 0 ? next : undefined)
+              }
+              entries={entries}
+              preferences={preferences}
+              emptyMessage="Uses main model."
+            />
+            <ModelList
+              label="Context compression"
+              description="Models used for context compression when this preset is active. If empty, the main model is used."
+              modelEntries={contextCompression ?? []}
+              onChange={(next) =>
+                setContextCompression(next.length > 0 ? next : undefined)
+              }
+              entries={entries}
+              preferences={preferences}
+              emptyMessage="Uses main model."
+            />
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => onOpenChange?.(false)}
+          >
+            Cancel
+          </Button>
+          <Button
+            size="sm"
+            onClick={handleSave}
+            disabled={!name.trim() || models.length === 0}
+          >
+            {isEdit ? 'Save changes' : 'Create preset'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main Section Component
+// ---------------------------------------------------------------------------
+
+export function ModelPresetsSection() {
+  const preferences = useKartonState((s) => s.preferences);
+  const updatePreferences = useKartonProcedure((p) => p.preferences.update);
+
+  const presets = preferences.agent.modelPresets ?? [];
+  const entries = useMemo(
+    () => getSelectableModelEntries(preferences),
+    [preferences],
+  );
+
+  const [editorOpen, setEditorOpen] = useState(false);
+  const [editingPreset, setEditingPreset] = useState<
+    UserPreferences['agent']['modelPresets'][number] | undefined
+  >(undefined);
+
+  const handleSavePreset = useCallback(
+    (data: {
+      id: string;
+      name: string;
+      models: PresetModelEntry[];
+      titleGeneration?: UtilityModelEntry[];
+      contextCompression?: UtilityModelEntry[];
+    }) => {
+      const [, patches] = produceWithPatches(preferences, (draft) => {
+        const existingIndex = draft.agent.modelPresets.findIndex(
+          (p) => p.id === data.id,
+        );
+        const preset = {
+          id: data.id,
+          name: data.name,
+          models: data.models,
+          titleGeneration: data.titleGeneration,
+          contextCompression: data.contextCompression,
+        };
+        if (existingIndex >= 0) {
+          draft.agent.modelPresets[existingIndex] = preset;
+        } else {
+          draft.agent.modelPresets.push(preset);
+        }
+      });
+      void updatePreferences(patches);
+    },
+    [preferences, updatePreferences],
+  );
+
+  const handleDeletePreset = useCallback(
+    (id: string) => {
+      const [, patches] = produceWithPatches(preferences, (draft) => {
+        draft.agent.modelPresets = draft.agent.modelPresets.filter(
+          (p) => p.id !== id,
+        );
+      });
+      void updatePreferences(patches);
+    },
+    [preferences, updatePreferences],
+  );
+
+  const handleAddPreset = () => {
+    setEditingPreset(undefined);
+    setEditorOpen(true);
+  };
+
+  const handleEditPreset = (
+    preset: UserPreferences['agent']['modelPresets'][number],
+  ) => {
+    setEditingPreset(preset);
+    setEditorOpen(true);
+  };
+
+  return (
+    <div className="space-y-8">
+      {/* Default Utility Models */}
+      <section className="space-y-4">
+        <div>
+          <h2 className="font-medium text-foreground text-lg">
+            Default utility models
+          </h2>
+          <p className="text-muted-foreground text-sm">
+            These models are used for background tasks when no preset-specific
+            configuration is set. The agent tries each model in order until one
+            succeeds.
+          </p>
+        </div>
+
+        <div className="space-y-6">
+          <UtilityModelList
+            task="titleGeneration"
+            label="Title generation"
+            description="Models used to generate conversation titles."
+          />
+          <UtilityModelList
+            task="contextCompression"
+            label="Context compression"
+            description="Models used to compress conversation history."
+          />
+        </div>
+      </section>
+
+      {/* Presets */}
+      <section className="space-y-4">
+        <div className="flex items-center justify-between">
+          <div>
+            <h2 className="font-medium text-foreground text-lg">Presets</h2>
+            <p className="text-muted-foreground text-sm">
+              Named model configurations for one-click switching. Shown at the
+              top of the model selector.
+            </p>
+          </div>
+          <Button variant="secondary" size="sm" onClick={handleAddPreset}>
+            <IconPlusOutline18 className="size-3.5" />
+            Add preset
+          </Button>
+        </div>
+
+        {presets.length > 0 ? (
+          <div className="space-y-2">
+            {presets.map((preset) => (
+              <PresetCard
+                key={preset.id}
+                preset={preset}
+                entries={entries}
+                preferences={preferences}
+                onEdit={() => handleEditPreset(preset)}
+                onDelete={() => handleDeletePreset(preset.id)}
+              />
+            ))}
+          </div>
+        ) : (
+          <div className="rounded-lg border border-derived border-dashed px-4 py-6 text-center">
+            <p className="text-muted-foreground text-sm">
+              No presets configured.
+            </p>
+            <p className="mt-1 text-muted-foreground text-xs">
+              Create a preset to quickly switch between model configurations.
+            </p>
+          </div>
+        )}
+      </section>
+
+      <PresetEditorDialog
+        preset={editingPreset}
+        open={editorOpen}
+        onOpenChange={setEditorOpen}
+        onSave={handleSavePreset}
+        entries={entries}
+        preferences={preferences}
+      />
+    </div>
+  );
+}

--- a/apps/browser/src/ui/screens/settings/sections/model-presets-section.tsx
+++ b/apps/browser/src/ui/screens/settings/sections/model-presets-section.tsx
@@ -273,6 +273,7 @@ function SortableModelItem({
           <InlineThinkingConfig
             model={thinkingModel}
             override={thinkingOverride}
+            effectiveOverride={effectiveThinkingOverride}
             defaultOptions={thinkingDefaultOptions}
             onChange={onThinkingChange}
             onReset={onThinkingReset}
@@ -433,17 +434,23 @@ function ModelPickerButton({
 function InlineThinkingConfig({
   model,
   override,
+  effectiveOverride,
   defaultOptions,
   onChange,
   onReset,
 }: {
   model: ThinkingPanelModel;
   override: ModelThinkingOverride | undefined;
+  effectiveOverride: ModelThinkingOverride | undefined;
   defaultOptions: ModelThinkingDefaultOptions | undefined;
   onChange: (override: ModelThinkingOverride) => void;
   onReset: () => void;
 }) {
-  const display = getModelThinkingDisplayState(model, override, defaultOptions);
+  const display = getModelThinkingDisplayState(
+    model,
+    effectiveOverride ?? override,
+    defaultOptions,
+  );
   if (!display) return null;
 
   const options = getModelThinkingOptions(model, defaultOptions);
@@ -496,7 +503,10 @@ function InlineThinkingConfig({
           </RadioLabel>
         ))}
       </RadioGroup>
-      {display.isOverride && (
+      {/* Only show reset when an explicit override is persisted —
+          alias-effective presets without a stored override should not
+          show a reset button. */}
+      {display.isOverride && override !== undefined && (
         <button
           type="button"
           className="text-2xs text-muted-foreground hover:text-foreground"

--- a/apps/browser/src/ui/screens/settings/sections/model-presets-section.tsx
+++ b/apps/browser/src/ui/screens/settings/sections/model-presets-section.tsx
@@ -78,6 +78,7 @@ import {
   type ThinkingPanelModel,
 } from '@ui/utils/model-thinking';
 import { cn } from '@ui/utils';
+import { getModelAlias } from '@shared/available-models';
 
 enablePatches();
 
@@ -155,6 +156,7 @@ function SortableModelItem({
   onThinkingReset,
   thinkingModel,
   thinkingDefaultOptions,
+  effectiveThinkingOverride,
 }: {
   itemKey: string;
   label?: string;
@@ -169,6 +171,7 @@ function SortableModelItem({
   onThinkingReset: () => void;
   thinkingModel: ThinkingPanelModel | undefined;
   thinkingDefaultOptions: ModelThinkingDefaultOptions | undefined;
+  effectiveThinkingOverride?: ModelThinkingOverride;
 }) {
   const {
     attributes,
@@ -186,10 +189,12 @@ function SortableModelItem({
   };
 
   const canThink = thinkingModel !== undefined;
+  // Use effectiveThinkingOverride for display so alias entries show
+  // their fixed thinkingPreset even when no explicit override is stored.
   const thinkingDisplay = thinkingModel
     ? getModelThinkingDisplayState(
         thinkingModel,
-        thinkingOverride,
+        effectiveThinkingOverride ?? thinkingOverride,
         thinkingDefaultOptions,
       )
     : undefined;
@@ -294,22 +299,29 @@ function ModelPickerButton({
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState('');
 
+  // Compute the picker key consistently with modelKey()/selectorToModelEntry():
+  // `stagewise-default` instance IDs are stripped (implicit), so the key
+  // becomes `modelId::` — matching the stored entry's key. Without this,
+  // already-added stagewise-default models would not be excluded from the
+  // picker, allowing duplicates with colliding React keys.
+  const pickerKey = (e: ModelSelectorEntry) =>
+    `${e.modelId}::${e.instanceId !== 'stagewise-default' ? e.instanceId : ''}`;
+
   const available = useMemo(
-    () =>
-      entries.filter((e) => !excludeIds.has(`${e.modelId}::${e.instanceId}`)),
+    () => entries.filter((e) => !excludeIds.has(pickerKey(e))),
     [entries, excludeIds],
   );
 
   const entryByKey = useMemo(() => {
     const map = new Map<string, ModelSelectorEntry>();
     for (const e of available) {
-      map.set(`${e.modelId}::${e.instanceId}`, e);
+      map.set(pickerKey(e), e);
     }
     return map;
   }, [available]);
 
   const allKeys = useMemo(
-    () => available.map((e) => `${e.modelId}::${e.instanceId}`),
+    () => available.map((e) => pickerKey(e)),
     [available],
   );
 
@@ -325,7 +337,7 @@ function ModelPickerButton({
   }, [available, query]);
 
   const filteredKeys = useMemo(
-    () => filtered.map((e) => `${e.modelId}::${e.instanceId}`),
+    () => filtered.map((e) => pickerKey(e)),
     [filtered],
   );
 
@@ -392,10 +404,10 @@ function ModelPickerButton({
               </div>
             )}
             {grouped.map((group) => (
-              <ComboboxGroup key={group.name}>
+              <ComboboxGroup key={group.entries[0]?.instanceId ?? group.name}>
                 <ComboboxGroupLabel>{group.name}</ComboboxGroupLabel>
                 {group.entries.map((entry) => {
-                  const key = `${entry.modelId}::${entry.instanceId}`;
+                  const key = pickerKey(entry);
                   return (
                     <ComboboxItem key={key} value={key} size="xs">
                       <ComboboxItemIndicator />
@@ -545,6 +557,14 @@ function useModelListItems(
         const thinkingModel = selectorEntry
           ? buildThinkingModel(selectorEntry, instanceMap)
           : undefined;
+        // For alias entries without an explicit thinking override, use the
+        // alias's fixed thinkingPreset so the UI shows the effective thinking
+        // configuration rather than the target model's default.
+        const effectiveThinkingOverride =
+          entry.thinkingOverride ??
+          (selectorEntry?.isAlias
+            ? getModelAlias(selectorEntry.modelId)?.thinkingPreset
+            : undefined);
         const thinkingDefaultOptions = instance
           ? getInstanceThinkingDefaultOptions(instance)
           : undefined;
@@ -559,6 +579,7 @@ function useModelListItems(
           valid,
           thinkingModel,
           thinkingDefaultOptions,
+          effectiveThinkingOverride,
         };
       }),
     [modelEntries, entries, preferences, instanceMap],
@@ -705,6 +726,7 @@ function ModelList({
                   onThinkingReset={() => handleThinkingReset(item.key)}
                   thinkingModel={item.thinkingModel}
                   thinkingDefaultOptions={item.thinkingDefaultOptions}
+                  effectiveThinkingOverride={item.effectiveThinkingOverride}
                 />
               ))}
             </div>
@@ -1062,6 +1084,12 @@ export function ModelPresetsSection() {
         draft.agent.modelPresets = draft.agent.modelPresets.filter(
           (p) => p.id !== id,
         );
+        // Clear activePresetId if it references the deleted preset —
+        // otherwise the agent would try to resolve a stale preset on
+        // the next step.
+        if (draft.agent.activePresetId === id) {
+          draft.agent.activePresetId = undefined;
+        }
       });
       void updatePreferences(patches);
     },

--- a/apps/browser/src/ui/screens/settings/sections/models-providers-section.tsx
+++ b/apps/browser/src/ui/screens/settings/sections/models-providers-section.tsx
@@ -56,6 +56,7 @@ import {
   endpointSaveDataToInstanceArgs,
   type EndpointSaveData,
 } from './custom-providers-section';
+import { ModelPresetsSection } from './model-presets-section';
 import {
   useEffect,
   useState,
@@ -3686,6 +3687,9 @@ export function ModelsProvidersSection() {
               onDelete={(id) => void handleDeleteInstance(id)}
             />
           </section>
+
+          {/* Model Presets & Utility Models */}
+          <ModelPresetsSection />
         </div>
       </OverlayScrollbar>
     </div>

--- a/packages/agent-core/src/agents/base-agent-provider-metadata.test.ts
+++ b/packages/agent-core/src/agents/base-agent-provider-metadata.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { ModelWithOptions } from '../host/models';
 import { ChatAgent } from './chat/chat';
+import { ModelFallbackManager } from './model-fallback-manager';
 
 type Deferred<T> = {
   promise: Promise<T>;
@@ -66,6 +67,7 @@ function createStubAgent(
   agent._stepProviderMode = 'current-mode';
   agent._stepCodingPlanId = 'current-plan';
   agent._stepProviderType = 'current-provider';
+  agent._fallbackManager = new ModelFallbackManager();
   agent.canRunStep = vi.fn().mockReturnValue(true);
   agent.generateContextForNewStep = vi.fn();
   agent.getToolsForStep = vi.fn();
@@ -82,6 +84,7 @@ function createStubAgent(
     commands: {
       beginStep: vi.fn().mockReturnValue({ queueFlushIndex: undefined }),
       recordStepError: vi.fn(),
+      setActiveModel: vi.fn(),
     },
   };
   agent.host = {

--- a/packages/agent-core/src/agents/base-agent.ts
+++ b/packages/agent-core/src/agents/base-agent.ts
@@ -1166,6 +1166,7 @@ export abstract class BaseAgent<
         this.instanceId,
         this.state.get().activeModelId,
         this.state.get().activeProviderInstanceId,
+        this.host,
       );
     } catch (e) {
       const error = e as Error;

--- a/packages/agent-core/src/agents/base-agent.ts
+++ b/packages/agent-core/src/agents/base-agent.ts
@@ -1670,6 +1670,14 @@ export abstract class BaseAgent<
       stepModelId = resolvedModel.modelId;
       stepProviderInstanceId = resolvedModel.providerInstanceId;
       presetThinkingOverride = resolvedModel.thinkingOverride;
+      this.host.logger.debug(
+        `[BaseAgent:${this.instanceId}] Chat model resolved — ` +
+          `preset="${presetId}", ` +
+          `index=${fallbackIndex}/${presetModels.length}, ` +
+          `model="${stepModelId}", ` +
+          `instance="${stepProviderInstanceId ?? 'default'}", ` +
+          `fallback=${fallbackIndex > 0 ? 'YES' : 'no'}.`,
+      );
       // Sync agent state so the UI and persistence reflect the current
       // preset model. This is idempotent — if the model hasn't changed,
       // the state mutation is a no-op.
@@ -1677,6 +1685,12 @@ export abstract class BaseAgent<
         modelId: stepModelId,
         providerInstanceId: stepProviderInstanceId,
       });
+    } else {
+      this.host.logger.debug(
+        `[BaseAgent:${this.instanceId}] Chat model resolved — ` +
+          `preset=none, model="${stepModelId}", ` +
+          `instance="${stepProviderInstanceId ?? 'default'}".`,
+      );
     }
 
     // Get the current model — wrapped in try-catch so a deleted custom model
@@ -1937,9 +1951,13 @@ export abstract class BaseAgent<
         if (parsedOverload?.kind === 'upstream-overload') {
           const advanced = this._fallbackManager.advanceOnFailure(presetModels);
           if (advanced) {
+            const fbIdx = this._fallbackManager.fallbackModelIndex;
+            const fbModel = presetModels?.[fbIdx];
             this.host.logger.info(
               `[BaseAgent:${this.instanceId}] Upstream overload on model "${stepModelId}" — ` +
-                `falling back to preset model index ${this._fallbackManager.fallbackModelIndex}.`,
+                `falling back to preset model index ${fbIdx}` +
+                ` (model="${fbModel?.modelId ?? '?'}", ` +
+                `instance="${fbModel?.providerInstanceId ?? 'default'}").`,
             );
             this.host.telemetry?.capture('model-fallback-triggered', {
               agent_type: this.agentType,
@@ -2094,6 +2112,10 @@ export abstract class BaseAgent<
         if (this._pendingFallbackRetry) {
           this._pendingFallbackRetry = false;
           this._pendingContinue = null;
+          this.host.logger.debug(
+            `[BaseAgent:${this.instanceId}] Fallback retry scheduled — ` +
+              `re-invoking runStep via setTimeout(0).`,
+          );
           setTimeout(() => void this.runStep(), 0);
         } else {
           const pending = this._pendingContinue;

--- a/packages/agent-core/src/agents/base-agent.ts
+++ b/packages/agent-core/src/agents/base-agent.ts
@@ -1165,6 +1165,7 @@ export abstract class BaseAgent<
         this.host.models,
         this.instanceId,
         this.state.get().activeModelId,
+        this.state.get().activeProviderInstanceId,
       );
     } catch (e) {
       const error = e as Error;
@@ -1187,14 +1188,13 @@ export abstract class BaseAgent<
    */
   protected async compressHistory(history: AgentMessage[]): Promise<string> {
     // The standard compaction logic is very simple. We can make this more sophisticated later on.
-    const { activeModelId, activeProviderInstanceId } = this.state.get();
     return await generateSimpleCompressedHistory(
       history,
       this.host.models,
       this.instanceId,
-      activeModelId,
+      this.state.get().activeModelId,
+      this.state.get().activeProviderInstanceId,
       this.host,
-      activeProviderInstanceId,
     );
   }
 
@@ -1668,8 +1668,7 @@ export abstract class BaseAgent<
       const resolvedModel: UtilityModelEntry =
         presetModels[fallbackIndex] ?? presetModels[0]!;
       stepModelId = resolvedModel.modelId;
-      stepProviderInstanceId =
-        resolvedModel.providerInstanceId ?? stepProviderInstanceId;
+      stepProviderInstanceId = resolvedModel.providerInstanceId;
       presetThinkingOverride = resolvedModel.thinkingOverride;
       // Sync agent state so the UI and persistence reflect the current
       // preset model. This is idempotent — if the model hasn't changed,
@@ -2156,6 +2155,17 @@ export abstract class BaseAgent<
       // of surfacing the error.
       if (this._pendingFallbackRetry) {
         this._pendingFallbackRetry = false;
+        // Force-terminate any non-terminal tool parts from the aborted
+        // step so canRunStep() does not block the retry. Without this,
+        // partial tool-call parts left in "input-streaming"/
+        // "input-available" state by the aborted stream would cause
+        // the fallback retry to be silently dropped.
+        this.state.commands.denyAllNonTerminalToolPartsInHistory({
+          approvalDenyReason:
+            'Model fallback triggered — retrying with fallback model.',
+          forceErrorText:
+            'Tool execution interrupted — upstream overload triggered model fallback.',
+        });
         try {
           this.stepAbortController?.abort();
         } catch {}

--- a/packages/agent-core/src/agents/base-agent.ts
+++ b/packages/agent-core/src/agents/base-agent.ts
@@ -28,10 +28,13 @@ import type { AgentStateMutations } from '../services/agent-manager/state-mutati
 import type { AgentHost } from '../host/host';
 import {
   MODEL_REQUEST_PURPOSE_METADATA_KEY,
+  PRESET_THINKING_OVERRIDE_METADATA_KEY,
   PROVIDER_INSTANCE_ID_METADATA_KEY,
   type ModelWithOptions,
+  type UtilityModelEntry,
 } from '../host/models';
 import type { AgentCtor, AgentTypeRegistry } from './agents-registry';
+import { ModelFallbackManager } from './model-fallback-manager';
 
 type ProviderApiError = {
   message?: string;
@@ -624,6 +627,22 @@ export abstract class BaseAgent<
   } | null = null;
 
   /**
+   * Manages automatic failover to the next model in the active
+   * preset's fallback list when the primary model fails with an
+   * upstream-overload error (429, 502, 503, 529). The fallback
+   * persists for 5 minutes after the last message, then resets to
+   * the primary. Changing the preset resets the pointer to index 0.
+   */
+  private _fallbackManager = new ModelFallbackManager();
+
+  /**
+   * Set by `onError` when an upstream-overload error triggers a
+   * fallback retry. The tail of `runStep` checks this flag and
+   * re-invokes `runStep` to retry with the next fallback model.
+   */
+  private _pendingFallbackRetry = false;
+
+  /**
    * Tracks approval IDs for which we have already emitted a
    * `tool-approval-requested` telemetry event. The stream merge loop runs
    * per chunk, so the same `approval-requested` state is observed many
@@ -1145,6 +1164,7 @@ export abstract class BaseAgent<
         messages,
         this.host.models,
         this.instanceId,
+        this.state.get().activeModelId,
       );
     } catch (e) {
       const error = e as Error;
@@ -1594,6 +1614,7 @@ export abstract class BaseAgent<
     // Reset continuation flag at the start of every step so a leftover
     // value from a prior aborted step cannot leak into the tail.
     this._pendingContinue = null;
+    this._pendingFallbackRetry = false;
 
     // Tracks whether the just-finished step ended on an open tool-approval
     // request. Used by the idle tail to suppress the `done` notification
@@ -1622,22 +1643,61 @@ export abstract class BaseAgent<
     // so any later read from async callbacks (telemetry, onError) could
     // attribute the outcome to a model the user switched to mid-flight.
     const stepState = this.state.get();
-    const stepModelId = stepState.activeModelId;
-    const stepProviderInstanceId = stepState.activeProviderInstanceId;
+    let stepModelId = stepState.activeModelId;
+    let stepProviderInstanceId = stepState.activeProviderInstanceId;
+
+    // ── Active preset resolution + fallback ──────────────────────────
+    // When a preset is active, resolve the model from the *current* preset
+    // definition (stored in user preferences) rather than the stale
+    // `activeModelId` that was written into agent state at preset selection
+    // time. This ensures that editing a preset in settings takes effect on
+    // the very next agent turn.
+    //
+    // The fallback manager checks for preset changes (resets to primary),
+    // 5-min expiry (resets to primary), and touches the persistence timer
+    // on every call. If a fallback is active (index > 0), the corresponding
+    // model from the preset's list is used instead of the main model.
+    let presetThinkingOverride: UtilityModelEntry['thinkingOverride'];
+    const presetId = this.host.models.getActivePresetId?.();
+    const presetModels = this.host.models.getActivePresetModels?.();
+    const fallbackIndex = this._fallbackManager.resolveModelIndex(
+      presetId,
+      presetModels,
+    );
+    if (presetModels && presetModels.length > 0) {
+      const resolvedModel: UtilityModelEntry =
+        presetModels[fallbackIndex] ?? presetModels[0]!;
+      stepModelId = resolvedModel.modelId;
+      stepProviderInstanceId =
+        resolvedModel.providerInstanceId ?? stepProviderInstanceId;
+      presetThinkingOverride = resolvedModel.thinkingOverride;
+      // Sync agent state so the UI and persistence reflect the current
+      // preset model. This is idempotent — if the model hasn't changed,
+      // the state mutation is a no-op.
+      this.state.commands.setActiveModel({
+        modelId: stepModelId,
+        providerInstanceId: stepProviderInstanceId,
+      });
+    }
 
     // Get the current model — wrapped in try-catch so a deleted custom model
     // or endpoint doesn't wedge the agent with isWorking=true and no error.
     let modelWithOptions: ModelWithOptions;
     try {
+      const resolutionMetadata: Record<string, unknown> = {
+        $ai_span_name: `${this.agentType}-history`,
+        $ai_parent_id: this.instanceId,
+        [MODEL_REQUEST_PURPOSE_METADATA_KEY]: 'agent-step',
+        [PROVIDER_INSTANCE_ID_METADATA_KEY]: stepProviderInstanceId,
+      };
+      if (presetThinkingOverride) {
+        resolutionMetadata[PRESET_THINKING_OVERRIDE_METADATA_KEY] =
+          presetThinkingOverride;
+      }
       modelWithOptions = await this.host.models.getWithOptions(
         stepModelId,
         this.instanceId,
-        {
-          $ai_span_name: `${this.agentType}-history`,
-          $ai_parent_id: this.instanceId,
-          [MODEL_REQUEST_PURPOSE_METADATA_KEY]: 'agent-step',
-          [PROVIDER_INSTANCE_ID_METADATA_KEY]: stepProviderInstanceId,
-        },
+        resolutionMetadata,
       );
       this.applyStepProviderMetadataIfCurrent(modelWithOptions, stepGen);
       if (this._stepGeneration !== stepGen) return;
@@ -1871,6 +1931,33 @@ export abstract class BaseAgent<
             status_code: parsedOverload.statusCode,
           });
         }
+        // ── Main-model fallback ──────────────────────────────────────
+        // When an upstream-overload error occurs and the active preset
+        // has fallback models, advance the fallback pointer and schedule
+        // a retry instead of surfacing the error to the user.
+        if (parsedOverload?.kind === 'upstream-overload') {
+          const advanced = this._fallbackManager.advanceOnFailure(presetModels);
+          if (advanced) {
+            this.host.logger.info(
+              `[BaseAgent:${this.instanceId}] Upstream overload on model "${stepModelId}" — ` +
+                `falling back to preset model index ${this._fallbackManager.fallbackModelIndex}.`,
+            );
+            this.host.telemetry?.capture('model-fallback-triggered', {
+              agent_type: this.agentType,
+              failed_model_id: stepModelId,
+              fallback_model_index: this._fallbackManager.fallbackModelIndex,
+              provider_mode: this._stepProviderMode,
+            });
+            // Signal the tail of runStep to retry with the next model.
+            this._pendingFallbackRetry = true;
+            this._pendingContinue = null;
+            try {
+              this.stepAbortController?.abort();
+            } catch {}
+            this.stepAbortController = null;
+            return;
+          }
+        }
         this.state.commands.recordStepError({
           error: parsedPlanLimit ??
             parsedModelRestricted ??
@@ -2001,35 +2088,46 @@ export abstract class BaseAgent<
       // mismatch in case `internalStop` bumped the generation while we
       // were awaiting fs I/O above.
       if (this._stepGeneration === stepGen) {
-        const pending = this._pendingContinue;
-        this._pendingContinue = null;
-        if (pending === true) {
-          // setTimeout to keep the call stack clean (unbounded recursion).
+        // ── Fallback retry ──────────────────────────────────────────
+        // If `onError` triggered a model fallback, re-run the step
+        // with the next model in the preset's fallback list. This
+        // takes priority over the normal continuation decision.
+        if (this._pendingFallbackRetry) {
+          this._pendingFallbackRetry = false;
+          this._pendingContinue = null;
           setTimeout(() => void this.runStep(), 0);
-        } else if (pending === false) {
-          // Mark unread only if history contains at least one assistant
-          // message (covers fresh-session edge case).
-          const hasAssistantMessage = this.state
-            .get()
-            .history.some((m) => m.role === 'assistant');
-          this.state.commands.recordStepError({
-            error: undefined,
-            markUnread: 'if-assistant-history',
-          });
-          this.onIdle();
-          // Only notify "done" for a genuine turn completion: there must
-          // be an assistant message and the agent must not be paused on an
-          // open approval request (that's a `question`, emitted elsewhere).
-          if (hasAssistantMessage && !stepHasApprovalRequest) {
-            this.emitNotificationEvent('done');
+        } else {
+          const pending = this._pendingContinue;
+          this._pendingContinue = null;
+          if (pending === true) {
+            // setTimeout to keep the call stack clean (unbounded recursion).
+            setTimeout(() => void this.runStep(), 0);
+          } else if (pending === false) {
+            // Mark unread only if history contains at least one assistant
+            // message (covers fresh-session edge case).
+            const hasAssistantMessage = this.state
+              .get()
+              .history.some((m) => m.role === 'assistant');
+            this.state.commands.recordStepError({
+              error: undefined,
+              markUnread: 'if-assistant-history',
+            });
+            this.onIdle();
+            // Only notify "done" for a genuine turn completion: there must
+            // be an assistant message and the agent must not be paused on an
+            // open approval request (that's a `question`, emitted elsewhere).
+            if (hasAssistantMessage && !stepHasApprovalRequest) {
+              this.emitNotificationEvent('done');
+            }
           }
+          // pending === null → onFinish never set a decision (error path,
+          // aborted, or superseded step). Nothing to do; the onError /
+          // onAbort / catch handlers own state cleanup.
         }
-        // pending === null → onFinish never set a decision (error path,
-        // aborted, or superseded step). Nothing to do; the onError /
-        // onAbort / catch handlers own state cleanup.
       } else {
-        // Superseded — just clear the flag so nothing leaks.
+        // Superseded — just clear the flags so nothing leaks.
         this._pendingContinue = null;
+        this._pendingFallbackRetry = false;
       }
     } catch (err) {
       const raw = err;
@@ -2054,6 +2152,17 @@ export abstract class BaseAgent<
       // the next step or fire onIdle after an error here.
       this._pendingContinue = null;
       this._pendingSyntheticContinuation = null;
+      // If onError already triggered a fallback retry, honor it instead
+      // of surfacing the error.
+      if (this._pendingFallbackRetry) {
+        this._pendingFallbackRetry = false;
+        try {
+          this.stepAbortController?.abort();
+        } catch {}
+        this.stepAbortController = null;
+        setTimeout(() => void this.runStep(), 0);
+        return;
+      }
       try {
         this.stepAbortController?.abort();
       } catch {}
@@ -2956,6 +3065,7 @@ export abstract class BaseAgent<
     // recovery path sets a fresh one after calling internalStop().
     this._pendingContinue = null;
     this._pendingSyntheticContinuation = null;
+    this._pendingFallbackRetry = false;
     try {
       this.stepAbortController?.abort();
     } catch {}

--- a/packages/agent-core/src/agents/index.ts
+++ b/packages/agent-core/src/agents/index.ts
@@ -47,9 +47,13 @@ export {
   type ProviderOptions,
 } from './shared/provider-options';
 export { MessageCacheAnalyzer } from './shared/message-cache-analyzer';
-export { generateSimpleTitle } from './shared/title-generation';
+export {
+  generateSimpleTitle,
+  TITLE_GENERATION_MODELS,
+} from './shared/title-generation';
 export {
   generateSimpleCompressedHistory,
+  HISTORY_COMPRESSION_MODELS,
   convertAgentMessagesToCompactMessageHistoryString,
   estimateMessageTokens,
   COMPRESSION_SYSTEM_PROMPT,

--- a/packages/agent-core/src/agents/model-fallback-manager.test.ts
+++ b/packages/agent-core/src/agents/model-fallback-manager.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from 'vitest';
+import {
+  FALLBACK_PERSISTENCE_MS,
+  ModelFallbackManager,
+} from './model-fallback-manager';
+import type { UtilityModelEntry } from '../host/models';
+
+const T0 = 1_000_000; // arbitrary base timestamp
+
+const models: UtilityModelEntry[] = [
+  { modelId: 'model-a' },
+  { modelId: 'model-b' },
+  { modelId: 'model-c' },
+];
+
+const singleModel: UtilityModelEntry[] = [{ modelId: 'only-model' }];
+
+describe('ModelFallbackManager', () => {
+  // ── resolveModelIndex ────────────────────────────────────────────
+
+  it('returns index 0 (primary) when no fallback is active', () => {
+    const m = new ModelFallbackManager();
+    expect(m.resolveModelIndex('preset-1', models, T0)).toBe(0);
+    expect(m.fallbackModelIndex).toBe(0);
+  });
+
+  it('returns 0 and resets when no preset is active', () => {
+    const m = new ModelFallbackManager();
+    // Activate a fallback first
+    expect(m.advanceOnFailure(models, T0)).toBe(true);
+    expect(m.fallbackModelIndex).toBe(1);
+    // No preset → reset
+    expect(m.resolveModelIndex(undefined, undefined, T0)).toBe(0);
+    expect(m.fallbackModelIndex).toBe(0);
+  });
+
+  it('returns 0 and resets when preset models list is empty', () => {
+    const m = new ModelFallbackManager();
+    expect(m.advanceOnFailure(models, T0)).toBe(true);
+    expect(m.fallbackModelIndex).toBe(1);
+    expect(m.resolveModelIndex('preset-1', [], T0)).toBe(0);
+    expect(m.fallbackModelIndex).toBe(0);
+  });
+
+  // ── advanceOnFailure ─────────────────────────────────────────────
+
+  it('cycles 0→1→2→0 and returns false at wraparound', () => {
+    const m = new ModelFallbackManager();
+    // Prime: resolveModelIndex sets lastPresetId
+    m.resolveModelIndex('preset-1', models, T0);
+
+    // 0→1
+    expect(m.advanceOnFailure(models, T0)).toBe(true);
+    expect(m.fallbackModelIndex).toBe(1);
+    // 1→2
+    expect(m.advanceOnFailure(models, T0 + 100)).toBe(true);
+    expect(m.fallbackModelIndex).toBe(2);
+    // 2→wraparound to 0
+    expect(m.advanceOnFailure(models, T0 + 200)).toBe(false);
+    expect(m.fallbackModelIndex).toBe(0);
+    expect(m.fallbackSetAt).toBe(0);
+  });
+
+  it('returns false when no preset models', () => {
+    const m = new ModelFallbackManager();
+    expect(m.advanceOnFailure(undefined, T0)).toBe(false);
+    expect(m.fallbackModelIndex).toBe(0);
+  });
+
+  it('returns false for single-model preset (no fallback possible)', () => {
+    const m = new ModelFallbackManager();
+    m.resolveModelIndex('preset-1', singleModel, T0);
+    expect(m.advanceOnFailure(singleModel, T0)).toBe(false);
+    expect(m.fallbackModelIndex).toBe(0);
+  });
+
+  // ── 5-minute persistence ─────────────────────────────────────────
+
+  it('fallback persists within the 5-minute window', () => {
+    const m = new ModelFallbackManager();
+    m.resolveModelIndex('preset-1', models, T0);
+    m.advanceOnFailure(models, T0); // activate fallback at T0, index=1
+
+    // Within window → still on fallback
+    expect(m.resolveModelIndex('preset-1', models, T0 + 60_000)).toBe(1);
+    expect(m.fallbackModelIndex).toBe(1);
+  });
+
+  it('fallback expires after 5 minutes', () => {
+    const m = new ModelFallbackManager();
+    m.resolveModelIndex('preset-1', models, T0);
+    m.advanceOnFailure(models, T0); // activate at T0, index=1
+
+    // After 5 min + 1 ms → expired, back to primary
+    expect(
+      m.resolveModelIndex('preset-1', models, T0 + FALLBACK_PERSISTENCE_MS + 1),
+    ).toBe(0);
+    expect(m.fallbackModelIndex).toBe(0);
+    expect(m.fallbackSetAt).toBe(0);
+  });
+
+  it('resolveModelIndex touches the timer, extending the window', () => {
+    const m = new ModelFallbackManager();
+    m.resolveModelIndex('preset-1', models, T0);
+    m.advanceOnFailure(models, T0); // set at T0
+
+    // Touch at T0 + 3min
+    const touchTime = T0 + 3 * 60_000;
+    m.resolveModelIndex('preset-1', models, touchTime);
+    expect(m.fallbackSetAt).toBe(touchTime);
+
+    // T0 + 5min would have expired the original window, but since we
+    // touched at T0+3min, the window extends to T0+3min+5min=T0+8min.
+    // So at T0+6min we're still within the window.
+    expect(m.resolveModelIndex('preset-1', models, T0 + 6 * 60_000)).toBe(1);
+  });
+
+  // ── Preset change ────────────────────────────────────────────────
+
+  it('changing the preset resets the fallback pointer to 0', () => {
+    const m = new ModelFallbackManager();
+    m.resolveModelIndex('preset-1', models, T0);
+    m.advanceOnFailure(models, T0); // index=1
+    expect(m.fallbackModelIndex).toBe(1);
+
+    // Switch to preset-2
+    expect(m.resolveModelIndex('preset-2', models, T0 + 1000)).toBe(0);
+    expect(m.fallbackModelIndex).toBe(0);
+    expect(m.fallbackSetAt).toBe(0);
+  });
+
+  // ── reset() ──────────────────────────────────────────────────────
+
+  it('reset() clears all state', () => {
+    const m = new ModelFallbackManager();
+    m.resolveModelIndex('preset-1', models, T0);
+    m.advanceOnFailure(models, T0);
+    expect(m.fallbackModelIndex).toBe(1);
+
+    m.reset();
+    expect(m.fallbackModelIndex).toBe(0);
+    expect(m.fallbackSetAt).toBe(0);
+  });
+
+  // ── Edge case: clamping when preset models shrink ────────────────
+
+  it('clamps index when preset models list shrinks below current index', () => {
+    const m = new ModelFallbackManager();
+    m.resolveModelIndex('preset-1', models, T0);
+    // Advance to index 2
+    m.advanceOnFailure(models, T0);
+    m.advanceOnFailure(models, T0 + 100);
+    expect(m.fallbackModelIndex).toBe(2);
+
+    // Preset edited to only 1 model — index 2 is out of bounds
+    expect(m.resolveModelIndex('preset-1', singleModel, T0 + 200)).toBe(0);
+    expect(m.fallbackModelIndex).toBe(0);
+  });
+});

--- a/packages/agent-core/src/agents/model-fallback-manager.test.ts
+++ b/packages/agent-core/src/agents/model-fallback-manager.test.ts
@@ -156,4 +156,61 @@ describe('ModelFallbackManager', () => {
     expect(m.resolveModelIndex('preset-1', singleModel, T0 + 200)).toBe(0);
     expect(m.fallbackModelIndex).toBe(0);
   });
+
+  // ── Preset edits (same ID, different model list) ─────────────────
+
+  it('resets to primary when preset models are reordered (same ID)', () => {
+    const m = new ModelFallbackManager();
+    m.resolveModelIndex('preset-1', models, T0);
+    m.advanceOnFailure(models, T0); // index=1 (model-b)
+    expect(m.fallbackModelIndex).toBe(1);
+
+    // Same preset ID, but models reordered — index 1 now points to
+    // a different model. Must reset to avoid silently using the
+    // wrong model.
+    const reordered: UtilityModelEntry[] = [
+      { modelId: 'model-c' },
+      { modelId: 'model-a' },
+      { modelId: 'model-b' },
+    ];
+    expect(m.resolveModelIndex('preset-1', reordered, T0 + 100)).toBe(0);
+    expect(m.fallbackModelIndex).toBe(0);
+    expect(m.fallbackSetAt).toBe(0);
+  });
+
+  it('resets to primary when a preset model is replaced (same ID, same length)', () => {
+    const m = new ModelFallbackManager();
+    m.resolveModelIndex('preset-1', models, T0);
+    m.advanceOnFailure(models, T0); // index=1 (model-b)
+    expect(m.fallbackModelIndex).toBe(1);
+
+    // Same preset ID, same length, but model at index 1 changed.
+    const replaced: UtilityModelEntry[] = [
+      { modelId: 'model-a' },
+      { modelId: 'model-x' },
+      { modelId: 'model-c' },
+    ];
+    expect(m.resolveModelIndex('preset-1', replaced, T0 + 100)).toBe(0);
+    expect(m.fallbackModelIndex).toBe(0);
+    expect(m.fallbackSetAt).toBe(0);
+  });
+
+  it('resets to primary when providerInstanceId changes on a preset model', () => {
+    const m = new ModelFallbackManager();
+    const withInstance: UtilityModelEntry[] = [
+      { modelId: 'model-a', providerInstanceId: 'inst-1' },
+      { modelId: 'model-b', providerInstanceId: 'inst-1' },
+    ];
+    m.resolveModelIndex('preset-1', withInstance, T0);
+    m.advanceOnFailure(withInstance, T0); // index=1
+    expect(m.fallbackModelIndex).toBe(1);
+
+    // Same model IDs, same preset ID, but provider instance changed.
+    const changedInstance: UtilityModelEntry[] = [
+      { modelId: 'model-a', providerInstanceId: 'inst-1' },
+      { modelId: 'model-b', providerInstanceId: 'inst-2' },
+    ];
+    expect(m.resolveModelIndex('preset-1', changedInstance, T0 + 100)).toBe(0);
+    expect(m.fallbackModelIndex).toBe(0);
+  });
 });

--- a/packages/agent-core/src/agents/model-fallback-manager.ts
+++ b/packages/agent-core/src/agents/model-fallback-manager.ts
@@ -1,0 +1,148 @@
+import type { UtilityModelEntry } from '../host/models';
+
+/**
+ * Duration (ms) that a fallback model selection persists after the
+ * last message. Once this window expires, the manager resets to the
+ * primary model (index 0) on the next `resolveModelIndex` call.
+ */
+export const FALLBACK_PERSISTENCE_MS = 5 * 60 * 1000;
+
+/**
+ * Manages automatic failover for the main chat model when a preset is
+ * active. When the primary model fails with an upstream-overload error
+ * (429, 502, 503, 529), the manager advances to the next model in the
+ * preset's fallback list. The fallback persists for
+ * {@link FALLBACK_PERSISTENCE_MS} after the last message, then resets
+ * to the primary. Changing the preset resets the pointer to index 0.
+ *
+ * All state logic is pure and synchronous; `BaseAgent` is responsible
+ * for wiring it into `runStep` and `onError`.
+ */
+export class ModelFallbackManager {
+  /**
+   * The current fallback index within the preset's model list.
+   * `0` means the primary model is in use (no fallback active).
+   */
+  private _fallbackModelIndex = 0;
+
+  /**
+   * Timestamp (ms since epoch) at which the fallback was activated.
+   * Used to compute the 5-minute persistence window. Reset to `0`
+   * when the manager returns to the primary model.
+   */
+  private _fallbackSetAt = 0;
+
+  /**
+   * The preset ID that was active when the fallback index was set.
+   * Used to detect preset changes and reset the pointer.
+   */
+  private _lastPresetId: string | undefined;
+
+  /** Returns the current fallback model index (0 = primary). */
+  get fallbackModelIndex(): number {
+    return this._fallbackModelIndex;
+  }
+
+  /** Returns the timestamp at which the fallback was activated. */
+  get fallbackSetAt(): number {
+    return this._fallbackSetAt;
+  }
+
+  /**
+   * Resolves the effective model index for the current step.
+   *
+   * Detects preset changes (resets to index 0), checks the 5-minute
+   * persistence window (resets to index 0 if expired), and touches
+   * the timer on each call so the window extends with every message.
+   *
+   * @param presetId - The active preset ID (or `undefined` if none).
+   * @param presetModels - The active preset's model list (or `undefined`).
+   * @param now - Current timestamp (injectable for tests).
+   * @returns The effective model index to use for this step.
+   */
+  resolveModelIndex(
+    presetId: string | undefined,
+    presetModels: UtilityModelEntry[] | undefined,
+    now: number = Date.now(),
+  ): number {
+    // No preset active — always primary.
+    if (!presetId || !presetModels || presetModels.length === 0) {
+      this.reset();
+      return 0;
+    }
+
+    // Preset changed — reset to primary.
+    if (this._lastPresetId !== presetId) {
+      this.reset();
+      this._lastPresetId = presetId;
+      return 0;
+    }
+
+    // Fallback active — check expiry.
+    if (this._fallbackModelIndex > 0) {
+      if (now - this._fallbackSetAt > FALLBACK_PERSISTENCE_MS) {
+        // Window expired — reset to primary.
+        this._fallbackModelIndex = 0;
+        this._fallbackSetAt = 0;
+        return 0;
+      }
+      // Touch the timer to extend the window.
+      this._fallbackSetAt = now;
+    }
+
+    // Clamp index to the available models (handles edge case where
+    // preset models were edited and the list shrank).
+    if (this._fallbackModelIndex >= presetModels.length) {
+      this._fallbackModelIndex = 0;
+      this._fallbackSetAt = 0;
+    }
+
+    return this._fallbackModelIndex;
+  }
+
+  /**
+   * Advances the fallback pointer after an upstream-overload error.
+   *
+   * Moves to the next model in the preset's list with wraparound.
+   * Returns `true` if a fallback model is available (the pointer
+   * advanced to a new model), or `false` if the pointer cycled back
+   * to the primary (index 0) — meaning all models have been tried
+   * and the error should be surfaced to the user.
+   *
+   * @param presetModels - The active preset's model list.
+   * @param now - Current timestamp (injectable for tests).
+   * @returns `true` if a fallback model was selected, `false` if
+   *   all models were tried and the pointer wrapped back to 0.
+   */
+  advanceOnFailure(
+    presetModels: UtilityModelEntry[] | undefined,
+    now: number = Date.now(),
+  ): boolean {
+    if (!presetModels || presetModels.length <= 1) {
+      return false;
+    }
+
+    const nextIndex = this._fallbackModelIndex + 1;
+
+    // Wraparound — all models tried.
+    if (nextIndex >= presetModels.length) {
+      this._fallbackModelIndex = 0;
+      this._fallbackSetAt = 0;
+      return false;
+    }
+
+    this._fallbackModelIndex = nextIndex;
+    this._fallbackSetAt = now;
+    return true;
+  }
+
+  /**
+   * Clears all fallback state. Called on preset change, when no
+   * preset is active, or when the agent is explicitly stopped.
+   */
+  reset(): void {
+    this._fallbackModelIndex = 0;
+    this._fallbackSetAt = 0;
+    this._lastPresetId = undefined;
+  }
+}

--- a/packages/agent-core/src/agents/model-fallback-manager.ts
+++ b/packages/agent-core/src/agents/model-fallback-manager.ts
@@ -38,6 +38,14 @@ export class ModelFallbackManager {
    */
   private _lastPresetId: string | undefined;
 
+  /**
+   * A structural signature of the preset's model list at the time
+   * the fallback index was established. Used to detect in-place
+   * edits (reorder, replace) that keep the same preset ID but
+   * change which model sits at each index.
+   */
+  private _lastPresetSignature: string | undefined;
+
   /** Returns the current fallback model index (0 = primary). */
   get fallbackModelIndex(): number {
     return this._fallbackModelIndex;
@@ -71,10 +79,15 @@ export class ModelFallbackManager {
       return 0;
     }
 
-    // Preset changed — reset to primary.
-    if (this._lastPresetId !== presetId) {
+    // Preset changed or model list edited — reset to primary.
+    const signature = presetSignature(presetModels);
+    if (
+      this._lastPresetId !== presetId ||
+      this._lastPresetSignature !== signature
+    ) {
       this.reset();
       this._lastPresetId = presetId;
+      this._lastPresetSignature = signature;
       return 0;
     }
 
@@ -144,5 +157,18 @@ export class ModelFallbackManager {
     this._fallbackModelIndex = 0;
     this._fallbackSetAt = 0;
     this._lastPresetId = undefined;
+    this._lastPresetSignature = undefined;
   }
 }
+
+/**
+ * Builds a compact structural signature from a preset's model list.
+ * Two lists produce the same signature iff they have the same models
+ * in the same order (by `modelId` + `providerInstanceId`).
+ */
+const presetSignature = (models: UtilityModelEntry[] | undefined): string => {
+  if (!models || models.length === 0) return '';
+  return models
+    .map((m) => `${m.modelId}::${m.providerInstanceId ?? ''}`)
+    .join('|');
+};

--- a/packages/agent-core/src/agents/shared/history-compression.test.ts
+++ b/packages/agent-core/src/agents/shared/history-compression.test.ts
@@ -1148,8 +1148,10 @@ describe('generateSimpleCompressedHistory', () => {
 
   it('routes the active fallback through its provider instance', async () => {
     generateTextMock
-      .mockRejectedValueOnce(new Error('Gemini failed'))
+      .mockRejectedValueOnce(new Error('Default failed'))
+      .mockRejectedValueOnce(new Error('DeepSeek failed'))
       .mockRejectedValueOnce(new Error('GPT failed'))
+      .mockRejectedValueOnce(new Error('Gemini failed'))
       .mockRejectedValueOnce(new Error('Haiku failed'))
       .mockResolvedValueOnce({
         text: 'The assistant provided an OpenRouter fallback summary.',
@@ -1161,12 +1163,11 @@ describe('generateSimpleCompressedHistory', () => {
       mps,
       'agent-1',
       'openrouter/free',
-      undefined,
       'openrouter-instance',
     );
 
     expect(mps.getWithOptions).toHaveBeenNthCalledWith(
-      4,
+      6,
       'openrouter/free',
       'agent-1',
       expect.objectContaining({
@@ -1175,18 +1176,20 @@ describe('generateSimpleCompressedHistory', () => {
     );
     expect(mps.getWithOptions).toHaveBeenNthCalledWith(
       1,
-      'gemini-3.1-flash-lite',
+      'default',
       'agent-1',
       expect.objectContaining({
-        $provider_instance_id: undefined,
+        $ai_span_name: 'history-compression',
       }),
     );
   });
 
   it('retries a cheap model ID through its active provider instance', async () => {
     generateTextMock
-      .mockRejectedValueOnce(new Error('Gemini failed'))
+      .mockRejectedValueOnce(new Error('Default failed'))
+      .mockRejectedValueOnce(new Error('DeepSeek failed'))
       .mockRejectedValueOnce(new Error('GPT failed'))
+      .mockRejectedValueOnce(new Error('Gemini failed'))
       .mockRejectedValueOnce(new Error('Haiku failed'))
       .mockResolvedValueOnce({
         text: 'The active provider instance supplied the compression summary.',
@@ -1198,24 +1201,23 @@ describe('generateSimpleCompressedHistory', () => {
       mps,
       'agent-1',
       'claude-haiku-4.5',
-      undefined,
       'active-haiku-instance',
     );
 
     expect(result).toBe(
       'The active provider instance supplied the compression summary.',
     );
-    expect(mps.getWithOptions).toHaveBeenCalledTimes(4);
+    expect(mps.getWithOptions).toHaveBeenCalledTimes(6);
     expect(mps.getWithOptions).toHaveBeenNthCalledWith(
-      3,
+      5,
       'claude-haiku-4.5',
       'agent-1',
       expect.objectContaining({
-        $provider_instance_id: undefined,
+        $ai_span_name: 'history-compression',
       }),
     );
     expect(mps.getWithOptions).toHaveBeenNthCalledWith(
-      4,
+      6,
       'claude-haiku-4.5',
       'agent-1',
       expect.objectContaining({

--- a/packages/agent-core/src/agents/shared/history-compression.test.ts
+++ b/packages/agent-core/src/agents/shared/history-compression.test.ts
@@ -788,7 +788,7 @@ describe('generateSimpleCompressedHistory', () => {
     expect(result).toBe('The user asked the assistant to help with a task.');
     expect(generateTextMock).toHaveBeenCalledTimes(1);
     expect(mps.getWithOptions).toHaveBeenCalledWith(
-      'gemini-3.1-flash-lite',
+      'default',
       'agent-1',
       expect.objectContaining({ $ai_span_name: 'history-compression' }),
     );
@@ -796,7 +796,34 @@ describe('generateSimpleCompressedHistory', () => {
 
   it('falls back to the second model when the first fails', async () => {
     generateTextMock
-      .mockRejectedValueOnce(new Error('Gemini failed'))
+      .mockRejectedValueOnce(new Error('Default failed'))
+      .mockResolvedValueOnce({
+        text: 'The assistant provided a DeepSeek-based summary of events.',
+      } as any);
+
+    const mps = makeMockHostModels();
+    const result = await generateSimpleCompressedHistory(
+      makeMessages(4),
+      mps,
+      'agent-1',
+    );
+
+    expect(result).toBe(
+      'The assistant provided a DeepSeek-based summary of events.',
+    );
+    expect(generateTextMock).toHaveBeenCalledTimes(2);
+    expect(mps.getWithOptions).toHaveBeenNthCalledWith(
+      2,
+      'deepseek-v4-flash',
+      'agent-1',
+      expect.any(Object),
+    );
+  });
+
+  it('falls back to the third model when the first two fail', async () => {
+    generateTextMock
+      .mockRejectedValueOnce(new Error('Default failed'))
+      .mockRejectedValueOnce(new Error('DeepSeek failed'))
       .mockResolvedValueOnce({
         text: 'The assistant provided a GPT-based summary of events.',
       } as any);
@@ -811,53 +838,28 @@ describe('generateSimpleCompressedHistory', () => {
     expect(result).toBe(
       'The assistant provided a GPT-based summary of events.',
     );
-    expect(generateTextMock).toHaveBeenCalledTimes(2);
-    expect(mps.getWithOptions).toHaveBeenNthCalledWith(
-      2,
-      'gpt-5.4-nano',
-      'agent-1',
-      expect.any(Object),
-    );
-  });
-
-  it('falls back to the third model when the first two fail', async () => {
-    generateTextMock
-      .mockRejectedValueOnce(new Error('Gemini failed'))
-      .mockRejectedValueOnce(new Error('GPT failed'))
-      .mockResolvedValueOnce({
-        text: 'The assistant provided a Haiku-based summary of events.',
-      } as any);
-
-    const mps = makeMockHostModels();
-    const result = await generateSimpleCompressedHistory(
-      makeMessages(4),
-      mps,
-      'agent-1',
-    );
-
-    expect(result).toBe(
-      'The assistant provided a Haiku-based summary of events.',
-    );
     expect(generateTextMock).toHaveBeenCalledTimes(3);
     expect(mps.getWithOptions).toHaveBeenNthCalledWith(
       3,
-      'claude-haiku-4.5',
+      'gpt-5.6-luna',
       'agent-1',
       expect.any(Object),
     );
   });
 
-  it('throws when all three models fail', async () => {
+  it('throws when all models fail', async () => {
     generateTextMock
-      .mockRejectedValueOnce(new Error('Gemini failed'))
+      .mockRejectedValueOnce(new Error('Default failed'))
+      .mockRejectedValueOnce(new Error('DeepSeek failed'))
       .mockRejectedValueOnce(new Error('GPT failed'))
+      .mockRejectedValueOnce(new Error('Gemini failed'))
       .mockRejectedValueOnce(new Error('Haiku failed'));
 
     const mps = makeMockHostModels();
     await expect(
       generateSimpleCompressedHistory(makeMessages(4), mps, 'agent-1'),
     ).rejects.toThrow('Haiku failed');
-    expect(generateTextMock).toHaveBeenCalledTimes(3);
+    expect(generateTextMock).toHaveBeenCalledTimes(5);
   });
 
   it('falls back when the abort signal fires (simulating timeout)', async () => {
@@ -907,13 +909,13 @@ describe('generateSimpleCompressedHistory', () => {
     expect(generateTextMock).toHaveBeenCalledTimes(2);
     expect(mps.getWithOptions).toHaveBeenNthCalledWith(
       1,
-      'gemini-3.1-flash-lite',
+      'default',
       'agent-1',
       expect.any(Object),
     );
     expect(mps.getWithOptions).toHaveBeenNthCalledWith(
       2,
-      'gpt-5.4-nano',
+      'deepseek-v4-flash',
       'agent-1',
       expect.any(Object),
     );
@@ -933,7 +935,7 @@ describe('generateSimpleCompressedHistory', () => {
     expect(mps.getWithOptions).toHaveBeenCalledTimes(1);
     expect(mps.getWithOptions).toHaveBeenNthCalledWith(
       1,
-      'gemini-3.1-flash-lite',
+      'default',
       'agent-1',
       expect.any(Object),
     );
@@ -947,27 +949,41 @@ describe('generateSimpleCompressedHistory', () => {
     generateTextMock
       .mockRejectedValueOnce(abortError)
       .mockRejectedValueOnce(abortError)
+      .mockRejectedValueOnce(abortError)
+      .mockRejectedValueOnce(abortError)
       .mockRejectedValueOnce(abortError);
 
     const mps = makeMockHostModels();
     await expect(
       generateSimpleCompressedHistory(makeMessages(4), mps, 'agent-1'),
     ).rejects.toThrow('aborted');
-    expect(generateTextMock).toHaveBeenCalledTimes(3);
+    expect(generateTextMock).toHaveBeenCalledTimes(5);
     expect(mps.getWithOptions).toHaveBeenNthCalledWith(
       1,
-      'gemini-3.1-flash-lite',
+      'default',
       'agent-1',
       expect.any(Object),
     );
     expect(mps.getWithOptions).toHaveBeenNthCalledWith(
       2,
-      'gpt-5.4-nano',
+      'deepseek-v4-flash',
       'agent-1',
       expect.any(Object),
     );
     expect(mps.getWithOptions).toHaveBeenNthCalledWith(
       3,
+      'gpt-5.6-luna',
+      'agent-1',
+      expect.any(Object),
+    );
+    expect(mps.getWithOptions).toHaveBeenNthCalledWith(
+      4,
+      'gemini-3.1-flash-lite',
+      'agent-1',
+      expect.any(Object),
+    );
+    expect(mps.getWithOptions).toHaveBeenNthCalledWith(
+      5,
       'claude-haiku-4.5',
       'agent-1',
       expect.any(Object),
@@ -1101,8 +1117,10 @@ describe('generateSimpleCompressedHistory', () => {
 
   it('tries fallbackModelId after all cheap models fail', async () => {
     generateTextMock
-      .mockRejectedValueOnce(new Error('Gemini failed'))
+      .mockRejectedValueOnce(new Error('Default failed'))
+      .mockRejectedValueOnce(new Error('DeepSeek failed'))
       .mockRejectedValueOnce(new Error('GPT failed'))
+      .mockRejectedValueOnce(new Error('Gemini failed'))
       .mockRejectedValueOnce(new Error('Haiku failed'))
       .mockResolvedValueOnce({
         text: 'The assistant provided a fallback-model summary of events.',
@@ -1119,9 +1137,9 @@ describe('generateSimpleCompressedHistory', () => {
     expect(result).toBe(
       'The assistant provided a fallback-model summary of events.',
     );
-    expect(generateTextMock).toHaveBeenCalledTimes(4);
+    expect(generateTextMock).toHaveBeenCalledTimes(6);
     expect(mps.getWithOptions).toHaveBeenNthCalledWith(
-      4,
+      6,
       'claude-sonnet-4.6',
       'agent-1',
       expect.objectContaining({ $ai_span_name: 'history-compression' }),
@@ -1208,8 +1226,10 @@ describe('generateSimpleCompressedHistory', () => {
 
   it('skips an unscoped fallbackModelId if it matches a cheap model ID', async () => {
     generateTextMock
-      .mockRejectedValueOnce(new Error('Gemini failed'))
+      .mockRejectedValueOnce(new Error('Default failed'))
+      .mockRejectedValueOnce(new Error('DeepSeek failed'))
       .mockRejectedValueOnce(new Error('GPT failed'))
+      .mockRejectedValueOnce(new Error('Gemini failed'))
       .mockRejectedValueOnce(new Error('Haiku failed'));
 
     const mps = makeMockHostModels();
@@ -1221,13 +1241,15 @@ describe('generateSimpleCompressedHistory', () => {
         'claude-haiku-4.5' as any,
       ),
     ).rejects.toThrow('Haiku failed');
-    expect(mps.getWithOptions).toHaveBeenCalledTimes(3);
+    expect(mps.getWithOptions).toHaveBeenCalledTimes(5);
   });
 
   it('throws when fallback model also fails', async () => {
     generateTextMock
-      .mockRejectedValueOnce(new Error('Gemini failed'))
+      .mockRejectedValueOnce(new Error('Default failed'))
+      .mockRejectedValueOnce(new Error('DeepSeek failed'))
       .mockRejectedValueOnce(new Error('GPT failed'))
+      .mockRejectedValueOnce(new Error('Gemini failed'))
       .mockRejectedValueOnce(new Error('Haiku failed'))
       .mockRejectedValueOnce(new Error('Sonnet failed'));
 
@@ -1240,7 +1262,7 @@ describe('generateSimpleCompressedHistory', () => {
         'claude-sonnet-4.6' as any,
       ),
     ).rejects.toThrow('Sonnet failed');
-    expect(generateTextMock).toHaveBeenCalledTimes(4);
+    expect(generateTextMock).toHaveBeenCalledTimes(6);
   });
 
   it('does not try fallbackModelId when a cheap model succeeds', async () => {
@@ -1260,7 +1282,7 @@ describe('generateSimpleCompressedHistory', () => {
     expect(generateTextMock).toHaveBeenCalledTimes(1);
     expect(mps.getWithOptions).toHaveBeenCalledTimes(1);
     expect(mps.getWithOptions).toHaveBeenCalledWith(
-      'gemini-3.1-flash-lite',
+      'default',
       'agent-1',
       expect.any(Object),
     );

--- a/packages/agent-core/src/agents/shared/history-compression.test.ts
+++ b/packages/agent-core/src/agents/shared/history-compression.test.ts
@@ -59,6 +59,23 @@ function makeMockHostModels(): HostModels {
   } as unknown as HostModels;
 }
 
+function makeMockHostModelsWithPreset(
+  presetModels: { modelId: string; providerInstanceId?: string }[],
+): HostModels {
+  const base = makeMockHostModels();
+  return {
+    ...base,
+    getActivePresetModels: vi.fn(() =>
+      presetModels.map((m) => ({
+        modelId: m.modelId,
+        ...(m.providerInstanceId
+          ? { providerInstanceId: m.providerInstanceId }
+          : {}),
+      })),
+    ),
+  } as unknown as HostModels;
+}
+
 // ---------------------------------------------------------------------------
 // convertAgentMessagesToCompactMessageHistoryString
 // ---------------------------------------------------------------------------
@@ -1109,6 +1126,110 @@ describe('generateSimpleCompressedHistory', () => {
     expect(result).toBe(
       'The assistant provided a provider-fallback summary of events.',
     );
+  });
+
+  // -----------------------------------------------------------------------
+  // preset models as fallback (appended after utility models)
+  // -----------------------------------------------------------------------
+
+  it('falls back to active preset models after all utility models fail', async () => {
+    generateTextMock
+      .mockRejectedValueOnce(new Error('Default failed'))
+      .mockRejectedValueOnce(new Error('DeepSeek failed'))
+      .mockRejectedValueOnce(new Error('GPT failed'))
+      .mockRejectedValueOnce(new Error('Gemini failed'))
+      .mockRejectedValueOnce(new Error('Haiku failed'))
+      .mockResolvedValueOnce({
+        text: 'The assistant provided a preset-model summary of events.',
+      } as any);
+
+    const mps = makeMockHostModelsWithPreset([
+      { modelId: 'claude-sonnet-4.6' },
+      { modelId: 'gpt-5.6-luna', providerInstanceId: 'openrouter-instance' },
+    ]);
+    const result = await generateSimpleCompressedHistory(
+      makeMessages(4),
+      mps,
+      'agent-1',
+    );
+
+    expect(result).toBe(
+      'The assistant provided a preset-model summary of events.',
+    );
+    expect(generateTextMock).toHaveBeenCalledTimes(6);
+    expect(mps.getWithOptions).toHaveBeenNthCalledWith(
+      6,
+      'claude-sonnet-4.6',
+      'agent-1',
+      expect.objectContaining({ $ai_span_name: 'history-compression' }),
+    );
+  });
+
+  it('tries all preset models in order as fallbacks', async () => {
+    generateTextMock
+      .mockRejectedValueOnce(new Error('Default failed'))
+      .mockRejectedValueOnce(new Error('DeepSeek failed'))
+      .mockRejectedValueOnce(new Error('GPT failed'))
+      .mockRejectedValueOnce(new Error('Gemini failed'))
+      .mockRejectedValueOnce(new Error('Haiku failed'))
+      .mockRejectedValueOnce(new Error('Sonnet failed'))
+      .mockResolvedValueOnce({
+        text: 'The assistant provided a second-preset summary of events.',
+      } as any);
+
+    const mps = makeMockHostModelsWithPreset([
+      { modelId: 'claude-sonnet-4.6' },
+      { modelId: 'gpt-5.6-luna', providerInstanceId: 'openrouter-instance' },
+    ]);
+    const result = await generateSimpleCompressedHistory(
+      makeMessages(4),
+      mps,
+      'agent-1',
+    );
+
+    expect(result).toBe(
+      'The assistant provided a second-preset summary of events.',
+    );
+    expect(generateTextMock).toHaveBeenCalledTimes(7);
+    expect(mps.getWithOptions).toHaveBeenNthCalledWith(
+      6,
+      'claude-sonnet-4.6',
+      'agent-1',
+      expect.any(Object),
+    );
+    expect(mps.getWithOptions).toHaveBeenNthCalledWith(
+      7,
+      'gpt-5.6-luna',
+      'agent-1',
+      expect.objectContaining({
+        $provider_instance_id: 'openrouter-instance',
+      }),
+    );
+  });
+
+  it('deduplicates preset models already in the utility list', async () => {
+    // 'gpt-5.6-luna' is both the 3rd utility model and a preset model.
+    // It should only be tried once (at its utility position), not retried.
+    generateTextMock
+      .mockRejectedValueOnce(new Error('Default failed'))
+      .mockRejectedValueOnce(new Error('DeepSeek failed'))
+      .mockResolvedValueOnce({
+        text: 'The assistant provided a GPT summary of events.',
+      } as any);
+
+    const mps = makeMockHostModelsWithPreset([
+      { modelId: 'gpt-5.6-luna' },
+      { modelId: 'claude-sonnet-4.6' },
+    ]);
+    const result = await generateSimpleCompressedHistory(
+      makeMessages(4),
+      mps,
+      'agent-1',
+    );
+
+    expect(result).toBe('The assistant provided a GPT summary of events.');
+    // Only 3 calls: default, deepseek, gpt — gpt is not retried from preset.
+    expect(generateTextMock).toHaveBeenCalledTimes(3);
   });
 
   // -----------------------------------------------------------------------

--- a/packages/agent-core/src/agents/shared/history-compression/index.ts
+++ b/packages/agent-core/src/agents/shared/history-compression/index.ts
@@ -244,14 +244,19 @@ export const generateSimpleCompressedHistory = async (
     }));
   }
 
-  const attemptedModelIds = new Set<string>();
+  const attemptedKeys = new Set<string>();
 
   for (const entry of entries) {
     // Skip models that are no longer available (deleted provider, etc.)
     // Pass `providerInstanceId` so discovered models (which only exist
     // on a specific instance) are not falsely rejected.
     if (!hostModels.has(entry.modelId, entry.providerInstanceId)) continue;
-    attemptedModelIds.add(entry.modelId);
+    // Deduplicate by (modelId, providerInstanceId) so the active
+    // fallback remains available even if a failed entry shared the
+    // same model ID on a different instance.
+    const key = `${entry.modelId}::${entry.providerInstanceId ?? ''}`;
+    if (attemptedKeys.has(key)) continue;
+    attemptedKeys.add(key);
     try {
       return await tryCompressWithModel(
         entry,
@@ -270,7 +275,8 @@ export const generateSimpleCompressedHistory = async (
   }
 
   // Last resort: try the active chat model if it wasn't already attempted.
-  if (fallbackModelId && !attemptedModelIds.has(fallbackModelId)) {
+  const fallbackKey = `${fallbackModelId}::${fallbackProviderInstanceId ?? ''}`;
+  if (fallbackModelId && !attemptedKeys.has(fallbackKey)) {
     console.warn(
       `History compression: all preferred models failed, falling back to active model: ${fallbackModelId}`,
     );

--- a/packages/agent-core/src/agents/shared/history-compression/index.ts
+++ b/packages/agent-core/src/agents/shared/history-compression/index.ts
@@ -91,6 +91,7 @@ const tryCompressWithModel = async (
   agentInstanceId: string,
   compactHistory: string,
   previousBriefingChars: number,
+  host?: AgentHost,
 ): Promise<string> => {
   const metadata: Record<string, unknown> = {
     $ai_span_name: 'history-compression',
@@ -108,7 +109,7 @@ const tryCompressWithModel = async (
     metadata,
   );
 
-  console.debug(
+  host?.logger.debug(
     `[history-compression] Attempting model "${entry.modelId}"` +
       ` (instance="${entry.providerInstanceId ?? 'default'}")` +
       ` for agent ${agentInstanceId}.`,
@@ -177,7 +178,7 @@ const tryCompressWithModel = async (
       );
     }
 
-    console.debug(
+    host?.logger.debug(
       `[history-compression] Success with model "${entry.modelId}"` +
         ` (instance="${entry.providerInstanceId ?? 'default'}")` +
         ` — ${compactionResult.length} chars.`,
@@ -275,6 +276,7 @@ export const generateSimpleCompressedHistory = async (
         agentInstanceId,
         compactConvertedChatHistory,
         previousBriefingChars,
+        host,
       );
     } catch (e) {
       lastError = e as Error;
@@ -288,7 +290,7 @@ export const generateSimpleCompressedHistory = async (
   // Last resort: try the active chat model if it wasn't already attempted.
   const fallbackKey = `${fallbackModelId}::${fallbackProviderInstanceId ?? ''}`;
   if (fallbackModelId && !attemptedKeys.has(fallbackKey)) {
-    console.warn(
+    host?.logger.warn(
       `History compression: all preferred models failed, falling back to active model: ${fallbackModelId}`,
     );
     try {
@@ -298,6 +300,7 @@ export const generateSimpleCompressedHistory = async (
         agentInstanceId,
         compactConvertedChatHistory,
         previousBriefingChars,
+        host,
       );
     } catch (e) {
       lastError = e as Error;

--- a/packages/agent-core/src/agents/shared/history-compression/index.ts
+++ b/packages/agent-core/src/agents/shared/history-compression/index.ts
@@ -3,7 +3,9 @@ import type { AgentMessage } from '../../../types/agent';
 import type { AgentHost } from '../../../host/host';
 import {
   PROVIDER_INSTANCE_ID_METADATA_KEY,
+  UTILITY_THINKING_OVERRIDE_METADATA_KEY,
   type HostModels,
+  type UtilityModelEntry,
 } from '../../../host/models';
 
 /**
@@ -47,9 +49,11 @@ export {
  * The first model is the primary; subsequent entries are fallbacks
  * tried in order when the previous one fails or times out.
  */
-const HISTORY_COMPRESSION_MODELS = [
+export const HISTORY_COMPRESSION_MODELS = [
+  'default',
+  'deepseek-v4-flash',
+  'gpt-5.6-luna',
   'gemini-3.1-flash-lite',
-  'gpt-5.4-nano',
   'claude-haiku-4.5',
 ] as const;
 
@@ -82,21 +86,26 @@ class HistoryCompressionUnsettledTimeoutError extends Error {
  * Returns the compressed text on success, or throws on failure.
  */
 const tryCompressWithModel = async (
-  modelId: string,
+  entry: UtilityModelEntry,
   hostModels: HostModels,
   agentInstanceId: string,
   compactHistory: string,
   previousBriefingChars: number,
-  providerInstanceId?: string,
 ): Promise<string> => {
+  const metadata: Record<string, unknown> = {
+    $ai_span_name: 'history-compression',
+    $ai_parent_id: `${agentInstanceId}`,
+  };
+  if (entry.providerInstanceId) {
+    metadata[PROVIDER_INSTANCE_ID_METADATA_KEY] = entry.providerInstanceId;
+  }
+  if (entry.thinkingOverride) {
+    metadata[UTILITY_THINKING_OVERRIDE_METADATA_KEY] = entry.thinkingOverride;
+  }
   const modelWithOptions = await hostModels.getWithOptions(
-    modelId,
+    entry.modelId,
     `${agentInstanceId}`,
-    {
-      $ai_span_name: 'history-compression',
-      $ai_parent_id: `${agentInstanceId}`,
-      [PROVIDER_INSTANCE_ID_METADATA_KEY]: providerInstanceId,
-    },
+    metadata,
   );
 
   const abortController = new AbortController();
@@ -152,7 +161,7 @@ const tryCompressWithModel = async (
           ]).then((settled) => {
             if (settled.status === 'fulfilled') return settled.result;
             if (settled.status === 'rejected') throw settled.error;
-            throw new HistoryCompressionUnsettledTimeoutError(modelId);
+            throw new HistoryCompressionUnsettledTimeoutError(entry.modelId);
           })
         : racedResult;
 
@@ -175,7 +184,6 @@ export const generateSimpleCompressedHistory = async (
   agentInstanceId: string,
   fallbackModelId?: string,
   host?: AgentHost,
-  fallbackProviderInstanceId?: string,
 ): Promise<string> => {
   const compactConvertedChatHistory =
     convertAgentMessagesToCompactMessageHistoryString(messages, host);
@@ -188,10 +196,55 @@ export const generateSimpleCompressedHistory = async (
 
   let lastError: Error | undefined;
 
-  for (const modelId of HISTORY_COMPRESSION_MODELS) {
+  // Use user-configured utility models when available.
+  // - undefined: not configured → use built-in defaults
+  // - []: explicitly cleared → use main chat model as fallback
+  // - [...items]: user-configured list
+  const configuredEntries = hostModels.getUtilityModelEntries?.(
+    'context-compression',
+  );
+  const configuredModels = hostModels.getUtilityModelIds?.(
+    'context-compression',
+  );
+
+  // Build a unified list of entries (with thinking overrides) from
+  // whichever method the host implements.
+  let entries: UtilityModelEntry[];
+  if (configuredEntries !== undefined) {
+    entries =
+      configuredEntries.length > 0
+        ? configuredEntries
+        : fallbackModelId
+          ? [{ modelId: fallbackModelId }]
+          : (HISTORY_COMPRESSION_MODELS as readonly string[]).map((id) => ({
+              modelId: id,
+            }));
+  } else if (configuredModels !== undefined) {
+    entries =
+      configuredModels.length > 0
+        ? configuredModels.map((id) => ({ modelId: id }))
+        : fallbackModelId
+          ? [{ modelId: fallbackModelId }]
+          : (HISTORY_COMPRESSION_MODELS as readonly string[]).map((id) => ({
+              modelId: id,
+            }));
+  } else {
+    entries = (HISTORY_COMPRESSION_MODELS as readonly string[]).map((id) => ({
+      modelId: id,
+    }));
+  }
+
+  const attemptedModelIds = new Set<string>();
+
+  for (const entry of entries) {
+    // Skip models that are no longer available (deleted provider, etc.)
+    // Pass `providerInstanceId` so discovered models (which only exist
+    // on a specific instance) are not falsely rejected.
+    if (!hostModels.has(entry.modelId, entry.providerInstanceId)) continue;
+    attemptedModelIds.add(entry.modelId);
     try {
       return await tryCompressWithModel(
-        modelId,
+        entry,
         hostModels,
         agentInstanceId,
         compactConvertedChatHistory,
@@ -206,27 +259,18 @@ export const generateSimpleCompressedHistory = async (
     }
   }
 
-  // Last resort: try the active chat model if the same resolution scope was
-  // not already attempted. An instance-scoped model with the same ID as a
-  // preferred model is distinct from the earlier unscoped lookup.
-  if (
-    fallbackModelId &&
-    (fallbackProviderInstanceId !== undefined ||
-      !(HISTORY_COMPRESSION_MODELS as readonly string[]).includes(
-        fallbackModelId,
-      ))
-  ) {
+  // Last resort: try the active chat model if it wasn't already attempted.
+  if (fallbackModelId && !attemptedModelIds.has(fallbackModelId)) {
     console.warn(
       `History compression: all preferred models failed, falling back to active model: ${fallbackModelId}`,
     );
     try {
       return await tryCompressWithModel(
-        fallbackModelId,
+        { modelId: fallbackModelId },
         hostModels,
         agentInstanceId,
         compactConvertedChatHistory,
         previousBriefingChars,
-        fallbackProviderInstanceId,
       );
     } catch (e) {
       lastError = e as Error;

--- a/packages/agent-core/src/agents/shared/history-compression/index.ts
+++ b/packages/agent-core/src/agents/shared/history-compression/index.ts
@@ -108,6 +108,12 @@ const tryCompressWithModel = async (
     metadata,
   );
 
+  console.debug(
+    `[history-compression] Attempting model "${entry.modelId}"` +
+      ` (instance="${entry.providerInstanceId ?? 'default'}")` +
+      ` for agent ${agentInstanceId}.`,
+  );
+
   const abortController = new AbortController();
   let timeout: ReturnType<typeof setTimeout> | undefined;
   let abortGraceTimeout: ReturnType<typeof setTimeout> | undefined;
@@ -171,6 +177,11 @@ const tryCompressWithModel = async (
       );
     }
 
+    console.debug(
+      `[history-compression] Success with model "${entry.modelId}"` +
+        ` (instance="${entry.providerInstanceId ?? 'default'}")` +
+        ` — ${compactionResult.length} chars.`,
+    );
     return compactionResult;
   } finally {
     if (timeout) clearTimeout(timeout);

--- a/packages/agent-core/src/agents/shared/history-compression/index.ts
+++ b/packages/agent-core/src/agents/shared/history-compression/index.ts
@@ -183,6 +183,7 @@ export const generateSimpleCompressedHistory = async (
   hostModels: HostModels,
   agentInstanceId: string,
   fallbackModelId?: string,
+  fallbackProviderInstanceId?: string,
   host?: AgentHost,
 ): Promise<string> => {
   const compactConvertedChatHistory =
@@ -209,13 +210,22 @@ export const generateSimpleCompressedHistory = async (
 
   // Build a unified list of entries (with thinking overrides) from
   // whichever method the host implements.
+  const fallbackEntry: UtilityModelEntry | null = fallbackModelId
+    ? {
+        modelId: fallbackModelId,
+        ...(fallbackProviderInstanceId
+          ? { providerInstanceId: fallbackProviderInstanceId }
+          : {}),
+      }
+    : null;
+
   let entries: UtilityModelEntry[];
   if (configuredEntries !== undefined) {
     entries =
       configuredEntries.length > 0
         ? configuredEntries
-        : fallbackModelId
-          ? [{ modelId: fallbackModelId }]
+        : fallbackEntry
+          ? [fallbackEntry]
           : (HISTORY_COMPRESSION_MODELS as readonly string[]).map((id) => ({
               modelId: id,
             }));
@@ -223,8 +233,8 @@ export const generateSimpleCompressedHistory = async (
     entries =
       configuredModels.length > 0
         ? configuredModels.map((id) => ({ modelId: id }))
-        : fallbackModelId
-          ? [{ modelId: fallbackModelId }]
+        : fallbackEntry
+          ? [fallbackEntry]
           : (HISTORY_COMPRESSION_MODELS as readonly string[]).map((id) => ({
               modelId: id,
             }));
@@ -266,7 +276,7 @@ export const generateSimpleCompressedHistory = async (
     );
     try {
       return await tryCompressWithModel(
-        { modelId: fallbackModelId },
+        fallbackEntry ?? { modelId: fallbackModelId },
         hostModels,
         agentInstanceId,
         compactConvertedChatHistory,

--- a/packages/agent-core/src/agents/shared/history-compression/index.ts
+++ b/packages/agent-core/src/agents/shared/history-compression/index.ts
@@ -256,6 +256,16 @@ export const generateSimpleCompressedHistory = async (
     }));
   }
 
+  // Append the active preset's model list (main model + fallbacks) so
+  // the main chat models serve as ordered fallbacks after all utility
+  // models are exhausted. Dedup by (modelId, providerInstanceId) in the
+  // loop below prevents double-attempts of models that appear in both
+  // lists.
+  const presetModels = hostModels.getActivePresetModels?.();
+  if (presetModels && presetModels.length > 0) {
+    entries = [...entries, ...presetModels];
+  }
+
   const attemptedKeys = new Set<string>();
 
   for (const entry of entries) {
@@ -287,7 +297,8 @@ export const generateSimpleCompressedHistory = async (
     }
   }
 
-  // Last resort: try the active chat model if it wasn't already attempted.
+  // Last resort: try the active chat model if it wasn't already
+  // attempted (e.g. when no preset models were available).
   const fallbackKey = `${fallbackModelId}::${fallbackProviderInstanceId ?? ''}`;
   if (fallbackModelId && !attemptedKeys.has(fallbackKey)) {
     host?.logger.warn(

--- a/packages/agent-core/src/agents/shared/title-generation.test.ts
+++ b/packages/agent-core/src/agents/shared/title-generation.test.ts
@@ -78,7 +78,7 @@ describe('generateSimpleTitle', () => {
     expect(title).toBe('My Title');
     expect(generateTextMock).toHaveBeenCalledTimes(1);
     expect(hm.getWithOptions).toHaveBeenCalledWith(
-      'gemini-3.1-flash-lite',
+      'default',
       'agent-1',
       expect.objectContaining({ $ai_span_name: 'title-generation' }),
     );
@@ -86,17 +86,17 @@ describe('generateSimpleTitle', () => {
 
   it('falls back to the second model when the first fails', async () => {
     generateTextMock
-      .mockRejectedValueOnce(new Error('Gemini failed'))
-      .mockResolvedValueOnce({ text: 'GPT Title' } as any);
+      .mockRejectedValueOnce(new Error('Default failed'))
+      .mockResolvedValueOnce({ text: 'DeepSeek Title' } as any);
 
     const hm = makeMockHostModels();
     const title = await generateSimpleTitle(makeMessages(2), hm, 'agent-1');
 
-    expect(title).toBe('GPT Title');
+    expect(title).toBe('DeepSeek Title');
     expect(generateTextMock).toHaveBeenCalledTimes(2);
     expect(hm.getWithOptions).toHaveBeenNthCalledWith(
       2,
-      'gpt-5.4-nano',
+      'deepseek-v4-flash',
       'agent-1',
       expect.any(Object),
     );
@@ -104,34 +104,36 @@ describe('generateSimpleTitle', () => {
 
   it('falls back to the third model when the first two fail', async () => {
     generateTextMock
-      .mockRejectedValueOnce(new Error('Gemini failed'))
-      .mockRejectedValueOnce(new Error('GPT failed'))
-      .mockResolvedValueOnce({ text: 'Haiku Title' } as any);
+      .mockRejectedValueOnce(new Error('Default failed'))
+      .mockRejectedValueOnce(new Error('DeepSeek failed'))
+      .mockResolvedValueOnce({ text: 'GPT Title' } as any);
 
     const hm = makeMockHostModels();
     const title = await generateSimpleTitle(makeMessages(2), hm, 'agent-1');
 
-    expect(title).toBe('Haiku Title');
+    expect(title).toBe('GPT Title');
     expect(generateTextMock).toHaveBeenCalledTimes(3);
     expect(hm.getWithOptions).toHaveBeenNthCalledWith(
       3,
-      'claude-haiku-4.5',
+      'gpt-5.6-luna',
       'agent-1',
       expect.any(Object),
     );
   });
 
-  it('throws when all three models fail', async () => {
+  it('throws when all models fail', async () => {
     generateTextMock
-      .mockRejectedValueOnce(new Error('Gemini failed'))
+      .mockRejectedValueOnce(new Error('Default failed'))
+      .mockRejectedValueOnce(new Error('DeepSeek failed'))
       .mockRejectedValueOnce(new Error('GPT failed'))
+      .mockRejectedValueOnce(new Error('Gemini failed'))
       .mockRejectedValueOnce(new Error('Haiku failed'));
 
     const hm = makeMockHostModels();
     await expect(
       generateSimpleTitle(makeMessages(2), hm, 'agent-1'),
     ).rejects.toThrow('Haiku failed');
-    expect(generateTextMock).toHaveBeenCalledTimes(3);
+    expect(generateTextMock).toHaveBeenCalledTimes(5);
   });
 
   it('falls back when getWithOptions throws for a model', async () => {
@@ -210,25 +212,27 @@ describe('generateSimpleTitle', () => {
     // First model attempted, then fallback
     expect(hm.getWithOptions).toHaveBeenNthCalledWith(
       1,
-      'gemini-3.1-flash-lite',
+      'default',
       'agent-1',
       expect.any(Object),
     );
     expect(hm.getWithOptions).toHaveBeenNthCalledWith(
       2,
-      'gpt-5.4-nano',
+      'deepseek-v4-flash',
       'agent-1',
       expect.any(Object),
     );
   });
 
   it('exhausts all models via timeout and throws', async () => {
-    // All three models fail instantly (simulates what happens after abort)
+    // All models fail instantly (simulates what happens after abort)
     const abortError = new DOMException(
       'The operation was aborted.',
       'AbortError',
     );
     generateTextMock
+      .mockRejectedValueOnce(abortError)
+      .mockRejectedValueOnce(abortError)
       .mockRejectedValueOnce(abortError)
       .mockRejectedValueOnce(abortError)
       .mockRejectedValueOnce(abortError);
@@ -237,21 +241,33 @@ describe('generateSimpleTitle', () => {
     await expect(
       generateSimpleTitle(makeMessages(2), hm, 'agent-1'),
     ).rejects.toThrow('aborted');
-    expect(generateTextMock).toHaveBeenCalledTimes(3);
+    expect(generateTextMock).toHaveBeenCalledTimes(5);
     expect(hm.getWithOptions).toHaveBeenNthCalledWith(
       1,
-      'gemini-3.1-flash-lite',
+      'default',
       'agent-1',
       expect.any(Object),
     );
     expect(hm.getWithOptions).toHaveBeenNthCalledWith(
       2,
-      'gpt-5.4-nano',
+      'deepseek-v4-flash',
       'agent-1',
       expect.any(Object),
     );
     expect(hm.getWithOptions).toHaveBeenNthCalledWith(
       3,
+      'gpt-5.6-luna',
+      'agent-1',
+      expect.any(Object),
+    );
+    expect(hm.getWithOptions).toHaveBeenNthCalledWith(
+      4,
+      'gemini-3.1-flash-lite',
+      'agent-1',
+      expect.any(Object),
+    );
+    expect(hm.getWithOptions).toHaveBeenNthCalledWith(
+      5,
       'claude-haiku-4.5',
       'agent-1',
       expect.any(Object),

--- a/packages/agent-core/src/agents/shared/title-generation.test.ts
+++ b/packages/agent-core/src/agents/shared/title-generation.test.ts
@@ -54,6 +54,23 @@ function makeMockHostModels(): HostModels {
   } as unknown as HostModels;
 }
 
+function makeMockHostModelsWithPreset(
+  presetModels: { modelId: string; providerInstanceId?: string }[],
+): HostModels {
+  const base = makeMockHostModels();
+  return {
+    ...base,
+    getActivePresetModels: vi.fn(() =>
+      presetModels.map((m) => ({
+        modelId: m.modelId,
+        ...(m.providerInstanceId
+          ? { providerInstanceId: m.providerInstanceId }
+          : {}),
+      })),
+    ),
+  } as unknown as HostModels;
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -134,6 +151,82 @@ describe('generateSimpleTitle', () => {
       generateSimpleTitle(makeMessages(2), hm, 'agent-1'),
     ).rejects.toThrow('Haiku failed');
     expect(generateTextMock).toHaveBeenCalledTimes(5);
+  });
+
+  // -----------------------------------------------------------------------
+  // preset models as fallback (appended after utility models)
+  // -----------------------------------------------------------------------
+
+  it('falls back to active preset models after all utility models fail', async () => {
+    generateTextMock
+      .mockRejectedValueOnce(new Error('Default failed'))
+      .mockRejectedValueOnce(new Error('DeepSeek failed'))
+      .mockRejectedValueOnce(new Error('GPT failed'))
+      .mockRejectedValueOnce(new Error('Gemini failed'))
+      .mockRejectedValueOnce(new Error('Haiku failed'))
+      .mockResolvedValueOnce({ text: 'Preset Title' } as any);
+
+    const hm = makeMockHostModelsWithPreset([
+      { modelId: 'claude-sonnet-4.6' },
+      { modelId: 'gpt-5.6-luna', providerInstanceId: 'openrouter-instance' },
+    ]);
+    const title = await generateSimpleTitle(makeMessages(2), hm, 'agent-1');
+
+    expect(title).toBe('Preset Title');
+    expect(generateTextMock).toHaveBeenCalledTimes(6);
+    expect(hm.getWithOptions).toHaveBeenNthCalledWith(
+      6,
+      'claude-sonnet-4.6',
+      'agent-1',
+      expect.any(Object),
+    );
+  });
+
+  it('tries all preset models in order as fallbacks', async () => {
+    generateTextMock
+      .mockRejectedValueOnce(new Error('Default failed'))
+      .mockRejectedValueOnce(new Error('DeepSeek failed'))
+      .mockRejectedValueOnce(new Error('GPT failed'))
+      .mockRejectedValueOnce(new Error('Gemini failed'))
+      .mockRejectedValueOnce(new Error('Haiku failed'))
+      .mockRejectedValueOnce(new Error('Sonnet failed'))
+      .mockResolvedValueOnce({ text: 'Second Preset Title' } as any);
+
+    const hm = makeMockHostModelsWithPreset([
+      { modelId: 'claude-sonnet-4.6' },
+      { modelId: 'gpt-5.6-luna', providerInstanceId: 'openrouter-instance' },
+    ]);
+    const title = await generateSimpleTitle(makeMessages(2), hm, 'agent-1');
+
+    expect(title).toBe('Second Preset Title');
+    expect(generateTextMock).toHaveBeenCalledTimes(7);
+    expect(hm.getWithOptions).toHaveBeenNthCalledWith(
+      7,
+      'gpt-5.6-luna',
+      'agent-1',
+      expect.objectContaining({
+        $provider_instance_id: 'openrouter-instance',
+      }),
+    );
+  });
+
+  it('deduplicates preset models already in the utility list', async () => {
+    // 'gpt-5.6-luna' is both the 3rd utility model and a preset model.
+    // It should only be tried once (at its utility position), not retried.
+    generateTextMock
+      .mockRejectedValueOnce(new Error('Default failed'))
+      .mockRejectedValueOnce(new Error('DeepSeek failed'))
+      .mockResolvedValueOnce({ text: 'GPT Title' } as any);
+
+    const hm = makeMockHostModelsWithPreset([
+      { modelId: 'gpt-5.6-luna' },
+      { modelId: 'claude-sonnet-4.6' },
+    ]);
+    const title = await generateSimpleTitle(makeMessages(2), hm, 'agent-1');
+
+    expect(title).toBe('GPT Title');
+    // Only 3 calls: default, deepseek, gpt — gpt is not retried from preset.
+    expect(generateTextMock).toHaveBeenCalledTimes(3);
   });
 
   it('falls back when getWithOptions throws for a model', async () => {

--- a/packages/agent-core/src/agents/shared/title-generation/index.ts
+++ b/packages/agent-core/src/agents/shared/title-generation/index.ts
@@ -1,6 +1,11 @@
 import { generateText } from 'ai';
 import type { AgentMessage } from '../../../types/agent';
-import type { HostModels } from '../../../host/models';
+import {
+  PROVIDER_INSTANCE_ID_METADATA_KEY,
+  UTILITY_THINKING_OVERRIDE_METADATA_KEY,
+  type HostModels,
+  type UtilityModelEntry,
+} from '../../../host/models';
 import { deepMergeProviderOptions } from '../provider-options';
 import { TITLE_GENERATION_SYSTEM_PROMPT } from './prompt';
 
@@ -9,9 +14,11 @@ import { TITLE_GENERATION_SYSTEM_PROMPT } from './prompt';
  * The first model is the primary; subsequent entries are fallbacks
  * tried in order when the previous one fails or times out.
  */
-const TITLE_GENERATION_MODELS = [
+export const TITLE_GENERATION_MODELS = [
+  'default',
+  'deepseek-v4-flash',
+  'gpt-5.6-luna',
   'gemini-3.1-flash-lite',
-  'gpt-5.4-nano',
   'claude-haiku-4.5',
 ] as const;
 
@@ -53,10 +60,15 @@ const sanitizeTitle = (raw: string): string => {
 /**
  * Generate a short conversation title for the given message history.
  *
- * Walks `TITLE_GENERATION_MODELS` in order, timing each attempt out at
+ * Walks the model list in order, timing each attempt out at
  * {@link TITLE_GENERATION_TIMEOUT_MS}. Returns the first title that
  * meets the length/word-count floor; rethrows the last error if every
  * fallback fails.
+ *
+ * The model list is sourced from `hostModels.getUtilityModelIds` when
+ * the host exposes user-configured utility models. An empty or absent
+ * return falls back to the built-in {@link TITLE_GENERATION_MODELS}.
+ * Each model ID is validated via `hostModels.has()` before attempting.
  *
  * The `hostModels` argument is the core `HostModels.getWithOptions`
  * seam — hosts translate it into their native model provider. Unlike
@@ -67,6 +79,7 @@ export const generateSimpleTitle = async (
   messages: AgentMessage[],
   hostModels: HostModels,
   agentInstanceId: string,
+  fallbackModelId?: string,
 ): Promise<string> => {
   const messageList = messages
     .filter(
@@ -83,15 +96,63 @@ export const generateSimpleTitle = async (
 
   let lastError: Error | undefined;
 
-  for (const modelId of TITLE_GENERATION_MODELS) {
+  // Use user-configured utility models when available.
+  // - undefined: not configured → use built-in defaults
+  // - []: explicitly cleared → use main chat model as fallback
+  // - [...items]: user-configured list
+  const configuredEntries =
+    hostModels.getUtilityModelEntries?.('title-generation');
+  const configuredModels = hostModels.getUtilityModelIds?.('title-generation');
+
+  // Build a unified list of entries (with thinking overrides) from
+  // whichever method the host implements.
+  let entries: UtilityModelEntry[];
+  if (configuredEntries !== undefined) {
+    entries =
+      configuredEntries.length > 0
+        ? configuredEntries
+        : fallbackModelId
+          ? [{ modelId: fallbackModelId }]
+          : (TITLE_GENERATION_MODELS as readonly string[]).map((id) => ({
+              modelId: id,
+            }));
+  } else if (configuredModels !== undefined) {
+    entries =
+      configuredModels.length > 0
+        ? configuredModels.map((id) => ({ modelId: id }))
+        : fallbackModelId
+          ? [{ modelId: fallbackModelId }]
+          : (TITLE_GENERATION_MODELS as readonly string[]).map((id) => ({
+              modelId: id,
+            }));
+  } else {
+    entries = (TITLE_GENERATION_MODELS as readonly string[]).map((id) => ({
+      modelId: id,
+    }));
+  }
+
+  for (const entry of entries) {
+    const modelId = entry.modelId;
+    // Skip models that are no longer available (deleted provider, etc.)
+    // Pass `providerInstanceId` so discovered models (which only exist
+    // on a specific instance) are not falsely rejected.
+    if (!hostModels.has(modelId, entry.providerInstanceId)) continue;
     try {
+      const metadata: Record<string, unknown> = {
+        $ai_span_name: 'title-generation',
+        $ai_parent_id: agentInstanceId,
+      };
+      if (entry.providerInstanceId) {
+        metadata[PROVIDER_INSTANCE_ID_METADATA_KEY] = entry.providerInstanceId;
+      }
+      if (entry.thinkingOverride) {
+        metadata[UTILITY_THINKING_OVERRIDE_METADATA_KEY] =
+          entry.thinkingOverride;
+      }
       const modelWithOptions = await hostModels.getWithOptions(
         modelId,
         `${agentInstanceId}`,
-        {
-          $ai_span_name: 'title-generation',
-          $ai_parent_id: agentInstanceId,
-        },
+        metadata,
       );
 
       const abortController = new AbortController();

--- a/packages/agent-core/src/agents/shared/title-generation/index.ts
+++ b/packages/agent-core/src/agents/shared/title-generation/index.ts
@@ -151,6 +151,16 @@ export const generateSimpleTitle = async (
     }));
   }
 
+  // Append the active preset's model list (main model + fallbacks) so
+  // the main chat models serve as ordered fallbacks after all utility
+  // models are exhausted. Dedup by (modelId, providerInstanceId) in the
+  // loop below prevents double-attempts of models that appear in both
+  // lists.
+  const presetModels = hostModels.getActivePresetModels?.();
+  if (presetModels && presetModels.length > 0) {
+    entries = [...entries, ...presetModels];
+  }
+
   for (const entry of entries) {
     const modelId = entry.modelId;
     // Skip models that are no longer available (deleted provider, etc.)

--- a/packages/agent-core/src/agents/shared/title-generation/index.ts
+++ b/packages/agent-core/src/agents/shared/title-generation/index.ts
@@ -180,17 +180,24 @@ export const generateSimpleTitle = async (
       );
 
       try {
-        // When a thinking override is configured for this entry, respect it.
+        // When a thinking override is configured for this entry, respect
+        // it — the host has already resolved it into providerOptions.
         // Otherwise, force-disable thinking to minimise token usage for
         // this lightweight task.
-        // Check `.enabled !== undefined` rather than truthiness so malformed
-        // or legacy overrides normalised to `{}` don't bypass the disable.
-        const providerOptions =
-          entry.thinkingOverride?.enabled !== undefined
-            ? modelWithOptions.providerOptions
-            : deepMergeProviderOptions(modelWithOptions.providerOptions, {
-                anthropic: { thinking: { type: 'disabled' } },
-              });
+        //
+        // Check for any populated field, not just `enabled`, so overrides
+        // that carry only `provider`/`value` (e.g. from legacy data or
+        // schema normalisation that stripped a non-boolean `enabled`)
+        // are still treated as configured. The schema normaliser returns
+        // `{}` for malformed/empty values, so the key-count check is safe.
+        const hasOverride =
+          entry.thinkingOverride !== undefined &&
+          Object.keys(entry.thinkingOverride).length > 0;
+        const providerOptions = hasOverride
+          ? modelWithOptions.providerOptions
+          : deepMergeProviderOptions(modelWithOptions.providerOptions, {
+              anthropic: { thinking: { type: 'disabled' } },
+            });
 
         const title = await generateText({
           model: modelWithOptions.model,

--- a/packages/agent-core/src/agents/shared/title-generation/index.ts
+++ b/packages/agent-core/src/agents/shared/title-generation/index.ts
@@ -1,5 +1,6 @@
 import { generateText } from 'ai';
 import type { AgentMessage } from '../../../types/agent';
+import type { AgentHost } from '../../../host/host';
 import {
   PROVIDER_INSTANCE_ID_METADATA_KEY,
   UTILITY_THINKING_OVERRIDE_METADATA_KEY,
@@ -89,6 +90,7 @@ export const generateSimpleTitle = async (
   agentInstanceId: string,
   fallbackModelId?: string,
   fallbackProviderInstanceId?: string,
+  host?: AgentHost,
 ): Promise<string> => {
   const messageList = messages
     .filter(
@@ -155,7 +157,7 @@ export const generateSimpleTitle = async (
     // Pass `providerInstanceId` so discovered models (which only exist
     // on a specific instance) are not falsely rejected.
     if (!hostModels.has(modelId, entry.providerInstanceId)) continue;
-    console.debug(
+    host?.logger.debug(
       `[title-generation] Attempting model "${modelId}"` +
         ` (instance="${entry.providerInstanceId ?? 'default'}")` +
         ` for agent ${agentInstanceId}.`,
@@ -235,7 +237,7 @@ ${messageList}
           throw new Error(`Title too few words: "${title}"`);
         }
 
-        console.debug(
+        host?.logger.debug(
           `[title-generation] Success with model "${modelId}"` +
             ` (instance="${entry.providerInstanceId ?? 'default'}")` +
             ` — title: "${title}".`,

--- a/packages/agent-core/src/agents/shared/title-generation/index.ts
+++ b/packages/agent-core/src/agents/shared/title-generation/index.ts
@@ -155,6 +155,11 @@ export const generateSimpleTitle = async (
     // Pass `providerInstanceId` so discovered models (which only exist
     // on a specific instance) are not falsely rejected.
     if (!hostModels.has(modelId, entry.providerInstanceId)) continue;
+    console.debug(
+      `[title-generation] Attempting model "${modelId}"` +
+        ` (instance="${entry.providerInstanceId ?? 'default'}")` +
+        ` for agent ${agentInstanceId}.`,
+    );
     try {
       const metadata: Record<string, unknown> = {
         $ai_span_name: 'title-generation',
@@ -230,6 +235,11 @@ ${messageList}
           throw new Error(`Title too few words: "${title}"`);
         }
 
+        console.debug(
+          `[title-generation] Success with model "${modelId}"` +
+            ` (instance="${entry.providerInstanceId ?? 'default'}")` +
+            ` — title: "${title}".`,
+        );
         return title;
       } finally {
         clearTimeout(timeout);

--- a/packages/agent-core/src/agents/shared/title-generation/index.ts
+++ b/packages/agent-core/src/agents/shared/title-generation/index.ts
@@ -65,10 +65,18 @@ const sanitizeTitle = (raw: string): string => {
  * meets the length/word-count floor; rethrows the last error if every
  * fallback fails.
  *
- * The model list is sourced from `hostModels.getUtilityModelIds` when
- * the host exposes user-configured utility models. An empty or absent
- * return falls back to the built-in {@link TITLE_GENERATION_MODELS}.
- * Each model ID is validated via `hostModels.has()` before attempting.
+ * The model list is sourced from `hostModels.getUtilityModelEntries` (or
+ * `getUtilityModelIds` as a fallback) when the host exposes user-configured
+ * utility models. An explicitly empty list falls back to the main chat
+ * model (`fallbackModelId` + `fallbackProviderInstanceId`) if provided;
+ * an absent return falls back to the built-in {@link TITLE_GENERATION_MODELS}.
+ * Each model ID is validated via `hostModels.has()` (with `providerInstanceId`)
+ * before attempting.
+ *
+ * When a `thinkingOverride` is configured on a utility model entry, it is
+ * forwarded via metadata to `getWithOptions` and the resulting provider
+ * options are used as-is. When no override is configured, thinking is
+ * force-disabled to minimise token usage for this lightweight task.
  *
  * The `hostModels` argument is the core `HostModels.getWithOptions`
  * seam — hosts translate it into their native model provider. Unlike
@@ -80,6 +88,7 @@ export const generateSimpleTitle = async (
   hostModels: HostModels,
   agentInstanceId: string,
   fallbackModelId?: string,
+  fallbackProviderInstanceId?: string,
 ): Promise<string> => {
   const messageList = messages
     .filter(
@@ -106,13 +115,22 @@ export const generateSimpleTitle = async (
 
   // Build a unified list of entries (with thinking overrides) from
   // whichever method the host implements.
+  const fallbackEntry: UtilityModelEntry | null = fallbackModelId
+    ? {
+        modelId: fallbackModelId,
+        ...(fallbackProviderInstanceId
+          ? { providerInstanceId: fallbackProviderInstanceId }
+          : {}),
+      }
+    : null;
+
   let entries: UtilityModelEntry[];
   if (configuredEntries !== undefined) {
     entries =
       configuredEntries.length > 0
         ? configuredEntries
-        : fallbackModelId
-          ? [{ modelId: fallbackModelId }]
+        : fallbackEntry
+          ? [fallbackEntry]
           : (TITLE_GENERATION_MODELS as readonly string[]).map((id) => ({
               modelId: id,
             }));
@@ -120,8 +138,8 @@ export const generateSimpleTitle = async (
     entries =
       configuredModels.length > 0
         ? configuredModels.map((id) => ({ modelId: id }))
-        : fallbackModelId
-          ? [{ modelId: fallbackModelId }]
+        : fallbackEntry
+          ? [fallbackEntry]
           : (TITLE_GENERATION_MODELS as readonly string[]).map((id) => ({
               modelId: id,
             }));
@@ -162,12 +180,18 @@ export const generateSimpleTitle = async (
       );
 
       try {
+        // When a thinking override is configured for this entry, respect it.
+        // Otherwise, force-disable thinking to minimise token usage for
+        // this lightweight task.
+        const providerOptions = entry.thinkingOverride
+          ? modelWithOptions.providerOptions
+          : deepMergeProviderOptions(modelWithOptions.providerOptions, {
+              anthropic: { thinking: { type: 'disabled' } },
+            });
+
         const title = await generateText({
           model: modelWithOptions.model,
-          providerOptions: deepMergeProviderOptions(
-            modelWithOptions.providerOptions,
-            { anthropic: { thinking: { type: 'disabled' } } },
-          ),
+          providerOptions,
           headers: modelWithOptions.headers,
           abortSignal: abortController.signal,
           messages: [

--- a/packages/agent-core/src/agents/shared/title-generation/index.ts
+++ b/packages/agent-core/src/agents/shared/title-generation/index.ts
@@ -183,11 +183,14 @@ export const generateSimpleTitle = async (
         // When a thinking override is configured for this entry, respect it.
         // Otherwise, force-disable thinking to minimise token usage for
         // this lightweight task.
-        const providerOptions = entry.thinkingOverride
-          ? modelWithOptions.providerOptions
-          : deepMergeProviderOptions(modelWithOptions.providerOptions, {
-              anthropic: { thinking: { type: 'disabled' } },
-            });
+        // Check `.enabled !== undefined` rather than truthiness so malformed
+        // or legacy overrides normalised to `{}` don't bypass the disable.
+        const providerOptions =
+          entry.thinkingOverride?.enabled !== undefined
+            ? modelWithOptions.providerOptions
+            : deepMergeProviderOptions(modelWithOptions.providerOptions, {
+                anthropic: { thinking: { type: 'disabled' } },
+              });
 
         const title = await generateText({
           model: modelWithOptions.model,

--- a/packages/agent-core/src/host/index.ts
+++ b/packages/agent-core/src/host/index.ts
@@ -23,11 +23,15 @@ export type {
 export type { Logger } from './logger';
 export {
   MODEL_REQUEST_PURPOSE_METADATA_KEY,
+  PRESET_THINKING_OVERRIDE_METADATA_KEY,
   PROVIDER_INSTANCE_ID_METADATA_KEY,
+  UTILITY_THINKING_OVERRIDE_METADATA_KEY,
   type HostModels,
   type ModelRequestPurpose,
   type ModelWithOptions,
   type ProviderMode,
+  type UtilityModelEntry,
+  type UtilityModelThinkingOverride,
 } from './models';
 export type { ModelCapabilities } from '../types/models';
 export type { HostPaths } from './paths';

--- a/packages/agent-core/src/host/models.ts
+++ b/packages/agent-core/src/host/models.ts
@@ -35,6 +35,49 @@ export const MODEL_REQUEST_PURPOSE_METADATA_KEY = '$model_request_purpose';
 export const PROVIDER_INSTANCE_ID_METADATA_KEY = '$provider_instance_id';
 
 /**
+ * Reserved metadata key for passing a thinking override for a utility
+ * model call (title generation, context compression). The host reads
+ * this to apply per-model thinking configuration to internal calls
+ * that would otherwise skip thinking resolution.
+ *
+ * The value must be a {@link UtilityModelThinkingOverride} or omitted.
+ */
+export const UTILITY_THINKING_OVERRIDE_METADATA_KEY =
+  '$utility_thinking_override';
+
+/**
+ * Reserved metadata key for passing a preset's thinking override for
+ * the main agent step. The host reads this to apply the active
+ * preset's per-model thinking configuration, taking precedence over
+ * the global `modelThinkingOverrides` stored in preferences.
+ *
+ * The value must be a {@link UtilityModelThinkingOverride} or omitted.
+ */
+export const PRESET_THINKING_OVERRIDE_METADATA_KEY =
+  '$preset_thinking_override';
+
+/**
+ * Thinking override shape for utility model calls. Mirrors the host's
+ * `ModelThinkingOverride` but kept as a structural type so agent-core
+ * does not depend on host-side schema definitions.
+ */
+export interface UtilityModelThinkingOverride {
+  enabled?: boolean;
+  provider?: string;
+  value?: string;
+}
+
+/**
+ * A model entry in a utility model list, carrying optional thinking
+ * override so the host can apply per-model thinking configuration.
+ */
+export interface UtilityModelEntry {
+  modelId: string;
+  providerInstanceId?: string;
+  thinkingOverride?: UtilityModelThinkingOverride;
+}
+
+/**
  * Fully-resolved model with all the options `BaseAgent` needs to
  * invoke `streamText` / `generateText`.
  *
@@ -133,6 +176,54 @@ export interface HostModels {
    * require their owning provider instance ID.
    */
   has(modelId: string, providerInstanceId?: string): boolean;
+
+  /**
+   * Returns the user-configured ordered list of model IDs for a
+   * background utility task (title generation, context compression).
+   *
+   * The first element is the primary; subsequent entries are
+   * fallbacks tried in order. An empty array (or an unimplemented
+   * method) signals the caller to use its built-in default list.
+   *
+   * Hosts that expose user-configurable utility models implement this;
+   * other hosts can omit it.
+   */
+  getUtilityModelIds?(
+    task: 'title-generation' | 'context-compression',
+  ): string[] | undefined;
+
+  /**
+   * Returns the user-configured ordered list of model entries for a
+   * background utility task, including per-model thinking overrides.
+   *
+   * When implemented, takes precedence over {@link getUtilityModelIds}.
+   * Each entry carries a `modelId`, optional `providerInstanceId`, and
+   * optional `thinkingOverride` so the host can apply per-model
+   * thinking configuration to internal utility calls.
+   */
+  getUtilityModelEntries?(
+    task: 'title-generation' | 'context-compression',
+  ): UtilityModelEntry[] | undefined;
+
+  /**
+   * Returns the active preset's ID from user preferences, or
+   * `undefined` when no preset is active.
+   *
+   * Used by the agent's fallback manager to detect preset changes
+   * and reset the fallback pointer to the primary model (index 0).
+   */
+  getActivePresetId?(): string | undefined;
+
+  /**
+   * Returns the active preset's full ordered list of model entries
+   * (main model first, then fallbacks), or `undefined` when no
+   * preset is active.
+   *
+   * Each entry carries `modelId`, optional `providerInstanceId`, and
+   * optional `thinkingOverride`. Used by the fallback manager to
+   * cycle through models on upstream-overload errors.
+   */
+  getActivePresetModels?(): UtilityModelEntry[] | undefined;
 
   /**
    * Returns the {@link ModelCapabilities} for `modelId` (input/output

--- a/packages/icons/src/nucleo/ui-outline-18/IconGripDotsVerticalOutline18.tsx
+++ b/packages/icons/src/nucleo/ui-outline-18/IconGripDotsVerticalOutline18.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import { Icon, type IconProps } from './Icon';
+
+interface IconGripDotsVerticalOutline18Props extends IconProps {
+  strokeWidth?: number;
+}
+export const IconGripDotsVerticalOutline18: React.FC<
+  IconGripDotsVerticalOutline18Props
+> = ({ strokeWidth = 1.5, ...props }) => {
+  return (
+    <Icon size="18px" {...props}>
+      <circle
+        cx="6.75"
+        cy="9"
+        r=".5"
+        fill="currentColor"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={strokeWidth}
+      />
+      <circle
+        cx="6.75"
+        cy="3.75"
+        r=".5"
+        fill="currentColor"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={strokeWidth}
+      />
+      <circle
+        cx="6.75"
+        cy="14.25"
+        r=".5"
+        fill="currentColor"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={strokeWidth}
+      />
+      <circle
+        cx="11.25"
+        cy="9"
+        r=".5"
+        fill="currentColor"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={strokeWidth}
+      />
+      <circle
+        cx="11.25"
+        cy="3.75"
+        r=".5"
+        fill="currentColor"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={strokeWidth}
+      />
+      <circle
+        cx="11.25"
+        cy="14.25"
+        r=".5"
+        fill="currentColor"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={strokeWidth}
+      />
+    </Icon>
+  );
+};

--- a/packages/icons/src/nucleo/ui-outline-18/index.ts
+++ b/packages/icons/src/nucleo/ui-outline-18/index.ts
@@ -45,6 +45,7 @@ export { IconFloppyDiskOutline18 } from './IconFloppyDiskOutline18';
 export { IconFolder5Outline18 } from './IconFolder5Outline18';
 export { IconFolderCloudOutline18 } from './IconFolderCloudOutline18';
 export { IconFolderOpenOutline18 } from './IconFolderOpenOutline18';
+export { IconGripDotsVerticalOutline18 } from './IconGripDotsVerticalOutline18';
 export { IconFolderOutline18 } from './IconFolderOutline18';
 export { IconFolderPenOutline18 } from './IconFolderPenOutline18';
 export { IconFolderPlusOutline18 } from './IconFolderPlusOutline18';


### PR DESCRIPTION
Introduce named model presets for one-click switching between model bundles, with per-preset fallback chains, thinking overrides, and utility model lists (title generation + context compression).

- Add ModelFallbackManager for automatic failover on upstream-overload errors (429/502/503/529) with 5-min persistence window and preset change detection
- Add HostModels interface methods: getUtilityModelEntries, getActivePresetId, getActivePresetModels
- Wire preset resolution into base-agent runStep -- models are resolved dynamically from current preferences, not snapshot at selection time
- Add thinking override metadata keys (UTILITY/PRESET) with precedence: utility > preset > global > catalog defaults
- Add Zod schema with legacy migration (modelId+fallbackModels to unified models array) and .default() entries for utility model lists
- Add settings UI (model-presets-section) with drag-and-drop reordering, per-model thinking config, and DRY consolidation via useModelListItems hook and unified ModelList component
- Add preset entries to model-select dropdown with active preset display
- Fix hostModels.has() to pass providerInstanceId for discovered models
- Add grip-dots icon for drag handle


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core agent stepping, LLM routing, and preferences defaults across browser and agent-core; behavior is heavily tested but misconfiguration or failover edge cases could affect which model runs on each turn.
> 
> **Overview**
> Adds **named model presets** (main model + ordered fallbacks, per-model thinking, optional per-preset utility lists) stored in user preferences, with legacy preset schema migration and default utility-model chains for title generation and context compression.
> 
> **Runtime behavior** resolves the chat model from the **current** active preset on every `runStep` (not a one-time snapshot), syncs agent state, and applies preset thinking via `PRESET_THINKING_OVERRIDE_METADATA_KEY`. **`ModelFallbackManager`** retries upstream overload errors (429/502/503/529) through the preset’s fallback list with a 5-minute sticky window and resets when the preset or model list changes.
> 
> The browser **`HostModels`** bridge exposes utility entries and active preset data (including a cheap `getAgentSnapshot()`), and **`resolveThinkingProviderOptions`** honors utility and preset thinking metadata ahead of global overrides. **UI**: presets section in Models & Providers (drag-and-drop lists, validity warnings) and preset rows in the model selector; thinking hotkey is disabled while a preset is active.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ada4e3418c641fbbe0bd291039c555111f013af6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds named model presets with one‑click switching and automatic failover, plus user‑configurable utility model chains for titles and history compression. Utility tasks now also fall back to the active preset’s model list before giving up.

- **New Features**
  - Automatic failover via `ModelFallbackManager` on 429/502/503/529 with 5‑minute persistence; dynamic model resolution in `BaseAgent.runStep`; per‑preset thinking via `PRESET_THINKING_OVERRIDE_METADATA_KEY`.
  - Utility model chains for title generation and history compression with per‑call thinking via `UTILITY_THINKING_OVERRIDE_METADATA_KEY` (precedence: utility > preset > global > catalog); exported defaults in `TITLE_GENERATION_MODELS` and `HISTORY_COMPRESSION_MODELS`; utility calls append the active preset’s models as fallbacks (dedup by model+instance).
  - `HostModels` adds `getUtilityModelEntries`, `getActivePresetId`, `getActivePresetModels`; the browser host uses a lazy `getAgentSnapshot()` for live `utilityModels`, `activePresetId`, and `modelPresets`.
  - Presets settings UI with drag‑and‑drop ordering, per‑model thinking, invalid entry warnings, and preset entries in the model selector with active preset display.

- **Bug Fixes**
  - Fallbacks reset when the active preset changes, its model list is edited (structural signature), or the preset is cleared.
  - `hostModels.has()` now supplies `providerInstanceId`; invalid or disabled `activePresetId` and unavailable entries are ignored.
  - Utility calls apply provider‑only thinking overrides, bypass the purpose gate, route debug logs through `host.logger`, await active preset resolution, and avoid races when clearing a preset; the thinking hotkey is disabled while a preset is active; history‑compression tests updated for the expanded model list and call signature.

<sup>Written for commit ada4e3418c641fbbe0bd291039c555111f013af6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1481?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a full “Model Presets” settings section to create, edit, reorder, and manage presets with ordered fallbacks.
  * Added configurable utility models for title generation and background compression, including optional per-model provider/instance targeting and “thinking” overrides.
  * Updated the model selector to support preset selection and improved display of model/instance details.
* **Bug Fixes**
  * Improved overload resilience with automatic retry/failover across the active preset’s fallback chain.
  * Title generation and history compression now skip unavailable utility-model options and apply “thinking” overrides correctly.
* **Tests**
  * Added/updated coverage for preset fallback cycling and revised title/history-compression fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

fixes #1471