### PR TITLE
feat(stagewise): support isolated dev instances

### DIFF
--- a/apps/browser/build-constants.ts
+++ b/apps/browser/build-constants.ts
@@ -1,4 +1,5 @@
 import path from 'node:path';
+import { createHash } from 'node:crypto';
 import { fileURLToPath } from 'node:url';
 import { readFileSync } from 'node:fs';
 import semver from 'semver';
@@ -20,6 +21,13 @@ export const __APP_RELEASE_CHANNEL__: ReleaseChannel = (() => {
 })();
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const worktreeRoot = path.resolve(__dirname, '../..');
+
+const devInstance =
+  __APP_RELEASE_CHANNEL__ === 'dev' &&
+  process.env.STAGEWISE_DEV_INSTANCE === 'auto'
+    ? createHash('sha256').update(worktreeRoot).digest('hex').slice(0, 8)
+    : null;
 
 // Read version from package.json
 const packageJson = JSON.parse(
@@ -36,7 +44,7 @@ export const __APP_BASE_NAME__ = (() => {
       return 'stagewise-prerelease';
     case 'dev':
     default:
-      return 'stagewise-dev';
+      return devInstance ? `stagewise-dev-${devInstance}` : 'stagewise-dev';
   }
 })();
 
@@ -51,7 +59,9 @@ export const __APP_NAME__ = (() => {
       return 'stagewise (Pre-Release)';
     case 'dev':
     default:
-      return 'stagewise (Dev-Build)';
+      return devInstance
+        ? `stagewise (Dev-Build ${devInstance})`
+        : 'stagewise (Dev-Build)';
   }
 })();
 

--- a/apps/browser/package.json
+++ b/apps/browser/package.json
@@ -16,6 +16,7 @@
     "package": "pnpm bundle:eslint && cross-env NODE_OPTIONS=--max-old-space-size=8192 dotenv -e ../../.env -- electron-forge package",
     "publish": "dotenv -e ../../.env -- electron-forge publish",
     "start": "concurrently -n typecheck,app -c yellow,green \"pnpm typecheck\" \"dotenv -e ../../.env.dev -- electron-forge start\"",
+    "start:isolated": "cross-env STAGEWISE_DEV_INSTANCE=auto pnpm start",
     "start:fast": "dotenv -e ../../.env.dev -- electron-forge start",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",

--- a/apps/browser/scripts/clean-data.ts
+++ b/apps/browser/scripts/clean-data.ts
@@ -111,8 +111,9 @@ async function getIsolatedDirectories(basePath: string): Promise<string[]> {
           entry.isDirectory() && entry.name.startsWith('stagewise-dev-'),
       )
       .map((entry) => path.join(basePath, entry.name));
-  } catch {
-    return [];
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return [];
+    throw error;
   }
 }
 

--- a/apps/browser/scripts/clean-data.ts
+++ b/apps/browser/scripts/clean-data.ts
@@ -103,43 +103,69 @@ async function cleanTempWorkspaces(tempBasePath: string): Promise<number> {
   return deletedCount;
 }
 
+async function getIsolatedDirectories(basePath: string): Promise<string[]> {
+  try {
+    return (await fs.readdir(basePath, { withFileTypes: true }))
+      .filter(
+        (entry) =>
+          entry.isDirectory() && entry.name.startsWith('stagewise-dev-'),
+      )
+      .map((entry) => path.join(basePath, entry.name));
+  } catch {
+    return [];
+  }
+}
+
 async function main() {
   log('\n🧹 Stagewise Browser Data Cleanup', colors.cyan);
   log('='.repeat(50), colors.cyan);
 
   const appDataPath = getAppDataPath();
   const tempPath = getTempPath();
+  const isolatedOnly = process.argv.includes('--isolated-only');
 
   log(`\nDetected platform: ${process.platform}`, colors.blue);
   log(`App data base path: ${appDataPath}`, colors.blue);
   log(`Temp base path: ${tempPath}`, colors.blue);
 
-  const pathsToClean = {
-    'Production userData': path.join(appDataPath, 'stagewise'),
-    'Development userData': path.join(appDataPath, 'stagewise-dev'),
-  };
-
   log('\n📂 Cleaning userData directories...', colors.cyan);
   let deletedCount = 0;
-  for (const [label, dirPath] of Object.entries(pathsToClean)) {
-    log(`\n${label}:`, colors.blue);
+  if (!isolatedOnly) {
+    const pathsToClean = {
+      'Production userData': path.join(appDataPath, 'stagewise'),
+      'Development userData': path.join(appDataPath, 'stagewise-dev'),
+    };
+    for (const [label, dirPath] of Object.entries(pathsToClean)) {
+      log(`\n${label}:`, colors.blue);
+      const deleted = await deleteDirectory(dirPath);
+      if (deleted) deletedCount++;
+    }
+  }
+  for (const dirPath of await getIsolatedDirectories(appDataPath)) {
     const deleted = await deleteDirectory(dirPath);
     if (deleted) deletedCount++;
   }
 
-  log('\n📂 Cleaning temp workspace directories...', colors.cyan);
-  log('\nProduction temp workspaces:', colors.blue);
-  const prodTempDeleted = await cleanTempWorkspaces(
-    path.join(tempPath, 'stagewise'),
-  );
-  log('\nDevelopment temp workspaces:', colors.blue);
-  const devTempDeleted = await cleanTempWorkspaces(
-    path.join(tempPath, 'stagewise-dev'),
-  );
+  log('\n📂 Cleaning temp directories...', colors.cyan);
+  let tempDeletedCount = 0;
+  if (!isolatedOnly) {
+    log('\nProduction temp workspaces:', colors.blue);
+    tempDeletedCount += await cleanTempWorkspaces(
+      path.join(tempPath, 'stagewise'),
+    );
+    log('\nDevelopment temp workspaces:', colors.blue);
+    tempDeletedCount += await cleanTempWorkspaces(
+      path.join(tempPath, 'stagewise-dev'),
+    );
+  }
+  for (const dirPath of await getIsolatedDirectories(tempPath)) {
+    const deleted = await deleteDirectory(dirPath);
+    if (deleted) tempDeletedCount++;
+  }
 
   log(`\n${'='.repeat(50)}`, colors.cyan);
   log(
-    `\n✓ Cleanup complete! Deleted ${deletedCount} userData directories and ${prodTempDeleted + devTempDeleted} temp workspace directories.`,
+    `\n✓ Cleanup complete! Deleted ${deletedCount} userData directories and ${tempDeletedCount} temp directories.`,
     colors.green,
   );
   log(

--- a/apps/browser/src/backend/index.ts
+++ b/apps/browser/src/backend/index.ts
@@ -6,6 +6,7 @@ import started from 'electron-squirrel-startup';
 import path from 'node:path';
 import { installStartupOpenUrlListener } from './startup-url-events';
 import { applyPendingAppDataReset } from './utils/app-data-reset';
+import { seedIsolatedDevProfile } from './utils/seed-isolated-dev-profile';
 
 // CRITICAL: `main` is imported dynamically (below in the 'ready' handler)
 // instead of statically. On Windows machines without the VC++ redistributable
@@ -22,45 +23,22 @@ if (started) {
   app.quit();
 }
 
-const appBaseName = (() => {
-  switch (__APP_RELEASE_CHANNEL__) {
-    case 'release':
-      return 'stagewise';
-    case 'nightly':
-      return 'stagewise-nightly';
-    case 'prerelease':
-      return 'stagewise-prerelease';
-    case 'dev':
-    default:
-      return 'stagewise-dev';
-  }
-})();
-
-const appName = (() => {
-  switch (__APP_RELEASE_CHANNEL__) {
-    case 'release':
-      return 'stagewise';
-    case 'nightly':
-      return 'stagewise Nightly';
-    case 'prerelease':
-      return 'stagewise (Pre-Release)';
-    case 'dev':
-    default:
-      return 'stagewise (Dev-Build)';
-  }
-})();
-
-// Set the app name for macOS menu bar
-app.setName(appName);
+// Keep the dev identity stable so isolated profiles can read safeStorage data
+// copied from the default dev profile. Window titles still use __APP_NAME__.
+app.setName(
+  __APP_RELEASE_CHANNEL__ === 'dev' ? 'stagewise (Dev-Build)' : __APP_NAME__,
+);
 if (process.platform === 'win32') {
-  app.setAppUserModelId(`com.squirrel.${appBaseName}.${appBaseName}`);
+  app.setAppUserModelId(
+    `com.squirrel.${__APP_BASE_NAME__}.${__APP_BASE_NAME__}`,
+  );
 }
 app.applicationMenu = null;
 installStartupOpenUrlListener();
 
 // Set the right path structure for the app
 // We keep userData where it is, but we will put session data into a sub-folder called "session"
-app.setPath('userData', path.join(app.getPath('appData'), appBaseName));
+app.setPath('userData', path.join(app.getPath('appData'), __APP_BASE_NAME__));
 app.setPath('sessionData', path.join(app.getPath('userData'), 'session'));
 
 // Register custom protocols as privileged (must happen before app.ready)
@@ -128,6 +106,21 @@ if (!singleInstanceLock) {
     applyPendingAppDataReset(app.getPath('userData'));
   } catch (error) {
     console.error('[AppDataReset] Failed to reset app data', error);
+  }
+
+  try {
+    const copiedFileCount = seedIsolatedDevProfile(
+      app.getPath('appData'),
+      app.getPath('userData'),
+      __APP_BASE_NAME__,
+    );
+    if (copiedFileCount > 0) {
+      console.log(
+        `[DevProfile] Seeded ${copiedFileCount} file(s) from the default dev profile`,
+      );
+    }
+  } catch (error) {
+    console.error('[DevProfile] Failed to seed isolated dev profile', error);
   }
 }
 

--- a/apps/browser/src/backend/utils/app-data-reset.test.ts
+++ b/apps/browser/src/backend/utils/app-data-reset.test.ts
@@ -6,6 +6,7 @@ import {
   applyPendingAppDataReset,
   requestAppDataReset,
 } from './app-data-reset';
+import { ISOLATED_DEV_SEED_MARKER } from './seed-isolated-dev-profile';
 
 let userDataDirectory: string;
 const tempDirectoryPrefix = path.join(os.tmpdir(), 'stagewise-reset-');
@@ -20,7 +21,7 @@ afterEach(() => {
 });
 
 describe('app data reset', () => {
-  it('deletes user data while preserving identity.json', () => {
+  it('deletes user data while preserving identity and seed markers', () => {
     const dataRoot = path.join(userDataDirectory, 'stagewise');
     const identityPath = path.join(dataRoot, 'identity.json');
     const identity = '{"machineId":"00000000-0000-4000-8000-000000000001"}';
@@ -30,6 +31,10 @@ describe('app data reset', () => {
     fs.writeFileSync(path.join(dataRoot, 'preferences.json'), '{}');
     fs.writeFileSync(path.join(userDataDirectory, 'session', 'Cookies'), 'x');
     fs.writeFileSync(path.join(userDataDirectory, 'SingletonLock'), 'lock');
+    fs.writeFileSync(
+      path.join(userDataDirectory, ISOLATED_DEV_SEED_MARKER),
+      '',
+    );
 
     requestAppDataReset(userDataDirectory);
 
@@ -40,6 +45,9 @@ describe('app data reset', () => {
     expect(fs.existsSync(path.join(userDataDirectory, 'SingletonLock'))).toBe(
       true,
     );
+    expect(
+      fs.existsSync(path.join(userDataDirectory, ISOLATED_DEV_SEED_MARKER)),
+    ).toBe(true);
   });
 
   it('deletes user data without an identity.json', () => {

--- a/apps/browser/src/backend/utils/app-data-reset.ts
+++ b/apps/browser/src/backend/utils/app-data-reset.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
+import { ISOLATED_DEV_SEED_MARKER } from './seed-isolated-dev-profile';
 
 const RESET_MARKER = '.reset-app-data';
 
@@ -15,6 +16,7 @@ export function applyPendingAppDataReset(userDataDirectory: string): void {
   for (const entry of fs.readdirSync(userDataDirectory)) {
     if (
       entry === RESET_MARKER ||
+      entry === ISOLATED_DEV_SEED_MARKER ||
       entry === 'stagewise' ||
       entry.startsWith('Singleton')
     )

--- a/apps/browser/src/backend/utils/paths.ts
+++ b/apps/browser/src/backend/utils/paths.ts
@@ -6,7 +6,12 @@ export const getDataRoot = (): string =>
   path.join(app.getPath('userData'), 'stagewise');
 
 export const getTempRoot = (): string =>
-  path.join(app.getPath('temp'), 'stagewise');
+  path.join(
+    app.getPath('temp'),
+    __APP_BASE_NAME__.startsWith('stagewise-dev-')
+      ? __APP_BASE_NAME__
+      : 'stagewise',
+  );
 
 export type DbName =
   | 'favicon'

--- a/apps/browser/src/backend/utils/seed-isolated-dev-profile.test.ts
+++ b/apps/browser/src/backend/utils/seed-isolated-dev-profile.test.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   ISOLATED_DEV_SEED_MARKER,
   seedIsolatedDevProfile,
@@ -21,16 +21,28 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  vi.restoreAllMocks();
   fs.rmSync(root, { recursive: true, force: true });
 });
 
 describe('seedIsolatedDevProfile', () => {
   it('copies only allowed missing files and seeds once', () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('win32');
     const targetDataRoot = path.join(userDataDirectory, 'stagewise');
+    const sourceSessionRoot = path.join(
+      appDataDirectory,
+      'stagewise-dev',
+      'session',
+    );
     fs.mkdirSync(targetDataRoot, { recursive: true });
+    fs.mkdirSync(sourceSessionRoot, { recursive: true });
     fs.writeFileSync(path.join(sourceDataRoot, 'auth-session.json'), 'auth');
     fs.writeFileSync(path.join(sourceDataRoot, 'preferences.json'), 'source');
     fs.writeFileSync(path.join(sourceDataRoot, 'window-state.json'), 'window');
+    fs.writeFileSync(
+      path.join(sourceSessionRoot, 'Local State'),
+      'local-state',
+    );
     fs.writeFileSync(path.join(targetDataRoot, 'preferences.json'), 'target');
 
     expect(
@@ -39,7 +51,7 @@ describe('seedIsolatedDevProfile', () => {
         userDataDirectory,
         'stagewise-dev-deadbeef',
       ),
-    ).toBe(1);
+    ).toBe(2);
     expect(
       fs.readFileSync(path.join(targetDataRoot, 'auth-session.json'), 'utf8'),
     ).toBe('auth');
@@ -52,6 +64,12 @@ describe('seedIsolatedDevProfile', () => {
     expect(
       fs.existsSync(path.join(userDataDirectory, ISOLATED_DEV_SEED_MARKER)),
     ).toBe(true);
+    expect(
+      fs.readFileSync(
+        path.join(userDataDirectory, 'session', 'Local State'),
+        'utf8',
+      ),
+    ).toBe('local-state');
     expect(
       seedIsolatedDevProfile(
         appDataDirectory,

--- a/apps/browser/src/backend/utils/seed-isolated-dev-profile.test.ts
+++ b/apps/browser/src/backend/utils/seed-isolated-dev-profile.test.ts
@@ -1,0 +1,73 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  ISOLATED_DEV_SEED_MARKER,
+  seedIsolatedDevProfile,
+} from './seed-isolated-dev-profile';
+
+let root: string;
+let appDataDirectory: string;
+let sourceDataRoot: string;
+let userDataDirectory: string;
+
+beforeEach(() => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), 'stagewise-dev-seed-'));
+  appDataDirectory = path.join(root, 'app-data');
+  sourceDataRoot = path.join(appDataDirectory, 'stagewise-dev', 'stagewise');
+  userDataDirectory = path.join(appDataDirectory, 'stagewise-dev-deadbeef');
+  fs.mkdirSync(sourceDataRoot, { recursive: true });
+});
+
+afterEach(() => {
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+describe('seedIsolatedDevProfile', () => {
+  it('copies only allowed missing files and seeds once', () => {
+    const targetDataRoot = path.join(userDataDirectory, 'stagewise');
+    fs.mkdirSync(targetDataRoot, { recursive: true });
+    fs.writeFileSync(path.join(sourceDataRoot, 'auth-session.json'), 'auth');
+    fs.writeFileSync(path.join(sourceDataRoot, 'preferences.json'), 'source');
+    fs.writeFileSync(path.join(sourceDataRoot, 'window-state.json'), 'window');
+    fs.writeFileSync(path.join(targetDataRoot, 'preferences.json'), 'target');
+
+    expect(
+      seedIsolatedDevProfile(
+        appDataDirectory,
+        userDataDirectory,
+        'stagewise-dev-deadbeef',
+      ),
+    ).toBe(1);
+    expect(
+      fs.readFileSync(path.join(targetDataRoot, 'auth-session.json'), 'utf8'),
+    ).toBe('auth');
+    expect(
+      fs.readFileSync(path.join(targetDataRoot, 'preferences.json'), 'utf8'),
+    ).toBe('target');
+    expect(fs.existsSync(path.join(targetDataRoot, 'window-state.json'))).toBe(
+      false,
+    );
+    expect(
+      fs.existsSync(path.join(userDataDirectory, ISOLATED_DEV_SEED_MARKER)),
+    ).toBe(true);
+    expect(
+      seedIsolatedDevProfile(
+        appDataDirectory,
+        userDataDirectory,
+        'stagewise-dev-deadbeef',
+      ),
+    ).toBe(0);
+  });
+
+  it('does not seed the default dev profile', () => {
+    expect(
+      seedIsolatedDevProfile(
+        appDataDirectory,
+        userDataDirectory,
+        'stagewise-dev',
+      ),
+    ).toBe(0);
+  });
+});

--- a/apps/browser/src/backend/utils/seed-isolated-dev-profile.ts
+++ b/apps/browser/src/backend/utils/seed-isolated-dev-profile.ts
@@ -22,11 +22,8 @@ export function seedIsolatedDevProfile(
   if (!appBaseName.startsWith('stagewise-dev-')) return 0;
 
   const markerPath = path.join(userDataDirectory, ISOLATED_DEV_SEED_MARKER);
-  const sourceDataRoot = path.join(
-    appDataDirectory,
-    'stagewise-dev',
-    'stagewise',
-  );
+  const sourceUserData = path.join(appDataDirectory, 'stagewise-dev');
+  const sourceDataRoot = path.join(sourceUserData, 'stagewise');
   if (fs.existsSync(markerPath) || !fs.existsSync(sourceDataRoot)) return 0;
 
   const targetDataRoot = path.join(userDataDirectory, 'stagewise');
@@ -39,6 +36,16 @@ export function seedIsolatedDevProfile(
     if (!fs.existsSync(sourcePath) || fs.existsSync(targetPath)) continue;
     fs.copyFileSync(sourcePath, targetPath);
     copiedFileCount++;
+  }
+
+  if (process.platform === 'win32') {
+    const sourcePath = path.join(sourceUserData, 'session', 'Local State');
+    const targetPath = path.join(userDataDirectory, 'session', 'Local State');
+    if (fs.existsSync(sourcePath) && !fs.existsSync(targetPath)) {
+      fs.mkdirSync(path.dirname(targetPath), { recursive: true });
+      fs.copyFileSync(sourcePath, targetPath);
+      copiedFileCount++;
+    }
   }
 
   fs.writeFileSync(markerPath, '');

--- a/apps/browser/src/backend/utils/seed-isolated-dev-profile.ts
+++ b/apps/browser/src/backend/utils/seed-isolated-dev-profile.ts
@@ -1,0 +1,46 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+export const ISOLATED_DEV_SEED_MARKER = '.isolated-dev-profile-seeded';
+
+const SEEDED_FILE_NAMES = [
+  'auth-session.json',
+  'preferences.json',
+  'credentials.json',
+  'config.json',
+  'identity.json',
+  'onboarding-state.json',
+  'tutorial-state.json',
+  'recently-opened-workspaces.json',
+];
+
+export function seedIsolatedDevProfile(
+  appDataDirectory: string,
+  userDataDirectory: string,
+  appBaseName: string,
+): number {
+  if (!appBaseName.startsWith('stagewise-dev-')) return 0;
+
+  const markerPath = path.join(userDataDirectory, ISOLATED_DEV_SEED_MARKER);
+  const sourceDataRoot = path.join(
+    appDataDirectory,
+    'stagewise-dev',
+    'stagewise',
+  );
+  if (fs.existsSync(markerPath) || !fs.existsSync(sourceDataRoot)) return 0;
+
+  const targetDataRoot = path.join(userDataDirectory, 'stagewise');
+  fs.mkdirSync(targetDataRoot, { recursive: true });
+
+  let copiedFileCount = 0;
+  for (const fileName of SEEDED_FILE_NAMES) {
+    const sourcePath = path.join(sourceDataRoot, fileName);
+    const targetPath = path.join(targetDataRoot, fileName);
+    if (!fs.existsSync(sourcePath) || fs.existsSync(targetPath)) continue;
+    fs.copyFileSync(sourcePath, targetPath);
+    copiedFileCount++;
+  }
+
+  fs.writeFileSync(markerPath, '');
+  return copiedFileCount;
+}

--- a/apps/browser/vite.pages.config.ts
+++ b/apps/browser/vite.pages.config.ts
@@ -19,6 +19,11 @@ const _appVersion = packageJson.version;
 // Release channel: 'dev' | 'prerelease' | 'release'
 const _releaseChannel = process.env.RELEASE_CHANNEL || 'dev';
 
+const pagesPort = buildConstants.__APP_BASE_NAME__.startsWith('stagewise-dev-')
+  ? 30000 +
+    (Number.parseInt(buildConstants.__APP_BASE_NAME__.slice(-8), 16) % 10000)
+  : 5174;
+
 // https://vite.dev/config/
 export default defineConfig({
   root: path.resolve(__dirname, './src/pages'),
@@ -86,7 +91,13 @@ export default defineConfig({
     include: ['use-sync-external-store', 'use-sync-external-store/**/*'],
   },
   server: {
-    port: 5174,
+    port: pagesPort,
+    strictPort: true,
+    hmr: {
+      protocol: 'ws',
+      host: 'localhost',
+      port: pagesPort,
+    },
   },
   cacheDir: 'node_modules/.vite/pages',
 });

--- a/apps/browser/vite.pages.config.ts
+++ b/apps/browser/vite.pages.config.ts
@@ -87,12 +87,6 @@ export default defineConfig({
   },
   server: {
     port: 5174,
-    strictPort: true,
-    hmr: {
-      protocol: 'ws',
-      host: 'localhost',
-      port: 5174,
-    },
   },
   cacheDir: 'node_modules/.vite/pages',
 });

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "clean": "git clean -xdf node_modules",
     "clean:workspaces": "turbo clean",
     "clean:browser-data": "pnpm -F stagewise clean-data",
+    "clean:browser-data-isolated": "pnpm -F stagewise clean-data --isolated-only",
     "dev": "turbo watch dev --concurrency 20",
     "dev:playgrounds": "turbo watch dev --filter='./playgrounds/*' --concurrency 20",
     "dev:examples": "turbo watch dev --filter='./examples/*' --concurrency 20",


### PR DESCRIPTION
## Summary

This makes it possible to run the stagewise Electron app from multiple Git worktrees at the same time, so multiple features can be developed and tested in parallel.

- add `pnpm -F stagewise start:isolated`
- derive a stable dev instance ID from the current worktree
- isolate Electron user data, temp data, ports, and single-instance locks
- seed shared development data such as login, credentials, preferences, and
  recent workspaces
- keep the regular `pnpm -F stagewise start` behavior unchanged

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Dev-only and opt-in, but it copies auth/credentials between profiles and changes Electron paths and ports; mistakes could affect local dev data or encryption on Windows.
> 
> **Overview**
> Adds **parallel dev Electron runs** from multiple worktrees via `pnpm -F stagewise start:isolated`, which sets `STAGEWISE_DEV_INSTANCE=auto` and derives a stable 8-character ID from the worktree path.
> 
> That ID drives **per-instance isolation**: `__APP_BASE_NAME__` becomes `stagewise-dev-<id>` (userData, temp roots, Windows App User Model ID, single-instance lock), and the pages Vite dev server uses a stable port in the 30000–39999 range derived from the suffix. Regular `start` is unchanged.
> 
> **First launch** of an isolated profile **one-time seeds** missing files (auth, credentials, preferences, identity, etc.) from the default `stagewise-dev` profile, with a marker so it does not repeat; app data reset keeps that marker. On Windows, dev `app.setName` stays on the default dev label so copied `session/Local State` can work with safeStorage, while display names still show the instance ID.
> 
> Cleanup adds `--isolated-only` on `clean-data` and root `clean:browser-data-isolated` to remove only `stagewise-dev-*` userData and temp directories.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c6f98a63342647cbca4b36c8253012655f60c1d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run multiple isolated Stagewise dev Electron instances from different Git worktrees in parallel with unique data, locks, and ports. Also improves cleanup by surfacing errors during isolated profile removal.

- **New Features**
  - Add `pnpm -F stagewise start:isolated` (`STAGEWISE_DEV_INSTANCE=auto`) that derives an 8-char ID from the worktree.
  - Isolate `userData`, temp folder, session/ports, and single-instance locks; app base name becomes `stagewise-dev-<id>`. Vite pages dev server and HMR use a stable port derived from the ID.
  - One-time seeding of selected files (auth, credentials, preferences, identity, recent workspaces) from the default `stagewise-dev` profile, guarded by a marker. On Windows, also copy `session/Local State`; keep a stable dev `app.setName` so encrypted/safeStorage data works.
  - Add `pnpm clean:browser-data-isolated` (alias of `pnpm -F stagewise clean-data --isolated-only`) to remove only isolated dev `userData` and temp directories.

- **Bug Fixes**
  - Surface errors when cleaning isolated dev profiles so failures are visible during `clean-data` runs.

<sup>Written for commit 2c6f98a63342647cbca4b36c8253012655f60c1d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1524?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an isolated development start option with a unique app identity, temporary data location, and development port for each workspace.
  - Development instances can reuse selected settings from the shared development profile.
  - Existing profile files are preserved, and setup is skipped when already completed.
  - Added an option to clean up isolated development data independently.

- **Bug Fixes**
  - Resetting app data now preserves isolated development profile information.

- **Tests**
  - Added coverage for profile setup, repeated launches, file preservation, and default development behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->