### PR TITLE
feat(stagewise): improve auto-update flow and release notes

### DIFF
--- a/apps/browser/src/backend/services/auto-update.ts
+++ b/apps/browser/src/backend/services/auto-update.ts
@@ -10,7 +10,7 @@
  * Platform support: macOS and Windows only (Linux is not supported by Electron's autoUpdater)
  */
 
-import { autoUpdater } from 'electron';
+import { autoUpdater, dialog } from 'electron';
 import { DisposableService } from './disposable';
 import type { Logger } from './logger';
 import type { NotificationService } from './notification';
@@ -28,20 +28,22 @@ declare const __APP_VERSION__: string;
 declare const __APP_PLATFORM__: string;
 declare const __APP_ARCH__: string;
 
+type UpdateInfo = {
+  releaseName: string;
+  releaseNotes?: string;
+};
+
 export class AutoUpdateService extends DisposableService {
   private readonly logger: Logger;
   private readonly notificationService: NotificationService;
   private readonly telemetryService: TelemetryService;
   private readonly preferencesService: PreferencesService;
   private readonly uiKarton: KartonService;
-  private updateDownloaded = false;
+  private pendingUpdate: UpdateInfo | null = null;
+  private downloadingUpdate: UpdateInfo | null = null;
+  private updateCheckInProgress = false;
+  private updateCheckRequestId = 0;
   private updateNotificationId: string | null = null;
-  private updateInfo: {
-    releaseName?: string;
-    releaseNotes?: string;
-    releaseDate?: Date;
-    updateURL?: string;
-  } | null = null;
 
   // Check for updates every 30 minutes
   private readonly UPDATE_CHECK_INTERVAL_MS = 30 * 60 * 1000;
@@ -103,20 +105,20 @@ export class AutoUpdateService extends DisposableService {
       return;
     }
 
-    // Don't run in dev builds - they shouldn't auto-update
     if (__APP_RELEASE_CHANNEL__ === 'dev') {
       this.logger.debug(
-        '[AutoUpdateService] Auto-updates disabled for dev builds, skipping initialization',
+        '[AutoUpdateService] Auto-updates disabled for dev builds',
       );
       this.setAutoUpdateState('unsupported');
       return;
     }
 
-    const feedURL = this.buildFeedURL();
+    const feedURL = this.buildUpdateURL('update');
     if (!feedURL) {
       this.logger.warn(
         '[AutoUpdateService] Could not build feed URL, auto-updates disabled',
       );
+      this.setAutoUpdateState('unsupported');
       return;
     }
 
@@ -155,26 +157,26 @@ export class AutoUpdateService extends DisposableService {
         }
       });
 
-      // Register Karton procedure handlers
-      this.uiKarton.registerServerProcedureHandler(
-        'autoUpdate.checkForUpdates',
-        async (_callingClientId: string) => {
-          this.checkForUpdates();
-        },
-      );
-      this.uiKarton.registerServerProcedureHandler(
-        'autoUpdate.quitAndInstall',
-        async (_callingClientId: string) => {
-          this.quitAndInstall();
-        },
-      );
+      this.registerProcedureHandlers();
     } catch (error) {
       this.logger.error(
         '[AutoUpdateService] Failed to initialize auto-updater',
         error,
       );
       this.report(error as Error, 'initialize');
+      this.setAutoUpdateState('unsupported');
     }
+  }
+
+  private registerProcedureHandlers(): void {
+    this.uiKarton.registerServerProcedureHandler(
+      'autoUpdate.checkForUpdates',
+      async () => this.checkForUpdates(),
+    );
+    this.uiKarton.registerServerProcedureHandler(
+      'autoUpdate.quitAndInstall',
+      async () => this.quitAndInstall(),
+    );
   }
 
   /**
@@ -182,7 +184,7 @@ export class AutoUpdateService extends DisposableService {
    * Re-configures the feed URL and triggers an immediate update check.
    */
   private onUpdateChannelChanged(): void {
-    const feedURL = this.buildFeedURL();
+    const feedURL = this.buildUpdateURL('update');
     if (!feedURL) {
       this.logger.warn(
         '[AutoUpdateService] Could not build feed URL after channel change',
@@ -197,22 +199,13 @@ export class AutoUpdateService extends DisposableService {
     try {
       autoUpdater.setFeedURL({ url: feedURL });
 
-      // Reset downloaded state so the guard in checkForUpdates() allows
-      // re-checking against the new channel's update feed.
-      this.dismissUpdateNotification();
-      this.updateDownloaded = false;
-      this.updateInfo = null;
-      this.setAutoUpdateState('idle');
-
-      // Re-start periodic checks if they were stopped after a previous download
-      if (!this.updateCheckIntervalId) {
-        this.updateCheckIntervalId = setInterval(() => {
-          if (!this.disposed) this.checkForUpdates();
-        }, this.UPDATE_CHECK_INTERVAL_MS);
+      // Let an active Electron download finish; otherwise restart the preflight
+      // against the new channel while preserving any installable update.
+      if (!this.downloadingUpdate) {
+        this.updateCheckRequestId += 1;
+        this.updateCheckInProgress = false;
+        this.checkForUpdates();
       }
-
-      // Trigger an immediate check with the new channel
-      this.checkForUpdates();
     } catch (error) {
       this.logger.error(
         '[AutoUpdateService] Failed to reconfigure feed URL after channel change',
@@ -267,7 +260,10 @@ export class AutoUpdateService extends DisposableService {
     }
   }
 
-  private buildFeedURL(): string | null {
+  private buildUpdateURL(
+    endpoint: 'update' | 'update-info',
+    version = __APP_VERSION__,
+  ): string | null {
     const updateServerOrigin = process.env.UPDATE_SERVER_ORIGIN;
 
     if (!updateServerOrigin) {
@@ -280,16 +276,13 @@ export class AutoUpdateService extends DisposableService {
     const platform = this.getPlatform();
     const arch = this.getArch();
     const channel = this.getReleaseChannel();
-    const version = __APP_VERSION__;
-
-    // Format: ${UPDATE_SERVER_ORIGIN}/update/stagewise/${RELEASE_CHANNEL}/${PLATFORM}/${ARCH}/${CURRENT_APP_VERSION}
-    const feedURL = `${updateServerOrigin}/update/stagewise/${channel}/${platform}/${arch}/${version}`;
+    const url = `${updateServerOrigin}/${endpoint}/stagewise/${channel}/${platform}/${arch}/${version}`;
 
     this.logger.debug(
-      `[AutoUpdateService] Built feed URL: ${feedURL} (platform: ${platform}, arch: ${arch}, channel: ${channel}, version: ${version})`,
+      `[AutoUpdateService] Built ${endpoint} URL: ${url} (platform: ${platform}, arch: ${arch}, channel: ${channel}, version: ${version})`,
     );
 
-    return feedURL;
+    return url;
   }
 
   private setupEventHandlers(): void {
@@ -298,73 +291,39 @@ export class AutoUpdateService extends DisposableService {
       this.logger.debug(`[AutoUpdateService] Error message: ${error.message}`);
       this.logger.debug(`[AutoUpdateService] Error stack: ${error.stack}`);
       this.report(error, 'autoUpdaterError');
-
-      // Keep the ready-to-install update visible.
-      if (this.updateDownloaded) return;
-
-      this.dismissUpdateNotification();
-      this.setAutoUpdateState('error', null, error.message);
-    });
-
-    autoUpdater.on('checking-for-update', () => {
-      this.logger.debug('[AutoUpdateService] Checking for updates...');
-      this.setAutoUpdateState('checking');
-    });
-
-    autoUpdater.on('update-available', () => {
-      this.logger.debug(
-        '[AutoUpdateService] Update available, download starting automatically',
-      );
-      this.dismissUpdateNotification();
-      this.updateNotificationId = this.notificationService.showNotification({
-        title: 'Update Available',
-        message: 'A new version is being downloaded.',
-        type: 'info',
-        icon: 'spinner',
-        actions: [],
-      });
-      this.setAutoUpdateState('downloading');
+      this.finishFailedUpdateAttempt('error', error.message);
     });
 
     autoUpdater.on('update-not-available', () => {
       this.logger.debug(
         '[AutoUpdateService] No update available, app is up to date',
       );
-      this.dismissUpdateNotification();
-      this.setAutoUpdateState('not-available');
+      this.finishFailedUpdateAttempt('not-available');
     });
 
     autoUpdater.on(
       'update-downloaded',
       (_event, releaseNotes, releaseName, releaseDate, updateURL) => {
-        this.updateDownloaded = true;
-        this.updateInfo = {
-          releaseName,
-          releaseNotes,
-          releaseDate,
-          updateURL,
+        this.pendingUpdate = {
+          releaseName: this.downloadingUpdate?.releaseName || releaseName,
+          releaseNotes:
+            this.downloadingUpdate?.releaseNotes || releaseNotes || undefined,
         };
+        this.updateCheckInProgress = false;
+        this.downloadingUpdate = null;
 
         this.logger.debug('[AutoUpdateService] Update downloaded successfully');
-        this.logger.debug(`[AutoUpdateService] Release name: ${releaseName}`);
-        this.logger.debug(`[AutoUpdateService] Release notes: ${releaseNotes}`);
+        this.logger.debug(
+          `[AutoUpdateService] Release name: ${this.pendingUpdate.releaseName}`,
+        );
+        this.logger.debug(
+          `[AutoUpdateService] Release notes: ${this.pendingUpdate.releaseNotes}`,
+        );
         this.logger.debug(`[AutoUpdateService] Release date: ${releaseDate}`);
         this.logger.debug(`[AutoUpdateService] Update URL: ${updateURL}`);
 
-        // Stop periodic checks — no need to re-check once an update is ready
-        if (this.updateCheckIntervalId) {
-          clearInterval(this.updateCheckIntervalId);
-          this.updateCheckIntervalId = null;
-        }
-
-        // Show notification to user
-        this.showUpdateReadyNotification(releaseName);
-
-        // Sync state to UI
-        this.setAutoUpdateState('ready', {
-          releaseName,
-          releaseNotes,
-        });
+        this.showUpdateNotification(true, this.pendingUpdate);
+        this.setAutoUpdateState('ready', this.pendingUpdate);
       },
     );
 
@@ -382,35 +341,117 @@ export class AutoUpdateService extends DisposableService {
     this.updateNotificationId = null;
   }
 
-  private showUpdateReadyNotification(releaseName: string): void {
-    const versionDisplay = releaseName || 'a new version';
+  private showUpdateNotification(ready: boolean, update: UpdateInfo): void {
+    const viewChangelogAction = {
+      label: 'View Changelog',
+      type: 'secondary' as const,
+      onClick: () => {
+        this.uiKarton.setState((draft) => {
+          draft.appScreen.mode = 'settings';
+          draft.appScreen.settingsRoute = { section: 'about' };
+        });
+      },
+    };
 
-    // Dismiss any previous update notification before showing a new one
     this.dismissUpdateNotification();
-
     this.updateNotificationId = this.notificationService.showNotification({
-      title: 'Update Ready',
-      message: `${versionDisplay} has been downloaded and is ready to install.`,
+      title: ready
+        ? `Update ${update.releaseName} is ready`
+        : `Update ${update.releaseName} is available`,
+      message: ready
+        ? 'Downloaded and ready to install.'
+        : 'Downloading in the background.',
       type: 'info',
-      actions: [
-        {
-          label: 'Restart & Install Now',
-          type: 'primary',
-          onClick: () => {
-            this.quitAndInstall();
-          },
-        },
-        {
-          label: 'Later',
-          type: 'secondary',
-          onClick: () => {
-            this.logger.debug(
-              '[AutoUpdateService] User chose to install update later',
-            );
-          },
-        },
-      ],
+      icon: ready ? undefined : 'spinner',
+      actions: ready
+        ? [
+            {
+              label: 'Restart & Install Now',
+              type: 'primary',
+              onClick: () => void this.quitAndInstall(),
+            },
+            viewChangelogAction,
+          ]
+        : [viewChangelogAction],
     });
+  }
+
+  private finishFailedUpdateAttempt(
+    fallbackStatus: 'not-available' | 'error',
+    errorMessage?: string,
+  ): void {
+    const replacementDownloadStarted = Boolean(this.downloadingUpdate);
+    this.updateCheckInProgress = false;
+    this.downloadingUpdate = null;
+
+    if (this.pendingUpdate) {
+      if (replacementDownloadStarted) {
+        this.showUpdateNotification(true, this.pendingUpdate);
+        this.setAutoUpdateState('ready', this.pendingUpdate);
+      }
+      return;
+    }
+
+    this.dismissUpdateNotification();
+    this.setAutoUpdateState(fallbackStatus, null, errorMessage);
+  }
+
+  // Preflight because Electron downloads immediately from checkForUpdates().
+  private async checkForNewerVersion(): Promise<void> {
+    const currentVersion = this.pendingUpdate?.releaseName ?? __APP_VERSION__;
+    const updateInfoURL = this.buildUpdateURL('update-info', currentVersion);
+    if (!updateInfoURL) {
+      this.logger.warn(
+        '[AutoUpdateService] Could not build update info URL, skipping check',
+      );
+      return;
+    }
+
+    const requestId = ++this.updateCheckRequestId;
+    this.updateCheckInProgress = true;
+    if (!this.pendingUpdate) this.setAutoUpdateState('checking', null);
+
+    try {
+      const response = await fetch(updateInfoURL, {
+        headers: { Accept: 'application/json' },
+      });
+
+      if (requestId !== this.updateCheckRequestId || this.disposed) return;
+      if (response.status === 204) {
+        this.finishFailedUpdateAttempt('not-available');
+        return;
+      }
+      if (!response.ok) {
+        throw new Error(
+          `Update info request failed: ${response.status} ${response.statusText}`,
+        );
+      }
+
+      const metadata = (await response.json()) as {
+        version: string;
+        notes?: string;
+      };
+
+      this.downloadingUpdate = {
+        releaseName: metadata.version,
+        releaseNotes: metadata.notes,
+      };
+
+      this.logger.debug(
+        `[AutoUpdateService] Newer version ${metadata.version} found, starting Electron updater`,
+      );
+      this.showUpdateNotification(false, this.downloadingUpdate);
+      this.setAutoUpdateState('downloading', this.downloadingUpdate);
+      autoUpdater.checkForUpdates();
+    } catch (error) {
+      if (requestId !== this.updateCheckRequestId || this.disposed) return;
+      this.logger.error(
+        '[AutoUpdateService] Error checking update metadata:',
+        error,
+      );
+      this.report(error as Error, 'checkUpdateMetadata', { currentVersion });
+      this.finishFailedUpdateAttempt('error', (error as Error).message);
+    }
   }
 
   /**
@@ -419,64 +460,59 @@ export class AutoUpdateService extends DisposableService {
   public checkForUpdates(): void {
     this.assertNotDisposed();
 
-    if (this.updateDownloaded) {
+    if (this.updateCheckInProgress) {
       this.logger.debug(
-        '[AutoUpdateService] Skipping update check - update already downloaded and ready to install',
-      );
-      return;
-    }
-
-    const platform = this.getPlatform();
-    if (platform !== 'macos' && platform !== 'win') {
-      this.logger.debug(
-        '[AutoUpdateService] Cannot check for updates on unsupported platform',
+        '[AutoUpdateService] Skipping update check - another check is in progress',
       );
       return;
     }
 
     this.logger.debug('[AutoUpdateService] Manually triggering update check');
-    try {
-      autoUpdater.checkForUpdates();
-    } catch (error) {
-      this.logger.error(
-        '[AutoUpdateService] Error checking for updates:',
-        error,
-      );
-      this.report(error as Error, 'checkForUpdates');
-    }
+    void this.checkForNewerVersion();
   }
 
   /**
    * Quit the app and install the downloaded update
    */
-  public quitAndInstall(): void {
+  public async quitAndInstall(): Promise<void> {
     this.assertNotDisposed();
 
-    if (!this.updateDownloaded) {
+    if (!this.pendingUpdate) {
       this.logger.warn(
         '[AutoUpdateService] Cannot quit and install - no update has been downloaded',
       );
       return;
     }
 
+    if (this.downloadingUpdate) {
+      this.logger.warn(
+        '[AutoUpdateService] Cannot install while a newer update is downloading',
+      );
+      return;
+    }
+
+    const hasWorkingAgents = Object.values(
+      this.uiKarton.state.agents.instances,
+    ).some((agent) => agent.state.isWorking);
+
+    if (hasWorkingAgents) {
+      const { response } = await dialog.showMessageBox({
+        type: 'warning',
+        title: 'Install Update',
+        message: 'Agents are still working',
+        detail: 'Restarting now will stop them. Install the update anyway?',
+        buttons: ['Restart & Install', 'Cancel'],
+        defaultId: 1,
+        cancelId: 1,
+        noLink: true,
+      });
+      if (response !== 0) return;
+    }
+
     this.logger.debug(
       '[AutoUpdateService] Quitting app and installing update...',
     );
     autoUpdater.quitAndInstall();
-  }
-
-  /**
-   * Check if an update has been downloaded and is ready to install
-   */
-  public isUpdateReady(): boolean {
-    return this.updateDownloaded;
-  }
-
-  /**
-   * Get information about the downloaded update
-   */
-  public getUpdateInfo(): typeof this.updateInfo {
-    return this.updateInfo;
   }
 
   /**
@@ -491,7 +527,7 @@ export class AutoUpdateService extends DisposableService {
       | 'not-available'
       | 'error'
       | 'unsupported',
-    updateInfo?: { releaseName?: string; releaseNotes?: string } | null,
+    updateInfo?: UpdateInfo | null,
     errorMessage?: string | null,
   ): void {
     this.uiKarton.setState((draft) => {
@@ -504,6 +540,7 @@ export class AutoUpdateService extends DisposableService {
   }
 
   protected onTeardown(): void {
+    this.updateCheckRequestId += 1;
     if (this.updateCheckIntervalId) {
       clearInterval(this.updateCheckIntervalId);
       this.updateCheckIntervalId = null;

--- a/apps/browser/src/backend/services/auto-update.ts
+++ b/apps/browser/src/backend/services/auto-update.ts
@@ -305,9 +305,11 @@ export class AutoUpdateService extends DisposableService {
       'update-downloaded',
       (_event, releaseNotes, releaseName, releaseDate, updateURL) => {
         this.pendingUpdate = {
-          releaseName: this.downloadingUpdate?.releaseName || releaseName,
+          releaseName,
           releaseNotes:
-            this.downloadingUpdate?.releaseNotes || releaseNotes || undefined,
+            this.downloadingUpdate?.releaseName === releaseName
+              ? this.downloadingUpdate.releaseNotes || releaseNotes || undefined
+              : releaseNotes || undefined,
         };
         this.updateCheckInProgress = false;
         this.downloadingUpdate = null;
@@ -414,6 +416,7 @@ export class AutoUpdateService extends DisposableService {
     try {
       const response = await fetch(updateInfoURL, {
         headers: { Accept: 'application/json' },
+        signal: AbortSignal.timeout(30_000),
       });
 
       if (requestId !== this.updateCheckRequestId || this.disposed) return;
@@ -428,9 +431,13 @@ export class AutoUpdateService extends DisposableService {
       }
 
       const metadata = (await response.json()) as {
-        version: string;
+        version?: unknown;
         notes?: string;
       };
+      if (requestId !== this.updateCheckRequestId || this.disposed) return;
+      if (typeof metadata.version !== 'string' || !metadata.version) {
+        throw new Error('Update info response missing version');
+      }
 
       this.downloadingUpdate = {
         releaseName: metadata.version,
@@ -506,7 +513,7 @@ export class AutoUpdateService extends DisposableService {
         cancelId: 1,
         noLink: true,
       });
-      if (response !== 0) return;
+      if (response !== 0 || this.downloadingUpdate) return;
     }
 
     this.logger.debug(

--- a/apps/browser/src/ui/components/release-notes.tsx
+++ b/apps/browser/src/ui/components/release-notes.tsx
@@ -1,0 +1,86 @@
+import { Button } from '@stagewise/stage-ui/components/button';
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@stagewise/stage-ui/components/dialog';
+import { cn } from '@stagewise/stage-ui/lib/utils';
+import { useState } from 'react';
+import ReactMarkdown from 'react-markdown';
+import releaseNotesMarkdown from '../../../../../.release-notes.md?raw';
+
+const LAST_SEEN_VERSION_KEY = 'stagewise-whats-new-version';
+const releaseNotes = releaseNotesMarkdown.trim();
+const hasCurrentReleaseNotes = releaseNotes.startsWith(
+  `## ${__APP_VERSION__} (`,
+);
+
+function wasCurrentVersionSeen(): boolean {
+  try {
+    return localStorage.getItem(LAST_SEEN_VERSION_KEY) === __APP_VERSION__;
+  } catch {
+    return false;
+  }
+}
+
+export function ReleaseNotes({
+  children,
+  className,
+}: {
+  children: string;
+  className?: string;
+}) {
+  return (
+    <div
+      className={cn(
+        'space-y-3 text-muted-foreground text-sm',
+        '[&_a]:text-primary-foreground [&_a]:underline',
+        '[&_code]:font-mono',
+        '[&_h2]:font-semibold [&_h2]:text-base [&_h2]:text-foreground',
+        '[&_h3]:font-medium [&_h3]:text-foreground',
+        '[&_ol]:list-decimal [&_ol]:space-y-1 [&_ol]:pl-5',
+        '[&_ul]:list-disc [&_ul]:space-y-1 [&_ul]:pl-5',
+        className,
+      )}
+    >
+      <ReactMarkdown>{children}</ReactMarkdown>
+    </div>
+  );
+}
+
+export function WhatsNewDialog() {
+  const [open, setOpen] = useState(
+    () => hasCurrentReleaseNotes && !wasCurrentVersionSeen(),
+  );
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    setOpen(nextOpen);
+    if (nextOpen) return;
+
+    try {
+      localStorage.setItem(LAST_SEEN_VERSION_KEY, __APP_VERSION__);
+    } catch {
+      // Show it again on the next launch if storage is unavailable.
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="max-h-[80vh] max-w-2xl gap-4 overflow-hidden">
+        <DialogClose />
+        <DialogHeader>
+          <DialogTitle>What’s new</DialogTitle>
+        </DialogHeader>
+        <div className="scrollbar-subtle min-h-0 overflow-y-auto rounded-lg bg-surface-1 p-4">
+          <ReleaseNotes>{releaseNotes}</ReleaseNotes>
+        </div>
+        <DialogFooter>
+          <Button onClick={() => handleOpenChange(false)}>Got it</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/browser/src/ui/components/release-notes.tsx
+++ b/apps/browser/src/ui/components/release-notes.tsx
@@ -9,7 +9,7 @@ import {
 } from '@stagewise/stage-ui/components/dialog';
 import { cn } from '@stagewise/stage-ui/lib/utils';
 import { useState } from 'react';
-import ReactMarkdown from 'react-markdown';
+import ReactMarkdown, { type Components } from 'react-markdown';
 import releaseNotesMarkdown from '../../../../../.release-notes.md?raw';
 
 const LAST_SEEN_VERSION_KEY = 'stagewise-whats-new-version';
@@ -17,6 +17,11 @@ const releaseNotes = releaseNotesMarkdown.trim();
 const hasCurrentReleaseNotes = releaseNotes.startsWith(
   `## ${__APP_VERSION__} (`,
 );
+const releaseNotesComponents: Components = {
+  a: ({ node: _node, ...props }) => (
+    <a {...props} target="_blank" rel="noopener noreferrer" />
+  ),
+};
 
 function wasCurrentVersionSeen(): boolean {
   try {
@@ -46,7 +51,9 @@ export function ReleaseNotes({
         className,
       )}
     >
-      <ReactMarkdown>{children}</ReactMarkdown>
+      <ReactMarkdown components={releaseNotesComponents}>
+        {children}
+      </ReactMarkdown>
     </div>
   );
 }

--- a/apps/browser/src/ui/screens/index.tsx
+++ b/apps/browser/src/ui/screens/index.tsx
@@ -7,6 +7,7 @@ import {
 import { Logo } from '@ui/components/ui/logo';
 import { WebContentsBoundsSyncer } from '@ui/components/web-contents-bounds-syncer';
 import { TutorialOverlay } from '@ui/components/tutorial/tutorial-overlay';
+import { WhatsNewDialog } from '@ui/components/release-notes';
 
 // Lazy-load the heavy screen trees. Both `DefaultLayout` and `OnboardingWizard`
 // only render *after* the karton connection is established, yet importing them
@@ -73,6 +74,7 @@ export function ScreenRouter() {
         <Suspense fallback={<LoadingScreen reconnectState={reconnectState} />}>
           <DefaultLayout show />
           <WebContentsBoundsSyncer />
+          <WhatsNewDialog />
         </Suspense>
       ) : (
         <Suspense fallback={<LoadingScreen reconnectState={reconnectState} />}>

--- a/apps/browser/src/ui/screens/main/_components/sidebar-auth-footer.tsx
+++ b/apps/browser/src/ui/screens/main/_components/sidebar-auth-footer.tsx
@@ -7,8 +7,10 @@ import {
 import { cn } from '@stagewise/stage-ui/lib/utils';
 import { useKartonProcedure, useKartonState } from '@ui/hooks/use-karton';
 import { useTrack } from '@ui/hooks/use-track';
+import { LoaderCircleIcon } from 'lucide-react';
 import { useCallback } from 'react';
 import {
+  IconDownload4Outline18,
   IconGear3Outline18,
   IconHotDrinkOutline18,
   IconOpenRectArrowInOutline18,
@@ -26,11 +28,16 @@ export function SidebarAuthFooter() {
   const toggleClosedLidSleep = useKartonProcedure(
     (p) => p.closedLidSleep.toggle,
   );
+  const quitAndInstall = useKartonProcedure((p) => p.autoUpdate.quitAndInstall);
 
   const appScreenMode = useKartonState((s) => s.appScreen.mode);
   const userAccount = useKartonState((s) => s.userAccount);
   const isMacOs = useKartonState((s) => s.appInfo.platform === 'darwin');
   const closedLidSleep = useKartonState((s) => s.closedLidSleep);
+  const updateStatus = useKartonState((s) => s.autoUpdate.status);
+  const updateVersion = useKartonState(
+    (s) => s.autoUpdate.updateInfo?.releaseName,
+  );
 
   const isAuthenticated =
     userAccount.status === 'authenticated' ||
@@ -39,6 +46,11 @@ export function SidebarAuthFooter() {
   const plan = userAccount.subscription?.plan;
   const avatarChar = email ? email[0]!.toUpperCase() : null;
   const isSettingsOpen = appScreenMode === 'settings';
+  const isUpdateReady = updateStatus === 'ready';
+  const updateVersionLabel = updateVersion ? ` ${updateVersion}` : '';
+  const updateLabel = isUpdateReady
+    ? `Update${updateVersionLabel} ready, restart and install`
+    : `Downloading update${updateVersionLabel}...`;
 
   const handleToggleSettings = useCallback(() => {
     if (isSettingsOpen) {
@@ -106,6 +118,30 @@ export function SidebarAuthFooter() {
         )}
 
         <div className="flex shrink-0 flex-row items-center gap-1">
+          {(updateStatus === 'downloading' || isUpdateReady) && (
+            <Tooltip>
+              <TooltipTrigger>
+                <Button
+                  variant="ghost"
+                  size="icon-sm"
+                  aria-label={updateLabel}
+                  aria-disabled={!isUpdateReady}
+                  className="app-no-drag shrink-0"
+                  onClick={
+                    isUpdateReady ? () => void quitAndInstall() : undefined
+                  }
+                >
+                  {isUpdateReady ? (
+                    <IconDownload4Outline18 className="size-4 text-primary-foreground" />
+                  ) : (
+                    <LoaderCircleIcon className="size-4 animate-spin text-primary-foreground" />
+                  )}
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="top">{updateLabel}</TooltipContent>
+            </Tooltip>
+          )}
+
           {isMacOs && (
             <Tooltip>
               <TooltipTrigger>

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/notification-banners.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/notification-banners.tsx
@@ -54,12 +54,13 @@ export function NotificationBanners() {
             </div>
           </div>
           {notification.actions.length > 0 && (
-            <div className="flex flex-row-reverse items-center gap-2">
+            <div className="flex flex-row-reverse flex-wrap items-center gap-2">
               {notification.actions.slice(0, 3).map((action, index) => (
                 <Button
                   key={action.label}
                   variant={index === 0 ? action.type : 'ghost'}
                   size="xs"
+                  className="whitespace-nowrap"
                   onClick={() => {
                     triggerAction(notification.id, index);
                     dismissNotification(notification.id);

--- a/apps/browser/src/ui/screens/main/sidebar/index.tsx
+++ b/apps/browser/src/ui/screens/main/sidebar/index.tsx
@@ -88,7 +88,7 @@ export function Sidebar() {
           >
             <AgentsList />
 
-            <div className="mt-8 flex shrink-0 flex-col gap-2">
+            <div className="mt-2 flex shrink-0 flex-col gap-2 empty:hidden">
               <SidebarExperienceSurvey />
               <NotificationBanners />
               <UsageWarningBadge />

--- a/apps/browser/src/ui/screens/settings/sections/about-section.tsx
+++ b/apps/browser/src/ui/screens/settings/sections/about-section.tsx
@@ -142,6 +142,10 @@ function AppUpdateStatus() {
 function UpdateChannelSetting() {
   const preferences = useKartonState((s) => s.preferences);
   const appInfo = useKartonState((s) => s.appInfo);
+  const channelLocked = useKartonState(
+    (s) =>
+      s.autoUpdate.status === 'downloading' || s.autoUpdate.status === 'ready',
+  );
   const updatePreferences = useKartonProcedure((p) => p.preferences.update);
 
   const inferredChannel: UpdateChannel = appInfo.version.includes('-alpha')
@@ -169,7 +173,11 @@ function UpdateChannelSetting() {
         </p>
       </div>
 
-      <RadioGroup value={currentChannel} onValueChange={handleChannelChange}>
+      <RadioGroup
+        value={currentChannel}
+        onValueChange={handleChannelChange}
+        disabled={channelLocked}
+      >
         <RadioLabel>
           <Radio value="beta" />
           <div className="flex flex-col">

--- a/apps/browser/src/ui/screens/settings/sections/about-section.tsx
+++ b/apps/browser/src/ui/screens/settings/sections/about-section.tsx
@@ -32,6 +32,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from '@stagewise/stage-ui/components/tooltip';
+import { ReleaseNotes } from '@ui/components/release-notes';
 
 enablePatches();
 
@@ -109,11 +110,16 @@ function AppUpdateStatus() {
     }
   };
 
+  const updateInfo = autoUpdate.updateInfo;
+
   return (
-    <div className="flex flex-col gap-2">
-      {autoUpdate.status === 'ready' && autoUpdate.updateInfo?.releaseName && (
+    <div className="flex flex-col gap-3">
+      {updateInfo?.releaseName && (
         <p className="text-muted-foreground text-sm">
-          Version {autoUpdate.updateInfo.releaseName} available
+          Update {updateInfo.releaseName}{' '}
+          {autoUpdate.status === 'downloading'
+            ? 'is downloading'
+            : 'is ready to install'}
         </p>
       )}
       {autoUpdate.status === 'error' && autoUpdate.errorMessage && (
@@ -122,6 +128,13 @@ function AppUpdateStatus() {
         </p>
       )}
       <div className="flex items-center gap-3">{renderButton()}</div>
+      {updateInfo?.releaseNotes && (
+        <div className="max-h-56 overflow-y-auto rounded-lg border border-derived-subtle bg-surface-1 p-3">
+          <ReleaseNotes className="text-xs">
+            {updateInfo.releaseNotes}
+          </ReleaseNotes>
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/update-server/spec.md
+++ b/apps/update-server/spec.md
@@ -83,6 +83,24 @@ The update response should look like this:
 - `notes`: The release notes of the release (max. first 512 chracters)
 - `pub_date`: The timestamp of the release (formatted like in the example)
 
+## Update metadata endpoint handling
+
+The metadata endpoint lets the application avoid downloading the same pending
+update again and show release notes while a newer update downloads.
+
+`GET /update-info/:appName/:channel/:platform/:arch/:version`
+
+When a newer release with compatible update assets exists, return:
+
+```json
+{
+  "version": "1.2.3",
+  "notes": "Release notes in Markdown"
+}
+```
+
+If no compatible newer update exists, respond with HTTP 204 (No Content).
+
 ## Windows update endpoint handling
 
 The update endpoint for Windows should offer the latest update for the given arch, channel and version. If there is no release at all available for the given arch, respond with an rempty response.

--- a/apps/update-server/src/releases.ts
+++ b/apps/update-server/src/releases.ts
@@ -9,6 +9,8 @@ export interface AssetMatch {
   asset: GitHubAsset;
 }
 
+type UpdatePlatform = 'macos' | 'win';
+
 function escapeRegex(str: string): string {
   return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
@@ -55,6 +57,57 @@ function buildMacOSZipPattern(
 
   const pattern = `^${escapedAppName}(?:-[a-zA-Z0-9]+)?-darwin-${escapedArch}-${escapedVersion}\\.zip$`;
   return new RegExp(pattern, 'i');
+}
+
+function findMacOSUpdateAssetInRelease(
+  release: Release,
+  arch: string,
+): GitHubAsset | null {
+  const pattern = buildMacOSZipPattern(config.appName, release.version, arch);
+  return findAsset(release, pattern);
+}
+
+function findWindowsReleasesAsset(
+  release: Release,
+  arch: string,
+): GitHubAsset | null {
+  const releasesFileName = `RELEASES-win32-${arch}`;
+  const releasesAsset = release.assets.find(
+    (asset) => asset.name === releasesFileName,
+  );
+
+  if (!releasesAsset) return null;
+
+  const nupkgPattern = buildAssetPattern(
+    config.appName,
+    release.version,
+    arch,
+    '-full.nupkg',
+  );
+  return findAsset(release, nupkgPattern) ? releasesAsset : null;
+}
+
+export async function findUpdateRelease(
+  channel: Channel,
+  platform: UpdatePlatform,
+  arch: string,
+  currentVersion: string,
+): Promise<Release | null> {
+  const releases = await getReleases();
+
+  for (const release of releases) {
+    if (!matchesChannel(release.parsedVersion, channel)) continue;
+    if (!isNewerVersion(release.version, currentVersion)) continue;
+
+    const hasUpdateAsset =
+      platform === 'macos'
+        ? findMacOSUpdateAssetInRelease(release, arch) !== null
+        : findWindowsReleasesAsset(release, arch) !== null;
+
+    if (hasUpdateAsset) return release;
+  }
+
+  return null;
 }
 
 // Arch aliases: .deb uses "amd64" while .rpm uses "x86_64" for the same arch.
@@ -106,8 +159,7 @@ export async function findMacOSUpdateAsset(
 
     // Look for .zip file for macOS updates
     // Format: appName[-suffix]-darwin-arch-version.zip
-    const pattern = buildMacOSZipPattern(config.appName, release.version, arch);
-    const asset = findAsset(release, pattern);
+    const asset = findMacOSUpdateAssetInRelease(release, arch);
 
     if (asset) {
       return { release, asset };
@@ -176,24 +228,8 @@ export async function findWindowsUpdateAsset(
   for (const release of releases) {
     if (!matchesChannel(release.parsedVersion, channel)) continue;
 
-    // Look for RELEASES file
-    const releasesFileName = `RELEASES-win32-${arch}`;
-    const releasesAsset = release.assets.find(
-      (a) => a.name === releasesFileName,
-    );
-
+    const releasesAsset = findWindowsReleasesAsset(release, arch);
     if (!releasesAsset) continue;
-
-    // Also check that the nupkg file exists (raw extension)
-    const nupkgPattern = buildAssetPattern(
-      config.appName,
-      release.version,
-      arch,
-      '-full.nupkg',
-    );
-    const nupkgAsset = findAsset(release, nupkgPattern);
-
-    if (!nupkgAsset) continue;
 
     // Fetch and transform the RELEASES content
     try {

--- a/apps/update-server/src/routes.ts
+++ b/apps/update-server/src/routes.ts
@@ -8,6 +8,7 @@ import {
   findWindowsDownloadAsset,
   findLinuxDownloadAsset,
   findNupkgAsset,
+  findUpdateRelease,
 } from './releases.js';
 
 /**
@@ -67,6 +68,45 @@ function truncateNotes(notes: string, maxLength = 512): string {
   if (notes.length <= maxLength) return notes;
   return `${notes.slice(0, maxLength).trim()}...`;
 }
+
+// GET /update-info/:appName/:channel/:platform/:arch/:version
+router.get(
+  '/update-info/:appName/:channel/:platform/:arch/:version',
+  async (req: Request, res: Response) => {
+    const { appName, channel, platform, arch, version } = req.params;
+
+    if (appName !== config.appName) {
+      res.status(404).send('App not found');
+      return;
+    }
+
+    if (
+      !isValidChannel(channel) ||
+      (platform !== 'macos' && platform !== 'win')
+    ) {
+      res.status(400).send('Invalid update request');
+      return;
+    }
+
+    try {
+      const release = await findUpdateRelease(channel, platform, arch, version);
+
+      res.setHeader('Cache-Control', 'no-store');
+      if (!release) {
+        res.status(204).send();
+        return;
+      }
+
+      res.json({
+        version: release.version,
+        notes: release.notes,
+      });
+    } catch (error) {
+      console.error('Error in update info endpoint:', error);
+      res.status(500).send('Internal server error');
+    }
+  },
+);
 
 // macOS update endpoint
 // GET /update/:appName/:channel/macos/:arch/:version

--- a/apps/update-server/src/routes.ts
+++ b/apps/update-server/src/routes.ts
@@ -1,6 +1,7 @@
 import { Router, type Request, type Response } from 'express';
 import type { Channel, LinuxFormat } from './config.js';
 import { config } from './config.js';
+import { parseVersion } from './version.js';
 import {
   findMacOSUpdateAsset,
   findMacOSDownloadAsset,
@@ -82,7 +83,8 @@ router.get(
 
     if (
       !isValidChannel(channel) ||
-      (platform !== 'macos' && platform !== 'win')
+      (platform !== 'macos' && platform !== 'win') ||
+      !parseVersion(version)
     ) {
       res.status(400).send('Invalid update request');
       return;

--- a/packages/icons/src/nucleo/ui-outline-18/IconDownload4Outline18.tsx
+++ b/packages/icons/src/nucleo/ui-outline-18/IconDownload4Outline18.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { Icon, type IconProps } from './Icon';
+
+interface IconDownload4Outline18Props extends IconProps {
+  strokeWidth?: number;
+}
+
+export const IconDownload4Outline18: React.FC<IconDownload4Outline18Props> = ({
+  strokeWidth = 1.5,
+  ...props
+}) => {
+  return (
+    <Icon size="18px" {...props}>
+      <path
+        d="M15.25,11.75v1.5c0,1.105-.895,2-2,2H4.75c-1.105,0-2-.895-2-2v-1.5"
+        fill="none"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={strokeWidth}
+      />
+      <polyline
+        points="5.5 6.75 9 10.25 12.5 6.75"
+        fill="none"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={strokeWidth}
+      />
+      <line
+        x1="9"
+        y1="10.25"
+        x2="9"
+        y2="2.75"
+        fill="none"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={strokeWidth}
+      />
+    </Icon>
+  );
+};

--- a/packages/icons/src/nucleo/ui-outline-18/index.ts
+++ b/packages/icons/src/nucleo/ui-outline-18/index.ts
@@ -34,6 +34,7 @@ export { IconCopyIdOutline18 } from './IconCopyIdOutline18';
 export { IconCopyOutline18 } from './IconCopyOutline18';
 export { IconDatabaseSearchOutline18 } from './IconDatabaseSearchOutline18';
 export { IconDotsOutline18 } from './IconDotsOutline18';
+export { IconDownload4Outline18 } from './IconDownload4Outline18';
 export { IconEarthOutline18 } from './IconEarthOutline18';
 export { IconEarthSearchOutline18 } from './IconEarthSearchOutline18';
 export { IconEnvelopeOutline18 } from './IconEnvelopeOutline18';


### PR DESCRIPTION
## Summary

- continue checking for updates after an update has already been downloaded
- replace a pending update when a newer compatible release becomes available
- add a platform- and architecture-aware update metadata preflight
- expose release notes while an update is downloading and ready to install
- show downloading and ready notifications with a link to Settings → About
- keep update status visible in the sidebar after dismissing a notification
- show a restart action once the update is ready
- warn before restarting when agents are still working
- render the changelog in Settings → About
- show a What’s New dialog once after starting a newly installed version
- use the generated `.release-notes.md` as the bundled What’s New content
- add a matching one-color update icon to the shared icon package
- remove the empty sidebar space when no notifications or status badges are visible

Closes #1165
Closes #1166
Closes #1372

<img width="984" height="422" alt="image" src="https://github.com/user-attachments/assets/fc10f8b1-ea3b-4f4a-92a8-15786f0c15c2" />
<img width="926" height="380" alt="image" src="https://github.com/user-attachments/assets/fcb2969c-a250-4ecd-a0e7-eedaba2b3de6" />
<img width="1756" height="942" alt="image" src="https://github.com/user-attachments/assets/8915c5d7-f065-4c40-b2a4-eeaa9c26788b" />
<img width="1876" height="1654" alt="image" src="https://github.com/user-attachments/assets/a54cc375-8212-4c4e-bf53-daf7411b490a" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes touch Electron auto-update behavior and a new server endpoint that gates downloads; mistakes could cause missed updates, duplicate downloads, or bad install timing, though preflight and agent warnings reduce restart risk.
> 
> **Overview**
> **Auto-update** now hits a new **`/update-info`** preflight before calling Electron’s `checkForUpdates()`, so the app can skip redundant downloads, keep periodic checks after an update is ready, and treat **pending vs downloading** separately (including when the update channel changes). Notifications and Karton state expose version-specific copy, a **View Changelog** action, and **`quitAndInstall`** blocks while a newer build downloads and shows a warning if agents are still working.
> 
> **UI** adds markdown **`ReleaseNotes`**, a one-time **What’s New** dialog from bundled `.release-notes.md`, changelog in **Settings → About** (with update channel locked while downloading/ready), a sidebar download/restart control, and small notification/sidebar layout tweaks plus **`IconDownload4Outline18`**.
> 
> **Update server** documents and implements **`GET /update-info/...`** (JSON or 204) via shared **`findUpdateRelease`** and refactored macOS/Windows asset helpers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a33d00369a309d8a5d27effe9dc68d99704455b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves the auto-update flow with a metadata preflight and continuous checks, and surfaces release notes throughout the update. Adds a one-time What’s New dialog and renders notes in Settings for a clearer, safer update experience.

- New Features
  - Preflight update metadata to avoid redundant downloads and show notes early.
  - Keep checking for newer updates and replace a pending update; keep the ready update visible on errors.
  - Notifications show download vs ready states, with a View Changelog link to Settings → About.
  - Sidebar shows update status (spinner while downloading, restart when ready).
  - Safer install: warn if agents are working and block install while a newer update is downloading.
  - Settings: render server-provided release notes; show a What’s New dialog once using bundled `.release-notes.md`; lock channel switching while updating.
  - Clean up empty sidebar space; add a one-color update icon.

- Update Server
  - Add GET `/update-info/:appName/:channel/:platform/:arch/:version` returning `{ version, notes }` or 204 when none.
  - Refactor asset lookups to reliably detect compatible macOS and Windows update assets.

<sup>Written for commit a33d00369a309d8a5d27effe9dc68d99704455b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1494?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a “What’s New” dialog that shows release notes per app version, with a “Got it” acknowledgement.
  - Enhanced update UI across sidebar and About screen, including release-name messaging and a scrollable release-notes panel.
  - Added an update metadata endpoint and improved client flow to check metadata first (before downloading).

- **Bug Fixes**
  - Prevented overlapping update checks/downloads and tightened in-flight request handling.
  - Added consistent failure handling that transitions the update system into an unsupported state on setup/reconfiguration errors.
  - Blocked or warned on installation when a newer download is in progress or background work is still running.

- **Style**
  - Improved notification action button layout/wrapping and refined sidebar spacing and conditional rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->