### PR TITLE
Fix: Sequential queued message processing and manual send behavior (#1491)

### DIFF
--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/footer-status-card/message-queue-section.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/footer-status-card/message-queue-section.tsx
@@ -113,7 +113,14 @@ export function MessageQueueSection(
           />
           {`${props.queuedMessages.length} Queued`}
         </div>
-        <Button variant="ghost" size="xs" onClick={props.onFlush}>
+        <Button
+          variant="ghost"
+          size="xs"
+          onClick={(e) => {
+            e.stopPropagation();
+            props.onFlush();
+          }}
+        >
           Send now
           <IconArrowUpOutline24 className="size-3" />
         </Button>

--- a/packages/agent-core/src/agents/base-agent.ts
+++ b/packages/agent-core/src/agents/base-agent.ts
@@ -615,7 +615,8 @@ export abstract class BaseAgent<
    * `null` means `onFinish` has not set a decision (e.g. error path,
    * aborted, or step superseded by a newer one) — the tail then no-ops.
    */
-  private _pendingContinue: boolean | null = null;
+  private _pendingContinue: { shouldRun: boolean; flushQueue: boolean } | null =
+    null;
 
   /**
    * Set only for runtime recovery after a suspend/resume or event-loop stall.
@@ -818,7 +819,7 @@ export abstract class BaseAgent<
     this.state.commands.appendHistoryMessage({ message: msg });
     this.scheduleMemorySnapshotWrite('user-message');
 
-    void this.runStep();
+    void this.runStep(false, false);
 
     return id;
   }
@@ -915,8 +916,8 @@ export abstract class BaseAgent<
 
     await this.internalStop('user-flushed-queue');
 
-    // Send all queued messages into the chat
-    this.state.commands.flushQueueIntoHistory();
+    // Let the runStep() at the end of this method handle popping the first queued message
+
     if (flushedCount > 0) {
       this.scheduleMemorySnapshotWrite('queued-messages');
     }
@@ -1596,7 +1597,10 @@ export abstract class BaseAgent<
   /**
    * Should be executed after a user or tool approval message was added to the agent
    */
-  private async runStep(isApprovalContinuation = false): Promise<void> {
+  private async runStep(
+    isApprovalContinuation = false,
+    flushQueue = !isApprovalContinuation,
+  ): Promise<void> {
     // Check canRunStep BEFORE setting isWorking to avoid deadlock
     if (!this.canRunStep()) {
       if (this._pendingSyntheticContinuation) {
@@ -1632,7 +1636,7 @@ export abstract class BaseAgent<
     // complete in isolation first. Queued messages will be picked up
     // by the follow-up runStep() triggered via shouldRunNewStep().
     const { queueFlushIndex: flushedIndex } = this.state.commands.beginStep({
-      flushQueue: !isApprovalContinuation,
+      flushQueue,
     });
     if (flushedIndex !== undefined) {
       this.scheduleMemorySnapshotWrite('queued-messages');
@@ -2119,27 +2123,36 @@ export abstract class BaseAgent<
           );
           setTimeout(() => void this.runStep(), 0);
         } else {
-          const pending = this._pendingContinue;
+          // Capture and clear atomically. The explicit cast breaks
+          // TypeScript's control-flow narrowing which would otherwise
+          // narrow `pending` to `never` after the null assignment to
+          // the backing field.
+          const pending = this._pendingContinue as {
+            shouldRun: boolean;
+            flushQueue: boolean;
+          } | null;
           this._pendingContinue = null;
-          if (pending === true) {
-            // setTimeout to keep the call stack clean (unbounded recursion).
-            setTimeout(() => void this.runStep(), 0);
-          } else if (pending === false) {
-            // Mark unread only if history contains at least one assistant
-            // message (covers fresh-session edge case).
-            const hasAssistantMessage = this.state
-              .get()
-              .history.some((m) => m.role === 'assistant');
-            this.state.commands.recordStepError({
-              error: undefined,
-              markUnread: 'if-assistant-history',
-            });
-            this.onIdle();
-            // Only notify "done" for a genuine turn completion: there must
-            // be an assistant message and the agent must not be paused on an
-            // open approval request (that's a `question`, emitted elsewhere).
-            if (hasAssistantMessage && !stepHasApprovalRequest) {
-              this.emitNotificationEvent('done');
+          if (pending !== null) {
+            if (pending.shouldRun) {
+              // setTimeout to keep the call stack clean (unbounded recursion).
+              setTimeout(() => void this.runStep(false, pending.flushQueue), 0);
+            } else {
+              // Mark unread only if history contains at least one assistant
+              // message (covers fresh-session edge case).
+              const hasAssistantMessage = this.state
+                .get()
+                .history.some((m) => m.role === 'assistant');
+              this.state.commands.recordStepError({
+                error: undefined,
+                markUnread: 'if-assistant-history',
+              });
+              this.onIdle();
+              // Only notify "done" for a genuine turn completion: there must
+              // be an assistant message and the agent must not be paused on an
+              // open approval request (that's a `question`, emitted elsewhere).
+              if (hasAssistantMessage && !stepHasApprovalRequest) {
+                this.emitNotificationEvent('done');
+              }
             }
           }
           // pending === null → onFinish never set a decision (error path,
@@ -2466,15 +2479,10 @@ export abstract class BaseAgent<
    *
    * @returns Whether the agent should run a new step based on the given conditions.
    */
-  private shouldRunNewStep(
-    r: StepResult<ToolSet>,
-    userWantsToContinue: boolean,
-  ): boolean {
-    if (this.state.get().queuedMessages.length > 0) {
-      // We should always continue if the user queued a message
-      return true;
-    }
-
+  private shouldRunNewStep(r: StepResult<ToolSet>): {
+    shouldRun: boolean;
+    flushQueue: boolean;
+  } {
     let stepsSinceLastMessage = 0;
     let lastUserMessageTime = 0;
     const historySnapshot = this.state.get().history;
@@ -2491,12 +2499,15 @@ export abstract class BaseAgent<
       }
     }
 
+    const hasQueuedMessages = this.state.get().queuedMessages.length > 0;
+
     // Check if the maximum number of steps has been reached
     if (this.config.maxSteps && stepsSinceLastMessage >= this.config.maxSteps) {
       this.host.logger.debug(
         `[BaseAgent:${this.instanceId}] Maximum number of steps reached: ${stepsSinceLastMessage} >= ${this.config.maxSteps}`,
       );
-      return false;
+      if (hasQueuedMessages) return { shouldRun: true, flushQueue: true };
+      return { shouldRun: false, flushQueue: false };
     }
 
     // Check if the maximum time has been reached
@@ -2507,7 +2518,8 @@ export abstract class BaseAgent<
       this.host.logger.debug(
         `[BaseAgent:${this.instanceId}] Maximum time reached: ${Date.now() - lastUserMessageTime} >= ${this.config.maxTime}`,
       );
-      return false;
+      if (hasQueuedMessages) return { shouldRun: true, flushQueue: true };
+      return { shouldRun: false, flushQueue: false };
     }
 
     //Also return a no-continue if one of the called tools is a "finish" tool and only the "finish" tool was called
@@ -2515,7 +2527,8 @@ export abstract class BaseAgent<
       this.host.logger.debug(
         `[BaseAgent:${this.instanceId}] Only the "finish" tool was called`,
       );
-      return false;
+      if (hasQueuedMessages) return { shouldRun: true, flushQueue: true };
+      return { shouldRun: false, flushQueue: false };
     }
 
     // Check if there are any open tool approval requests
@@ -2523,11 +2536,8 @@ export abstract class BaseAgent<
       this.host.logger.debug(
         `[BaseAgent:${this.instanceId}] There are open tool approval requests`,
       );
-      return false;
+      return { shouldRun: false, flushQueue: false };
     }
-
-    // If the user does not want to continue, we don't run a new step
-    if (!userWantsToContinue) return false;
 
     // We assume that approved tool calls are executed and results are attached,
     // because this is what AI-SDK with controlled tool execution promises us
@@ -2541,7 +2551,7 @@ export abstract class BaseAgent<
       this.host.logger.warn(
         `[BaseAgent:${this.instanceId}] Output truncated (finishReason=length). Model will see error results and retry.`,
       );
-      return true;
+      return { shouldRun: true, flushQueue: false };
     }
 
     // Check if the finish reason is not tool-calls (which means user intervention is needed)
@@ -2549,10 +2559,11 @@ export abstract class BaseAgent<
       this.host.logger.debug(
         `[BaseAgent:${this.instanceId}] The finish reason is not "tool-calls", but "${r.finishReason}"`,
       );
-      return false;
+      if (hasQueuedMessages) return { shouldRun: true, flushQueue: true };
+      return { shouldRun: false, flushQueue: false };
     }
 
-    return true;
+    return { shouldRun: true, flushQueue: false };
   }
 
   /**
@@ -2560,7 +2571,9 @@ export abstract class BaseAgent<
    *
    * @returns Whether the agent should run a new step based on the given conditions.
    */
-  private async handlePostStep(result: StepResult<ToolSet>): Promise<boolean> {
+  private async handlePostStep(
+    result: StepResult<ToolSet>,
+  ): Promise<{ shouldRun: boolean; flushQueue: boolean }> {
     this.state.commands.recordUsage({
       totalTokens: result.usage.totalTokens ?? 0,
     });
@@ -2638,20 +2651,18 @@ export abstract class BaseAgent<
     }
 
     const userWantsToContinue = (await this.onStepFinished(result)) ?? true;
-    const shouldRunNewStep = this.shouldRunNewStep(result, userWantsToContinue);
 
-    if (!shouldRunNewStep) {
-      this.host.logger.debug(
-        `[BaseAgent:${this.instanceId}] Not running new step. Agent Type: ${this.agentType}`,
-      );
-      return false;
+    if (!userWantsToContinue) {
+      return { shouldRun: false, flushQueue: false };
     }
+
+    const shouldRunNewStep = this.shouldRunNewStep(result);
 
     this.host.logger.debug(
       `[BaseAgent:${this.instanceId}] Running new step. Agent Type: ${this.agentType}`,
     );
 
-    return true;
+    return shouldRunNewStep;
   }
 
   /**

--- a/packages/agent-core/src/agents/base-agent.ts
+++ b/packages/agent-core/src/agents/base-agent.ts
@@ -967,7 +967,7 @@ export abstract class BaseAgent<
     this.state.commands.setIsWorkingFalse();
 
     this._pendingSyntheticContinuation = { reason };
-    void this.runStep();
+    void this.runStep(false, false);
   }
 
   /**
@@ -2206,7 +2206,7 @@ export abstract class BaseAgent<
           this.stepAbortController?.abort();
         } catch {}
         this.stepAbortController = null;
-        setTimeout(() => void this.runStep(), 0);
+        setTimeout(() => void this.runStep(false, false), 0);
         return;
       }
       try {
@@ -2653,6 +2653,9 @@ export abstract class BaseAgent<
     const userWantsToContinue = (await this.onStepFinished(result)) ?? true;
 
     if (!userWantsToContinue) {
+      if (this.state.get().queuedMessages.length > 0) {
+        return { shouldRun: true, flushQueue: true };
+      }
       return { shouldRun: false, flushQueue: false };
     }
 

--- a/packages/agent-core/src/agents/base-agent.ts
+++ b/packages/agent-core/src/agents/base-agent.ts
@@ -903,8 +903,8 @@ export abstract class BaseAgent<
   }
 
   /**
-   * Immediately flushes the queue by stopping the agent (aborts any ongoing streams)
-   * and sending all of the queued messages at once.
+   * Immediately triggers queue processing by stopping the agent (aborts any ongoing streams)
+   * and initiating a new step to dequeue and process the next queued message.
    *
    * @note Pending tool approvals will be denied with reason "User sent new message instead. Retry if necessary." or configurable response.
    * @note Pending tool calls will be aborted with reason "User sent new message instead. Retry if necessary." or configurable response.

--- a/packages/agent-core/src/agents/base-agent.ts
+++ b/packages/agent-core/src/agents/base-agent.ts
@@ -926,7 +926,7 @@ export abstract class BaseAgent<
       this.host.telemetry?.capture('agent-queue-flushed', {
         agent_type: this.agentType,
         agent_instance_id: this.instanceId,
-        flushed_message_count: flushedCount,
+        flushed_message_count: 1,
       });
     }
 

--- a/packages/agent-core/src/services/agent-manager/state-mutations/bind.ts
+++ b/packages/agent-core/src/services/agent-manager/state-mutations/bind.ts
@@ -19,7 +19,6 @@ import {
 import {
   clearQueuedMessages,
   enqueueUserMessage,
-  flushQueueIntoHistory,
   removeQueuedMessage,
 } from './queue';
 import {
@@ -83,7 +82,6 @@ export function bindStateMutations(store: AgentStore, agentInstanceId: string) {
     removeQueuedMessage: (args: Parameters<typeof removeQueuedMessage>[2]) =>
       removeQueuedMessage(store, agentInstanceId, args),
     clearQueuedMessages: () => clearQueuedMessages(store, agentInstanceId),
-    flushQueueIntoHistory: () => flushQueueIntoHistory(store, agentInstanceId),
 
     appendHistoryMessage: (args: Parameters<typeof appendHistoryMessage>[2]) =>
       appendHistoryMessage(store, agentInstanceId, args),

--- a/packages/agent-core/src/services/agent-manager/state-mutations/lifecycle.ts
+++ b/packages/agent-core/src/services/agent-manager/state-mutations/lifecycle.ts
@@ -61,8 +61,8 @@ export function beginStep(
     state.error = undefined;
     if (args.flushQueue && state.queuedMessages.length > 0) {
       queueFlushIndex = state.history.length;
-      state.history.push(...state.queuedMessages);
-      state.queuedMessages = [];
+      const nextMessage = state.queuedMessages.shift();
+      if (nextMessage) state.history.push(nextMessage);
     }
   });
   return { queueFlushIndex };

--- a/packages/agent-core/src/services/agent-manager/state-mutations/queue.ts
+++ b/packages/agent-core/src/services/agent-manager/state-mutations/queue.ts
@@ -52,7 +52,9 @@ export function flushQueueIntoHistory(
   agentInstanceId: string,
 ): void {
   updateAgentInstanceState(store, agentInstanceId, (state) => {
-    state.history.push(...state.queuedMessages);
-    state.queuedMessages = [];
+    const nextMessage = state.queuedMessages.shift();
+    if (nextMessage) {
+      state.history.push(nextMessage);
+    }
   });
 }

--- a/packages/agent-core/src/services/agent-manager/state-mutations/queue.ts
+++ b/packages/agent-core/src/services/agent-manager/state-mutations/queue.ts
@@ -46,15 +46,3 @@ export function clearQueuedMessages(
     state.queuedMessages = [];
   });
 }
-
-export function flushQueueIntoHistory(
-  store: AgentStore,
-  agentInstanceId: string,
-): void {
-  updateAgentInstanceState(store, agentInstanceId, (state) => {
-    const nextMessage = state.queuedMessages.shift();
-    if (nextMessage) {
-      state.history.push(nextMessage);
-    }
-  });
-}


### PR DESCRIPTION
### Description

Fixes **#1491**.

This PR resolves edge cases surrounding queued message processing, ensuring that queued prompts are processed strictly one-by-one and only when the agent has fully completed its current task.

**Problems Addressed:**
1. **Premature Queue Flushing Mid-Request**: The agent was indiscriminately pulling queued messages into context right in the middle of multi-step tool executions (e.g., while waiting for a terminal process), rather than waiting for the entire request to naturally complete.
2. **Unintended Queue Dumping on Manual Send**: When an agent was stopped and the user typed a *new* prompt, the agent would mistakenly append the new prompt *and* simultaneously flush the existing queue into history, running them all at once.
3. **Dropdown Auto-Collapse Behavior**: Clicking the "Send Now" button in the queue dropdown triggered an event bubble that caused the accordion to close immediately, requiring the user to manually re-open it if they wanted to interact with the remaining queued items.

**Changes Made:**
- **`agent-core`**: 
  - **Sequential Processing Refactor**: Deleted the premature early-return in `shouldRunNewStep` that bypassed tool-execution checks when the queue was populated. Refactored `shouldRunNewStep` and `handlePostStep` to return a `{ shouldRun, flushQueue }` object. The agent now properly finishes all internal tool loops and only pops the next queued message when it reaches a true idle state.
  - **Queue Payload Fix**: Refactored `beginStep` and `flushQueueIntoHistory` to shift exactly one queued message at a time, rather than appending the entire array into history at once.
  - **Manual Send Fix**: Updated `sendUserMessage` to invoke `runStep(false, false)` to explicitly bypass queue flushing when a fresh prompt is submitted to a stopped agent.
- **`browser`**: 
  - **Dropdown UX**: Added `e.stopPropagation()` to the "Send Now" button in `message-queue-section.tsx` to stop the click event from bubbling up to the `Collapsible` trigger, keeping the accordion open during manual queue interactions.

### Testing/Verification
- [x] Verified that queued prompts are processed sequentially one-by-one automatically *only after* the agent has fully completed its current multi-step response.
- [x] Verified that typing a new prompt to an idle/stopped agent processes only that new prompt in isolation, leaving the existing queue untouched.
- [x] Tested native Electron app (`pnpm -F stagewise start`) to verify that clicking the "Send Now" button successfully pushes the prompt while keeping the accordion menu open.
- [x] Ran `pnpm test` (all 619 `agent-core` tests passing).
- [x] Ran `pnpm typecheck` successfully across the monorepo.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #1491 by processing queued messages strictly one-by-one at true idle points and isolating manual sends. Keeps the queue dropdown open and corrects telemetry to count a single dequeued message.

- **Bug Fixes**
  - `agent-core`: continuation now returns `{ shouldRun, flushQueue }`; dequeues only at idle. `beginStep` shifts one queued message per step. Manual sends run via `runStep(false, false)`. Telemetry `flushed_message_count` now reports 1.
  - `browser`: “Send now” stops event propagation so the dropdown stays open.

- **Refactors**
  - Removed unused `flushQueueIntoHistory` and its binding.
  - Updated `flushQueue` JSDoc to document single-message dequeue behavior.

<sup>Written for commit 6820b7bbd1496eb3ed24cb53c983d610ebb1c01e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1492?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core agent step/continuation and queue semantics in `base-agent` and `beginStep`, which affect when user prompts enter model context during tool loops and after stop/flush.
> 
> **Overview**
> Fixes queued-message handling so prompts run **one at a time** at real turn boundaries, and manual sends no longer drag the whole queue into the same run.
> 
> **`agent-core`:** Continuation decisions are now `{ shouldRun, flushQueue }` instead of a bare boolean, so the next step only **dequeues one** message when appropriate (e.g. after idle, max steps/time, or non–tool-call finishes) while **tool-call loops** keep `flushQueue: false` and finish multi-step work first. `beginStep` **shifts** a single queued message into history (replacing bulk `flushQueueIntoHistory`). **`sendUserMessage`** on an idle agent calls **`runStep(false, false)`** so a new prompt does not flush the queue; **`flushQueue`** stops the run and lets the next step pop one message (telemetry **`flushed_message_count: 1`**).
> 
> **`browser`:** **Send now** uses **`stopPropagation`** so the queue collapsible stays open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6820b7bbd1496eb3ed24cb53c983d610ebb1c01e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved queued-message handling so queued messages are moved into chat history one at a time (preserving order) instead of being bulk-flushed.
  * Fixed the “Send now” control to prevent unintended parent UI actions when flushing queued messages.
  * Improved agent step continuation so queue flushing coordinates correctly with tool approvals, max step/time limits, and resumes reliably after interruptions and internal retry paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->