### PR TITLE
fix(stagewise): add missing mimetypes for linux makers

### DIFF
--- a/apps/browser/forge.config.mts
+++ b/apps/browser/forge.config.mts
@@ -37,6 +37,27 @@ const visualAssetChannel =
     ? 'nightly'
     : buildConstants.__APP_RELEASE_CHANNEL__;
 
+const getAuthCallbackScheme = (): string => {
+  switch (buildConstants.__APP_RELEASE_CHANNEL__) {
+    case 'release':
+      return 'stagewise';
+    case 'prerelease':
+      return 'stagewise-prerelease';
+    case 'nightly':
+      return 'stagewise-nightly';
+    default:
+      return 'stagewise-dev';
+  }
+};
+
+const protocolSchemes = Array.from(
+  new Set(['stagewise', getAuthCallbackScheme()]),
+);
+
+const linuxMimeTypes = protocolSchemes.map(
+  (scheme) => `x-scheme-handler/${scheme}`,
+);
+
 // DMG volume name (shown when mounted)
 const dmgVolumeName = 'Install stagewise';
 
@@ -380,6 +401,7 @@ const config: ForgeConfig = {
         icon: `./assets/icons/${visualAssetChannel}/icon.png`,
         homepage: 'https://stagewise.io',
         categories: ['Development', 'Network', 'Utility'],
+        mimeType: linuxMimeTypes,
       },
     }),
     new MakerDeb({
@@ -393,6 +415,7 @@ const config: ForgeConfig = {
         categories: ['Development', 'Network', 'Utility'],
         section: 'devel',
         priority: 'standard',
+        mimeType: linuxMimeTypes,
       },
     }),
     new MakerDMG({


### PR DESCRIPTION
- Fixes #1409 
- Added missing mimeTypes required for Linux makers to successfully open the desktop app once authenticated
- Tested the flow by making a local build and completing the login using GitHub

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging-only change to Linux installer metadata; no runtime auth or application logic changes.
> 
> **Overview**
> Linux **`.deb` / `.rpm`** packages now declare **`x-scheme-handler/...` MIME types** so the desktop app can be opened when the browser redirects after login.
> 
> `forge.config.mts` derives the auth callback scheme from **`__APP_RELEASE_CHANNEL__`** (e.g. `stagewise`, `stagewise-nightly`, `stagewise-dev`) and registers both that scheme and **`stagewise`** on **MakerDeb** and **MakerRpm** via **`mimeType: linuxMimeTypes`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c41eee8d73adadec1314bc2f08554ba037748126. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Linux deep-link handling by adding required x-scheme-handler MIME types to `electron-forge` makers. This lets the app open after OAuth redirect across release channels and addresses Linear ISS-1409.

- **Bug Fixes**
  - Register `x-scheme-handler/stagewise` and a channel-specific auth callback scheme in AppImage and Deb makers via `mimeType`.
  - Scheme is derived from the release channel to ensure login redirects reliably open the app on Linux.

<sup>Written for commit c41eee8d73adadec1314bc2f08554ba037748126. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1506?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added release-channel-specific authentication callback handling.
  * Registered authentication callback MIME types for RPM and DEB Linux packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->