### PR TITLE
fix(stagewise): split Qwen subscription plans

### DIFF
--- a/apps/browser/src/backend/agents/model-provider.test.ts
+++ b/apps/browser/src/backend/agents/model-provider.test.ts
@@ -1284,7 +1284,7 @@ describe('official provider endpoint resolution', () => {
         },
         enabledModelIds: [],
         disabledModelIds: [],
-        discoveredModels: [],
+        discoveredModels: [{ modelId: 'glm-5.2', displayName: 'GLM 5.2' }],
       },
     ];
 
@@ -1301,7 +1301,85 @@ describe('official provider endpoint resolution', () => {
     );
   });
 
-  it('prefers an explicit coding-plan instance URL over the plan endpoint', () => {
+  it('keeps coexisting Qwen plans scoped to their selected endpoints', () => {
+    const service = createTestModelProviderService();
+    const preferences = (service as any).preferencesService.get();
+    preferences.providerInstances = [
+      {
+        id: 'qwen-coding',
+        typeId: 'coding-plan',
+        name: 'Qwen Coding Plan',
+        config: { encryptedApiKey: 'coding-key', planId: 'qwen-plan' },
+        enabledModelIds: [],
+        disabledModelIds: [],
+        discoveredModels: [
+          { modelId: 'qwen3.7-plus', displayName: 'Qwen 3.7 Plus' },
+        ],
+      },
+      {
+        id: 'qwen-token',
+        typeId: 'coding-plan',
+        name: 'Qwen Token Plan',
+        config: { encryptedApiKey: 'token-key', planId: 'qwen-token-plan' },
+        enabledModelIds: [],
+        disabledModelIds: [],
+        discoveredModels: [
+          { modelId: 'qwen3.7-plus', displayName: 'Qwen 3.7 Plus' },
+        ],
+      },
+    ];
+
+    const coding = service.getModelWithOptions(
+      'qwen3.7-plus',
+      'trace-coding',
+      undefined,
+      'qwen-coding',
+    );
+    const token = service.getModelWithOptions(
+      'qwen3.7-plus',
+      'trace-token',
+      undefined,
+      'qwen-token',
+    );
+
+    expect(getModelRequestUrl(coding)).toBe(
+      'https://coding-intl.dashscope.aliyuncs.com/v1/chat/completions',
+    );
+    expect(getModelRequestUrl(token)).toBe(
+      'https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1/chat/completions',
+    );
+  });
+
+  it('fails legacy routing when multiple vendor plans are ambiguous', () => {
+    const service = createTestModelProviderService();
+    const preferences = (service as any).preferencesService.get();
+    preferences.providerInstances = [
+      {
+        id: 'qwen-coding',
+        typeId: 'coding-plan',
+        name: 'Qwen Coding Plan',
+        config: { encryptedApiKey: 'coding-key', planId: 'qwen-plan' },
+        enabledModelIds: [],
+        disabledModelIds: [],
+        discoveredModels: [],
+      },
+      {
+        id: 'qwen-token',
+        typeId: 'coding-plan',
+        name: 'Qwen Token Plan',
+        config: { encryptedApiKey: 'token-key', planId: 'qwen-token-plan' },
+        enabledModelIds: [],
+        disabledModelIds: [],
+        discoveredModels: [],
+      },
+    ];
+
+    expect(() => service.getModelWithOptions('qwen3-32b', 'trace-1')).toThrow(
+      'Multiple coding plans are configured for alibaba; select a provider instance explicitly',
+    );
+  });
+
+  it('prefers and normalizes an explicit coding-plan instance URL', () => {
     const service = createTestModelProviderService();
     const preferences = (service as any).preferencesService.get();
     preferences.providerInstances = [
@@ -1312,11 +1390,11 @@ describe('official provider endpoint resolution', () => {
         config: {
           encryptedApiKey: 'selected-plan-key',
           planId: 'glm-coding-plan',
-          baseUrl: 'https://override.example.com/v4',
+          baseUrl: ' https://override.example.com/v4/ ',
         },
         enabledModelIds: [],
         disabledModelIds: [],
-        discoveredModels: [],
+        discoveredModels: [{ modelId: 'glm-5.2', displayName: 'GLM 5.2' }],
       },
     ];
 
@@ -1330,6 +1408,35 @@ describe('official provider endpoint resolution', () => {
     expect(getModelRequestUrl(result)).toBe(
       'https://override.example.com/v4/chat/completions',
     );
+  });
+
+  it('rejects invalid explicit coding-plan instance URLs at runtime', () => {
+    const service = createTestModelProviderService();
+    const preferences = (service as any).preferencesService.get();
+    preferences.providerInstances = [
+      {
+        id: 'coding-plan-selected',
+        typeId: 'coding-plan',
+        name: 'Selected GLM Coding Plan',
+        config: {
+          encryptedApiKey: 'selected-plan-key',
+          planId: 'glm-coding-plan',
+          baseUrl: 'http://override.example.com/v4',
+        },
+        enabledModelIds: [],
+        disabledModelIds: [],
+        discoveredModels: [{ modelId: 'glm-5.2', displayName: 'GLM 5.2' }],
+      },
+    ];
+
+    expect(() =>
+      service.getModelWithOptions(
+        'glm-5.2',
+        'trace-1',
+        undefined,
+        'coding-plan-selected',
+      ),
+    ).toThrow('The API endpoint must use HTTPS.');
   });
 
   it('keeps normal official Z.ai requests on the general endpoint', () => {

--- a/apps/browser/src/backend/agents/model-provider.ts
+++ b/apps/browser/src/backend/agents/model-provider.ts
@@ -20,7 +20,7 @@ import {
   getAvailableModel,
   getModelAlias,
 } from '@shared/available-models';
-import { CODING_PLANS } from '@shared/coding-plans';
+import { CODING_PLANS, resolveCodingPlanBaseUrl } from '@shared/coding-plans';
 import type { AuthService } from '@/services/auth';
 import type { PreferencesService } from '@/services/preferences';
 import type { streamText } from 'ai';
@@ -177,20 +177,20 @@ export class ModelProviderService {
     type: ProviderType,
   ): string | undefined {
     const config = instance.config as Record<string, unknown>;
-    const baseUrl =
-      typeof config.baseUrl === 'string' ? config.baseUrl.trim() : undefined;
-    if (baseUrl) return baseUrl;
-
     if (instance.typeId === 'coding-plan') {
       const planConfig = config as CodingPlanConfig;
       const plan = CODING_PLANS[planConfig.planId as keyof typeof CODING_PLANS];
       return (
-        plan?.baseUrl ??
+        (plan
+          ? resolveCodingPlanBaseUrl(plan, planConfig.baseUrl)
+          : undefined) ??
         getProviderTypeByVendor(getCodingPlanVendor(planConfig)).defaultBaseUrl
       );
     }
 
-    return type.defaultBaseUrl;
+    const baseUrl =
+      typeof config.baseUrl === 'string' ? config.baseUrl.trim() : undefined;
+    return baseUrl || type.defaultBaseUrl;
   }
 
   // ===========================================================================
@@ -215,6 +215,19 @@ export class ModelProviderService {
       process.env.LLM_PROXY_URL || 'https://llm.stagewise.io';
 
     const instance = findInstanceForVendor(prefs, provider);
+    if (!instance) {
+      const matchingPlanCount = prefs.providerInstances.filter((candidate) => {
+        if (candidate.typeId !== 'coding-plan') return false;
+        const plan =
+          CODING_PLANS[candidate.config.planId as keyof typeof CODING_PLANS];
+        return plan?.provider === provider;
+      }).length;
+      if (matchingPlanCount > 1) {
+        throw new Error(
+          `Multiple coding plans are configured for ${provider}; select a provider instance explicitly`,
+        );
+      }
+    }
     if (!instance || instance.typeId === 'stagewise') {
       return {
         instance: undefined,

--- a/apps/browser/src/backend/agents/providers/coding-plan.test.ts
+++ b/apps/browser/src/backend/agents/providers/coding-plan.test.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { codingPlanProviderType } from './coding-plan';
+
+const getInitialModelsMock = vi.hoisted(() => vi.fn());
+
+vi.mock('./official-api', () => ({
+  OFFICIAL_API_TYPES: {
+    alibaba: {
+      getInitialModels: getInitialModelsMock,
+      createLanguageModel: vi.fn(),
+    },
+  },
+}));
+
+describe('codingPlanProviderType model discovery', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('keeps every model returned by Token Plan discovery', async () => {
+    getInitialModelsMock.mockResolvedValue([
+      { modelId: 'qwen3.8-max-preview', displayName: 'Qwen 3.8 Max' },
+      { modelId: 'wan2.7-image', displayName: 'Wan Image' },
+      { modelId: 'unlisted-chat-model', displayName: 'Unlisted' },
+    ]);
+
+    const models = await codingPlanProviderType.getInitialModels!(
+      { planId: 'qwen-token-plan' },
+      { encryptedApiKey: 'token-key' },
+    );
+
+    expect(models).toEqual([
+      { modelId: 'qwen3.8-max-preview', displayName: 'Qwen 3.8 Max' },
+      { modelId: 'wan2.7-image', displayName: 'Wan Image' },
+      { modelId: 'unlisted-chat-model', displayName: 'Unlisted' },
+    ]);
+    expect(getInitialModelsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        baseUrl:
+          'https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1',
+      }),
+      { encryptedApiKey: 'token-key' },
+    );
+  });
+
+  it('uses a custom Token Plan endpoint for discovery', async () => {
+    getInitialModelsMock.mockResolvedValue([]);
+
+    await codingPlanProviderType.getInitialModels!(
+      {
+        planId: 'qwen-token-plan',
+        baseUrl: ' https://token-plan.eu.example.com/compatible-mode/v1/ ',
+      },
+      { encryptedApiKey: 'token-key' },
+    );
+
+    expect(getInitialModelsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        baseUrl: 'https://token-plan.eu.example.com/compatible-mode/v1',
+      }),
+      { encryptedApiKey: 'token-key' },
+    );
+  });
+
+  it('keeps newly discovered Coding Plan models outside the fallback', async () => {
+    getInitialModelsMock.mockResolvedValue([
+      { modelId: 'qwen-new-model', displayName: 'Qwen New Model' },
+    ]);
+
+    const models = await codingPlanProviderType.getInitialModels!(
+      { planId: 'qwen-plan' },
+      { encryptedApiKey: 'coding-key' },
+    );
+
+    expect(models).toEqual([
+      { modelId: 'qwen-new-model', displayName: 'Qwen New Model' },
+    ]);
+  });
+
+  it('propagates explicit refresh failures', async () => {
+    getInitialModelsMock.mockRejectedValue(new Error('models unavailable'));
+
+    await expect(
+      codingPlanProviderType.refreshModels!(
+        { planId: 'qwen-token-plan' },
+        { encryptedApiKey: 'token-key' },
+      ),
+    ).rejects.toThrow('models unavailable');
+  });
+
+  it('seeds Coding Plan models when initial discovery is unavailable', async () => {
+    getInitialModelsMock.mockRejectedValue(new Error('models unavailable'));
+
+    const models = await codingPlanProviderType.getInitialModels!(
+      { planId: 'qwen-plan' },
+      { encryptedApiKey: 'coding-key' },
+    );
+
+    expect(models.map((model) => model.modelId)).toContain('qwen3.7-plus');
+    expect(models.map((model) => model.modelId)).toContain('MiniMax-M2.5');
+    expect(models.map((model) => model.modelId)).not.toContain('qwen3-32b');
+  });
+});

--- a/apps/browser/src/backend/agents/providers/coding-plan.ts
+++ b/apps/browser/src/backend/agents/providers/coding-plan.ts
@@ -8,6 +8,7 @@ import { PROVIDER_TYPE_DISPLAY_INFO } from '@shared/karton-contracts/ui/shared-t
 import {
   CODING_PLANS,
   isCodingPlanId,
+  resolveCodingPlanBaseUrl,
   type CodingPlanId,
 } from '@shared/coding-plans';
 import type { ProviderType } from './types';
@@ -28,6 +29,24 @@ export function getCodingPlanVendor(config: CodingPlanConfig): ModelProvider {
     throw new Error(`Unknown coding plan ID: ${config.planId}`);
   }
   return plan.provider;
+}
+
+async function discoverCodingPlanModels(
+  config: CodingPlanConfig,
+  decryptedConfig: Record<string, string>,
+): Promise<DiscoveredModel[]> {
+  const plan = CODING_PLANS[config.planId as CodingPlanId];
+  const vendor = getCodingPlanVendor(config);
+  const apiType = OFFICIAL_API_TYPES[vendor];
+  if (!apiType.getInitialModels) return [];
+
+  return apiType.getInitialModels(
+    {
+      ...config,
+      baseUrl: resolveCodingPlanBaseUrl(plan, config.baseUrl),
+    } as never,
+    decryptedConfig,
+  );
 }
 
 export const codingPlanProviderType: ProviderType<CodingPlanConfig> = {
@@ -64,7 +83,7 @@ export const codingPlanProviderType: ProviderType<CodingPlanConfig> = {
     const { validateCodingPlanApiKey } = await import(
       '../../utils/validate-api-keys'
     );
-    const result = await validateCodingPlanApiKey(plan, apiKey);
+    const result = await validateCodingPlanApiKey(plan, apiKey, config.baseUrl);
     if (!result) {
       return { success: false, error: 'Validation was skipped' };
     }
@@ -75,18 +94,24 @@ export const codingPlanProviderType: ProviderType<CodingPlanConfig> = {
     config: CodingPlanConfig,
     decryptedConfig: Record<string, string>,
   ): Promise<DiscoveredModel[]> {
-    const vendor = getCodingPlanVendor(config);
-    const apiType = OFFICIAL_API_TYPES[vendor];
-    if (!apiType.getInitialModels) return [];
-    // Use the plan's dedicated base URL if set, otherwise fall through
-    // to the vendor type's defaultBaseUrl.
-    const planConfig: CodingPlanConfig = {
-      ...config,
-      baseUrl:
-        config.baseUrl ?? CODING_PLANS[config.planId as CodingPlanId]?.baseUrl,
-    };
-    return apiType.getInitialModels(planConfig as never, decryptedConfig);
+    const plan = CODING_PLANS[config.planId as CodingPlanId];
+    try {
+      return await discoverCodingPlanModels(config, decryptedConfig);
+    } catch (error) {
+      // Some coding plans document their models but restrict `/models`.
+      // Initial setup may use that documented fallback, while explicit refresh
+      // remains strict so endpoint changes cannot hide connectivity failures.
+      if (plan.fallbackModelIds) {
+        return plan.fallbackModelIds.map((modelId) => ({
+          modelId,
+          displayName: modelId,
+        }));
+      }
+      throw error;
+    }
   },
+
+  refreshModels: discoverCodingPlanModels,
 
   createLanguageModel({
     modelId,

--- a/apps/browser/src/backend/services/preferences.test.ts
+++ b/apps/browser/src/backend/services/preferences.test.ts
@@ -500,12 +500,15 @@ describe('PreferencesService legacy provider migration', () => {
         endpointId: undefined,
       }),
     );
-    for (const plan of Object.values(CODING_PLANS)) {
+    // The legacy shape stores one connected plan per vendor, so the last
+    // configured Alibaba plan is the only Qwen plan it can represent.
+    for (const config of Object.values(preferences.providerConfigs)) {
+      if (!config.connectedCodingPlanId) continue;
       expect(
         instances.filter(
           (instance) =>
             instance.typeId === 'coding-plan' &&
-            instance.config.planId === plan.id,
+            instance.config.planId === config.connectedCodingPlanId,
         ),
       ).toHaveLength(1);
     }
@@ -603,6 +606,42 @@ describe('PreferencesService legacy provider migration', () => {
     );
   });
 
+  it('migrates stale Qwen discovery to the dedicated Coding Plan endpoint', async () => {
+    const preferences = cloneDefaultPreferences();
+    preferences.providerInstances = [
+      {
+        id: 'legacy-qwen',
+        typeId: 'coding-plan',
+        name: 'Qwen Coding Plan',
+        config: {
+          encryptedApiKey: 'legacy-key',
+          planId: 'qwen-plan',
+          baseUrl: 'https://dashscope-intl.aliyuncs.com/compatible-mode/v1',
+        },
+        enabledModelIds: [],
+        disabledModelIds: [],
+        discoveredModels: [
+          { modelId: 'qwen3-32b', displayName: 'Stale DashScope model' },
+        ],
+      },
+    ];
+
+    const service = await createServiceWithPreferences(preferences);
+    const instance = service
+      .get()
+      .providerInstances.find((candidate) => candidate.id === 'legacy-qwen');
+
+    expect(instance?.config).toMatchObject({
+      baseUrl: 'https://coding-intl.dashscope.aliyuncs.com/v1',
+    });
+    expect(instance?.discoveredModels?.map((model) => model.modelId)).toContain(
+      'qwen3.7-plus',
+    );
+    expect(
+      instance?.discoveredModels?.map((model) => model.modelId),
+    ).not.toContain('qwen3-32b');
+  });
+
   it('reconciles a legacy coding plan when provider instances already exist', async () => {
     const preferences = cloneDefaultPreferences();
     preferences.providerInstances = [
@@ -670,6 +709,7 @@ describe('PreferencesService coding plan connection state', () => {
         validationModelId: 'glm-5.2',
       }),
       'glm-key',
+      'https://api.z.ai/api/coding/paas/v4',
     );
     expect(validationMock.validateApiKeys).not.toHaveBeenCalled();
 
@@ -693,6 +733,126 @@ describe('PreferencesService coding plan connection state', () => {
     expect(service.get().providerConfigs['z-ai']).toEqual(
       defaultUserPreferences.providerConfigs['z-ai'],
     );
+  });
+
+  it.each([
+    [
+      'qwen-plan',
+      'Qwen Coding Plan',
+      'https://coding-intl.dashscope.aliyuncs.com/v1',
+    ],
+    [
+      'qwen-token-plan',
+      'Qwen Token Plan',
+      'https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1',
+    ],
+  ] as const)('connects %s with its dedicated endpoint', async (planId, displayName, baseUrl) => {
+    const service = await createServiceWithPreferences();
+
+    const result = await service.connectCodingPlan(planId, 'qwen-plan-key');
+
+    expect(result).toEqual({ success: true });
+    expect(validationMock.validateCodingPlanApiKey).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: planId,
+        baseUrl,
+        validationBaseUrl: baseUrl,
+        validationModelId: 'qwen3.7-plus',
+      }),
+      'qwen-plan-key',
+      baseUrl,
+    );
+    expect(service.get().providerInstances).toContainEqual(
+      expect.objectContaining({
+        typeId: 'coding-plan',
+        name: displayName,
+        config: expect.objectContaining({ planId, baseUrl }),
+      }),
+    );
+  });
+
+  it('normalizes and validates a custom Token Plan endpoint', async () => {
+    const service = await createServiceWithPreferences();
+
+    const result = await service.addProviderInstance({
+      typeId: 'coding-plan',
+      config: {
+        planId: 'qwen-token-plan',
+        baseUrl: ' https://token-plan.eu.example.com/compatible-mode/v1/ ',
+      },
+      validateApiKey: 'token-key',
+    });
+
+    expect(result).toMatchObject({ success: true });
+    expect(validationMock.validateCodingPlanApiKey).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'qwen-token-plan' }),
+      'token-key',
+      'https://token-plan.eu.example.com/compatible-mode/v1',
+    );
+    expect(service.get().providerInstances).toContainEqual(
+      expect.objectContaining({
+        config: expect.objectContaining({
+          planId: 'qwen-token-plan',
+          baseUrl: 'https://token-plan.eu.example.com/compatible-mode/v1',
+        }),
+      }),
+    );
+  });
+
+  it('normalizes coding-plan endpoints when updating an instance', async () => {
+    const service = await createServiceWithPreferences();
+    const result = await service.addProviderInstance({
+      typeId: 'coding-plan',
+      config: { planId: 'qwen-token-plan' },
+      validateApiKey: 'token-key',
+    });
+    if (!result.success) throw new Error(result.error);
+
+    await service.updateProviderInstance(result.instanceId, {
+      baseUrl: ' https://token-plan.eu.example.com/v1/ ',
+    });
+
+    expect(
+      service
+        .get()
+        .providerInstances.find((instance) => instance.id === result.instanceId)
+        ?.config,
+    ).toMatchObject({ baseUrl: 'https://token-plan.eu.example.com/v1' });
+  });
+
+  it('rejects invalid coding-plan endpoints when updating an instance', async () => {
+    const service = await createServiceWithPreferences();
+    const result = await service.addProviderInstance({
+      typeId: 'coding-plan',
+      config: { planId: 'qwen-token-plan' },
+      validateApiKey: 'token-key',
+    });
+    if (!result.success) throw new Error(result.error);
+
+    await expect(
+      service.updateProviderInstance(result.instanceId, {
+        baseUrl: 'http://token-plan.example.com/v1',
+      }),
+    ).rejects.toThrow('The API endpoint must use HTTPS.');
+  });
+
+  it('rejects an invalid custom plan endpoint before credential validation', async () => {
+    const service = await createServiceWithPreferences();
+
+    const result = await service.addProviderInstance({
+      typeId: 'coding-plan',
+      config: {
+        planId: 'qwen-token-plan',
+        baseUrl: 'http://token-plan.example.com/v1',
+      },
+      validateApiKey: 'token-key',
+    });
+
+    expect(result).toEqual({
+      success: false,
+      error: 'The API endpoint must use HTTPS.',
+    });
+    expect(validationMock.validateCodingPlanApiKey).not.toHaveBeenCalled();
   });
 
   it('does not mutate preferences when coding-plan validation fails', async () => {

--- a/apps/browser/src/backend/services/preferences.ts
+++ b/apps/browser/src/backend/services/preferences.ts
@@ -28,6 +28,7 @@ import { safeStorage } from 'electron';
 import {
   CODING_PLANS,
   isCodingPlanId,
+  resolveCodingPlanBaseUrl,
   type CodingPlanId,
 } from '@shared/coding-plans';
 import {
@@ -141,6 +142,7 @@ export class PreferencesService extends DisposableService {
     // coding-plan connection. Reconcile those records independently so the
     // migration remains safe when the instance array is already non-empty.
     await this.migrateLegacyCodingPlansToProviderInstances();
+    await this.migrateLegacyQwenCodingPlanEndpoint();
 
     this.logger.debug('[PreferencesService] Loaded preferences', {
       telemetryLevel: this.preferences.privacy.telemetryLevel,
@@ -453,6 +455,43 @@ export class PreferencesService extends DisposableService {
       '[PreferencesService] Migrated legacy coding plans to provider instances',
       { count: instancesToAdd.length },
     );
+  }
+
+  /**
+   * Older Qwen instances used the general DashScope route and may retain a
+   * catalog discovered there. Move only those legacy records to the dedicated
+   * Coding Plan endpoint and seed its documented models.
+   */
+  private async migrateLegacyQwenCodingPlanEndpoint(): Promise<void> {
+    const plan = CODING_PLANS['qwen-plan'];
+    const expectedBaseUrl = resolveCodingPlanBaseUrl(plan);
+    const legacyInstances = this.preferences.providerInstances.filter(
+      (instance) =>
+        instance.typeId === 'coding-plan' &&
+        instance.config.planId === 'qwen-plan' &&
+        instance.config.baseUrl !== expectedBaseUrl,
+    );
+    if (legacyInstances.length === 0) return;
+
+    const legacyIds = new Set(legacyInstances.map((instance) => instance.id));
+    const discoveredModels = (plan.fallbackModelIds ?? []).map((modelId) => ({
+      modelId,
+      displayName: modelId,
+    }));
+    this.preferences = {
+      ...this.preferences,
+      providerInstances: this.preferences.providerInstances.map((instance) => {
+        if (!legacyIds.has(instance.id) || instance.typeId !== 'coding-plan') {
+          return instance;
+        }
+        return {
+          ...instance,
+          config: { ...instance.config, baseUrl: expectedBaseUrl },
+          discoveredModels,
+        };
+      }),
+    };
+    await this.save();
   }
 
   /**
@@ -1814,8 +1853,33 @@ export class PreferencesService extends DisposableService {
   > {
     this.assertNotDisposed();
 
-    const { typeId, config, validateApiKey } = args;
+    const { typeId, validateApiKey } = args;
+    let config = args.config;
     const providerType = getProviderType(typeId);
+
+    if (typeId === 'coding-plan') {
+      const plan = CODING_PLANS[config.planId as CodingPlanId];
+      if (!plan) {
+        return {
+          success: false,
+          error: `Unknown coding plan: ${config.planId}`,
+        };
+      }
+      try {
+        config = {
+          ...config,
+          baseUrl: resolveCodingPlanBaseUrl(
+            plan,
+            typeof config.baseUrl === 'string' ? config.baseUrl : undefined,
+          ),
+        };
+      } catch (error) {
+        return {
+          success: false,
+          error: error instanceof Error ? error.message : String(error),
+        };
+      }
+    }
 
     // Build the decrypted sensitive-values map up front so it can be used
     // for both validation and discovery.
@@ -1995,6 +2059,16 @@ export class PreferencesService extends DisposableService {
     const nextConfig = isTypeReplacement
       ? { ...partialConfig }
       : { ...currentConfig, ...partialConfig };
+    if (typeId === 'coding-plan') {
+      const planId = nextConfig.planId as CodingPlanId;
+      const plan = CODING_PLANS[planId];
+      if (plan) {
+        nextConfig.baseUrl = resolveCodingPlanBaseUrl(
+          plan,
+          nextConfig.baseUrl as string | undefined,
+        );
+      }
+    }
     // Validate the replacement discriminant and config together before persisting.
     userPreferencesSchema.parse({
       ...this.preferences,
@@ -2169,7 +2243,11 @@ export class PreferencesService extends DisposableService {
       const plan =
         CODING_PLANS[instance.config.planId as keyof typeof CODING_PLANS];
       if (!plan) return null;
-      return validateCodingPlanApiKey(plan, apiKey);
+      return validateCodingPlanApiKey(
+        plan,
+        apiKey,
+        (instance.config as { baseUrl?: string }).baseUrl,
+      );
     }
     return null;
   }

--- a/apps/browser/src/backend/services/telemetry.ts
+++ b/apps/browser/src/backend/services/telemetry.ts
@@ -48,6 +48,7 @@ const codingPlanIdSchema = z.enum([
   'glm-coding-plan',
   'kimi-plan',
   'qwen-plan',
+  'qwen-token-plan',
   'minimax-plan',
   'mimo-plan',
 ]);

--- a/apps/browser/src/backend/utils/validate-api-keys.test.ts
+++ b/apps/browser/src/backend/utils/validate-api-keys.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import type { CodingPlan } from '@shared/coding-plans';
+import { CODING_PLANS, type CodingPlan } from '@shared/coding-plans';
 import { generateText } from 'ai';
 import { validateCodingPlanApiKey } from './validate-api-keys';
 
@@ -59,6 +59,55 @@ describe('validateCodingPlanApiKey', () => {
       baseURL: 'https://validation.example/v1',
     });
     expect(openAiMock.chat).toHaveBeenCalledWith('glm-validation');
+  });
+
+  it.each([
+    ['qwen-plan', 'https://coding-intl.dashscope.aliyuncs.com/v1'],
+    [
+      'qwen-token-plan',
+      'https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1',
+    ],
+  ] as const)('validates %s against its dedicated endpoint', async (planId, baseURL) => {
+    const result = await validateCodingPlanApiKey(
+      CODING_PLANS[planId],
+      'test-key',
+    );
+
+    expect(result).toEqual({ success: true });
+    expect(createOpenAIMock).toHaveBeenCalledWith({
+      apiKey: 'test-key',
+      baseURL,
+    });
+    expect(openAiMock.chat).toHaveBeenCalledWith('qwen3.7-plus');
+  });
+
+  it('prefers a custom instance endpoint for validation', async () => {
+    const result = await validateCodingPlanApiKey(
+      CODING_PLANS['qwen-token-plan'],
+      'test-key',
+      ' https://token-plan.eu.example.com/compatible-mode/v1/ ',
+    );
+
+    expect(result).toEqual({ success: true });
+    expect(createOpenAIMock).toHaveBeenCalledWith({
+      apiKey: 'test-key',
+      baseURL: 'https://token-plan.eu.example.com/compatible-mode/v1',
+    });
+  });
+
+  it('rejects an invalid endpoint before making a request', async () => {
+    const result = await validateCodingPlanApiKey(
+      CODING_PLANS['qwen-token-plan'],
+      'test-key',
+      'http://token-plan.example.com/v1',
+    );
+
+    expect(result).toEqual({
+      success: false,
+      error: 'The API endpoint must use HTTPS.',
+    });
+    expect(createOpenAIMock).not.toHaveBeenCalled();
+    expect(generateText).not.toHaveBeenCalled();
   });
 
   it('falls back to provider validation when custom validation metadata is incomplete', async () => {

--- a/apps/browser/src/backend/utils/validate-api-keys.ts
+++ b/apps/browser/src/backend/utils/validate-api-keys.ts
@@ -1,7 +1,10 @@
 import { createAnthropic } from '@ai-sdk/anthropic';
 import { createGoogleGenerativeAI } from '@ai-sdk/google';
 import { createOpenAI } from '@ai-sdk/openai';
-import type { CodingPlan } from '@shared/coding-plans';
+import {
+  resolveCodingPlanValidationBaseUrl,
+  type CodingPlan,
+} from '@shared/coding-plans';
 import { generateText, type ModelMessage } from 'ai';
 
 export type ApiKeyProvider =
@@ -137,6 +140,7 @@ async function validateModel(model: ValidationModel): Promise<void> {
 export async function validateCodingPlanApiKey(
   plan: CodingPlan,
   apiKey: string,
+  instanceBaseUrl?: string,
 ): Promise<ApiKeyValidationResult> {
   // MiniMax Token Plan keys use a dedicated lightweight quota endpoint
   // with auto-region detection instead of a chat completion probe.
@@ -144,7 +148,18 @@ export async function validateCodingPlanApiKey(
     return validateMiniMaxTokenPlanKey(apiKey);
   }
 
-  const validationBaseURL = plan.validationBaseUrl ?? plan.baseUrl;
+  let validationBaseURL: string | undefined;
+  try {
+    validationBaseURL = resolveCodingPlanValidationBaseUrl(
+      plan,
+      instanceBaseUrl,
+    );
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
 
   if (validationBaseURL && plan.validationModelId) {
     try {

--- a/apps/browser/src/shared/coding-plan-ids.ts
+++ b/apps/browser/src/shared/coding-plan-ids.ts
@@ -2,6 +2,7 @@ export const codingPlanIds = [
   'glm-coding-plan',
   'kimi-plan',
   'qwen-plan',
+  'qwen-token-plan',
   'minimax-plan',
   'mimo-plan',
 ] as const;

--- a/apps/browser/src/shared/coding-plans.test.ts
+++ b/apps/browser/src/shared/coding-plans.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import {
+  CODING_PLANS,
+  resolveCodingPlanBaseUrl,
+  resolveCodingPlanValidationBaseUrl,
+  validateCodingPlanBaseUrl,
+} from './coding-plans';
+
+describe('coding plan endpoint helpers', () => {
+  const tokenPlan = CODING_PLANS['qwen-token-plan'];
+
+  it('resolves the plan defaults', () => {
+    expect(resolveCodingPlanBaseUrl(tokenPlan)).toBe(tokenPlan.baseUrl);
+    expect(resolveCodingPlanValidationBaseUrl(tokenPlan)).toBe(
+      tokenPlan.validationBaseUrl,
+    );
+  });
+
+  it('normalizes and prefers an explicit endpoint', () => {
+    const explicit = '  https://token-plan.example.com/compatible-mode/v1/// ';
+    expect(resolveCodingPlanBaseUrl(tokenPlan, explicit)).toBe(
+      'https://token-plan.example.com/compatible-mode/v1',
+    );
+    expect(resolveCodingPlanValidationBaseUrl(tokenPlan, explicit)).toBe(
+      'https://token-plan.example.com/compatible-mode/v1',
+    );
+  });
+
+  it.each([
+    ['http://example.com/v1', 'must use HTTPS'],
+    ['https://user:password@example.com/v1', 'must not contain credentials'],
+    ['https://example.com/v1?region=eu', 'must not contain a query string'],
+    ['https://example.com/v1#region', 'must not contain a query string'],
+    ['not-a-url', 'valid absolute URL'],
+  ])('rejects unsafe endpoint %s', (value, error) => {
+    expect(validateCodingPlanBaseUrl(value)).toEqual({
+      success: false,
+      error: expect.stringContaining(error),
+    });
+  });
+});

--- a/apps/browser/src/shared/coding-plans.ts
+++ b/apps/browser/src/shared/coding-plans.ts
@@ -32,13 +32,21 @@ export type CodingPlan = {
   baseUrl?: string;
   /** Dedicated validation base URL. Defaults to `baseUrl` when omitted. */
   validationBaseUrl?: string;
+  /** Opts this plan into a user-editable endpoint field in generic plan UI. */
+  configurableEndpoint?: {
+    label: string;
+    placeholder?: string;
+    helpText: string;
+  };
   /** Provider-native model ID to use for validation. */
   validationModelId?: string;
   /** Additional endpoint note rendered in plan UI. */
   endpointHelpText?: string;
   /** Optional disclaimer rendered below the help text (e.g. unofficial status). */
   disclaimer?: string;
-  /** Featured model IDs (must exist in availableModels) — for card copy. */
+  /** Models to expose only when the plan's model-discovery route fails. */
+  fallbackModelIds?: string[];
+  /** Featured provider-native model IDs for card copy. */
   featuredModelIds: string[];
 };
 
@@ -75,12 +83,70 @@ export const CODING_PLANS: Record<CodingPlanId, CodingPlan> = {
     id: 'qwen-plan',
     provider: 'alibaba',
     displayName: 'Qwen Coding Plan',
-    tagline: 'Qwen3-Coder via Alibaba DashScope',
-    subscribeUrl: 'https://www.alibabacloud.com/product/modelstudio',
-    apiKeyUrl: 'https://dashscope.console.aliyun.com/apiKey',
-    helpText: 'Create one at dashscope.console.aliyun.com → API-KEY',
-    apiKeyPattern: '^sk-[a-f0-9]{32}$',
-    featuredModelIds: ['qwen3-coder-30b-a3b-instruct', 'qwen3-32b'],
+    tagline: 'Qwen and partner coding models via Coding Plan',
+    subscribeUrl:
+      'https://www.alibabacloud.com/help/en/model-studio/coding-plan',
+    apiKeyUrl: 'https://modelstudio.console.alibabacloud.com/',
+    helpText:
+      'Copy the subscription key from Model Studio → Coding Plan. Plan keys commonly start with sk-sp-.',
+    apiKeyPattern: '^sk-(?:sp-)?[A-Za-z0-9_-]+$',
+    baseUrl: 'https://coding-intl.dashscope.aliyuncs.com/v1',
+    validationBaseUrl: 'https://coding-intl.dashscope.aliyuncs.com/v1',
+    validationModelId: 'qwen3.7-plus',
+    endpointHelpText:
+      'Routed through the international Coding Plan endpoint at coding-intl.dashscope.aliyuncs.com/v1.',
+    disclaimer:
+      'This subscription is limited to interactive coding-agent use and is not a general-purpose or batch API.',
+    fallbackModelIds: [
+      'qwen3.7-plus',
+      'kimi-k2.5',
+      'glm-5',
+      'MiniMax-M2.5',
+      'qwen3.6-plus',
+      'qwen3.5-plus',
+      'qwen3-max-2026-01-23',
+      'qwen3-coder-next',
+      'qwen3-coder-plus',
+      'glm-4.7',
+    ],
+    featuredModelIds: ['qwen3.7-plus', 'qwen3-coder-next'],
+  },
+  'qwen-token-plan': {
+    id: 'qwen-token-plan',
+    provider: 'alibaba',
+    displayName: 'Qwen Token Plan',
+    tagline: 'Qwen and partner models via Token Plan subscription',
+    subscribeUrl:
+      'https://www.alibabacloud.com/help/en/model-studio/token-plan',
+    apiKeyUrl: 'https://modelstudio.console.alibabacloud.com/',
+    helpText:
+      'Copy the subscription key from Model Studio → Token Plan. Plan keys commonly start with sk-sp-.',
+    apiKeyPattern: '^sk-(?:sp-)?[A-Za-z0-9_-]+$',
+    baseUrl:
+      'https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1',
+    validationBaseUrl:
+      'https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1',
+    validationModelId: 'qwen3.7-plus',
+    configurableEndpoint: {
+      label: 'Token Plan endpoint',
+      placeholder:
+        'https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1',
+      helpText:
+        'Use the OpenAI-compatible endpoint shown in your Model Studio dashboard. The default is the Singapore endpoint.',
+    },
+    endpointHelpText:
+      'Defaults to the Singapore Token Plan endpoint. Replace it with the endpoint from your Model Studio dashboard when it differs.',
+    disclaimer:
+      'This subscription is intended for interactive coding-agent traffic; image models use separate APIs and are not exposed here.',
+    fallbackModelIds: [
+      'qwen3.8-max-preview',
+      'qwen3.7-max',
+      'qwen3.7-plus',
+      'qwen3.6-flash',
+      'glm-5.2',
+      'deepseek-v4-pro',
+    ],
+    featuredModelIds: ['qwen3.8-max-preview', 'qwen3.7-plus'],
   },
   'minimax-plan': {
     id: 'minimax-plan',
@@ -114,6 +180,80 @@ export const CODING_PLANS: Record<CodingPlanId, CodingPlan> = {
     featuredModelIds: ['mimo-v2.5-pro', 'mimo-v2.5'],
   },
 };
+
+export type CodingPlanEndpointValidationResult =
+  | { success: true; baseUrl: string }
+  | { success: false; error: string };
+
+/** Validate and normalize a hosted coding-plan endpoint before it is persisted. */
+export function validateCodingPlanBaseUrl(
+  value: string,
+): CodingPlanEndpointValidationResult {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return { success: false, error: 'Enter an API endpoint.' };
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    return { success: false, error: 'Enter a valid absolute URL.' };
+  }
+
+  if (parsed.protocol !== 'https:') {
+    return { success: false, error: 'The API endpoint must use HTTPS.' };
+  }
+  if (parsed.username || parsed.password) {
+    return {
+      success: false,
+      error: 'The API endpoint must not contain credentials.',
+    };
+  }
+  if (parsed.search || parsed.hash) {
+    return {
+      success: false,
+      error: 'The API endpoint must not contain a query string or fragment.',
+    };
+  }
+
+  const pathname = parsed.pathname.replace(/\/+$/, '');
+  return {
+    success: true,
+    baseUrl: `${parsed.origin}${pathname === '/' ? '' : pathname}`,
+  };
+}
+
+function normalizeResolvedBaseUrl(
+  value: string | undefined,
+): string | undefined {
+  if (!value?.trim()) return undefined;
+  const result = validateCodingPlanBaseUrl(value);
+  if (!result.success) throw new Error(result.error);
+  return result.baseUrl;
+}
+
+/** Resolve the endpoint used for model discovery and runtime requests. */
+export function resolveCodingPlanBaseUrl(
+  plan: CodingPlan,
+  instanceBaseUrl?: string,
+): string | undefined {
+  return (
+    normalizeResolvedBaseUrl(instanceBaseUrl) ??
+    normalizeResolvedBaseUrl(plan.baseUrl)
+  );
+}
+
+/** Resolve validation, preferring the same explicit instance endpoint. */
+export function resolveCodingPlanValidationBaseUrl(
+  plan: CodingPlan,
+  instanceBaseUrl?: string,
+): string | undefined {
+  return (
+    normalizeResolvedBaseUrl(instanceBaseUrl) ??
+    normalizeResolvedBaseUrl(plan.validationBaseUrl ?? plan.baseUrl)
+  );
+}
 
 const codingPlanIdSet = new Set<string>(codingPlanIds);
 

--- a/apps/browser/src/shared/flagship-models.test.ts
+++ b/apps/browser/src/shared/flagship-models.test.ts
@@ -25,8 +25,8 @@ describe('isFlagshipFilteringEnabled', () => {
     expect(isFlagshipFilteringEnabled('openrouter')).toBe(true);
   });
 
-  it('returns true for coding-plan', () => {
-    expect(isFlagshipFilteringEnabled('coding-plan')).toBe(true);
+  it('returns false for coding-plan so discovered models remain enabled', () => {
+    expect(isFlagshipFilteringEnabled('coding-plan')).toBe(false);
   });
 
   it('returns true for vendor API types (except anthropic)', () => {
@@ -309,13 +309,10 @@ describe('computeDisabledModelIdsAfterDiscovery', () => {
   // -- Coding plan ---------------------------------------------------------
 
   describe('Coding plan', () => {
-    it('resolves vendor from config and applies vendor filtering', () => {
-      // GLM coding plan → vendor 'z-ai'. Catalog: glm-5.2, glm-5.1, glm-5v-turbo
+    it('keeps every newly discovered model enabled', () => {
       const discovered: DiscoveredModel[] = [
-        makeDiscoveredModel('glm-5.2'), // catalog
-        makeDiscoveredModel('glm-5.1'), // catalog
-        makeDiscoveredModel('glm-4.5'), // non-flagship discovered-only
-        makeDiscoveredModel('glm-4.5-air'), // non-flagship discovered-only
+        makeDiscoveredModel('glm-5.2'),
+        makeDiscoveredModel('glm-new-model'),
       ];
 
       const result = computeDisabledModelIdsAfterDiscovery({
@@ -326,10 +323,7 @@ describe('computeDisabledModelIdsAfterDiscovery', () => {
         existingDiscoveredModelIds: new Set(),
       });
 
-      expect(result).not.toContain('glm-5.2');
-      expect(result).not.toContain('glm-5.1');
-      expect(result).toContain('glm-4.5');
-      expect(result).toContain('glm-4.5-air');
+      expect(result).toEqual([]);
     });
   });
 

--- a/apps/browser/src/shared/flagship-models.ts
+++ b/apps/browser/src/shared/flagship-models.ts
@@ -3,11 +3,6 @@ import type {
   ModelProvider,
 } from './karton-contracts/ui/shared-types';
 import { availableModels } from './available-models';
-import {
-  CODING_PLANS,
-  type CodingPlanId,
-  isCodingPlanId,
-} from './coding-plans';
 
 // ============================================================================
 // Flagship model curation for API providers
@@ -121,7 +116,6 @@ const CATALOG_MODEL_IDS_BY_VENDOR: Partial<Record<ModelProvider, Set<string>>> =
  */
 export function isFlagshipFilteringEnabled(typeId: string): boolean {
   if (typeId === 'openrouter') return true;
-  if (typeId === 'coding-plan') return true;
   // Vendor API types end in '-api'
   if (typeId.endsWith('-api') && typeId !== 'anthropic-api') return true;
   return false;
@@ -135,7 +129,7 @@ export function isFlagshipFilteringEnabled(typeId: string): boolean {
  * existing user choices are preserved.
  *
  * @param params.typeId - The provider instance type ID.
- * @param params.config - The provider instance config (used for coding-plan vendor resolution).
+ * @param params.config - The provider instance config.
  * @param params.discoveredModels - The freshly discovered model list.
  * @param params.existingDisabledModelIds - The instance's current `disabledModelIds`.
  * @param params.existingDiscoveredModelIds - Set of model IDs from the *previous* discovery (for refresh).
@@ -150,7 +144,6 @@ export function computeDisabledModelIdsAfterDiscovery(params: {
 }): string[] {
   const {
     typeId,
-    config,
     discoveredModels,
     existingDisabledModelIds,
     existingDiscoveredModelIds,
@@ -161,7 +154,7 @@ export function computeDisabledModelIdsAfterDiscovery(params: {
   }
 
   // Resolve the flagship set and catalog IDs for this instance type.
-  const { flagshipIds, catalogIds } = resolveFlagshipSet(typeId, config);
+  const { flagshipIds, catalogIds } = resolveFlagshipSet(typeId);
 
   // Build the set of currently-discovered model IDs (lowercase).
   const currentDiscoveredIds = new Set(
@@ -220,10 +213,10 @@ export function computeDisabledModelIdsAfterDiscovery(params: {
  * Resolve the flagship model set and catalog model ID set for a given
  * provider instance type.
  */
-function resolveFlagshipSet(
-  typeId: string,
-  config: Record<string, unknown>,
-): { flagshipIds: Set<string>; catalogIds: Set<string> } {
+function resolveFlagshipSet(typeId: string): {
+  flagshipIds: Set<string>;
+  catalogIds: Set<string>;
+} {
   if (typeId === 'openrouter') {
     // OpenRouter: all models are discovered, no catalog overlap.
     return {
@@ -232,17 +225,9 @@ function resolveFlagshipSet(
     };
   }
 
-  // Resolve vendor: either from typeId (*-api) or from coding-plan config.
-  let vendor: ModelProvider | undefined;
-
-  if (typeId === 'coding-plan') {
-    const planId = config.planId as string;
-    if (isCodingPlanId(planId)) {
-      vendor = CODING_PLANS[planId as CodingPlanId]?.provider;
-    }
-  } else if (typeId.endsWith('-api')) {
-    vendor = typeId.slice(0, -4) as ModelProvider;
-  }
+  const vendor = typeId.endsWith('-api')
+    ? (typeId.slice(0, -4) as ModelProvider)
+    : undefined;
 
   if (!vendor) {
     return { flagshipIds: new Set(), catalogIds: new Set() };

--- a/apps/browser/src/shared/karton-contracts/ui/index.ts
+++ b/apps/browser/src/shared/karton-contracts/ui/index.ts
@@ -1607,6 +1607,7 @@ export type KartonContract = {
                   | 'glm-coding-plan'
                   | 'kimi-plan'
                   | 'qwen-plan'
+                  | 'qwen-token-plan'
                   | 'minimax-plan'
                   | 'mimo-plan';
               };

--- a/apps/browser/src/shared/provider-instance-helpers.test.ts
+++ b/apps/browser/src/shared/provider-instance-helpers.test.ts
@@ -242,6 +242,67 @@ describe('discovered model catalog matching', () => {
     expect(getInstanceModelCount(instance, prefs)).toBe(entries.length);
   });
 
+  it('keeps Qwen plan models instance-scoped and excludes stale catalog models', () => {
+    const codingPlan: ProviderInstance = {
+      id: 'qwen-coding',
+      typeId: 'coding-plan',
+      name: 'Qwen Coding Plan',
+      config: {
+        encryptedApiKey: 'coding-key',
+        planId: 'qwen-plan',
+      },
+      enabledModelIds: [],
+      disabledModelIds: [],
+      discoveredModels: [
+        { modelId: 'qwen3.7-plus', displayName: 'Qwen 3.7 Plus' },
+        { modelId: 'qwen3.7-plus', displayName: 'Duplicate' },
+      ],
+    };
+    const tokenPlan: ProviderInstance = {
+      ...codingPlan,
+      id: 'qwen-token',
+      name: 'Qwen Token Plan',
+      config: {
+        encryptedApiKey: 'token-key',
+        planId: 'qwen-token-plan',
+      },
+      discoveredModels: [
+        { modelId: 'qwen3.7-plus', displayName: 'Qwen 3.7 Plus' },
+        { modelId: 'qwen3.8-max-preview', displayName: 'Qwen 3.8 Max' },
+        { modelId: 'qwen-new-model', displayName: 'Qwen New Model' },
+      ],
+    };
+
+    const entries = getSelectableModelEntries({
+      providerInstances: [codingPlan, tokenPlan],
+      customModels: [],
+    });
+
+    expect(
+      entries.filter(
+        (entry) =>
+          entry.instanceId === 'qwen-coding' &&
+          entry.modelId === 'qwen3.7-plus',
+      ),
+    ).toHaveLength(1);
+    expect(entries).toContainEqual(
+      expect.objectContaining({
+        instanceId: 'qwen-token',
+        modelId: 'qwen3.8-max-preview',
+      }),
+    );
+    expect(entries).toContainEqual(
+      expect.objectContaining({
+        instanceId: 'qwen-token',
+        modelId: 'qwen-new-model',
+      }),
+    );
+    expect(entries.some((entry) => entry.modelId === 'qwen3-32b')).toBe(false);
+    expect(getInstanceModelCount(codingPlan)).toBe(
+      entries.filter((entry) => entry.instanceId === codingPlan.id).length,
+    );
+  });
+
   it('counts non-catalog discovered models for coding plans', () => {
     const codingPlanInstance: ProviderInstance = {
       id: 'coding-plan:glm-coding-plan',
@@ -301,6 +362,56 @@ describe('vendor instance routing', () => {
     expect(getVendorInstanceId(preferences, 'z-ai')).toBe(planInstance.id);
     expect(vendorHasApiKey(preferences, 'z-ai')).toBe(true);
     expect(getVendorMode(preferences, 'z-ai')).toBe('official');
+  });
+
+  it('uses the legacy selected plan when a vendor has multiple plans', () => {
+    const preferences = createPreferences();
+    const codingPlan: ProviderInstance = {
+      id: 'qwen-coding',
+      typeId: 'coding-plan',
+      name: 'Qwen Coding Plan',
+      config: { encryptedApiKey: 'coding-key', planId: 'qwen-plan' },
+      enabledModelIds: [],
+      disabledModelIds: [],
+      discoveredModels: [],
+    };
+    const tokenPlan: ProviderInstance = {
+      ...codingPlan,
+      id: 'qwen-token',
+      name: 'Qwen Token Plan',
+      config: { encryptedApiKey: 'token-key', planId: 'qwen-token-plan' },
+    };
+    preferences.providerConfigs.alibaba.connectedCodingPlanId =
+      'qwen-token-plan';
+    preferences.providerInstances = [codingPlan, tokenPlan];
+
+    expect(findInstanceForVendor(preferences, 'alibaba')).toBe(tokenPlan);
+  });
+
+  it('does not arbitrarily route a vendor with multiple unselected plans', () => {
+    const preferences = createPreferences();
+    preferences.providerInstances = [
+      {
+        id: 'qwen-coding',
+        typeId: 'coding-plan',
+        name: 'Qwen Coding Plan',
+        config: { encryptedApiKey: 'coding-key', planId: 'qwen-plan' },
+        enabledModelIds: [],
+        disabledModelIds: [],
+        discoveredModels: [],
+      },
+      {
+        id: 'qwen-token',
+        typeId: 'coding-plan',
+        name: 'Qwen Token Plan',
+        config: { encryptedApiKey: 'token-key', planId: 'qwen-token-plan' },
+        enabledModelIds: [],
+        disabledModelIds: [],
+        discoveredModels: [],
+      },
+    ];
+
+    expect(findInstanceForVendor(preferences, 'alibaba')).toBeUndefined();
   });
 
   it('uses the explicit custom-provider link for custom mode', () => {

--- a/apps/browser/src/shared/provider-instance-helpers.ts
+++ b/apps/browser/src/shared/provider-instance-helpers.ts
@@ -224,7 +224,11 @@ export function findInstanceForVendor(
     );
   }
 
-  return findVendorApiInstance(instances, vendor);
+  return findVendorApiInstance(
+    instances,
+    vendor,
+    legacyConfig?.connectedCodingPlanId,
+  );
 }
 
 /**
@@ -234,13 +238,24 @@ export function findInstanceForVendor(
 function findVendorApiInstance(
   instances: ProviderInstance[],
   vendor: ModelProvider,
+  connectedCodingPlanId?: CodingPlanId,
 ): ProviderInstance | undefined {
-  const codingPlanInstance = instances.find((instance) => {
+  const codingPlanInstances = instances.filter((instance) => {
     if (instance.typeId !== 'coding-plan') return false;
     const plan = CODING_PLANS[instance.config.planId as CodingPlanId];
     return plan?.provider === vendor;
   });
+  const codingPlanInstance = connectedCodingPlanId
+    ? codingPlanInstances.find(
+        (instance) =>
+          (instance.config as { planId: string }).planId ===
+          connectedCodingPlanId,
+      )
+    : codingPlanInstances.length === 1
+      ? codingPlanInstances[0]
+      : undefined;
   if (codingPlanInstance) return codingPlanInstance;
+  if (codingPlanInstances.length > 1) return undefined;
 
   return instances.find(
     (instance) =>
@@ -707,13 +722,21 @@ export function getSelectableModelEntries(
         catalogModelIds.add(getCatalogMatchId(instance, model.modelId));
       }
     } else if (instance.typeId === 'coding-plan') {
-      // Serve the plan vendor's catalog models
+      // Enrich only models returned by this plan's discovery route with
+      // catalog metadata. The vendor catalog is broader than the subscription.
       const planId = (instance.config as { planId: string })
         .planId as CodingPlanId;
       const plan = CODING_PLANS[planId];
       if (plan) {
+        const discoveredIds = new Set(
+          (instance.discoveredModels ?? []).map((model) =>
+            getCatalogMatchId(instance, model.modelId),
+          ),
+        );
         for (const model of availableModels) {
           if (model.officialProvider !== plan.provider) continue;
+          if (!discoveredIds.has(getCatalogMatchId(instance, model.modelId)))
+            continue;
           if (isDisabled(model.modelId)) continue;
           entries.push(
             makeBuiltInEntry(
@@ -785,15 +808,19 @@ export function getSelectableModelEntries(
       const enabled = new Set(instance.enabledModelIds ?? []);
       const hasEnabledList =
         instance.enabledModelIds && instance.enabledModelIds.length > 0;
+      const discoveredModelIds = new Set<string>();
       for (const dm of instance.discoveredModels) {
+        const matchId = getCatalogMatchId(instance, dm.modelId);
         if (
-          catalogModelIds.has(getCatalogMatchId(instance, dm.modelId)) ||
-          customModelIds.has(getCatalogMatchId(instance, dm.modelId))
+          catalogModelIds.has(matchId) ||
+          customModelIds.has(matchId) ||
+          discoveredModelIds.has(matchId)
         ) {
           continue;
         }
         if (isDisabled(dm.modelId)) continue;
         if (hasEnabledList && !enabled.has(dm.modelId)) continue;
+        discoveredModelIds.add(matchId);
         entries.push(makeDiscoveredEntry(instance, dm));
       }
     }
@@ -869,8 +896,16 @@ export function getInstanceModelCount(
       .planId as CodingPlanId;
     const plan = CODING_PLANS[planId];
     if (plan) {
+      const discoveredIds = new Set(
+        (instance.discoveredModels ?? []).map((model) =>
+          getCatalogMatchId(instance, model.modelId),
+        ),
+      );
       const vendorModels = availableModels.filter(
-        (m) => m.officialProvider === plan.provider && !disabled.has(m.modelId),
+        (m) =>
+          m.officialProvider === plan.provider &&
+          discoveredIds.has(getCatalogMatchId(instance, m.modelId)) &&
+          !disabled.has(m.modelId),
       );
       count += vendorModels.length;
       for (const m of vendorModels)
@@ -904,16 +939,19 @@ export function getInstanceModelCount(
     const enabled = new Set(instance.enabledModelIds ?? []);
     const hasEnabledList =
       instance.enabledModelIds && instance.enabledModelIds.length > 0;
+    const discoveredModelIds = new Set<string>();
     for (const dm of instance.discoveredModels) {
       const normalizedModelId = getCatalogMatchId(instance, dm.modelId);
       if (
         catalogModelIds.has(normalizedModelId) ||
-        customModelIds.has(normalizedModelId)
+        customModelIds.has(normalizedModelId) ||
+        discoveredModelIds.has(normalizedModelId)
       ) {
         continue;
       }
       if (disabled.has(dm.modelId)) continue;
       if (hasEnabledList && !enabled.has(dm.modelId)) continue;
+      discoveredModelIds.add(normalizedModelId);
       count++;
     }
   }

--- a/apps/browser/src/ui/screens/onboarding/steps/06-configure-providers.test.tsx
+++ b/apps/browser/src/ui/screens/onboarding/steps/06-configure-providers.test.tsx
@@ -234,6 +234,91 @@ describe('ConnectionDetailView telemetry', () => {
     );
   });
 
+  it('persists a normalized Token Plan endpoint without telemetry leakage', async () => {
+    mocks.addProviderInstance.mockResolvedValue({
+      success: true,
+      discoveredModels: [],
+    });
+    const entry: ProviderEntry = {
+      key: 'plan:qwen-token-plan',
+      kind: 'coding-plan',
+      typeId: 'alibaba-api',
+      displayName: 'Qwen Token Plan',
+      tagline: 'Token Plan',
+      planId: 'qwen-token-plan',
+      defaultBaseUrl:
+        'https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1',
+      configurableEndpoint: {
+        label: 'Token Plan endpoint',
+        helpText: 'Use the dashboard endpoint.',
+      },
+    };
+    render(
+      <ConnectionDetailView
+        entry={entry}
+        onBack={vi.fn()}
+        onboardingRunId="run-1"
+        getNextAttemptNumber={() => 1}
+        onConnectionResult={vi.fn()}
+      />,
+    );
+
+    fireEvent.change(screen.getByDisplayValue(entry.defaultBaseUrl!), {
+      target: { value: ' https://token-plan.eu.example.com/v1/ ' },
+    });
+    await connectWithSecret();
+
+    expect(mocks.addProviderInstance).toHaveBeenCalledWith({
+      typeId: 'coding-plan',
+      config: {
+        planId: 'qwen-token-plan',
+        baseUrl: 'https://token-plan.eu.example.com/v1',
+      },
+      validateApiKey: 'sk-sensitive',
+    });
+    const telemetry = JSON.stringify(mocks.track.mock.calls);
+    expect(telemetry).not.toContain('token-plan.eu.example.com');
+    expect(telemetry).not.toContain('sk-sensitive');
+  });
+
+  it('rejects an invalid Token Plan endpoint before calling the backend', async () => {
+    const entry: ProviderEntry = {
+      key: 'plan:qwen-token-plan',
+      kind: 'coding-plan',
+      typeId: 'alibaba-api',
+      displayName: 'Qwen Token Plan',
+      tagline: 'Token Plan',
+      planId: 'qwen-token-plan',
+      defaultBaseUrl: 'https://token-plan.example.com/v1',
+      configurableEndpoint: {
+        label: 'Token Plan endpoint',
+        helpText: 'Use the dashboard endpoint.',
+      },
+    };
+    render(
+      <ConnectionDetailView
+        entry={entry}
+        onBack={vi.fn()}
+        onboardingRunId="run-1"
+        getNextAttemptNumber={() => 1}
+        onConnectionResult={vi.fn()}
+      />,
+    );
+    fireEvent.change(screen.getByDisplayValue(entry.defaultBaseUrl!), {
+      target: { value: 'http://token-plan.example.com/v1' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('Enter API key...'), {
+      target: { value: 'sk-sensitive' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Connect' }));
+
+    expect(
+      await screen.findByText('The API endpoint must use HTTPS.'),
+    ).toBeTruthy();
+    expect(mocks.addProviderInstance).not.toHaveBeenCalled();
+    expect(mocks.track).not.toHaveBeenCalled();
+  });
+
   it('tracks structured validation failures and increments retries', async () => {
     mocks.addProviderInstance
       .mockResolvedValueOnce({ success: false, error: 'raw backend secret' })

--- a/apps/browser/src/ui/screens/onboarding/steps/06-configure-providers.tsx
+++ b/apps/browser/src/ui/screens/onboarding/steps/06-configure-providers.tsx
@@ -26,7 +26,12 @@ import type {
   ProviderInstanceTypeId,
 } from '@shared/karton-contracts/ui/shared-types';
 import { getTypeDisplayInfo } from '@shared/provider-instance-helpers';
-import { CODING_PLANS, type CodingPlanId } from '@shared/coding-plans';
+import {
+  CODING_PLANS,
+  validateCodingPlanBaseUrl,
+  type CodingPlan,
+  type CodingPlanId,
+} from '@shared/coding-plans';
 import { ProviderLogo } from '@ui/components/provider-logos';
 import { OllamaLogo } from '@ui/components/provider-logos/ollama';
 import { OpenRouterLogo } from '@ui/components/provider-logos/openrouter';
@@ -51,6 +56,7 @@ export type ProviderEntry = {
   /** Extra endpoint routing info shown below the help text. */
   endpointHelpText?: string;
   defaultBaseUrl?: string;
+  configurableEndpoint?: CodingPlan['configurableEndpoint'];
 };
 
 /** All vendor API types shown in the unified provider list. */
@@ -112,6 +118,8 @@ function buildUnifiedEntries(): ProviderEntry[] {
       planId: plan.id,
       disclaimer: plan.disclaimer,
       endpointHelpText: plan.endpointHelpText,
+      defaultBaseUrl: plan.baseUrl,
+      configurableEndpoint: plan.configurableEndpoint,
     });
   }
 
@@ -402,11 +410,21 @@ export function ConnectionDetailView({
   const [apiKey, setApiKey] = useState(
     entry.kind === 'self-hosted' ? (entry.defaultBaseUrl ?? '') : '',
   );
+  const [endpoint, setEndpoint] = useState(
+    entry.configurableEndpoint ? (entry.defaultBaseUrl ?? '') : '',
+  );
   const [isConnecting, setIsConnecting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const handleConnect = useCallback(async () => {
     if (!apiKey.trim()) return;
+    const endpointResult = entry.configurableEndpoint
+      ? validateCodingPlanBaseUrl(endpoint)
+      : undefined;
+    if (endpointResult && !endpointResult.success) {
+      setError(endpointResult.error);
+      return;
+    }
     setIsConnecting(true);
     setError(null);
     const attemptNumber = getNextAttemptNumber(entry);
@@ -462,7 +480,12 @@ export function ConnectionDetailView({
         const plan = CODING_PLANS[entry.planId];
         const result = await addProviderInstance({
           typeId: 'coding-plan',
-          config: { planId: plan.id, baseUrl: plan.baseUrl },
+          config: {
+            planId: plan.id,
+            baseUrl: endpointResult?.success
+              ? endpointResult.baseUrl
+              : plan.baseUrl,
+          },
           validateApiKey: apiKey.trim(),
         });
         if (!result.success) {
@@ -505,6 +528,7 @@ export function ConnectionDetailView({
     }
   }, [
     apiKey,
+    endpoint,
     entry,
     addProviderInstance,
     getNextAttemptNumber,
@@ -533,6 +557,30 @@ export function ConnectionDetailView({
             )}
           </div>
         </div>
+
+        {entry.configurableEndpoint && (
+          <div className="space-y-1">
+            <p className="font-medium text-muted-foreground text-xs">
+              {entry.configurableEndpoint.label}
+            </p>
+            <Input
+              type="url"
+              placeholder={entry.configurableEndpoint.placeholder}
+              value={endpoint}
+              onValueChange={(value) => {
+                setEndpoint(value);
+                setError(null);
+              }}
+              disabled={isConnecting}
+              aria-invalid={error ? true : undefined}
+              size="sm"
+              style={{ maxWidth: 'none' }}
+            />
+            <p className="text-subtle-foreground text-xs">
+              {entry.configurableEndpoint.helpText}
+            </p>
+          </div>
+        )}
 
         <Input
           autoFocus
@@ -605,7 +653,11 @@ export function ConnectionDetailView({
         <Button
           variant="primary"
           size="sm"
-          disabled={!apiKey.trim() || isConnecting}
+          disabled={
+            !apiKey.trim() ||
+            isConnecting ||
+            (!!entry.configurableEndpoint && !endpoint.trim())
+          }
           onClick={() => void handleConnect()}
         >
           {isConnecting ? 'Connecting...' : 'Connect'}

--- a/apps/browser/src/ui/screens/settings/sections/models-providers-section.test.tsx
+++ b/apps/browser/src/ui/screens/settings/sections/models-providers-section.test.tsx
@@ -1,0 +1,108 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ProviderInstance } from '@shared/karton-contracts/ui/shared-types';
+
+const mocks = vi.hoisted(() => ({
+  updateProviderInstance: vi.fn(),
+  refreshInstanceModels: vi.fn(),
+}));
+
+vi.mock('@ui/hooks/use-karton', () => ({
+  useKartonState: vi.fn(() => ({ providerInstances: [] })),
+  useKartonProcedure: vi.fn((selector) =>
+    selector({
+      preferences: {
+        updateProviderInstance: mocks.updateProviderInstance,
+        refreshInstanceModels: mocks.refreshInstanceModels,
+      },
+    }),
+  ),
+}));
+vi.mock('@ui/hooks/use-track', () => ({ useTrack: () => vi.fn() }));
+vi.mock('@ui/hooks/use-is-truncated', () => ({
+  useIsTruncated: () => ({ ref: { current: null }, isTruncated: false }),
+}));
+
+import { CodingPlanEndpointConnection } from './models-providers-section';
+
+const instance = {
+  id: 'qwen-token',
+  typeId: 'coding-plan',
+  name: 'Qwen Token Plan',
+  config: {
+    planId: 'qwen-token-plan',
+    encryptedApiKey: 'encrypted-key',
+    baseUrl:
+      'https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1',
+  },
+  enabledModelIds: [],
+  disabledModelIds: [],
+  discoveredModels: [],
+} satisfies ProviderInstance;
+
+describe('CodingPlanEndpointConnection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.updateProviderInstance.mockResolvedValue(undefined);
+    mocks.refreshInstanceModels.mockResolvedValue([]);
+  });
+
+  it('normalizes and saves an endpoint without replacing credentials', async () => {
+    render(<CodingPlanEndpointConnection instance={instance} />);
+    fireEvent.change(screen.getByDisplayValue(instance.config.baseUrl), {
+      target: { value: ' https://token-plan.eu.example.com/v1/ ' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() =>
+      expect(mocks.refreshInstanceModels).toHaveBeenCalledWith(instance.id),
+    );
+    expect(mocks.updateProviderInstance).toHaveBeenCalledWith(instance.id, {
+      baseUrl: 'https://token-plan.eu.example.com/v1',
+    });
+    expect(mocks.updateProviderInstance).not.toHaveBeenCalledWith(
+      instance.id,
+      expect.objectContaining({ encryptedApiKey: expect.anything() }),
+    );
+  });
+
+  it('shows both errors when discovery and rollback fail', async () => {
+    mocks.refreshInstanceModels.mockRejectedValueOnce(new Error('Unavailable'));
+    mocks.updateProviderInstance
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error('Rollback unavailable'));
+    render(<CodingPlanEndpointConnection instance={instance} />);
+    fireEvent.change(screen.getByDisplayValue(instance.config.baseUrl), {
+      target: { value: 'https://broken.example.com/v1' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    expect(
+      await screen.findByText(
+        'Unavailable Failed to restore the previous endpoint: Rollback unavailable',
+      ),
+    ).toBeTruthy();
+    expect(screen.getByDisplayValue(instance.config.baseUrl)).toBeTruthy();
+  });
+
+  it('restores the previous endpoint when discovery fails', async () => {
+    mocks.refreshInstanceModels.mockRejectedValueOnce(new Error('Unavailable'));
+    render(<CodingPlanEndpointConnection instance={instance} />);
+    fireEvent.change(screen.getByDisplayValue(instance.config.baseUrl), {
+      target: { value: 'https://broken.example.com/v1' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() =>
+      expect(mocks.updateProviderInstance).toHaveBeenCalledTimes(2),
+    );
+    expect(screen.getByText('Unavailable')).toBeTruthy();
+    expect(mocks.updateProviderInstance).toHaveBeenNthCalledWith(
+      2,
+      instance.id,
+      {
+        baseUrl: instance.config.baseUrl,
+      },
+    );
+  });
+});

--- a/apps/browser/src/ui/screens/settings/sections/models-providers-section.tsx
+++ b/apps/browser/src/ui/screens/settings/sections/models-providers-section.tsx
@@ -38,7 +38,11 @@ import {
   type ThinkingPanelModel,
 } from '@ui/utils/model-thinking';
 import { ModelThinkingPanel } from '@ui/components/model-thinking-panel';
-import { CODING_PLANS, type CodingPlanId } from '@shared/coding-plans';
+import {
+  CODING_PLANS,
+  validateCodingPlanBaseUrl,
+  type CodingPlanId,
+} from '@shared/coding-plans';
 import { ProviderLogo } from '@ui/components/provider-logos';
 import { OllamaLogo } from '@ui/components/provider-logos/ollama';
 import { OpenRouterLogo } from '@ui/components/provider-logos/openrouter';
@@ -540,6 +544,7 @@ function AddProviderGrid({
   const openExternalUrl = useKartonProcedure((p) => p.openExternalUrl);
   const [selected, setSelected] = useState<SelectionKey | null>(null);
   const [apiKey, setApiKey] = useState('');
+  const [endpoint, setEndpoint] = useState('');
   const [isConnecting, setIsConnecting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState('');
@@ -585,11 +590,23 @@ function AddProviderGrid({
         const isSelfHosted = ADDABLE_SELF_HOSTED_TYPES.includes(
           key as ProviderInstanceTypeId,
         );
+        const endpointResult = plan?.configurableEndpoint
+          ? validateCodingPlanBaseUrl(endpoint)
+          : undefined;
+        if (endpointResult && !endpointResult.success) {
+          setError(endpointResult.error);
+          return;
+        }
 
         const result = await addProviderInstance({
           typeId: plan ? 'coding-plan' : key,
           config: plan
-            ? { planId: plan.id, baseUrl: plan.baseUrl }
+            ? {
+                planId: plan.id,
+                baseUrl: endpointResult?.success
+                  ? endpointResult.baseUrl
+                  : plan.baseUrl,
+              }
             : isSelfHosted
               ? { baseUrl: value.trim() }
               : {},
@@ -606,7 +623,7 @@ function AddProviderGrid({
         setIsConnecting(false);
       }
     },
-    [addProviderInstance, onConnected],
+    [addProviderInstance, endpoint, onConnected],
   );
 
   // Resolve display info for the current selection
@@ -645,6 +662,7 @@ function AddProviderGrid({
   const handleBack = useCallback(() => {
     setSelected(null);
     setApiKey('');
+    setEndpoint('');
     setSearchQuery('');
     setError(null);
   }, []);
@@ -770,6 +788,33 @@ function AddProviderGrid({
                 </div>
               </div>
 
+              {selectedPlan?.configurableEndpoint && (
+                <div className="space-y-1">
+                  <p className="font-medium text-muted-foreground text-xs">
+                    {selectedPlan.configurableEndpoint.label}
+                  </p>
+                  <Input
+                    type="url"
+                    placeholder={
+                      selectedPlan.configurableEndpoint.placeholder ??
+                      'https://example.com/v1'
+                    }
+                    value={endpoint}
+                    onValueChange={(value) => {
+                      setEndpoint(value);
+                      setError(null);
+                    }}
+                    disabled={isConnecting}
+                    aria-invalid={error ? true : undefined}
+                    size="sm"
+                    style={{ maxWidth: 'none' }}
+                  />
+                  <p className="text-subtle-foreground text-xs">
+                    {selectedPlan.configurableEndpoint.helpText}
+                  </p>
+                </div>
+              )}
+
               <Input
                 autoFocus
                 type={isSelfHosted ? 'text' : 'password'}
@@ -843,7 +888,11 @@ function AddProviderGrid({
               <Button
                 variant="primary"
                 size="sm"
-                disabled={!apiKey.trim() || isConnecting}
+                disabled={
+                  !apiKey.trim() ||
+                  isConnecting ||
+                  (!!selectedPlan?.configurableEndpoint && !endpoint.trim())
+                }
                 onClick={() => void handleConnect(selected, apiKey)}
               >
                 {isConnecting
@@ -893,6 +942,7 @@ function AddProviderGrid({
                             onClick={() => {
                               setSelected(planKey);
                               setApiKey('');
+                              setEndpoint(plan.baseUrl ?? '');
                               setError(null);
                             }}
                             className={cn(
@@ -3153,6 +3203,117 @@ function ProviderNameEditor({
 }
 
 // =============================================================================
+// Configurable Coding Plan Endpoint (detail page)
+// =============================================================================
+
+export function CodingPlanEndpointConnection({
+  instance,
+}: {
+  instance: ProviderInstance;
+}) {
+  const updateProviderInstance = useKartonProcedure(
+    (p) => p.preferences.updateProviderInstance,
+  );
+  const refreshInstanceModels = useKartonProcedure(
+    (p) => p.preferences.refreshInstanceModels,
+  );
+  const planId = (instance.config as { planId?: CodingPlanId }).planId;
+  const plan = planId ? CODING_PLANS[planId] : undefined;
+  const metadata = plan?.configurableEndpoint;
+  const savedBaseUrl =
+    (instance.config as { baseUrl?: string }).baseUrl ?? plan?.baseUrl ?? '';
+  const [baseUrl, setBaseUrl] = useState(savedBaseUrl);
+  const [isSaving, setIsSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => setBaseUrl(savedBaseUrl), [savedBaseUrl]);
+
+  if (!metadata) return null;
+
+  const handleSave = async () => {
+    const validation = validateCodingPlanBaseUrl(baseUrl);
+    if (!validation.success) {
+      setError(validation.error);
+      return;
+    }
+    if (validation.baseUrl === savedBaseUrl) return;
+
+    setIsSaving(true);
+    setError(null);
+    try {
+      await updateProviderInstance(instance.id, {
+        baseUrl: validation.baseUrl,
+      });
+      await refreshInstanceModels(instance.id);
+      setBaseUrl(validation.baseUrl);
+    } catch (cause) {
+      const failureMessage =
+        cause instanceof Error
+          ? cause.message
+          : 'Failed to refresh models from this endpoint.';
+      let rollbackMessage: string | undefined;
+      try {
+        await updateProviderInstance(instance.id, { baseUrl: savedBaseUrl });
+      } catch (rollbackCause) {
+        rollbackMessage =
+          rollbackCause instanceof Error
+            ? rollbackCause.message
+            : 'unknown rollback error';
+      }
+      setBaseUrl(savedBaseUrl);
+      setError(
+        rollbackMessage
+          ? `${failureMessage} Failed to restore the previous endpoint: ${rollbackMessage}`
+          : failureMessage,
+      );
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const isDirty = baseUrl.trim() !== savedBaseUrl;
+  return (
+    <div className="space-y-2 rounded-lg border border-derived p-3">
+      <p className="font-medium text-muted-foreground text-xs">
+        {metadata.label}
+      </p>
+      <div className="flex gap-2">
+        <Input
+          type="url"
+          value={baseUrl}
+          placeholder={metadata.placeholder}
+          onValueChange={(value) => {
+            setBaseUrl(value);
+            setError(null);
+          }}
+          onKeyDown={(event) => {
+            if (event.key === 'Enter' && isDirty && !isSaving) {
+              void handleSave();
+            }
+          }}
+          disabled={isSaving}
+          size="sm"
+          style={{ maxWidth: 'none' }}
+          className="flex-1"
+        />
+        {isDirty && (
+          <Button
+            variant="primary"
+            size="sm"
+            disabled={!baseUrl.trim() || isSaving}
+            onClick={() => void handleSave()}
+          >
+            {isSaving ? 'Saving...' : 'Save'}
+          </Button>
+        )}
+      </div>
+      <p className="text-subtle-foreground text-xs">{metadata.helpText}</p>
+      {error && <TruncatedErrorText text={error} />}
+    </div>
+  );
+}
+
+// =============================================================================
 // Self-Hosted Connection (detail page)
 // =============================================================================
 
@@ -3409,6 +3570,10 @@ export function ModelsProvidersSection() {
                 <div className="rounded-lg border border-derived p-3">
                   <VendorApiKeyInput instance={detailInstance} />
                 </div>
+              )}
+
+              {detailInstance.typeId === 'coding-plan' && (
+                <CodingPlanEndpointConnection instance={detailInstance} />
               )}
 
               {credentialType === 'base-url' && (


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes LLM routing, credential validation, and model discovery for coding-plan providers; mis-routing or migration edge cases could break Qwen subscriptions until users pick the right instance or endpoint.
> 
> **Overview**
> Splits Alibaba Qwen into **Qwen Coding Plan** (`qwen-plan`) and **Qwen Token Plan** (`qwen-token-plan`), each with its own default base URL, validation probe, and optional `fallbackModelIds` when `/models` is unavailable on first connect.
> 
> Adds shared **`resolveCodingPlanBaseUrl`** / **`validateCodingPlanBaseUrl`** so instance endpoints are trimmed, HTTPS-only, and used consistently for validation, discovery, refresh, and chat routing. Token Plan can expose a **configurable endpoint** in onboarding and settings; invalid URLs fail before network calls, and settings refresh rolls back the URL if model discovery fails.
> 
> **Instance-scoped behavior:** coexisting Qwen plans route to different URLs when selected explicitly; legacy vendor routing errors when multiple Alibaba plans exist without a choice, or picks `connectedCodingPlanId` when set. Coding-plan model lists no longer pull the full vendor catalog—only models that instance discovery returned (with deduping). Flagship auto-disable is turned off for `coding-plan` so discovered subscription models stay enabled. A preference migration moves stale `qwen-plan` instances off the old DashScope URL and reseeds documented models.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c34700a982dd7a5cf38a560566118f395ec41fa6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split Alibaba Qwen into two subscription plans with dedicated endpoints—`qwen-plan` (Coding Plan) and `qwen-token-plan` (Token Plan)—and make endpoint handling instance‑safe across validation, discovery, and runtime. Adds a user‑editable Token Plan endpoint with strict normalization and safer model discovery and routing.

- **New Features**
  - Added `qwen-plan` and `qwen-token-plan` with dedicated base/validation URLs and `qwen3.7-plus` validation; centralized `resolveCodingPlanBaseUrl`/`resolveCodingPlanValidationBaseUrl`.
  - Token Plan endpoint is editable in onboarding and settings; input is normalized (HTTPS‑only, no credentials/query), used for validation/discovery/runtime, and never sent in telemetry; saves refresh models and roll back on failure.
  - Discovery uses the resolved plan/instance endpoint; Coding Plan seeds `fallbackModelIds` when `/models` is unavailable; Token Plan keeps all models returned.
  - Model list and counts include only models the instance actually discovered; vendor catalog entries are enriched only when discovered by that instance.

- **Bug Fixes**
  - Strict instance scoping when `qwen-plan` and `qwen-token-plan` coexist; legacy “selected plan” is honored, and ambiguous vendor routing now errors unless an instance is specified.
  - Prefer and normalize explicit instance `baseUrl`; reject invalid endpoints at add/update and at runtime; validation prefers the explicit instance endpoint.
  - Migrated legacy Qwen Coding Plan instances to the dedicated endpoint and seeded updated models; removes stale DashScope‑only models.
  - Disabled flagship curation for `coding-plan` so newly discovered subscription models remain enabled; de‑duplicated discovered entries.

<sup>Written for commit c34700a982dd7a5cf38a560566118f395ec41fa6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1482?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Qwen Token Plan support with a user-configurable coding-plan endpoint.
  * Enabled plan-aware endpoint validation and discovery for coding-plan providers in onboarding and provider settings.
  * Updated onboarding/auth and telemetry flows to recognize the new Token Plan identifier.
* **Bug Fixes**
  * Fixed instance-scoped model discovery/routing when multiple coding-plan providers share models; require explicit instance selection in ambiguous cases.
  * Normalized coding-plan endpoints (trim whitespace/clean slashes) and reject non-HTTPS endpoints.
  * Improved fallback behavior on discovery/refresh failures, including correct rollback and combined error messaging.
  * Corrected coding-plan model enablement (removed incorrect flagship/catalog disabling).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->