### PR TITLE
feat(stagewise): add chat forking from sidebar

### DIFF
--- a/apps/browser/src/backend/services/agent-manager/agent-manager.ts
+++ b/apps/browser/src/backend/services/agent-manager/agent-manager.ts
@@ -27,6 +27,7 @@ import { renderBrowserExtraMention } from '@/agents/shared/base-agent/utils';
 
 const AGENT_RPC_COMMANDS = [
   'agents.create',
+  'agents.fork',
   'agents.createSideChat',
   'agents.promoteSideChat',
   'agents.discardSideChat',

--- a/apps/browser/src/shared/karton-contracts/ui/index.ts
+++ b/apps/browser/src/shared/karton-contracts/ui/index.ts
@@ -1347,6 +1347,7 @@ export type KartonContract = {
         workspacePaths?: string[],
         preserveWorkspacePaths?: boolean,
       ) => Promise<string>;
+      fork: (sourceAgentId: string) => Promise<string>;
       createSideChat: (sourceAgentId: string) => Promise<string>;
       promoteSideChat: (agentId: string) => Promise<void>;
       discardSideChat: (agentId: string) => Promise<void>;

--- a/apps/browser/src/ui/screens/main/_components/shared-agent-context-menu.tsx
+++ b/apps/browser/src/ui/screens/main/_components/shared-agent-context-menu.tsx
@@ -4,6 +4,7 @@ import { cn } from '@stagewise/stage-ui/lib/utils';
 import { useKartonProcedure, useKartonState } from '@ui/hooks/use-karton';
 import { IconTrash2Outline24 } from '@stagewise/icons';
 import {
+  IconCopyOutline18,
   IconCopyIdOutline18,
   IconFolderOpenOutline18,
   IconPen2Outline18,
@@ -96,6 +97,8 @@ export function buildAgentContextMenuHandler(
 export interface SharedAgentContextMenuHostProps {
   target: AgentContextMenuTarget | null;
   onClose: () => void;
+  /** Duplicate the selected chat, including its history and workspace state. */
+  onForkRequest: (id: string) => void;
   /** User picked "Permanently delete" — caller is expected to show a confirm dialog.
    * Cursor coordinates are forwarded so the confirm popover can anchor
    * right above the click position. */
@@ -106,6 +109,7 @@ export const SharedAgentContextMenuHost = memo(
   function SharedAgentContextMenuHost({
     target,
     onClose,
+    onForkRequest,
     onDeleteRequest,
   }: SharedAgentContextMenuHostProps) {
     const revealWorkingDirectory = useKartonProcedure(
@@ -202,6 +206,15 @@ export const SharedAgentContextMenuHost = memo(
               >
                 <IconPen2Outline18 className="size-3.5 shrink-0" />
                 <span>Rename</span>
+              </AgentMenuItem>
+              <AgentMenuItem
+                onClick={() => {
+                  onForkRequest(agentId);
+                  onClose();
+                }}
+              >
+                <IconCopyOutline18 className="size-3.5 shrink-0" />
+                <span>Fork chat</span>
               </AgentMenuItem>
               {togglePinned && (
                 <AgentMenuItem

--- a/apps/browser/src/ui/screens/main/sidebar/agents-list/index.tsx
+++ b/apps/browser/src/ui/screens/main/sidebar/agents-list/index.tsx
@@ -77,6 +77,7 @@ import type {
   ToolApprovalMode,
 } from '@shared/karton-contracts/ui/shared-types';
 import { Button } from '@stagewise/stage-ui/components/button';
+import { toast } from '@stagewise/stage-ui/components/toaster';
 import { Checkbox } from '@stagewise/stage-ui/components/checkbox';
 import {
   Tooltip,
@@ -684,6 +685,7 @@ export function AgentsList() {
   const [openAgent, setOpenAgent] = useOpenAgent();
   const { previewAgentId } = useAgentSwitcher();
   const createAgent = useKartonProcedure((p) => p.agents.create);
+  const forkAgent = useKartonProcedure((p) => p.agents.fork);
   const resumeAgent = useKartonProcedure((p) => p.agents.resume);
   const setLastOpenAgentId = useKartonProcedure(
     (p) => p.browser.setLastOpenAgentId,
@@ -902,6 +904,27 @@ export function AgentsList() {
   }, [agents.length, createAgent, emptyAgentIdRef, setOpenAgent, track]);
 
   const pendingScrollToCreatedAgentRef = useRef<string | null>(null);
+
+  const handleFork = useCallback(
+    (sourceAgentId: string) => {
+      void forkAgent(sourceAgentId)
+        .then((forkId) => {
+          pendingScrollToCreatedAgentRef.current = forkId;
+          setOpenAgent(forkId);
+          void setLastOpenAgentId(forkId);
+        })
+        .catch((error) => {
+          toast({
+            id: `agent-fork-error-${sourceAgentId}`,
+            title: 'Could not fork chat',
+            message: error instanceof Error ? error.message : String(error),
+            type: 'error',
+            actions: [],
+          });
+        });
+    },
+    [forkAgent, setLastOpenAgentId, setOpenAgent],
+  );
 
   const handleOpenWorkspaceInFileManager = useCallback(
     (workspacePath: string) => {
@@ -2539,6 +2562,7 @@ export function AgentsList() {
       <SharedAgentContextMenuHost
         target={ctxMenuTarget}
         onClose={handleCtxMenuClose}
+        onForkRequest={handleFork}
         onDeleteRequest={handleCtxDeleteRequest}
       />
       <DeleteConfirmPopover

--- a/apps/browser/src/ui/screens/main/sidebar/agents-list/index.tsx
+++ b/apps/browser/src/ui/screens/main/sidebar/agents-list/index.tsx
@@ -910,6 +910,7 @@ export function AgentsList() {
       void forkAgent(sourceAgentId)
         .then((forkId) => {
           pendingScrollToCreatedAgentRef.current = forkId;
+          window.dispatchEvent(new Event('sidebar-chat-panel-opened'));
           setOpenAgent(forkId);
           void setLastOpenAgentId(forkId);
         })

--- a/packages/agent-core/src/services/agent-manager/agent-manager.create-handler.test.ts
+++ b/packages/agent-core/src/services/agent-manager/agent-manager.create-handler.test.ts
@@ -319,3 +319,48 @@ describe('AgentManager agents.create handler', () => {
     await manager.teardown();
   });
 });
+
+describe('AgentManager agents.fork handler', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('resumes the source and promotes a titled side-chat clone', async () => {
+    const deps = createDeps();
+    const sourceEnvelope = {
+      type: AgentTypes.CHAT,
+      sideChatParentId: null,
+      state: { title: 'Original chat' },
+    };
+    deps.agentStore.get.mockReturnValue({
+      agents: { instances: { source: sourceEnvelope } },
+      toolbox: {},
+    });
+    const manager = buildManager(deps);
+    const resumeSpy = vi
+      .spyOn(manager, 'resumeAgent')
+      .mockResolvedValue({} as any);
+    const createSideChatSpy = vi
+      .spyOn(manager as any, 'createSideChat')
+      .mockResolvedValue('fork-1');
+    const promoteSpy = vi
+      .spyOn(manager as any, 'promoteSideChat')
+      .mockResolvedValue(undefined);
+
+    const forkId = await deps.registry.dispatch<unknown[], string>(
+      'agents.fork',
+      { callerId: 'test' },
+      ['source'],
+    );
+
+    expect(forkId).toBe('fork-1');
+    expect(resumeSpy).toHaveBeenCalledWith('source');
+    expect(createSideChatSpy).toHaveBeenCalledWith('source', {
+      title: 'Fork: Original chat',
+      titleLockedByUser: true,
+    });
+    expect(promoteSpy).toHaveBeenCalledWith('fork-1');
+
+    await manager.teardown();
+  });
+});

--- a/packages/agent-core/src/services/agent-manager/agent-manager.ts
+++ b/packages/agent-core/src/services/agent-manager/agent-manager.ts
@@ -496,6 +496,9 @@ export class AgentManager extends DisposableService {
         return agent.instanceId;
       },
     );
+    this.wrapAgentRpc('agents.fork', (sourceAgentId: string) =>
+      this.forkChat(sourceAgentId),
+    );
     this.wrapAgentRpc('agents.createSideChat', (sourceAgentId: string) =>
       this.createSideChat(sourceAgentId),
     );
@@ -1291,7 +1294,35 @@ export class AgentManager extends DisposableService {
     );
   }
 
-  private async createSideChat(sourceAgentId: string): Promise<string> {
+  private async forkChat(sourceAgentId: string): Promise<string> {
+    // History rows are not necessarily hydrated. Reuse the resume path first
+    // so forking behaves identically for active and persisted chats.
+    await this.resumeAgent(sourceAgentId);
+
+    const sourceEnvelope = getAgentInstance(this.agentStore, sourceAgentId);
+    if (!sourceEnvelope) {
+      throw new Error(`Agent with instance id ${sourceAgentId} not found`);
+    }
+
+    const originalTitle = sourceEnvelope.state.title || 'New chat';
+    const forkId = await this.createSideChat(sourceAgentId, {
+      title: `Fork: ${originalTitle}`,
+      titleLockedByUser: true,
+    });
+
+    try {
+      await this.promoteSideChat(forkId);
+      return forkId;
+    } catch (error) {
+      await this.deleteAgent(forkId);
+      throw error;
+    }
+  }
+
+  private async createSideChat(
+    sourceAgentId: string,
+    titleOverride?: { title: string; titleLockedByUser: boolean },
+  ): Promise<string> {
     const sourceEnvelope = getAgentInstance(this.agentStore, sourceAgentId);
     if (!sourceEnvelope) {
       throw new Error(`Agent with instance id ${sourceAgentId} not found`);
@@ -1311,9 +1342,12 @@ export class AgentManager extends DisposableService {
       undefined,
       undefined,
       {
-        title: sourceEnvelope.state.title
-          ? `Side chat: ${sourceEnvelope.state.title}`
-          : 'Side chat',
+        title:
+          titleOverride?.title ??
+          (sourceEnvelope.state.title
+            ? `Side chat: ${sourceEnvelope.state.title}`
+            : 'Side chat'),
+        titleLockedByUser: titleOverride?.titleLockedByUser,
         history: sourceEnvelope.state.history.slice(),
         activeModelId: sourceEnvelope.state.activeModelId,
         activeProviderInstanceId: sourceEnvelope.state.activeProviderInstanceId,


### PR DESCRIPTION
## Summary

- add a “Fork chat” action to the sidebar context menu
- reuse side-chat cloning to copy history, attachments, model settings, approval mode, and workspace mounts
- support forking inactive chats from history
- name forks using `Fork: {original title}`
- open the new fork automatically
- clean up incomplete forks if promotion fails

<img width="446" height="223" alt="image" src="https://github.com/user-attachments/assets/1e7f8bc6-ec86-4bf5-aa34-8c59e5a08d22" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Forking duplicates persisted agent state (history, mounts, settings) and uses resume/promote/delete paths; mistakes could leave orphan agents or incomplete clones, though promotion failure is explicitly cleaned up.
> 
> **Overview**
> Users can **fork** an agent chat from the sidebar context menu. The UI calls a new **`agents.fork`** Karton procedure and switches to the returned agent, with an error toast if forking fails.
> 
> **Backend:** `forkChat` resumes the source (so inactive history chats hydrate first), clones via **`createSideChat`** with optional title override (`Fork: {title}`, user-locked title), then **`promoteSideChat`** so the copy is a top-level chat. Failed promotion triggers cleanup with **`deleteAgent`**. `createSideChat` now accepts title overrides while still copying history, model/provider, tool approval mode, and workspace mounts.
> 
> **Wiring:** Browser agent RPC list and Karton contract expose `fork`; tests assert resume → clone → promote. Sidebar **`handleFork`** scrolls to the new agent like workspace-created chats.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7851e5a1c311e26b5e25a9a1fa59ac4a9827482b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds chat forking from the sidebar so users can duplicate a conversation into a new top-level chat. Introduces `agents.fork` to create a titled clone that’s promoted to its own thread.

- New Features
  - Adds “Fork chat” to the sidebar context menu.
  - Clones history, attachments, model settings, approval mode, and workspace mounts via the side‑chat path.
  - Supports forking inactive chats by resuming first.
  - Names forks “Fork: {original title}” and locks the title.
  - Promotes the clone to a standalone chat; rolls back and shows an error toast on failure.
  - Adds `agents.fork` to `KartonContract` with handler tests.

- Bug Fixes
  - Always opens the chat panel to the new fork after creation.

<sup>Written for commit 7851e5a1c311e26b5e25a9a1fa59ac4a9827482b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1495?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a “Fork chat” action to the chat context menu.
  - Forked chats are created with a “Fork: [original title]” name and open automatically.
  - Displays an error notification if chat forking fails.

- **Bug Fixes**
  - Cleans up a newly created fork if it cannot be completed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->