### PR TITLE
fix(stagewise): improve chat streaming behavior

### DIFF
--- a/apps/browser/src/ui/app.css
+++ b/apps/browser/src/ui/app.css
@@ -5,7 +5,6 @@
 
 @import "../shared/tailwind/browser-base.css";
 
-@import "../../../../node_modules/streamdown/styles.css";
 @import "../../../../node_modules/katex/dist/katex.min.css";
 
 /* Source paths for Tailwind to scan for class usage */
@@ -13,4 +12,3 @@
 @source "../../node_modules/streamdown/dist/*.js";
 @source "../../node_modules/@streamdown/math/dist/*.js";
 @source ".";
- 

--- a/apps/browser/src/ui/components/streamdown/AnchorLinkAliases.stories.tsx
+++ b/apps/browser/src/ui/components/streamdown/AnchorLinkAliases.stories.tsx
@@ -29,7 +29,6 @@ type Story = StoryObj<typeof Streamdown>;
  */
 export const AllAliases: Story = {
   args: {
-    isAnimating: false,
     children: [
       'Here are all the link aliases:',
       '',
@@ -50,7 +49,6 @@ export const AllAliases: Story = {
  */
 export const AgentIssueLink: Story = {
   args: {
-    isAnimating: false,
     children:
       "If something isn't working right, you can [report the issue here](report-agent-issue).",
   },
@@ -64,7 +62,6 @@ export const AgentIssueLink: Story = {
  */
 export const FeatureRequestLink: Story = {
   args: {
-    isAnimating: false,
     children:
       "I can't do that yet, but you can [request this feature](request-new-feature) and the team will consider it!",
   },
@@ -78,7 +75,6 @@ export const FeatureRequestLink: Story = {
  */
 export const SocialLinks: Story = {
   args: {
-    isAnimating: false,
     children: [
       'Connect with us:',
       '',
@@ -97,7 +93,6 @@ export const SocialLinks: Story = {
  */
 export const MixedContent: Story = {
   args: {
-    isAnimating: false,
     children: [
       '## Help & Resources',
       '',

--- a/apps/browser/src/ui/components/streamdown/index.tsx
+++ b/apps/browser/src/ui/components/streamdown/index.tsx
@@ -291,7 +291,7 @@ const preprocessMarkdown = (markdown: string): string => {
 export function InlineMarkdown({ children }: { children: string }) {
   return (
     <span className="inline [&>div]:inline [&_p]:m-0 [&_p]:inline">
-      <Streamdown isAnimating={false}>{children}</Streamdown>
+      <Streamdown>{children}</Streamdown>
     </span>
   );
 }
@@ -999,13 +999,6 @@ MemoInput.displayName = 'MarkdownInput';
 
 // ── Static Streamdown config (hoisted here so Memo* consts are initialized) ──
 
-const STREAMDOWN_ANIMATED = {
-  animation: 'fadeIn',
-  duration: 100,
-  easing: 'ease-out',
-  sep: 'word',
-} as const;
-
 const STREAMDOWN_SHIKI_THEME: ['light-plus', 'dark-plus'] = [
   'light-plus',
   'dark-plus',
@@ -1047,7 +1040,13 @@ const STREAMDOWN_COMPONENTS = {
 const STREAMDOWN_REHYPE_PLUGINS = [defaultRehypePlugins.raw!];
 
 export const Streamdown = memo(
-  ({ isAnimating, children }: { isAnimating: boolean; children: string }) => {
+  ({
+    isStreaming = false,
+    children,
+  }: {
+    isStreaming?: boolean;
+    children: string;
+  }) => {
     const processed = useMemo(() => preprocessMarkdown(children), [children]);
     const createTab = useKartonProcedure((p) => p.browser.createTab);
     const isAltPressed = useChatLinkAltPressed();
@@ -1081,16 +1080,15 @@ export const Streamdown = memo(
     );
 
     return (
-      <StreamdownProvider isStreaming={isAnimating}>
+      <StreamdownProvider isStreaming={isStreaming}>
         <ChatLinkModifierContext.Provider value={isAltPressed}>
           <div
             onClickCapture={handleClickCapture}
             onMouseMoveCapture={handleMouseMoveCapture}
           >
             <StreamdownBase
-              animated={STREAMDOWN_ANIMATED}
-              isAnimating={isAnimating}
-              mode={isAnimating ? 'streaming' : 'static'}
+              isAnimating={isStreaming}
+              mode={isStreaming ? 'streaming' : 'static'}
               shikiTheme={STREAMDOWN_SHIKI_THEME}
               controls={STREAMDOWN_CONTROLS}
               plugins={STREAMDOWN_PLUGINS}

--- a/apps/browser/src/ui/hooks/use-auto-scroll.test.tsx
+++ b/apps/browser/src/ui/hooks/use-auto-scroll.test.tsx
@@ -150,6 +150,30 @@ describe('useAutoScroll', () => {
     expect(second.viewport.scrollTop).toBe(2_000);
   });
 
+  it('realigns after Virtuoso finishes measuring a new scroller', () => {
+    const { result } = renderHook(() => useAutoScroll({ mode: 'virtuoso' }));
+    const { viewport, setHeight } = createViewport();
+
+    act(() => result.current.scrollerRef(viewport));
+    flushScroll();
+    expect(viewport.scrollTop).toBe(1_000);
+
+    setHeight(2_000);
+    act(() => result.current.atBottomStateChange(false));
+    flushScroll();
+
+    expect(viewport.scrollTop).toBe(2_000);
+    expect(result.current.followOutput).toBe('auto');
+
+    viewport.scrollTop = 400;
+    act(() => viewport.dispatchEvent(new WheelEvent('wheel', { deltaY: -1 })));
+    setHeight(3_000);
+    act(() => result.current.atBottomStateChange(false));
+    flushScroll();
+
+    expect(viewport.scrollTop).toBe(400);
+  });
+
   it('follows mutations in a regular scroll container', async () => {
     const { result } = renderHook(() =>
       useAutoScroll({ initializeAtBottom: false }),

--- a/apps/browser/src/ui/hooks/use-auto-scroll.ts
+++ b/apps/browser/src/ui/hooks/use-auto-scroll.ts
@@ -64,8 +64,9 @@ export function useAutoScroll({
     (atBottom: boolean) => {
       setIsAtBottom(atBottom);
       if (atBottom) setShouldFollow(true);
+      else if (shouldFollowRef.current) scrollToBottom();
     },
-    [setShouldFollow],
+    [scrollToBottom, setShouldFollow],
   );
 
   useEffect(() => {

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/footer-status-card/user-question-section.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/footer-status-card/user-question-section.tsx
@@ -325,9 +325,7 @@ function UserQuestionForm({
       >
         {currentStepData.description && (
           <span className="shrink-0 text-muted-foreground text-xs [&_p]:m-0 [&_p]:inline">
-            <Streamdown isAnimating={false}>
-              {currentStepData.description}
-            </Streamdown>
+            <Streamdown>{currentStepData.description}</Streamdown>
           </span>
         )}
 

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/message-assistant.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/message-assistant.tsx
@@ -119,7 +119,12 @@ const SinglePartRenderer = memo(
           <TextPart
             key={stableKey}
             part={part as TextUIPart}
-            messageRole="assistant"
+            isStreaming={
+              isWorking &&
+              isLastMessage &&
+              isLastPart &&
+              part.state === 'streaming'
+            }
           />
         );
       case 'reasoning':

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/message-part-ui/text.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/message-part-ui/text.tsx
@@ -4,25 +4,15 @@ import { Streamdown } from '@ui/components/streamdown';
 
 interface TextPartProps {
   part: TextUIPart;
-  messageRole: 'user' | 'assistant' | 'system';
+  isStreaming: boolean;
 }
 
 export const TextPart = memo(
-  ({ part, messageRole }: TextPartProps) => {
-    // Only render markdown for assistant messages
-    if (messageRole === 'assistant')
-      return (
-        <Streamdown isAnimating={part.state === 'streaming'}>
-          {part.text}
-        </Streamdown>
-      );
-
-    // Render plain text for user messages
-    return <span className="whitespace-pre-wrap">{part.text}</span>;
-  },
+  ({ part, isStreaming }: TextPartProps) => (
+    <Streamdown isStreaming={isStreaming}>{part.text}</Streamdown>
+  ),
   // Custom comparison to prevent re-renders when only reference changes
   (prevProps, nextProps) =>
     prevProps.part.text === nextProps.part.text &&
-    prevProps.part.state === nextProps.part.state &&
-    prevProps.messageRole === nextProps.messageRole,
+    prevProps.isStreaming === nextProps.isStreaming,
 );

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/message-part-ui/thinking.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/message-part-ui/thinking.tsx
@@ -69,9 +69,7 @@ export const ThinkingPart = ({
       }
       content={
         <div className={cn('pb-1 opacity-75', capMaxHeight ? 'max-h-24!' : '')}>
-          <Streamdown isAnimating={part.state === 'streaming'}>
-            {part.text}
-          </Streamdown>
+          <Streamdown isStreaming={isStreaming}>{part.text}</Streamdown>
         </div>
       }
     />

--- a/apps/browser/src/ui/screens/main/file-tree/file-preview-tab-content.tsx
+++ b/apps/browser/src/ui/screens/main/file-tree/file-preview-tab-content.tsx
@@ -2528,7 +2528,7 @@ function MarkdownPreview({
       <div className="min-h-0 flex-1">
         {mode === 'preview' ? (
           <div className="[&_[data-streamdown=image-wrapper]]:!items-start scrollbar-subtle size-full overflow-auto p-6 text-foreground [&_[data-streamdown=image-wrapper]>div:first-child]:hidden">
-            <Streamdown isAnimating={false}>{text}</Streamdown>
+            <Streamdown>{text}</Streamdown>
           </div>
         ) : (
           <div


### PR DESCRIPTION
## Summary

- remove Streamdown's redundant word-level animation layer so streamed Markdown appears in source order
- keep only the currently active assistant text part in streaming mode, immediately finalizing earlier parts when a following part appears
- prevent list markers and inline code from appearing ahead of the surrounding text
- avoid replaying text animations when returning to an actively streaming task
- realign Virtuoso after delayed measurements when auto-follow is active, without pulling users back down after they scroll up
- simplify static Streamdown call sites and clarify the distinction between streaming state and visual animation state
- add regression coverage for delayed Virtuoso measurements and user-controlled scrolling

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit dc38ce6d798843c86abe4fec7530f47c34f71075. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes chat message streaming so Markdown renders in the correct order and only the latest assistant text part streams. Auto-follow now realigns reliably with Virtuoso without tugging users when they scroll up, and the `Streamdown` API is simpler.

- **Bug Fixes**
  - Streamed Markdown now renders in source order; list markers and inline code no longer jump ahead.
  - Only the active assistant text part streams; earlier parts finalize immediately.
  - No more replayed text animations when returning to an active stream.
  - Auto-follow realigns after delayed Virtuoso measurements without pulling users back down.
  - Added regression tests for Virtuoso realignment and user-controlled scrolling.

- **Refactors**
  - Simplified `Streamdown` API: replace `isAnimating` with `isStreaming`; drop the `animated` config.
  - Updated call sites (`TextPart`, `ThinkingPart`, previews, stories) to use the new prop.
  - Removed redundant `streamdown/styles.css` import from app CSS.
  - Clarified streaming vs visual animation state internally.

<sup>Written for commit dc38ce6d798843c86abe4fec7530f47c34f71075. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1509?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved streaming Markdown rendering in agent conversations, with clearer handling for live and completed responses.
  * Markdown previews now use consistent static rendering when content is not streaming.

* **Bug Fixes**
  * Improved chat auto-scroll behavior after content or scrollers finish loading.
  * Preserved the user’s manual scroll position when auto-follow is disabled.

* **Tests**
  * Added coverage for auto-scroll realignment and manual scrolling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->