### PR TITLE
fix(stagewise): improve chat auto-scroll and add scroll-to-bottom button

### DIFF
--- a/apps/browser/src/ui/hooks/use-auto-scroll.test.tsx
+++ b/apps/browser/src/ui/hooks/use-auto-scroll.test.tsx
@@ -21,13 +21,20 @@ describe('useAutoScroll', () => {
   const createViewport = (height = 1_000) => {
     const viewport = document.createElement('div');
     let scrollHeight = height;
+    let clientHeight = 0;
     Object.defineProperty(viewport, 'scrollHeight', {
       get: () => scrollHeight,
+    });
+    Object.defineProperty(viewport, 'clientHeight', {
+      get: () => clientHeight,
     });
     return {
       viewport,
       setHeight: (nextHeight: number) => {
         scrollHeight = nextHeight;
+      },
+      setClientHeight: (nextHeight: number) => {
+        clientHeight = nextHeight;
       },
     };
   };
@@ -54,6 +61,36 @@ describe('useAutoScroll', () => {
     expect(result.current.followOutput).toBe('auto');
   });
 
+  it('does not pause on wheel-up without scrollable overflow', () => {
+    const { result } = renderHook(() => useAutoScroll({ mode: 'virtuoso' }));
+    const { viewport, setClientHeight } = createViewport();
+
+    setClientHeight(1_000);
+    act(() => result.current.scrollerRef(viewport));
+    flushScroll();
+    act(() => viewport.dispatchEvent(new WheelEvent('wheel', { deltaY: -1 })));
+
+    expect(result.current.isAutoScrollEnabled()).toBe(true);
+    expect(result.current.followOutput).toBe('auto');
+  });
+
+  it('resumes following when Virtuoso reports the bottom', () => {
+    const { result } = renderHook(() => useAutoScroll({ mode: 'virtuoso' }));
+    const { viewport, setClientHeight } = createViewport();
+
+    setClientHeight(500);
+    act(() => result.current.scrollerRef(viewport));
+    flushScroll();
+    act(() => viewport.dispatchEvent(new WheelEvent('wheel', { deltaY: -1 })));
+    expect(result.current.isAutoScrollEnabled()).toBe(false);
+
+    act(() => result.current.atBottomStateChange(true));
+
+    expect(result.current.isAtBottom).toBe(true);
+    expect(result.current.isAutoScrollEnabled()).toBe(true);
+    expect(result.current.followOutput).toBe('auto');
+  });
+
   it('follows content growth but pauses when scrolling upward', () => {
     const { result } = renderHook(() => useAutoScroll({ mode: 'virtuoso' }));
     const { viewport, setHeight } = createViewport();
@@ -75,6 +112,28 @@ describe('useAutoScroll', () => {
     act(() => viewport.dispatchEvent(new Event('scroll')));
     act(() => viewport.dispatchEvent(new Event('scrollend')));
     expect(result.current.isAutoScrollEnabled()).toBe(true);
+  });
+
+  it('keeps following when a resize lowers scrollTop at the bottom', () => {
+    const { result } = renderHook(() =>
+      useAutoScroll({ mode: 'virtuoso', scrollEndThreshold: 100 }),
+    );
+    const { viewport, setHeight, setClientHeight } = createViewport();
+
+    act(() => result.current.scrollerRef(viewport));
+    flushScroll();
+
+    setHeight(1_500);
+    setClientHeight(500);
+    viewport.scrollTop = 1_000;
+    act(() => viewport.dispatchEvent(new Event('scroll')));
+
+    setClientHeight(600);
+    viewport.scrollTop = 900;
+    act(() => viewport.dispatchEvent(new Event('scroll')));
+
+    expect(result.current.isAutoScrollEnabled()).toBe(true);
+    expect(result.current.followOutput).toBe('auto');
   });
 
   it('starts following when Virtuoso mounts a new scroller', () => {

--- a/apps/browser/src/ui/hooks/use-auto-scroll.ts
+++ b/apps/browser/src/ui/hooks/use-auto-scroll.ts
@@ -18,6 +18,7 @@ export function useAutoScroll({
   const scrollFrameRef = useRef<number | null>(null);
   const [scroller, setScroller] = useState<HTMLElement | null>(null);
   const [followOutput, setFollowOutput] = useState<'auto' | false>('auto');
+  const [isAtBottom, setIsAtBottom] = useState(true);
 
   const setShouldFollow = useCallback((shouldFollow: boolean) => {
     if (shouldFollowRef.current === shouldFollow) return;
@@ -59,21 +60,37 @@ export function useAutoScroll({
 
   const isAutoScrollEnabled = useCallback(() => shouldFollowRef.current, []);
 
+  const atBottomStateChange = useCallback(
+    (atBottom: boolean) => {
+      setIsAtBottom(atBottom);
+      if (atBottom) setShouldFollow(true);
+    },
+    [setShouldFollow],
+  );
+
   useEffect(() => {
     if (!scroller || !enabled) return;
 
+    const getDistanceFromBottom = () =>
+      scroller.scrollHeight - (scroller.scrollTop + scroller.clientHeight);
+
     let previousScrollTop = scroller.scrollTop;
     const handleScroll = () => {
-      if (scroller.scrollTop < previousScrollTop) setShouldFollow(false);
-      previousScrollTop = scroller.scrollTop;
+      const currentScrollTop = scroller.scrollTop;
+      if (
+        currentScrollTop < previousScrollTop &&
+        getDistanceFromBottom() > scrollEndThreshold
+      ) {
+        setShouldFollow(false);
+      }
+      previousScrollTop = currentScrollTop;
     };
     const handleScrollEnd = () => {
-      const distanceFromBottom =
-        scroller.scrollHeight - (scroller.scrollTop + scroller.clientHeight);
-      if (distanceFromBottom <= scrollEndThreshold) setShouldFollow(true);
+      if (getDistanceFromBottom() <= scrollEndThreshold) setShouldFollow(true);
     };
     const handleWheel = (event: WheelEvent) => {
-      if (event.deltaY < 0) setShouldFollow(false);
+      if (event.deltaY < 0 && scroller.scrollHeight > scroller.clientHeight)
+        setShouldFollow(false);
     };
 
     scroller.addEventListener('wheel', handleWheel, { passive: true });
@@ -118,5 +135,7 @@ export function useAutoScroll({
     disableAutoScroll,
     isAutoScrollEnabled,
     followOutput,
+    isAtBottom,
+    atBottomStateChange,
   };
 }

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/chat-history.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/chat-history.tsx
@@ -43,6 +43,13 @@ import {
   getWorkspaceMountsFromMessage,
   resolveBrowserContextFromMessages,
 } from '@shared/env-metadata';
+import { IconChevronDownOutline18 } from '@stagewise/icons';
+import { Button } from '@stagewise/stage-ui/components/button';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@stagewise/stage-ui/components/tooltip';
 
 // Top inset reserved for titlebar-level chrome (sidebar toggle, future
 // top-right buttons). Sits as a sibling spacer ABOVE Virtuoso so items can
@@ -267,6 +274,8 @@ export const ChatHistory = ({ flushTop = false }: { flushTop?: boolean }) => {
     disableAutoScroll,
     isAutoScrollEnabled,
     followOutput,
+    isAtBottom,
+    atBottomStateChange,
   } = useAutoScroll({ mode: 'virtuoso', scrollEndThreshold: 100 });
 
   // Track scroll offset to drive the top fade overlay. We only need an
@@ -1306,10 +1315,29 @@ export const ChatHistory = ({ flushTop = false }: { flushTop?: boolean }) => {
             heightEstimates={estimatedHeights}
             itemContent={itemContent}
             atBottomThreshold={100}
+            atBottomStateChange={atBottomStateChange}
             followOutput={followOutput}
             computeItemKey={(_, message) => message.id}
             totalCount={filteredMessages.length}
           />
+          {!isAtBottom && (
+            <div className="pointer-events-none absolute inset-x-0 bottom-[calc(12px+var(--status-card-height,0px))] z-10 flex justify-center">
+              <Tooltip>
+                <TooltipTrigger>
+                  <Button
+                    aria-label="Scroll to bottom"
+                    className="pointer-events-auto shadow-elevation-1"
+                    size="icon-sm"
+                    variant="secondary"
+                    onClick={forceEnableAutoScroll}
+                  >
+                    <IconChevronDownOutline18 className="size-3.5" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>Scroll to bottom</TooltipContent>
+              </Tooltip>
+            </div>
+          )}
         </div>
       </AttachmentMetadataProvider>
     </MountedPathsProvider>


### PR DESCRIPTION
## Summary

- preserve auto-follow when viewport resizing changes `scrollTop`
- synchronize Virtuoso's bottom state with the auto-scroll controller
- avoid disabling auto-follow on wheel-up without scrollable overflow
- add a scroll-to-bottom button when the user moves away from the bottom
- keep the button stacked above queued messages and other status cards

<img width="705" height="275" alt="image" src="https://github.com/user-attachments/assets/ee52b91c-28ed-4e0d-a8dd-bd6e73b45a98" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized chat scroll UX and hook behavior with new unit tests; no auth, data, or API changes.
> 
> **Overview**
> **Tightens Virtuoso chat auto-follow** so streaming and layout changes are less likely to drop the user out of “stick to bottom” mode, and **adds a scroll-to-bottom control** when they leave the end of the list.
> 
> `useAutoScroll` now tracks **`isAtBottom`** via **`atBottomStateChange`** (wired to Virtuoso’s `atBottomStateChange`) and re-enables follow when Virtuoso reports the bottom. Upward scroll / wheel-up only pauses follow when there is real overflow and the user is meaningfully above the bottom (`scrollEndThreshold`); wheel-up with no scrollable content no longer disables follow. Resize-driven `scrollTop` drops while still near the bottom no longer turn off auto-follow.
> 
> **Chat history** shows a floating chevron button (above status cards via `--status-card-height`) when `!isAtBottom`; it calls **`forceEnableAutoScroll`** to jump back and resume following.
> 
> Tests extend the viewport mock with **`clientHeight`** and cover no-overflow wheel, Virtuoso bottom resume, and resize-at-bottom behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 975360c51ab5e54f423f332d0cdb8b7b672b9d95. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves chat auto-scroll so it reliably follows new messages and adds a scroll-to-bottom button when you move away from the bottom. This makes the chat feel smoother and easier to control.

- New Features
  - Show a scroll-to-bottom button when not at the bottom; it sits above queued messages and status cards.
  - `useAutoScroll` now exposes `isAtBottom` and `atBottomStateChange` for better sync with the list.

- Bug Fixes
  - Keep auto-follow when a viewport resize lowers `scrollTop` while at the bottom.
  - Sync Virtuoso’s “at bottom” state with the auto-scroll controller to resume following when appropriate.
  - Don’t disable auto-follow on wheel-up when there’s no vertical overflow.

<sup>Written for commit 975360c51ab5e54f423f332d0cdb8b7b672b9d95. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1496?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Scroll to bottom” control in chat history when viewing earlier messages.
  * Auto-scrolling now accurately tracks whether the chat is at the bottom and can resume when returning there.

* **Bug Fixes**
  * Improved scrolling behavior when there is no overflow, during wheel scrolling, and after window resizing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->