### PR TITLE
feat(stagewise): show status for stalled message streams

### DIFF
--- a/apps/browser/src/ui/hooks/use-debounced-value.tsx
+++ b/apps/browser/src/ui/hooks/use-debounced-value.tsx
@@ -1,7 +1,11 @@
 import { useEffect, useState } from 'react';
 
-export function useDebouncedValue<T>(value: T, delay: number): T {
-  const [debouncedValue, setDebouncedValue] = useState<T>(value);
+export function useDebouncedValue<T>(
+  value: T,
+  delay: number,
+  initialValue: T = value,
+): T {
+  const [debouncedValue, setDebouncedValue] = useState<T>(() => initialValue);
   useEffect(() => {
     const timeout = setTimeout(() => {
       setDebouncedValue(value);

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/message-assistant.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/message-assistant.tsx
@@ -31,8 +31,9 @@ import { ExecuteSandboxJsToolPart } from './message-part-ui/tools/execute-sandbo
 import { ReadConsoleLogsToolPart } from './message-part-ui/tools/read-console-logs';
 import { AskUserQuestionsToolPart } from './message-part-ui/tools/ask-user-questions';
 import { ExecuteShellCommandToolPart } from './message-part-ui/tools/execute-shell-command';
-import { isToolOrReasoningPart } from './message-utils';
+import { hasUnfinishedParts, isToolOrReasoningPart } from './message-utils';
 import { MessageBetweenSteps } from './message-between-steps';
+import { MessageStalledStream } from './message-stalled-stream';
 import { IconDotsOutline18 } from '@stagewise/icons';
 import {
   Menu,
@@ -371,6 +372,9 @@ export const MessageAssistant = memo(
                   );
                 });
               })()}
+              {isWorking && isLastMessage && hasUnfinishedParts(msg) ? (
+                <MessageStalledStream parts={msg.parts} />
+              ) : null}
               {showBetweenStepsIndicator && <MessageBetweenSteps />}
               {/* Actions menu — hidden on last message (restore would be a noop) and while streaming */}
               {!isLastMessage && (

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/message-stalled-stream.test.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/message-stalled-stream.test.tsx
@@ -1,0 +1,34 @@
+import { act, render, screen } from '@testing-library/react';
+import type { TextUIPart } from 'ai';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  MessageStalledStream,
+  STALLED_STREAM_MESSAGE,
+} from './message-stalled-stream';
+
+const createStreamingParts = (text: string): TextUIPart[] => [
+  { type: 'text', text, state: 'streaming' },
+];
+
+describe('MessageStalledStream', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it('appears after five quiet seconds and resets on the next chunk', () => {
+    const initialParts = createStreamingParts('Partial');
+    const { rerender } = render(<MessageStalledStream parts={initialParts} />);
+
+    act(() => vi.advanceTimersByTime(4_999));
+    expect(screen.queryByText(STALLED_STREAM_MESSAGE)).toBeNull();
+
+    act(() => vi.advanceTimersByTime(1));
+    expect(screen.getByText(STALLED_STREAM_MESSAGE)).toBeTruthy();
+
+    const updatedParts = createStreamingParts('Partial response');
+    rerender(<MessageStalledStream parts={updatedParts} />);
+    expect(screen.queryByText(STALLED_STREAM_MESSAGE)).toBeNull();
+
+    act(() => vi.advanceTimersByTime(5_000));
+    expect(screen.getByText(STALLED_STREAM_MESSAGE)).toBeTruthy();
+  });
+});

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/message-stalled-stream.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/message-stalled-stream.tsx
@@ -1,0 +1,26 @@
+import type { AgentMessage } from '@shared/karton-contracts/ui/agent';
+import { useDebouncedValue } from '@ui/hooks/use-debounced-value';
+
+const STALL_DELAY_MS = 5_000;
+
+export const STALLED_STREAM_MESSAGE = 'Still on it…';
+
+export function MessageStalledStream({
+  parts,
+}: {
+  parts: AgentMessage['parts'];
+}) {
+  const stalledParts = useDebouncedValue<AgentMessage['parts'] | null>(
+    parts,
+    STALL_DELAY_MS,
+    null,
+  );
+
+  if (stalledParts !== parts) return null;
+
+  return (
+    <div className="text-muted-foreground text-xs italic">
+      {STALLED_STREAM_MESSAGE}
+    </div>
+  );
+}

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/message-utils.ts
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/message-utils.ts
@@ -66,6 +66,10 @@ function isPartSettled(
   return true;
 }
 
+export function hasUnfinishedParts(msg: AgentMessage): boolean {
+  return msg.parts.some((part) => !isPartSettled(part));
+}
+
 /**
  * Check if all parts in a message have reached a terminal state
  * AND the indicator would not be redundant. Returns false when:

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/message-utils.ts
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/message-utils.ts
@@ -60,7 +60,11 @@ function isPartSettled(
 
   if (part.type.startsWith('tool-') || part.type === 'dynamic-tool') {
     const state = (part as AgentToolUIPart | DynamicToolUIPart).state;
-    return state === 'output-available' || state === 'output-error';
+    return (
+      state === 'output-available' ||
+      state === 'output-error' ||
+      state === 'output-denied'
+    );
   }
 
   return true;


### PR DESCRIPTION
## Summary

- show a muted, italic “Still on it…” message after an unfinished assistant stream remains unchanged for five seconds

Closes #1155

<img width="612" height="312" alt="image" src="https://github.com/user-attachments/assets/6d235016-bb80-42fa-b6fc-4d21478f8deb" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only streaming feedback and a backward-compatible debounce hook change; no auth or data-path impact.
> 
> **Overview**
> Adds a **“Still on it…”** hint when the last assistant message is still streaming but **no new chunks arrive for 5 seconds**, so quiet gaps feel intentional rather than broken.
> 
> `MessageStalledStream` debounces `parts` with `useDebouncedValue(..., null)` and only renders when the debounced snapshot is the **same reference** as the current `parts` (new chunks reset the timer). It is shown from `MessageAssistant` only while **`isWorking`**, on the **last message**, and when **`hasUnfinishedParts`** is true.
> 
> `useDebouncedValue` gains an optional **`initialValue`** (defaults unchanged for existing callers). **`hasUnfinishedParts`** is exported from `message-utils`, and **`output-denied`** tool parts count as settled. Vitest covers the 5s delay and reset-on-chunk behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02cf822cf37d8593445f2701ca2112bcf856ca2a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows a subtle “Still on it…” indicator when an assistant stream is quiet for 5 seconds, so users know the agent is still working. Closes #1155.

- **New Features**
  - Added `MessageStalledStream` with a 5s debounce; hides on the next chunk.
  - Renders only for the last, unfinished assistant message while `isWorking`.
  - Extended `useDebouncedValue` with an optional `initialValue`; added `hasUnfinishedParts` and tests for stall timing/reset.

- **Bug Fixes**
  - Treat `output-denied` tool results as settled in `message-utils` to avoid false stall hints.

<sup>Written for commit 02cf822cf37d8593445f2701ca2112bcf856ca2a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1498?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Still on it…” indicator for assistant messages that stall during streaming (after 5 seconds of inactivity, resets when new content arrives).
* **Bug Fixes**
  * Improved debounced UI behavior by supporting an optional initial value.
  * Updated message completion detection so denied tool outputs no longer count as unfinished.
* **Tests**
  * Added automated tests covering stalled timing, reset behavior, and repeated stalls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->