### PR TITLE
fix(stagewise): show workspace action while git options load

### DIFF
--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/workspace-select.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/workspace-select.tsx
@@ -50,7 +50,7 @@ import {
 import { Switch } from '@stagewise/stage-ui/components/switch';
 import { OverlayScrollbar } from '@stagewise/stage-ui/components/overlay-scrollbar';
 import { cn } from '@stagewise/stage-ui/lib/utils';
-import { CheckIcon, XIcon } from 'lucide-react';
+import { CheckIcon, Loader2Icon, XIcon } from 'lucide-react';
 
 import { useKartonProcedure, useKartonState } from '@ui/hooks/use-karton';
 import { useTrack } from '@ui/hooks/use-track';
@@ -2663,7 +2663,7 @@ type ConnectInlineActionSelectProps = {
   sourceBranchItems: SelectItem<string>[];
   checkoutBranchItems: SelectItem<string>[];
   worktreeItems: SelectItem<string>[];
-  onOpen?: () => void;
+  loading: boolean;
   onUpdate: (partial: Partial<ConnectActionState>) => void;
 };
 
@@ -2672,7 +2672,7 @@ function ConnectInlineActionSelect({
   sourceBranchItems,
   checkoutBranchItems,
   worktreeItems,
-  onOpen,
+  loading,
   onUpdate,
 }: ConnectInlineActionSelectProps) {
   const [open, setOpen] = useState(false);
@@ -2693,16 +2693,8 @@ function ConnectInlineActionSelect({
     [handleActionUpdate],
   );
 
-  const handleOpenChange = useCallback(
-    (next: boolean) => {
-      setOpen(next);
-      if (next) onOpen?.();
-    },
-    [onOpen],
-  );
-
   return (
-    <Popover open={open} onOpenChange={handleOpenChange}>
+    <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger>
         <button
           type="button"
@@ -2752,15 +2744,22 @@ function ConnectInlineActionSelect({
             )}
           >
             <div data-connect-action-popup="">
-              <WorkspaceActionPickerContent
-                config={state}
-                sourceBranchItems={sourceBranchItems}
-                checkoutBranchItems={checkoutBranchItems}
-                worktreeItems={worktreeItems}
-                branchSelectPortalContainer={popupRef}
-                onCommit={handleSelect}
-                onUpdateAction={handleActionUpdate}
-              />
+              {loading ? (
+                <div className="flex items-center gap-2 px-2.5 py-2 text-muted-foreground text-xs">
+                  <Loader2Icon className="size-3.5 shrink-0 animate-spin" />
+                  <span>Loading branches and worktrees…</span>
+                </div>
+              ) : (
+                <WorkspaceActionPickerContent
+                  config={state}
+                  sourceBranchItems={sourceBranchItems}
+                  checkoutBranchItems={checkoutBranchItems}
+                  worktreeItems={worktreeItems}
+                  branchSelectPortalContainer={popupRef}
+                  onCommit={handleSelect}
+                  onUpdateAction={handleActionUpdate}
+                />
+              )}
             </div>
           </PopoverBase.Popup>
         </PopoverBase.Positioner>
@@ -3407,18 +3406,13 @@ const ConnectWorkspaceSelect = memo(function ConnectWorkspaceSelectInner({
                               : null,
                           )}
                         >
-                          {gitCapability === 'git' && (
+                          {gitCapability !== 'not-git' && (
                             <ConnectInlineActionSelect
                               state={rowState}
                               sourceBranchItems={sourceBranchItems}
                               checkoutBranchItems={checkoutBranchItems}
                               worktreeItems={worktreeItems}
-                              onOpen={() =>
-                                void loadGitOptionsForPath(
-                                  workspace.path,
-                                  rowKey,
-                                )
-                              }
+                              loading={gitCapability !== 'git'}
                               onUpdate={(partial) =>
                                 updateRowState(rowKey, partial)
                               }


### PR DESCRIPTION
## Summary

- show the selected workspace action immediately for recent workspaces
- display a loading state inside the action popover while Git options load
- replace fallback options with real branch and worktree data once available
- avoid triggering a duplicate Git options request when opening the action popover

<img width="1128" height="366" alt="image" src="https://github.com/user-attachments/assets/c7490636-e268-416c-9814-416a9d223a34" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 67f2191bded94e7a4651483ba6ac8596c6f9e80f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the workspace action immediately and display a spinner while branches and worktrees load, then swap in real data when ready. Also stops duplicate Git options requests for a smoother, faster UI.

- **Bug Fixes**
  - Action popover shows a loading state instead of fallback options.
  - Replaced `onOpen`-based fetch with a `loading` prop to prevent duplicate requests.
  - Only render the action selector in Git-capable workspaces; show spinner until confirmed.

<sup>Written for commit 67f2191bded94e7a4651483ba6ac8596c6f9e80f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1513?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a loading indicator and status message while workspace information is being checked.
  - Workspace actions now appear automatically once loading is complete.
  - Recent workspace entries display the selector when their Git status is still being determined.

- **Bug Fixes**
  - Improved workspace selection behavior for paths with unknown or pending Git status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->