### PR TITLE
feat(stagewise): enrich custom model telemetry

### DIFF
--- a/apps/browser/src/backend/services/telemetry.test.ts
+++ b/apps/browser/src/backend/services/telemetry.test.ts
@@ -118,6 +118,33 @@ describe('main UI telemetry schemas', () => {
     ).toBeNull();
   });
 
+  it('validates custom-model telemetry payloads', () => {
+    expect(
+      parseUIEventProperties('custom-model-add-started', {
+        initial_provider_type: 'custom-openai-chat',
+      }),
+    ).toEqual({ initial_provider_type: 'custom-openai-chat' });
+    expect(
+      parseUIEventProperties('custom-model-add-finished', {
+        provider_type: 'custom-openai-chat',
+      }),
+    ).toEqual({ provider_type: 'custom-openai-chat' });
+    expect(
+      parseUIEventProperties('custom-model-add-finished', {
+        model_id: 'private-model',
+        provider_type: 'custom-openai-chat',
+      }),
+    ).toEqual({
+      model_id: 'private-model',
+      provider_type: 'custom-openai-chat',
+    });
+    expect(
+      parseUIEventProperties('custom-model-add-started', {
+        provider_type: 'custom-openai-chat',
+      }),
+    ).toBeNull();
+  });
+
   it('accepts omitted and diagnostic custom-provider abort payloads', () => {
     expect(
       parseUIEventProperties('custom-provider-add-aborted', undefined),

--- a/apps/browser/src/backend/services/telemetry.ts
+++ b/apps/browser/src/backend/services/telemetry.ts
@@ -444,11 +444,17 @@ export type BackendEventProperties = {
   };
   'element-selection-started': undefined;
   'element-selection-stopped': { element_selected: boolean };
-  'custom-model-add-started': undefined;
-  'custom-model-add-finished': undefined;
+  'custom-model-add-started': {
+    initial_provider_type: string;
+  };
+  'custom-model-add-finished': {
+    model_id?: string;
+    provider_type: string;
+  };
   'custom-model-add-aborted': {
     had_validation_errors: boolean;
     any_field_touched: boolean;
+    provider_type: string;
   };
   'custom-provider-add-started': undefined;
   'custom-provider-add-finished': {
@@ -622,9 +628,15 @@ const UI_TELEMETRY_EVENT_SCHEMAS = {
   'custom-model-add-aborted': z.object({
     had_validation_errors: z.boolean(),
     any_field_touched: z.boolean(),
+    provider_type: z.enum([...providerInstanceTypeIds, 'unknown']),
   }),
-  'custom-model-add-finished': z.undefined().optional(),
-  'custom-model-add-started': z.undefined().optional(),
+  'custom-model-add-finished': z.object({
+    model_id: z.string().optional(),
+    provider_type: z.enum([...providerInstanceTypeIds, 'unknown']),
+  }),
+  'custom-model-add-started': z.object({
+    initial_provider_type: z.enum([...providerInstanceTypeIds, 'unknown']),
+  }),
   'custom-provider-add-aborted': z
     .object({
       had_validation_errors: z.boolean(),
@@ -1049,8 +1061,19 @@ export class TelemetryService extends DisposableService {
 
       const distinctId = this.getDistinctId();
 
+      const privacySafeProperties =
+        eventName === 'custom-model-add-finished' &&
+        telemetryLevel !== 'full' &&
+        typeof properties === 'object' &&
+        properties !== null
+          ? (({ model_id: _, ...safeProperties }) => safeProperties)(
+              properties as Record<string, unknown>,
+            )
+          : properties;
       const finalProperties = {
-        ...(typeof properties === 'object' ? properties : {}),
+        ...(typeof privacySafeProperties === 'object'
+          ? privacySafeProperties
+          : {}),
         product: 'stagewise-browser',
         telemetry_level: telemetryLevel,
         app_version: __APP_VERSION__,

--- a/apps/browser/src/shared/karton-contracts/ui/telemetry.ts
+++ b/apps/browser/src/shared/karton-contracts/ui/telemetry.ts
@@ -50,9 +50,15 @@ export type UIEventProperties = {
   'custom-model-add-aborted': {
     had_validation_errors: boolean;
     any_field_touched: boolean;
+    provider_type: ProviderInstanceTypeId | 'unknown';
   };
-  'custom-model-add-finished': undefined;
-  'custom-model-add-started': undefined;
+  'custom-model-add-finished': {
+    model_id?: string;
+    provider_type: ProviderInstanceTypeId | 'unknown';
+  };
+  'custom-model-add-started': {
+    initial_provider_type: ProviderInstanceTypeId | 'unknown';
+  };
   'custom-provider-add-aborted':
     | {
         had_validation_errors: boolean;

--- a/apps/browser/src/ui/screens/settings/sections/models-providers-section.tsx
+++ b/apps/browser/src/ui/screens/settings/sections/models-providers-section.tsx
@@ -1222,6 +1222,7 @@ function CustomModelDialog({
   onSave,
   existingModelIds,
   providerInstances,
+  defaultProviderInstanceId,
 }: {
   model?: CustomModel;
   open: boolean;
@@ -1231,13 +1232,22 @@ function CustomModelDialog({
       providerOptions: Record<string, unknown>;
       headers: Record<string, string>;
     },
-  ) => void;
+  ) => Promise<void>;
   existingModelIds: Set<string>;
   providerInstances: ProviderInstance[];
+  defaultProviderInstanceId?: string;
 }) {
   const track = useTrack();
+  const telemetryLevel = useKartonState(
+    (state) => state.preferences.privacy.telemetryLevel,
+  );
   const isAddMode = !model;
   const savedRef = useRef(false);
+  const initialProviderInstanceId =
+    model?.providerInstanceId ??
+    model?.endpointId ??
+    defaultProviderInstanceId ??
+    '';
 
   const [modelId, setModelId] = useState(model?.modelId ?? '');
   const [displayName, setDisplayName] = useState(model?.displayName ?? '');
@@ -1246,7 +1256,7 @@ function CustomModelDialog({
     model?.contextWindowSize ?? 128000,
   );
   const [providerInstanceId, setProviderInstanceId] = useState(
-    model?.providerInstanceId ?? model?.endpointId ?? '',
+    initialProviderInstanceId,
   );
   const [thinkingEnabled, setThinkingEnabled] = useState(
     model?.thinkingEnabled ?? false,
@@ -1283,6 +1293,8 @@ function CustomModelDialog({
   );
   const [showAdvanced, setShowAdvanced] = useState(false);
   const [jsonError, setJsonError] = useState<string | null>(null);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
 
   useEffect(() => {
     if (!open) return;
@@ -1290,7 +1302,7 @@ function CustomModelDialog({
     setDisplayName(model?.displayName ?? '');
     setDescription(model?.description ?? '');
     setContextWindowSize(model?.contextWindowSize ?? 128000);
-    setProviderInstanceId(model?.providerInstanceId ?? model?.endpointId ?? '');
+    setProviderInstanceId(initialProviderInstanceId);
     setThinkingEnabled(model?.thinkingEnabled ?? false);
     setCapabilities(model?.capabilities ?? defaultCaps);
     setProviderOptionsJson(
@@ -1305,9 +1317,17 @@ function CustomModelDialog({
     );
     setShowAdvanced(false);
     setJsonError(null);
+    setSaveError(null);
+    setIsSaving(false);
     savedRef.current = false;
     if (isAddMode) {
-      track('custom-model-add-started');
+      const providerType =
+        providerInstances.find(
+          (instance) => instance.id === defaultProviderInstanceId,
+        )?.typeId ?? 'unknown';
+      track('custom-model-add-started', {
+        initial_provider_type: providerType,
+      });
     }
   }, [open]);
 
@@ -1328,8 +1348,7 @@ function CustomModelDialog({
     displayName !== (model?.displayName ?? '') ||
     description !== (model?.description ?? '') ||
     contextWindowSize !== (model?.contextWindowSize ?? 128000) ||
-    providerInstanceId !==
-      (model?.providerInstanceId ?? model?.endpointId ?? '') ||
+    providerInstanceId !== initialProviderInstanceId ||
     thinkingEnabled !== (model?.thinkingEnabled ?? false) ||
     providerOptionsJson !==
       (model?.providerOptions && Object.keys(model.providerOptions).length > 0
@@ -1343,12 +1362,17 @@ function CustomModelDialog({
       JSON.stringify(model?.capabilities ?? defaultCaps);
 
   const hadValidationErrors = isDuplicate || jsonError !== null;
+  const selectedProviderType =
+    providerInstances.find((instance) => instance.id === providerInstanceId)
+      ?.typeId ?? 'unknown';
 
   const handleDialogOpenChange = (next: boolean) => {
+    if (!next && isSaving) return;
     if (!next && open && isAddMode && !savedRef.current) {
       track('custom-model-add-aborted', {
         had_validation_errors: hadValidationErrors,
         any_field_touched: anyFieldTouched,
+        provider_type: selectedProviderType,
       });
     }
     onOpenChange(next);
@@ -1368,7 +1392,8 @@ function CustomModelDialog({
       }));
   }, [providerInstances]);
 
-  const handleSave = () => {
+  const handleSave = async () => {
+    setSaveError(null);
     let providerOptions: Record<string, unknown> = {};
     let headers: Record<string, string> = {};
 
@@ -1389,22 +1414,34 @@ function CustomModelDialog({
       }
     }
 
-    onSave({
-      modelId: modelId.trim(),
-      displayName: displayName.trim(),
-      description: description.trim(),
-      contextWindowSize,
-      providerInstanceId,
-      thinkingEnabled,
-      capabilities,
-      providerOptions,
-      headers,
-    });
-    if (isAddMode) {
-      track('custom-model-add-finished');
+    setIsSaving(true);
+    try {
+      await onSave({
+        modelId: modelId.trim(),
+        displayName: displayName.trim(),
+        description: description.trim(),
+        contextWindowSize,
+        providerInstanceId,
+        thinkingEnabled,
+        capabilities,
+        providerOptions,
+        headers,
+      });
+      if (isAddMode) {
+        track('custom-model-add-finished', {
+          ...(telemetryLevel === 'full' && { model_id: modelId.trim() }),
+          provider_type: selectedProviderType,
+        });
+      }
+      savedRef.current = true;
+      onOpenChange(false);
+    } catch (error) {
+      setSaveError(
+        error instanceof Error ? error.message : 'Failed to save model.',
+      );
+    } finally {
+      setIsSaving(false);
     }
-    savedRef.current = true;
-    onOpenChange(false);
   };
 
   return (
@@ -1638,18 +1675,20 @@ function CustomModelDialog({
           </div>
         </OverlayScrollbar>
 
+        {saveError && <TruncatedErrorText text={saveError} />}
         <DialogFooter>
           <Button
             variant="primary"
             size="sm"
-            disabled={!canSave}
-            onClick={handleSave}
+            disabled={!canSave || isSaving}
+            onClick={() => void handleSave()}
           >
-            {model ? 'Save Changes' : 'Add Model'}
+            {isSaving ? 'Saving...' : model ? 'Save Changes' : 'Add Model'}
           </Button>
           <Button
             variant="ghost"
             size="sm"
+            disabled={isSaving}
             onClick={() => handleDialogOpenChange(false)}
           >
             Cancel
@@ -3024,6 +3063,7 @@ function ModelsSection({
         onSave={handleSave}
         existingModelIds={existingModelIds}
         providerInstances={providerInstances}
+        defaultProviderInstanceId={filterInstanceId}
       />
     </div>
   );


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Telemetry schema and settings UI only; privacy stripping for model_id is explicit and tested.
> 
> **Overview**
> **Custom model add telemetry** now carries provider context on start, abort, and finish instead of empty payloads. `custom-model-add-started` requires `initial_provider_type`; finish and abort include `provider_type`, and finish may include optional `model_id`. `custom-model-add-aborted` also gains `provider_type`. Contracts and Zod schemas in the karton UI layer and backend telemetry service are aligned, with validation tests added.
> 
> **Privacy:** `model_id` on `custom-model-add-finished` is only sent from the UI when telemetry is `full`, and the backend strips `model_id` before PostHog capture when level is not `full`.
> 
> **Settings UI:** `CustomModelDialog` accepts `defaultProviderInstanceId` (wired from the filtered provider detail view), preselects that endpoint, derives provider type for events, and makes save async with loading/error states so finish telemetry fires only after a successful save.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9db9ba9237bb4be7ddbcc1b58d9ca39b917be65. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enriched telemetry for the custom model add flow with provider context on all steps and privacy-safe handling of model IDs.

- **New Features**
  - Event payloads: `custom-model-add-started` now sends `initial_provider_type`; `custom-model-add-aborted` sends `provider_type`; `custom-model-add-finished` sends `provider_type` and `model_id` (the `model_id` is only included at telemetry level 'full' and is stripped otherwise).
  - Updated backend and shared contract schemas to validate the new shapes using `providerInstanceTypeIds` plus `'unknown'`, with tests covering valid/invalid cases.
  - The dialog accepts `defaultProviderInstanceId`, preselects it, tracks `initial_provider_type` on start and `provider_type` on abort/finish; save is now async with a spinner and error display, and abort telemetry is suppressed while saving.

<sup>Written for commit c9db9ba9237bb4be7ddbcc1b58d9ca39b917be65. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1485?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added richer analytics for the custom model add flow, including provider type (and optional model ID).
  * The custom model dialog now preselects and restores the relevant provider context when opened from a filtered view.

* **Bug Fixes**
  * Custom models are now correctly associated with the active provider when added from a filtered view.

* **Tests**
  * Added coverage to validate the custom model telemetry payload shapes and required fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->