### PR TITLE
fix(stagewise): restore next-chat navigation

### DIFF
--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/index.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/index.tsx
@@ -16,6 +16,7 @@ import { ChatPanelFooter } from './panel-footer';
 import { useKartonProcedure, useKartonState } from '@ui/hooks/use-karton';
 import { cn } from '@ui/utils';
 import {
+  useAgentSwitcher,
   useOpenAgent,
   OpenAgentContext,
   noopAgentSwitcher,
@@ -34,6 +35,7 @@ export function ChatPanel({ agentId }: { agentId?: string }) {
 function ChatPanelInner({ agentId }: { agentId?: string }) {
   const { forwardDropEvent } = useMessageEditState();
   const [openAgent, setOpenAgent, removeFromHistory] = useOpenAgent();
+  const { focusAgentFromHotkey } = useAgentSwitcher();
   const requestedAgent = agentId ?? openAgent;
 
   const openAgentExists = useKartonState((s) =>
@@ -147,7 +149,10 @@ function ChatPanelInner({ agentId }: { agentId?: string }) {
           <ChatHistory flushTop={Boolean(agentId)} />
         )}
         <div className="mx-auto flex w-full max-w-3xl shrink-0 flex-col items-stretch">
-          <ChatPanelFooter key={requestedAgent} />
+          <ChatPanelFooter
+            key={requestedAgent}
+            focusAgent={focusAgentFromHotkey}
+          />
         </div>
       </OpenAgentContext.Provider>
     </div>

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/panel-footer.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/panel-footer.tsx
@@ -202,7 +202,11 @@ function getPendingWorkspacePreparationKind(
   return preparationKind;
 }
 
-export const ChatPanelFooter = memo(function ChatPanelFooter() {
+export const ChatPanelFooter = memo(function ChatPanelFooter({
+  focusAgent,
+}: {
+  focusAgent: (id: string | null) => void;
+}) {
   const chatInputRef = useRef<ChatInputHandle>(null);
   const chatInputContainerRef = useRef<HTMLDivElement>(null);
   const { registerDraftGetter } = useChatDraft();
@@ -1167,7 +1171,7 @@ export const ChatPanelFooter = memo(function ChatPanelFooter() {
   const handleNextAttentionAgentClick = () => {
     if (!nextAttentionTarget) return;
 
-    setOpenAgent(nextAttentionTarget.id);
+    focusAgent(nextAttentionTarget.id);
     void setLastOpenAgentId(nextAttentionTarget.id).catch(() => undefined);
   };
   const canUseNextAttention =

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/panel-footer.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/panel-footer.tsx
@@ -65,7 +65,7 @@ import { normalizePath } from '@shared/path-utils';
 import { selectedElementToSwDomElement } from '@shared/selected-elements/swdomelement';
 import type { AgentMessage } from '@shared/karton-contracts/ui/agent';
 import { EMPTY_MOUNTS, type MountEntry } from '@shared/karton-contracts/ui';
-import { useAgentSwitcher, useOpenAgent } from '@ui/hooks/use-open-chat';
+import { useOpenAgent } from '@ui/hooks/use-open-chat';
 import { useNextAgentRequiringAttention } from '@ui/hooks/use-next-agent-requiring-attention';
 import { useCmdEnterTarget } from '@ui/hooks/use-cmd-enter-target';
 import { CmdEnterPriority } from '@ui/utils/cmd-enter-registry';
@@ -216,7 +216,6 @@ export const ChatPanelFooter = memo(function ChatPanelFooter() {
   }, [registerDraftGetter]);
 
   const [openAgent, setOpenAgent] = useOpenAgent();
-  const { focusAgentFromHotkey } = useAgentSwitcher();
   const nextAttentionTarget = useNextAgentRequiringAttention(openAgent);
   const { isOpen: isCommandCenterOpen } = useCommandCenter();
   const { collapsed: contentCollapsed } = useContentCollapsed();
@@ -1168,7 +1167,7 @@ export const ChatPanelFooter = memo(function ChatPanelFooter() {
   const handleNextAttentionAgentClick = () => {
     if (!nextAttentionTarget) return;
 
-    focusAgentFromHotkey(nextAttentionTarget.id);
+    setOpenAgent(nextAttentionTarget.id);
     void setLastOpenAgentId(nextAttentionTarget.id).catch(() => undefined);
   };
   const canUseNextAttention =


### PR DESCRIPTION
## Summary

Fix the “Next Chat” action in the chat footer.

The footer is rendered inside a deferred `OpenAgentContext` that exposes a no-op agent switcher. As a result, both clicking “Next Chat” and pressing Cmd/Ctrl+Enter called a handler that did not switch chats.

Use the functional `setOpenAgent` callback provided by the local context instead.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI wiring fix for agent focus navigation with no auth, data, or backend changes.
> 
> **Overview**
> **Next Chat** in the chat footer stopped switching agents because `ChatPanelFooter` lives under the deferred `OpenAgentContext`, which supplies `noopAgentSwitcher`—so `focusAgentFromHotkey` from `useAgentSwitcher()` was a no-op for both the button and Cmd/Ctrl+Enter.
> 
> `ChatPanelInner` now reads `focusAgentFromHotkey` from the real provider (outside that override) and passes it into `ChatPanelFooter` as a `focusAgent` prop. The footer uses that callback for **Next Chat** instead of calling `useAgentSwitcher()` inside the deferred context.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d2a5c06b74d1550545ceff452343d828588f728. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore “Next Chat” navigation in the chat footer. Use the parent-provided `focusAgentFromHotkey` so clicking “Next Chat” or pressing Cmd/Ctrl+Enter switches to the next agent, preserves agent-cycle cleanup, and persists `setLastOpenAgentId`.

<sup>Written for commit 5d2a5c06b74d1550545ceff452343d828588f728. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1512?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved navigation between agents from the chat panel’s next-attention control.
  - Ensured the selected agent receives focus before the app records it as the last opened agent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->