### PR TITLE
feat(browser): add Claude Opus 5 support

### DIFF
--- a/.agents/skills/add-llm-model/SKILL.md
+++ b/.agents/skills/add-llm-model/SKILL.md
@@ -1,46 +1,101 @@
 ---
 name: add-llm-model
-description: Use when adding a new LLM/model to stagewise model catalogs, provider routing, validation, docs, or showcase UI.
+description: Use when adding a new LLM/model to stagewise model catalogs, provider instances, routing, validation, docs, or showcase UI.
 ---
 
 # Add LLM Model
 
 Use this workflow when adding or updating model support in stagewise.
 
+## Architecture First
+
+Models are no longer a single global enabled/disabled list. Routing and model
+availability are scoped to entries in `preferences.providerInstances`.
+
+- `apps/browser/src/shared/available-models.ts` is the curated metadata catalog.
+- `apps/browser/src/backend/agents/providers/` contains stateless provider-type
+  implementations. `registry.ts` maps each `ProviderInstanceTypeId` to its type.
+- `apps/browser/src/backend/agents/model-provider.ts` resolves a provider
+  instance, then delegates ID conversion and model creation to its provider type.
+- Each provider instance owns `enabledModelIds`, `disabledModelIds`, and
+  `discoveredModels`.
+- `apps/browser/src/shared/flagship-models.ts` curates newly discovered models
+  per provider instance. Catalog models on official APIs are considered
+  flagship. OpenRouter has its own prefixed-ID flagship set.
+
+Read those files and the relevant provider implementation before deciding the
+change surface. Do not apply guidance written for the old global model list.
+
 ## Required Checks
 
-1. Inspect existing provider entries before editing.
-   - Read `apps/browser/src/shared/available-models.ts` around the provider.
-   - Keep still-supported sibling models. Do not replace old models with the new one unless explicitly requested.
+1. **Research authoritative metadata.**
+   - Confirm the canonical ID, native provider ID, context window, modalities,
+     tool support, reasoning support, and pricing.
+   - Prefer provider documentation for native behavior and OpenRouter data for
+     the Stagewise/OpenRouter route.
+   - Keep still-supported sibling models unless removal was explicitly requested.
 
-2. Wire the model through all relevant product surfaces.
-   - Model catalog: `apps/browser/src/shared/available-models.ts`.
-   - Provider routing: `apps/browser/src/backend/agents/model-provider.ts`.
-   - API-key validation: `apps/browser/src/backend/utils/validate-api-keys.ts`.
+2. **Add or update catalog metadata.**
+   - Edit `apps/browser/src/shared/available-models.ts`.
+   - Match the field order and provider options of the nearest sibling.
+   - Update `apps/browser/src/shared/model-thinking-capabilities.ts` when the
+     model supports configurable thinking/reasoning.
+
+3. **Audit provider-instance routing.**
+   - Inspect `apps/browser/src/backend/agents/providers/registry.ts` and the
+     relevant implementation in `apps/browser/src/backend/agents/providers/`.
+   - Existing providers are normally model-agnostic; do not add a per-model
+     branch unless the wire ID or API behavior genuinely differs.
+   - Put canonical-to-wire ID conversion in the provider type's
+     `toWireModelId`, not in new branches in the central model provider.
+   - Stagewise routing prefixes canonical IDs for OpenRouter in
+     `providers/stagewise.ts`.
+   - Explicit custom endpoint `modelIdMapping` values must override defaults.
+
+4. **Curate discovery intentionally.**
+   - For OpenRouter, update `OPENROUTER_FLAGSHIP_MODELS` in
+     `apps/browser/src/shared/flagship-models.ts` when the new model should be
+     enabled on first discovery. IDs must include the OpenRouter vendor prefix.
+   - Remove a superseded model from that set only if it should stop being a
+     default for *new discovery*. Existing user choices are intentionally
+     preserved by `computeDisabledModelIdsAfterDiscovery`.
+   - Official-provider catalog entries are already treated as flagship; do not
+     duplicate them in `VENDOR_FLAGSHIP_DISCOVERED_MODELS`.
+
+5. **Do not seed model deprecations in the legacy provider migration.**
+   - Never add a new model ID to the `stagewise-default.disabledModelIds`
+     literal inside `PreferencesService.migrateToProviderInstances`.
+   - That function runs only when `providerInstances` is empty. Such a change
+     affects only users crossing the legacy migration and misses users whose
+     instances already exist, creating inconsistent availability.
+   - Do not patch the ID on every startup either; that would override a user's
+     later decision to re-enable the model.
+   - If product requirements call for changing existing users' model choices,
+     ask first and implement an explicit, idempotent, versioned preference
+     migration with tests. Define which provider-instance types are in scope
+     and preserve choices after the migration has run once.
+   - If the old model remains supported, keep it in the catalog and leave
+     existing per-instance state untouched. Discovery flagship curation controls
+     defaults for newly discovered provider models.
+
+6. **Keep credential validation cheap and broadly available.**
+   - Validation now belongs to the provider type's `validateCredentials`
+     implementation, usually in `providers/official-api.ts`, rather than being
+     hardcoded in central routing.
+   - Do not switch validation to a new flagship/high-tier model by default.
+     Prefer a cheap model broadly available to provider keys.
+   - Legacy `validate-api-keys.ts` paths may still exist for compatibility;
+     inspect callers before editing them.
+
+7. **Audit other product surfaces rather than editing mechanically.**
    - Coding plans: `apps/browser/src/shared/coding-plans.ts`.
-   - Website showcase: `apps/website/src/app/(home)/_components/model-provider-showcase.tsx`.
-   - README files and localized README variants.
+   - Homepage showcase:
+     `apps/website/src/app/(home)/_components/model-provider-showcase.tsx`.
+   - README files and localized variants.
+   - Thinking tests, provider tests, and model-selector tests.
+   - Historical benchmark/comparison copy must not be renamed without evidence.
 
-3. Keep plan docs aligned with plan config.
-   - If `featuredModelIds` lists multiple models, README subscription tables must list the same featured lineup in readable display names.
-   - The later full model lists may include more models, but must not contradict the plan table.
-
-4. Preserve showcase truthfulness.
-   - If the homepage showcase is curated, make that intentional.
-   - Otherwise include still-supported sibling models so marketing does not understate provider support.
-
-5. Handle provider-native IDs everywhere requests can route.
-   - Internal model IDs may differ from native provider IDs.
-   - Apply native ID mapping in official provider mode.
-   - Apply the same default native ID mapping for built-in models routed through custom endpoints.
-   - Explicit `customEndpoint.modelIdMapping` must always override default mapping.
-
-6. Validate API keys with broadly accessible probes.
-   - Do not validate a provider exclusively against the newest or highest-tier model if older supported models remain available.
-   - Prefer a cheap broadly available model, or fallback probes that accept success from any supported entitlement.
-   - Keep validation errors compatible with existing `{ success: false; error: string }` callers.
-
-7. **Always verify subscription-plan base URLs.**
+8. **Always verify subscription-plan base URLs.**
    - Many providers use **different API endpoints** for subscription/token-plan keys vs. pay-as-you-go (BYOK) keys.
    - Example: GLM uses `https://api.z.ai/api/paas/v4` for BYOK but `https://api.z.ai/api/coding/paas/v4` for coding-plan subscriptions. Xiaomi MiMo uses `https://api.xiaomimimo.com/v1` for BYOK but `https://token-plan-cn.xiaomimimo.com/v1` for token-plan subscriptions.
    - The two key types are often **non-interchangeable** — a subscription key will be rejected by the BYOK endpoint and vice versa.
@@ -56,7 +111,12 @@ Use this workflow when adding or updating model support in stagewise.
 
 After changes:
 
-- Run targeted LSP/lint diagnostics on edited files.
-- Search for the new model ID and display name across code/docs.
-- Confirm request routing uses native provider IDs in official and built-in custom endpoint modes.
-- Confirm docs, coding-plan `featuredModelIds`, and showcase entries are intentionally aligned.
+- Run targeted tests for catalog metadata, thinking capabilities, flagship
+  discovery, provider routing, and any preference migration touched.
+- Run browser typecheck and Biome on all edited files.
+- Search for the new and superseded model IDs across browser and website code.
+- Confirm Stagewise/OpenRouter and official-provider wire IDs independently.
+- Confirm docs, coding-plan `featuredModelIds`, and showcase entries are
+  intentionally aligned.
+- If preference migration changed, test both empty and already-populated
+  `providerInstances`, idempotence, and preservation of user choices.

--- a/apps/browser/src/backend/services/preferences.test.ts
+++ b/apps/browser/src/backend/services/preferences.test.ts
@@ -479,6 +479,12 @@ describe('PreferencesService legacy provider migration', () => {
 
     expect(instances).toContainEqual(
       expect.objectContaining({
+        id: 'stagewise-default',
+        disabledModelIds: [],
+      }),
+    );
+    expect(instances).toContainEqual(
+      expect.objectContaining({
         id: 'openai-api-default',
         typeId: 'openai-api',
         config: expect.objectContaining({ encryptedApiKey: 'openai-key' }),

--- a/apps/browser/src/shared/available-models.ts
+++ b/apps/browser/src/shared/available-models.ts
@@ -153,6 +153,47 @@ export const availableModels = [
   // Anthropic Models
   {
     officialProvider: 'anthropic',
+    modelId: 'claude-opus-5',
+    modelDisplayName: 'Opus 5',
+    modelDescription:
+      "Anthropic's flagship model for demanding reasoning, coding, and long-horizon agentic work.",
+    modelContext: '1M context',
+    modelContextRaw: 1000000,
+    headers: anthropicHeaders,
+    providerOptions: {
+      stagewise: { reasoning: { enabled: true, effort: 'medium' } },
+      anthropic: {
+        thinking: { type: 'adaptive' },
+        effort: 'medium',
+      },
+    },
+    thinkingEnabled: true,
+    pricing: {
+      inputPerMillion: 5.0,
+      outputPerMillion: 25.0,
+      relativeMultiplier: 5.3,
+    },
+    capabilities: {
+      inputModalities: {
+        text: true,
+        audio: false,
+        image: true,
+        video: false,
+        file: true,
+      },
+      outputModalities: {
+        text: true,
+        audio: false,
+        image: false,
+        video: false,
+        file: false,
+      },
+      inputConstraints: ANTHROPIC_INPUT_CONSTRAINTS,
+      toolCalling: true,
+    },
+  },
+  {
+    officialProvider: 'anthropic',
     modelId: 'claude-fable-5',
     modelDisplayName: 'Fable 5',
     modelDescription:

--- a/apps/browser/src/shared/flagship-models.ts
+++ b/apps/browser/src/shared/flagship-models.ts
@@ -28,8 +28,8 @@ import { availableModels } from './available-models';
 
 const OPENROUTER_FLAGSHIP_MODELS = new Set<string>([
   // Anthropic
+  'anthropic/claude-opus-5',
   'anthropic/claude-sonnet-5',
-  'anthropic/claude-opus-4.8',
   'anthropic/claude-fable-5',
   'anthropic/claude-opus-4.7',
   // OpenAI

--- a/apps/browser/src/shared/model-thinking-capabilities.ts
+++ b/apps/browser/src/shared/model-thinking-capabilities.ts
@@ -407,6 +407,7 @@ function getGoogleOptions(modelId: string): ThinkingOption[] {
 
 function getAnthropicOptions(modelId: string): ThinkingOption[] {
   if (
+    modelId.startsWith('claude-opus-5') ||
     modelId.startsWith('claude-fable-5') ||
     modelId.startsWith('claude-mythos-5') ||
     modelId.startsWith('claude-mythos-preview') ||

--- a/apps/website/src/app/(home)/_components/model-provider-showcase.tsx
+++ b/apps/website/src/app/(home)/_components/model-provider-showcase.tsx
@@ -52,7 +52,7 @@ const PROVIDERS: ProviderInfo[] = [
       'Best-in-class instruction following and long-context reasoning.',
     models: [
       { name: 'Fable 5', tier: 'frontier' },
-      { name: 'Opus 4.8', tier: 'frontier' },
+      { name: 'Opus 5', tier: 'frontier' },
       { name: 'Opus 4.7', tier: 'frontier' },
       { name: 'Opus 4.6', tier: 'frontier' },
       { name: 'Sonnet 5', tier: 'general' },
@@ -165,7 +165,7 @@ const PROVIDERS: ProviderInfo[] = [
     description:
       'Access 345+ models from all major vendors through a single API key.',
     models: [
-      { name: 'Claude Opus 4.8', tier: 'frontier' },
+      { name: 'Claude Opus 5', tier: 'frontier' },
       { name: 'GPT-5.6 Sol', tier: 'frontier' },
       { name: 'Gemini 3.1 Pro', tier: 'frontier' },
       { name: 'DeepSeek V4 Pro', tier: 'general' },


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Catalog, curation, and showcase-only changes with no provider routing or auth changes; main product impact is which OpenRouter-discovered models enable by default for new discoveries.
> 
> **Overview**
> Adds **`claude-opus-5`** to the browser model catalog with 1M context, adaptive thinking (medium effort), tool calling, image/PDF input, and pricing metadata aligned with other Opus-tier Anthropic entries.
> 
> **OpenRouter discovery** now treats **`anthropic/claude-opus-5`** as a flagship default instead of **`anthropic/claude-opus-4.8`**; Opus 4.8 stays in the catalog and is not seeded into legacy migration `disabledModelIds`. Thinking UI maps **`claude-opus-5`** to the same advanced Opus option set as Fable 5 and Opus 4.7/4.8.
> 
> The **website provider showcase** (Anthropic and OpenRouter) promotes **Opus 5** over Opus 4.8. A **preferences migration test** asserts **`stagewise-default`** has an empty **`disabledModelIds`** after migration. The **`add-llm-model`** agent skill is rewritten around **provider-instance** routing, flagship curation, and deprecation/migration rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a19d1716dbfeed42a9067429b099aec07b17569c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Claude Opus 5 as a first-class model in the browser with 1M context and adaptive thinking. Replaces Opus 4.8 in OpenRouter flagship and website showcase; no migration disables 4.8 for existing instances.

- **New Features**
  - Added `claude-opus-5` with 1M context, image/file input, tool calling, adaptive thinking defaults (medium), and pricing ($5 in / $25 out per 1M).
  - Marked `anthropic/claude-opus-5` as an OpenRouter flagship and removed `anthropic/claude-opus-4.8`; updated the website showcase to “Opus 5”.
  - Enabled advanced thinking options for Opus 5 in the UI.

<sup>Written for commit a19d1716dbfeed42a9067429b099aec07b17569c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1487?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Anthropic’s Claude Opus 5 model, including reasoning capabilities, tool calling, and updated model details.
  * Added Claude Opus 5 to curated model selections and provider showcases.

* **Documentation**
  * Expanded model onboarding guidance with provider routing, metadata, validation, and subscription endpoint checks.

* **Tests**
  * Enhanced provider migration coverage to verify default provider availability and model settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->