### PR TITLE
fix(agent-core): resolve instance-scoped model lookups

### DIFF
--- a/packages/agent-core/src/agents/base-agent.ts
+++ b/packages/agent-core/src/agents/base-agent.ts
@@ -1167,12 +1167,14 @@ export abstract class BaseAgent<
    */
   protected async compressHistory(history: AgentMessage[]): Promise<string> {
     // The standard compaction logic is very simple. We can make this more sophisticated later on.
+    const { activeModelId, activeProviderInstanceId } = this.state.get();
     return await generateSimpleCompressedHistory(
       history,
       this.host.models,
       this.instanceId,
-      this.state.get().activeModelId,
+      activeModelId,
       this.host,
+      activeProviderInstanceId,
     );
   }
 
@@ -1237,7 +1239,7 @@ export abstract class BaseAgent<
     reasoningSignatureSource?: ReasoningSignatureSource,
     allowedEnvDomainIds?: readonly string[],
   ): Promise<ModelMessage[]> {
-    const activeModelId = this.state.get().activeModelId;
+    const { activeModelId, activeProviderInstanceId } = this.state.get();
     const fileReadCache = this.fileReadCacheService;
     const capabilities = this.host.models.getCapabilities(activeModelId);
 
@@ -1249,6 +1251,9 @@ export abstract class BaseAgent<
       const { contextWindowSize } = await this.host.models.getWithOptions(
         activeModelId,
         '',
+        {
+          [PROVIDER_INSTANCE_ID_METADATA_KEY]: activeProviderInstanceId,
+        },
       );
       contentLimits = {
         maxReadChars: deriveMaxReadChars(contextWindowSize),
@@ -2107,7 +2112,9 @@ export abstract class BaseAgent<
       let contextWindowSize: number;
       try {
         contextWindowSize = (
-          await this.host.models.getWithOptions(state.activeModelId, '')
+          await this.host.models.getWithOptions(state.activeModelId, '', {
+            [PROVIDER_INSTANCE_ID_METADATA_KEY]: state.activeProviderInstanceId,
+          })
         ).contextWindowSize;
       } catch {
         // Model may have been deleted — fall back to a conservative size
@@ -2466,11 +2473,12 @@ export abstract class BaseAgent<
     // far more tokens than the fractional sweet-spot tuned for 200k models.
     const compactionThreshold = this.config.historyCompressionThreshold ?? 0.65;
     try {
+      const postStepState = this.state.get();
       const contextWindowSize = (
-        await this.host.models.getWithOptions(
-          this.state.get().activeModelId,
-          '',
-        )
+        await this.host.models.getWithOptions(postStepState.activeModelId, '', {
+          [PROVIDER_INSTANCE_ID_METADATA_KEY]:
+            postStepState.activeProviderInstanceId,
+        })
       ).contextWindowSize;
       const fractionalTriggerTokens = compactionThreshold * contextWindowSize;
       const effectiveTriggerTokens = Math.min(

--- a/packages/agent-core/src/agents/shared/history-compression.test.ts
+++ b/packages/agent-core/src/agents/shared/history-compression.test.ts
@@ -1128,7 +1128,85 @@ describe('generateSimpleCompressedHistory', () => {
     );
   });
 
-  it('skips fallbackModelId if it matches a cheap model ID', async () => {
+  it('routes the active fallback through its provider instance', async () => {
+    generateTextMock
+      .mockRejectedValueOnce(new Error('Gemini failed'))
+      .mockRejectedValueOnce(new Error('GPT failed'))
+      .mockRejectedValueOnce(new Error('Haiku failed'))
+      .mockResolvedValueOnce({
+        text: 'The assistant provided an OpenRouter fallback summary.',
+      } as any);
+
+    const mps = makeMockHostModels();
+    await generateSimpleCompressedHistory(
+      makeMessages(4),
+      mps,
+      'agent-1',
+      'openrouter/free',
+      undefined,
+      'openrouter-instance',
+    );
+
+    expect(mps.getWithOptions).toHaveBeenNthCalledWith(
+      4,
+      'openrouter/free',
+      'agent-1',
+      expect.objectContaining({
+        $provider_instance_id: 'openrouter-instance',
+      }),
+    );
+    expect(mps.getWithOptions).toHaveBeenNthCalledWith(
+      1,
+      'gemini-3.1-flash-lite',
+      'agent-1',
+      expect.objectContaining({
+        $provider_instance_id: undefined,
+      }),
+    );
+  });
+
+  it('retries a cheap model ID through its active provider instance', async () => {
+    generateTextMock
+      .mockRejectedValueOnce(new Error('Gemini failed'))
+      .mockRejectedValueOnce(new Error('GPT failed'))
+      .mockRejectedValueOnce(new Error('Haiku failed'))
+      .mockResolvedValueOnce({
+        text: 'The active provider instance supplied the compression summary.',
+      } as any);
+
+    const mps = makeMockHostModels();
+    const result = await generateSimpleCompressedHistory(
+      makeMessages(4),
+      mps,
+      'agent-1',
+      'claude-haiku-4.5',
+      undefined,
+      'active-haiku-instance',
+    );
+
+    expect(result).toBe(
+      'The active provider instance supplied the compression summary.',
+    );
+    expect(mps.getWithOptions).toHaveBeenCalledTimes(4);
+    expect(mps.getWithOptions).toHaveBeenNthCalledWith(
+      3,
+      'claude-haiku-4.5',
+      'agent-1',
+      expect.objectContaining({
+        $provider_instance_id: undefined,
+      }),
+    );
+    expect(mps.getWithOptions).toHaveBeenNthCalledWith(
+      4,
+      'claude-haiku-4.5',
+      'agent-1',
+      expect.objectContaining({
+        $provider_instance_id: 'active-haiku-instance',
+      }),
+    );
+  });
+
+  it('skips an unscoped fallbackModelId if it matches a cheap model ID', async () => {
     generateTextMock
       .mockRejectedValueOnce(new Error('Gemini failed'))
       .mockRejectedValueOnce(new Error('GPT failed'))

--- a/packages/agent-core/src/agents/shared/history-compression/index.ts
+++ b/packages/agent-core/src/agents/shared/history-compression/index.ts
@@ -1,7 +1,10 @@
 import { generateText, type UITools } from 'ai';
 import type { AgentMessage } from '../../../types/agent';
 import type { AgentHost } from '../../../host/host';
-import type { HostModels } from '../../../host/models';
+import {
+  PROVIDER_INSTANCE_ID_METADATA_KEY,
+  type HostModels,
+} from '../../../host/models';
 
 /**
  * Wide AgentMessage type accepting any tool set and any metadata shape.
@@ -84,6 +87,7 @@ const tryCompressWithModel = async (
   agentInstanceId: string,
   compactHistory: string,
   previousBriefingChars: number,
+  providerInstanceId?: string,
 ): Promise<string> => {
   const modelWithOptions = await hostModels.getWithOptions(
     modelId,
@@ -91,6 +95,7 @@ const tryCompressWithModel = async (
     {
       $ai_span_name: 'history-compression',
       $ai_parent_id: `${agentInstanceId}`,
+      [PROVIDER_INSTANCE_ID_METADATA_KEY]: providerInstanceId,
     },
   );
 
@@ -170,6 +175,7 @@ export const generateSimpleCompressedHistory = async (
   agentInstanceId: string,
   fallbackModelId?: string,
   host?: AgentHost,
+  fallbackProviderInstanceId?: string,
 ): Promise<string> => {
   const compactConvertedChatHistory =
     convertAgentMessagesToCompactMessageHistoryString(messages, host);
@@ -200,10 +206,15 @@ export const generateSimpleCompressedHistory = async (
     }
   }
 
-  // Last resort: try the active chat model if it wasn't already attempted.
+  // Last resort: try the active chat model if the same resolution scope was
+  // not already attempted. An instance-scoped model with the same ID as a
+  // preferred model is distinct from the earlier unscoped lookup.
   if (
     fallbackModelId &&
-    !(HISTORY_COMPRESSION_MODELS as readonly string[]).includes(fallbackModelId)
+    (fallbackProviderInstanceId !== undefined ||
+      !(HISTORY_COMPRESSION_MODELS as readonly string[]).includes(
+        fallbackModelId,
+      ))
   ) {
     console.warn(
       `History compression: all preferred models failed, falling back to active model: ${fallbackModelId}`,
@@ -215,6 +226,7 @@ export const generateSimpleCompressedHistory = async (
         agentInstanceId,
         compactConvertedChatHistory,
         previousBriefingChars,
+        fallbackProviderInstanceId,
       );
     } catch (e) {
       lastError = e as Error;


### PR DESCRIPTION
## Summary
- pass the active provider instance ID to context-window model lookups
- preserve the provider instance when history compression falls back to the active model
- add regression coverage for instance-scoped OpenRouter fallback models

## Validation
- `pnpm -F @stagewise/agent-core typecheck`
- `pnpm -F @stagewise/agent-core test -- src/agents/shared/history-compression.test.ts` (46 files, 597 tests passed)
- `pnpm -F stagewise typecheck`
- Biome check on the three changed files

The repository-wide `pnpm check` remains blocked by an unrelated nested Biome root at `.claude/worktrees/inspiring-agnesi-48dd06/biome.jsonc`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core agent model resolution and history compression paths; mis-routing could affect wrong provider credentials or context limits, but scope is narrow and covered by new tests.
> 
> **Overview**
> Fixes **instance-scoped model resolution** by threading `activeProviderInstanceId` into `host.models.getWithOptions` wherever the agent needs context-window size or compression routing, instead of resolving models without a provider instance.
> 
> **`BaseAgent`** now passes `PROVIDER_INSTANCE_ID_METADATA_KEY` when deriving content limits for message conversion, when sizing the kept-message budget during compression, and when deciding post-step history compression triggers. **`compressHistory`** forwards the active provider instance into **`generateSimpleCompressedHistory`**, which passes it through **`tryCompressWithModel`** on the last-resort active-model fallback.
> 
> Fallback logic is adjusted so an instance-scoped active model is still attempted when its ID matches a preferred cheap model (unscoped vs scoped lookups are treated as distinct). Regression tests cover OpenRouter-style fallbacks and instance-scoped retries for cheap model IDs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cbb68a3c356e8cecff83c3cced3db61da60435dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes instance-scoped model lookups by passing the active provider instance ID into context-window queries and history compression. Ensures fallbacks and retries route through the correct provider instance instead of a global model.

- **Bug Fixes**
  - Thread `activeProviderInstanceId` into `host.models.getWithOptions` for context-window sizing, compaction thresholds, and history compression in `BaseAgent`.
  - Preserve and forward the provider instance via `PROVIDER_INSTANCE_ID_METADATA_KEY` in `generateSimpleCompressedHistory` and `tryCompressWithModel`; preferred cheap models remain unscoped, and a matching active model ID is retried only when instance-scoped.
  - Add tests for instance-scoped OpenRouter fallback and for retrying a cheap model through its active provider instance; skip an unscoped fallback if it matches a cheap model ID.

<sup>Written for commit cbb68a3c356e8cecff83c3cced3db61da60435dd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1486?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved conversation history compression to account for provider-instance–scoped model options during context sizing and per-request limits.
  * Enhanced fallback compression routing so instance-scoped models are treated distinctly when selecting the “last resort” model.
* **Tests**
  * Added/updated test coverage to verify provider-instance metadata propagation for both fallback and retry scenarios, including clarified skip conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->