### PR TITLE
fix(stagewise): sort inference models last

### DIFF
--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/model-select.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/model-select.tsx
@@ -258,7 +258,11 @@ export const ModelSelect = memo(function ModelSelect({
     return map;
   }, [selectableEntries]);
 
-  // Group entries by provider instance
+  // Group entries by provider instance.
+  // Stagewise inference instances are sorted last so that user-connected
+  // providers appear at the top of the dropdown. Array.sort is stable in
+  // modern engines (per ES2019), so non-stagewise groups preserve their
+  // original insertion order.
   const groupedByInstance = useMemo<InstanceGroup[]>(() => {
     const groups = new Map<string, InstanceGroup>();
     for (const entry of selectableEntries) {
@@ -274,7 +278,12 @@ export const ModelSelect = memo(function ModelSelect({
       }
       group.entries.push(entry);
     }
-    return Array.from(groups.values());
+    return Array.from(groups.values()).sort((a, b) => {
+      const aStagewise = a.typeId === 'stagewise';
+      const bStagewise = b.typeId === 'stagewise';
+      if (aStagewise !== bStagewise) return aStagewise ? 1 : -1;
+      return 0;
+    });
   }, [selectableEntries]);
 
   // Build preset entries for the dropdown
@@ -345,8 +354,13 @@ export const ModelSelect = memo(function ModelSelect({
   );
 
   const allEntryKeys = useMemo(
-    () => selectableEntries.map((e) => encodeKey(e.instanceId, e.modelId)),
-    [selectableEntries],
+    () =>
+      groupedByInstance.flatMap((group) =>
+        group.entries.map((entry) =>
+          encodeKey(entry.instanceId, entry.modelId),
+        ),
+      ),
+    [groupedByInstance],
   );
 
   const presetKeys = useMemo(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> UI-only ordering in the model selector with no auth, data, or model-selection logic changes beyond display/navigation order.
> 
> **Overview**
> **Stagewise inference provider groups are moved to the bottom** of the agent chat model dropdown so user-connected providers show first.
> 
> `groupedByInstance` now applies a **stable sort** that pushes `typeId === 'stagewise'` instance groups after all others, without reordering non-stagewise groups among themselves.
> 
> **`allEntryKeys` is built from `groupedByInstance`** instead of the flat `selectableEntries` list, so combobox `items` and keyboard navigation follow the same order as the grouped UI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45f327809ee295c0a33f8509843a8154fb199488. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sorts `typeId === 'stagewise'` inference groups to the bottom of the model dropdown so user-connected providers appear first, using a stable sort to preserve other group order. Also aligns `allEntryKeys` with the grouped order for consistent navigation and presets.

<sup>Written for commit 45f327809ee295c0a33f8509843a8154fb199488. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1493?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Updated the model selector dropdown to sort provider instance groups so “stagewise” instances appear at the end.
  * Kept the relative order of all other (non-stagewise) instance groups for a consistent selection experience.
  * Adjusted the computed dropdown item values to match the new sorted ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->