### PR TITLE
feat(stagewise): allow expanding long user messages

### DIFF
--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/chat-history.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/chat-history.tsx
@@ -213,6 +213,7 @@ export const ChatHistory = ({ flushTop = false }: { flushTop?: boolean }) => {
   // Element refs for direct measurement in useLayoutEffect
   const lastUserElementRef = useRef<HTMLDivElement | null>(null);
   const lastAssistantElementRef = useRef<HTMLDivElement | null>(null);
+  const disconnectLastUserResizeObserverRef = useRef<(() => void) | null>(null);
 
   // Extracted measurement function - called from both callback ref and useLayoutEffect
   // Uses direct DOM mutation only (no state) to avoid extra re-renders and flickering
@@ -234,12 +235,21 @@ export const ChatHistory = ({ flushTop = false }: { flushTop?: boolean }) => {
   // Callback ref for last user message - stores element for measurement AND triggers height update
   const lastUserMessageRef = useCallback(
     (node: HTMLDivElement | null) => {
+      disconnectLastUserResizeObserverRef.current?.();
+      disconnectLastUserResizeObserverRef.current = null;
       lastUserElementRef.current = node;
-      // Trigger height measurement when a new element is mounted
-      if (node) updateSpacerHeight();
+      if (!node) return;
+
+      const { observer, disconnect } =
+        createRafResizeObserver(updateSpacerHeight);
+      observer.observe(node);
+      disconnectLastUserResizeObserverRef.current = disconnect;
+      updateSpacerHeight();
     },
     [updateSpacerHeight],
   );
+
+  useEffect(() => () => disconnectLastUserResizeObserverRef.current?.(), []);
 
   // Callback ref for last assistant message - stores element for measurement AND triggers height update
   const lastAssistantMessageRef = useCallback(

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/chat-input-view-only.test.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/chat-input-view-only.test.tsx
@@ -1,0 +1,72 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('./rich-text/attachments', () => ({
+  AttachmentRegistryNodeView: () => null,
+  ElementAttachmentView: () => null,
+}));
+vi.mock('./rich-text/mentions', () => ({ MentionNodeView: () => null }));
+vi.mock('./rich-text/slash/slash-node-view', () => ({
+  SlashNodeView: () => null,
+}));
+
+import { ChatInputViewOnly } from './chat-input-view-only';
+
+class ResizeObserverMock {
+  observe() {}
+  disconnect() {}
+}
+
+describe('ChatInputViewOnly', () => {
+  beforeEach(() => {
+    vi.stubGlobal('ResizeObserver', ResizeObserverMock);
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+      callback(0);
+      return 0;
+    });
+    vi.stubGlobal('cancelAnimationFrame', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('does not render a toggle when the message fits', () => {
+    vi.spyOn(HTMLElement.prototype, 'scrollHeight', 'get').mockReturnValue(174);
+
+    render(<ChatInputViewOnly tipTapContent="Short message" />);
+
+    expect(screen.queryByRole('button')).toBeNull();
+  });
+
+  it('toggles overflowing content without triggering the message action', () => {
+    vi.spyOn(HTMLElement.prototype, 'scrollHeight', 'get').mockReturnValue(175);
+    const onEdit = vi.fn();
+
+    render(<ChatInputViewOnly tipTapContent="Long message" onEdit={onEdit} />);
+
+    const showMoreButton = screen.getByRole('button', { name: 'Show more' });
+    expect(showMoreButton.getAttribute('aria-expanded')).toBe('false');
+
+    fireEvent.click(showMoreButton);
+
+    const showLessButton = screen.getByRole('button', { name: 'Show less' });
+    expect(showLessButton.getAttribute('aria-expanded')).toBe('true');
+    expect(onEdit).not.toHaveBeenCalled();
+
+    const messageButton = screen.getByRole('button', { name: 'Long message' });
+    fireEvent.click(messageButton);
+    expect(onEdit).toHaveBeenCalledOnce();
+
+    fireEvent.keyDown(messageButton, { key: 'Enter' });
+    expect(onEdit).toHaveBeenCalledTimes(2);
+
+    fireEvent.click(showLessButton);
+    expect(
+      screen
+        .getByRole('button', { name: 'Show more' })
+        .getAttribute('aria-expanded'),
+    ).toBe('false');
+  });
+});

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/chat-input-view-only.test.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/chat-input-view-only.test.tsx
@@ -43,8 +43,13 @@ describe('ChatInputViewOnly', () => {
   it('toggles overflowing content without triggering the message action', () => {
     vi.spyOn(HTMLElement.prototype, 'scrollHeight', 'get').mockReturnValue(175);
     const onEdit = vi.fn();
+    const onBubbleClick = vi.fn();
 
-    render(<ChatInputViewOnly tipTapContent="Long message" onEdit={onEdit} />);
+    render(
+      <div onClick={onBubbleClick}>
+        <ChatInputViewOnly tipTapContent="Long message" onEdit={onEdit} />
+      </div>,
+    );
 
     const showMoreButton = screen.getByRole('button', { name: 'Show more' });
     expect(showMoreButton.getAttribute('aria-expanded')).toBe('false');
@@ -54,6 +59,7 @@ describe('ChatInputViewOnly', () => {
     const showLessButton = screen.getByRole('button', { name: 'Show less' });
     expect(showLessButton.getAttribute('aria-expanded')).toBe('true');
     expect(onEdit).not.toHaveBeenCalled();
+    expect(onBubbleClick).not.toHaveBeenCalled();
 
     const messageButton = screen.getByRole('button', { name: 'Long message' });
     fireEvent.click(messageButton);

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/chat-input-view-only.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/chat-input-view-only.tsx
@@ -6,6 +6,12 @@ import {
 import { MentionNodeView } from './rich-text/mentions';
 import { SlashNodeView } from './rich-text/slash/slash-node-view';
 import type { Content } from '@tiptap/core';
+import { IconChevronDownOutline18 } from '@stagewise/icons';
+import { useLayoutEffect, useRef, useState } from 'react';
+import { createRafResizeObserver } from '@ui/utils/resize-observer';
+import { Button } from '@stagewise/stage-ui/components/button';
+
+const COLLAPSED_CONTENT_HEIGHT_PX = 174;
 
 /**
  * TipTap document structure types for parsing JSON content.
@@ -27,6 +33,8 @@ export interface ChatInputViewOnlyProps {
   tipTapContent?: Content;
   /** Additional CSS classes */
   className?: string;
+  /** Opens the message editor when the content area is activated. */
+  onEdit?: () => void;
 }
 
 /**
@@ -45,37 +53,90 @@ export interface ChatInputViewOnlyProps {
 export function ChatInputViewOnly({
   tipTapContent,
   className,
+  onEdit,
 }: ChatInputViewOnlyProps) {
+  const contentRef = useRef<HTMLDivElement>(null);
+  const [isCollapsible, setIsCollapsible] = useState(false);
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  useLayoutEffect(() => {
+    const content = contentRef.current;
+    if (!content) return;
+
+    const checkIsCollapsible = () => {
+      const nextIsCollapsible =
+        content.scrollHeight > COLLAPSED_CONTENT_HEIGHT_PX;
+      setIsCollapsible(nextIsCollapsible);
+
+      if (!nextIsCollapsible) setIsExpanded(false);
+    };
+
+    checkIsCollapsible();
+
+    const { observer, disconnect } =
+      createRafResizeObserver(checkIsCollapsible);
+    observer.observe(content);
+
+    return () => disconnect();
+  }, [tipTapContent]);
+
+  const handleToggleExpanded = () => {
+    setIsExpanded((expanded) => !expanded);
+  };
+
+  const handleContentKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (!onEdit || (event.key !== 'Enter' && event.key !== ' ')) return;
+
+    event.preventDefault();
+    onEdit();
+  };
+
   // If no valid JSON content, render plain text fallback
   if (!tipTapContent) return null;
-  else if (typeof tipTapContent === 'string') {
-    return (
-      <div
-        className={cn(
-          'scroll-fade-b scroll-fade-4 max-h-43.5 w-full overflow-y-hidden',
-          className,
-        )}
-      >
-        <p className="m-0 min-h-[1.5em] leading-relaxed">{tipTapContent}</p>
-      </div>
-    );
-  }
 
   return (
-    <div
-      className={cn(
-        // Max height with overflow fade
-        'scroll-fade-b scroll-fade-4 max-h-43.5 overflow-y-hidden',
-        // Match ChatInput prose styling
-        'h-full w-full text-foreground text-sm',
-        'prose prose-sm max-w-none',
-        '[&_p]:m-0 [&_p]:leading-relaxed',
-        className,
-      )}
-    >
-      {(tipTapContent as TiptapDoc)?.content?.map((node, index) => (
-        <RenderNode key={getNodeKey(node, index)} node={node} />
-      ))}
+    <div className={cn('w-full', className)}>
+      <div
+        className={cn(
+          !isExpanded && 'max-h-43.5 overflow-y-hidden',
+          !isExpanded && isCollapsible && 'scroll-fade-b scroll-fade-4',
+        )}
+        onClick={onEdit}
+        onKeyDown={handleContentKeyDown}
+        role={onEdit ? 'button' : undefined}
+        tabIndex={onEdit ? 0 : undefined}
+      >
+        <div
+          ref={contentRef}
+          className="prose prose-sm h-full w-full max-w-none text-foreground text-sm [&_p]:m-0 [&_p]:leading-relaxed"
+        >
+          {typeof tipTapContent === 'string' ? (
+            <p className="m-0 min-h-[1.5em] leading-relaxed">{tipTapContent}</p>
+          ) : (
+            (tipTapContent as TiptapDoc)?.content?.map((node, index) => (
+              <RenderNode key={getNodeKey(node, index)} node={node} />
+            ))
+          )}
+        </div>
+      </div>
+      {isCollapsible ? (
+        <Button
+          type="button"
+          variant="ghost"
+          size="xs"
+          className="mt-1 h-auto px-0 py-0"
+          aria-expanded={isExpanded}
+          onClick={handleToggleExpanded}
+        >
+          {isExpanded ? 'Show less' : 'Show more'}
+          <IconChevronDownOutline18
+            className={cn(
+              'size-3 transition-transform duration-150',
+              isExpanded && 'rotate-180',
+            )}
+          />
+        </Button>
+      ) : null}
     </div>
   );
 }

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/chat-input-view-only.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/chat-input-view-only.tsx
@@ -80,8 +80,14 @@ export function ChatInputViewOnly({
     return () => disconnect();
   }, [tipTapContent]);
 
-  const handleToggleExpanded = () => {
+  const handleToggleExpanded = (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.stopPropagation();
     setIsExpanded((expanded) => !expanded);
+  };
+
+  const handleContentClick = (event: React.MouseEvent<HTMLDivElement>) => {
+    event.stopPropagation();
+    onEdit?.();
   };
 
   const handleContentKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
@@ -101,7 +107,7 @@ export function ChatInputViewOnly({
           !isExpanded && 'max-h-43.5 overflow-y-hidden',
           !isExpanded && isCollapsible && 'scroll-fade-b scroll-fade-4',
         )}
-        onClick={onEdit}
+        onClick={onEdit ? handleContentClick : undefined}
         onKeyDown={handleContentKeyDown}
         role={onEdit ? 'button' : undefined}
         tabIndex={onEdit ? 0 : undefined}

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/message-user.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/message-user.tsx
@@ -744,6 +744,7 @@ export const MessageUser = memo(
                 data-editable-user-message-id={
                   !isEditing && canEdit ? msg.id : undefined
                 }
+                onClick={!isEditing && canEdit ? handleStartEditing : undefined}
               >
                 {/* View mode: lightweight static renderer */}
                 {!isEditing && (

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/message-user.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/message-user.tsx
@@ -744,25 +744,13 @@ export const MessageUser = memo(
                 data-editable-user-message-id={
                   !isEditing && canEdit ? msg.id : undefined
                 }
-                onClick={!isEditing && canEdit ? handleStartEditing : undefined}
-                role={!isEditing && canEdit ? 'button' : undefined}
-                tabIndex={!isEditing && canEdit ? 0 : undefined}
-                onKeyDown={
-                  !isEditing && canEdit
-                    ? (e) => {
-                        if (e.key === 'Enter' || e.key === ' ') {
-                          e.preventDefault();
-                          handleStartEditing();
-                        }
-                      }
-                    : undefined
-                }
               >
                 {/* View mode: lightweight static renderer */}
                 {!isEditing && (
                   <ChatInputViewOnly
                     tipTapContent={viewModeTipTapContent}
                     className="w-full"
+                    onEdit={canEdit ? handleStartEditing : undefined}
                   />
                 )}
                 {/* Edit mode: full TipTap editor */}

--- a/apps/browser/src/ui/utils/calculate-chat-item-height.ts
+++ b/apps/browser/src/ui/utils/calculate-chat-item-height.ts
@@ -25,6 +25,7 @@ const HEIGHTS = {
   // User message
   USER_PADDING_V: 6, // py-1.5 - user message vertical padding
   USER_MAX_HEIGHT: 174, // max-h-43.5 - user message max content height
+  USER_COLLAPSE_TOGGLE_HEIGHT: 20, // mt-1 + text-xs line height
   USER_MARGIN_TOP: 8, // mt-2 - user message top margin
 
   // Assistant message
@@ -339,10 +340,14 @@ function estimateUserMessageHeight(
 
   // Apply max-height cap (user messages are capped at 174px content height)
   const cappedTextHeight = Math.min(textHeight, HEIGHTS.USER_MAX_HEIGHT);
+  const isCollapsible = textHeight > HEIGHTS.USER_MAX_HEIGHT;
 
   // Add padding and margins
   return (
-    HEIGHTS.USER_MARGIN_TOP + cappedTextHeight + HEIGHTS.USER_PADDING_V * 2
+    HEIGHTS.USER_MARGIN_TOP +
+    cappedTextHeight +
+    (isCollapsible ? HEIGHTS.USER_COLLAPSE_TOGGLE_HEIGHT : 0) +
+    HEIGHTS.USER_PADDING_V * 2
   );
 }
 


### PR DESCRIPTION
## Summary

- add Show more / Show less controls to overflowing user messages
- automatically detect overflow and respond to content size changes
- keep message editing and expansion as separate accessible controls
- update the chat spacer when an expanded user message changes height
- preserve the collapsed fade treatment for long messages

<img width="811" height="385" alt="image" src="https://github.com/user-attachments/assets/8321f312-b775-4dd7-86da-4693d630976c" />
<img width="847" height="326" alt="image" src="https://github.com/user-attachments/assets/7b1a826f-4971-465b-a481-1b73976d4f8a" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized chat UI and layout estimation changes with tests; no auth, data, or backend impact.
> 
> **Overview**
> Long user messages in view mode can be **expanded and collapsed** with **Show more / Show less**, without entering edit mode.
> 
> **`ChatInputViewOnly`** detects overflow against a 174px cap (via `scrollHeight` and `createRafResizeObserver`), applies the collapsed max-height and fade only when needed, and exposes an optional **`onEdit`** on the content area (click / Enter / Space) as a separate control from the toggle (`stopPropagation` on the button).
> 
> **`MessageUser`** passes `onEdit` into the view-only renderer and removes bubble-level button semantics and keyboard handlers so edit and expand stay distinct.
> 
> **`ChatHistory`** attaches a RAF resize observer to the last user message so the assistant **spacer** `minHeight` updates when that message grows or shrinks (e.g. after expand).
> 
> Virtuoso height estimates in **`calculate-chat-item-height`** include ~20px for the collapse toggle when text would exceed the cap. New tests cover non-overflow UI and toggle vs edit behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 141f9651a1e274af5af6c9ffb80033249e7df19c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Show more/Show less to long user messages so users can expand content without entering edit mode. Overflow is auto-detected and the chat layout stays in sync as message height changes.

- **New Features**
  - Collapsible `ChatInputViewOnly` with an accessible toggle (aria-expanded) and a separate `onEdit` action; keeps the collapsed fade.
  - Detects overflow and size changes via `createRafResizeObserver`.
  - `ChatHistory` observes the last user message and adjusts the spacer on resize.

- **Bug Fixes**
  - Stop event propagation so Show more/less doesn’t trigger edit or parent clicks; content area uses role=button with Enter/Space to edit.
  - Cleanly disconnect the last user message resize observer to prevent stale listeners.
  - Include the toggle control height in `calculate-chat-item-height` for accurate spacer estimates.
  - Tests cover non-overflow, toggle behavior, keyboard edit, and no bubble click.

<sup>Written for commit 141f9651a1e274af5af6c9ffb80033249e7df19c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1520?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Long user messages can be expanded or collapsed with “Show more” and “Show less” controls.
  * Messages support editing through click or keyboard interactions.
  * Content automatically adapts when message size changes.
  * Message layout remains accurate when expanded content is resized.

* **Tests**
  * Added coverage for message expansion, collapsing, keyboard navigation, and edit interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->