### PR TITLE
fix(stagewise): prevent onboarding release notes overlap

### DIFF
--- a/apps/browser/src/ui/components/release-notes.test.tsx
+++ b/apps/browser/src/ui/components/release-notes.test.tsx
@@ -1,0 +1,30 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../../../../.release-notes.md?raw', () => ({
+  default: '## 0.0.0-test (2026-08-03)\n\n### Features\n\n* Test',
+}));
+
+describe('WhatsNewDialog', () => {
+  afterEach(() => {
+    cleanup();
+    localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  it('stays closed after onboarding marks the current version as seen', async () => {
+    vi.resetModules();
+    const { markCurrentReleaseNotesSeen, WhatsNewDialog } = await import(
+      './release-notes'
+    );
+
+    const beforeOnboardingCompletion = render(<WhatsNewDialog />);
+    expect(await screen.findByText('What’s new')).toBeTruthy();
+    beforeOnboardingCompletion.unmount();
+
+    markCurrentReleaseNotesSeen();
+    render(<WhatsNewDialog />);
+
+    expect(screen.queryByText('What’s new')).toBeNull();
+  });
+});

--- a/apps/browser/src/ui/components/release-notes.tsx
+++ b/apps/browser/src/ui/components/release-notes.tsx
@@ -31,6 +31,14 @@ function wasCurrentVersionSeen(): boolean {
   }
 }
 
+export function markCurrentReleaseNotesSeen(): void {
+  try {
+    localStorage.setItem(LAST_SEEN_VERSION_KEY, __APP_VERSION__);
+  } catch {
+    // Show them again on the next launch if storage is unavailable.
+  }
+}
+
 export function ReleaseNotes({
   children,
   className,
@@ -67,11 +75,7 @@ export function WhatsNewDialog() {
     setOpen(nextOpen);
     if (nextOpen) return;
 
-    try {
-      localStorage.setItem(LAST_SEEN_VERSION_KEY, __APP_VERSION__);
-    } catch {
-      // Show it again on the next launch if storage is unavailable.
-    }
+    markCurrentReleaseNotesSeen();
   };
 
   return (

--- a/apps/browser/src/ui/screens/onboarding/index.test.tsx
+++ b/apps/browser/src/ui/screens/onboarding/index.test.tsx
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const mocks = vi.hoisted(() => ({
   track: vi.fn(),
   setHasSeenOnboardingFlow: vi.fn(),
+  markCurrentReleaseNotesSeen: vi.fn(),
   state: {
     userAccount: { status: 'unauthenticated' },
     preferences: { providerInstances: [] as unknown[] },
@@ -11,6 +12,9 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock('@ui/hooks/use-track', () => ({ useTrack: () => mocks.track }));
+vi.mock('@ui/components/release-notes', () => ({
+  markCurrentReleaseNotesSeen: mocks.markCurrentReleaseNotesSeen,
+}));
 vi.mock('@ui/hooks/use-karton', () => ({
   useKartonState: vi.fn((selector) => selector(mocks.state)),
   useKartonProcedure: vi.fn((selector) =>
@@ -98,6 +102,7 @@ describe('OnboardingWizard telemetry', () => {
     mocks.track.mockReset();
     mocks.track.mockResolvedValue(undefined);
     mocks.setHasSeenOnboardingFlow.mockReset();
+    mocks.markCurrentReleaseNotesSeen.mockReset();
     mocks.state.userAccount.status = 'unauthenticated';
     mocks.state.preferences.providerInstances = [];
     vi.spyOn(globalThis.crypto, 'randomUUID').mockReturnValue(
@@ -173,7 +178,13 @@ describe('OnboardingWizard telemetry', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Change theme' }));
     fireEvent.click(screen.getByRole('button', { name: 'Finish' }));
 
+    expect(mocks.markCurrentReleaseNotesSeen).toHaveBeenCalledOnce();
     expect(mocks.setHasSeenOnboardingFlow).toHaveBeenCalledOnce();
+    expect(
+      mocks.markCurrentReleaseNotesSeen.mock.invocationCallOrder[0],
+    ).toBeLessThan(
+      mocks.setHasSeenOnboardingFlow.mock.invocationCallOrder[0] ?? 0,
+    );
     expect(mocks.setHasSeenOnboardingFlow).toHaveBeenCalledWith({
       value: true,
       auth: { auth_method: 'stagewise' },

--- a/apps/browser/src/ui/screens/onboarding/index.tsx
+++ b/apps/browser/src/ui/screens/onboarding/index.tsx
@@ -12,6 +12,7 @@ import {
   TooltipContent,
 } from '@stagewise/stage-ui/components/tooltip';
 import { IconArrowLeftFill18, IconArrowRightFill18 } from '@stagewise/icons';
+import { markCurrentReleaseNotesSeen } from '@ui/components/release-notes';
 import { useKartonProcedure, useKartonState } from '@ui/hooks/use-karton';
 import { useTrack } from '@ui/hooks/use-track';
 import { cn } from '@ui/utils';
@@ -106,6 +107,7 @@ export function OnboardingWizard() {
       duration_ms: performance.now() - stepEnteredAtRef.current,
     });
     const providerSummary = providerSummaryRef.current;
+    markCurrentReleaseNotesSeen();
     setHasSeenOnboardingFlow({
       value: true,
       auth: authCompletion ?? { auth_method: 'unknown' },


### PR DESCRIPTION
## Summary

- mark the current release notes as seen when initial onboarding completes
- prevent the “What’s new” dialog from overlapping the main UI tutorial
- reuse the existing release-notes persistence logic
- add regression coverage for the onboarding transition and dialog state

Closes #1508

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UX/localStorage change with no auth or data-path impact; behavior is covered by new unit tests.
> 
> **Overview**
> Stops the **What’s new** dialog from appearing on top of the post-onboarding tutorial by marking the current app version’s release notes as seen when the user **finishes onboarding**, not only when they dismiss the dialog.
> 
> The localStorage write is moved into a shared **`markCurrentReleaseNotesSeen`** helper (still used when closing the dialog) and **`OnboardingWizard.complete`** invokes it immediately before persisting onboarding completion.
> 
> Regression tests cover the dialog staying closed after that mark, and that onboarding finish calls the helper once before **`setHasSeenOnboardingFlow`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3362caaa808677afc1b31ca4e6a4e4fa3d33a144. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents the “What’s new” dialog from overlapping the onboarding tutorial by marking the current release notes as seen when onboarding completes. Centralizes release notes persistence and adds regression tests.

- **Bug Fixes**
  - Call `markCurrentReleaseNotesSeen()` on onboarding finish (before `setHasSeenOnboardingFlow()`), so the dialog stays closed for the current version.
  - Reuse `markCurrentReleaseNotesSeen()` in `WhatsNewDialog` when the dialog closes to keep logic in one place.
  - Add tests: new `release-notes.test.tsx` and updated onboarding tests to verify dialog state and call order.

<sup>Written for commit 3362caaa808677afc1b31ca4e6a4e4fa3d33a144. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1510?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed release notes from reappearing after completing onboarding.
  - Release notes are now marked as seen when onboarding is completed, ensuring the “What’s New” dialog remains dismissed on subsequent visits.
  - Improved handling when saving the viewed release-note status is unavailable or fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->