### PR TITLE
fix(stagewise): use explicit info color for agent in-progress status dot

### DIFF
--- a/apps/browser/src/ui/screens/main/_lib/agent-list-model.ts
+++ b/apps/browser/src/ui/screens/main/_lib/agent-list-model.ts
@@ -267,7 +267,7 @@ export function getSeverityDotClass(
     case 'success':
       return 'bg-success-solid';
     case 'info':
-      return 'bg-primary-solid';
+      return 'bg-info-solid';
     default:
       return null;
   }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 67a13a7c9d57dcc3bee313860f085a4c4f0eb247. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Use the explicit info color for the agent in‑progress status dot. Replaces `bg-primary-solid` with `bg-info-solid` in `getSeverityDotClass` so the 'info' state displays correctly.

<sup>Written for commit 67a13a7c9d57dcc3bee313860f085a4c4f0eb247. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1521?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the visual indicator for informational status to use the correct informational color.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->