### PR TITLE
fix(stagewise): improve queued message handling

### DIFF
--- a/apps/browser/src/backend/services/agent-manager/agent-manager.ts
+++ b/apps/browser/src/backend/services/agent-manager/agent-manager.ts
@@ -44,6 +44,7 @@ const AGENT_RPC_COMMANDS = [
   'agents.flushQueue',
   'agents.clearQueue',
   'agents.deleteQueuedMessage',
+  'agents.moveQueuedMessage',
   'agents.revertToUserMessage',
   'agents.replaceUserMessage',
   'agents.delete',

--- a/apps/browser/src/shared/karton-contracts/ui/index.ts
+++ b/apps/browser/src/shared/karton-contracts/ui/index.ts
@@ -1390,11 +1390,16 @@ export type KartonContract = {
         source?: 'panel-combobox' | 'inline-approval-button',
       ) => Promise<void>;
       stop: (agentId: string) => Promise<void>;
-      flushQueue: (agentId: string) => Promise<void>;
+      flushQueue: (agentId: string, messageId?: string) => Promise<void>;
       clearQueue: (agentId: string) => Promise<void>;
       deleteQueuedMessage: (
         agentId: string,
         messageId: string,
+      ) => Promise<void>;
+      moveQueuedMessage: (
+        agentId: string,
+        messageId: string,
+        toIndex: number,
       ) => Promise<void>;
       revertToUserMessage: (
         agentId: string,

--- a/apps/browser/src/ui/hooks/use-send-implement.ts
+++ b/apps/browser/src/ui/hooks/use-send-implement.ts
@@ -1,5 +1,5 @@
 import { useCallback } from 'react';
-import { useKartonProcedure } from './use-karton';
+import { useKartonProcedure, useKartonState } from './use-karton';
 import { useOpenAgent } from './use-open-chat';
 import { generateId } from '@ui/utils';
 import type { AgentMessage } from '@shared/karton-contracts/ui/agent';
@@ -18,6 +18,16 @@ import type { AgentMessage } from '@shared/karton-contracts/ui/agent';
 export function useSendImplement(): () => void {
   const [openAgentId] = useOpenAgent();
   const sendUserMessage = useKartonProcedure((p) => p.agents.sendUserMessage);
+  const shouldDispatchOptimisticMessage = useKartonState((s) => {
+    const agentState = openAgentId
+      ? s.agents.instances[openAgentId]?.state
+      : undefined;
+    return (
+      agentState !== undefined &&
+      !agentState.isWorking &&
+      agentState.queuedMessages.length === 0
+    );
+  });
 
   return useCallback(() => {
     if (!openAgentId) return;
@@ -37,13 +47,13 @@ export function useSendImplement(): () => void {
       },
     };
 
-    // Dispatch for optimistic rendering + auto-scroll
-    window.dispatchEvent(
-      new CustomEvent('chat-message-sent', {
-        detail: { agentId: openAgentId, message },
-      }),
-    );
+    if (shouldDispatchOptimisticMessage)
+      window.dispatchEvent(
+        new CustomEvent('chat-message-sent', {
+          detail: { agentId: openAgentId, message },
+        }),
+      );
 
     void sendUserMessage(openAgentId, message);
-  }, [openAgentId, sendUserMessage]);
+  }, [openAgentId, sendUserMessage, shouldDispatchOptimisticMessage]);
 }

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/footer-status-card/index.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/footer-status-card/index.tsx
@@ -120,6 +120,9 @@ export function StatusCard() {
   const deleteQueuedMessage = useKartonProcedure(
     (p) => p.agents.deleteQueuedMessage,
   );
+  const moveQueuedMessage = useKartonProcedure(
+    (p) => p.agents.moveQueuedMessage,
+  );
 
   // Procedure to send a queued message immediately (aborts current work)
   const flushQueue = useKartonProcedure((p) => p.agents.flushQueue);
@@ -246,17 +249,16 @@ export function StatusCard() {
     });
 
     if (userQuestionSection) result.push(userQuestionSection);
-    const messageQueueSection = MessageQueueSection({
-      queuedMessages: messageQueue ?? [],
-      onRemoveMessage: async (messageId) => {
-        if (!openAgentId) return;
-        await deleteQueuedMessage(openAgentId, messageId);
-      },
-      onFlush: async () => {
-        if (!openAgentId) return;
-        await flushQueue(openAgentId);
-      },
-    });
+    const messageQueueSection = openAgentId
+      ? MessageQueueSection({
+          queuedMessages: messageQueue,
+          onRemoveMessage: (messageId) =>
+            void deleteQueuedMessage(openAgentId, messageId),
+          onSendMessage: (messageId) => void flushQueue(openAgentId, messageId),
+          onMoveMessage: (messageId, toIndex) =>
+            void moveQueuedMessage(openAgentId, messageId, toIndex),
+        })
+      : null;
     if (messageQueueSection) result.push(messageQueueSection);
 
     const planSections = buildPlanSections({
@@ -284,6 +286,7 @@ export function StatusCard() {
     handleImplement,
     messageQueue,
     deleteQueuedMessage,
+    moveQueuedMessage,
     flushQueue,
     pendingUserQuestion,
     submitUserQuestionStep,

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/footer-status-card/message-queue-section.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/footer-status-card/message-queue-section.tsx
@@ -1,7 +1,23 @@
 import { Button } from '@stagewise/stage-ui/components/button';
-import { IconTrash2Outline24, IconArrowUpOutline24 } from '@stagewise/icons';
+import {
+  IconArrowUpOutline24,
+  IconGripDotsVerticalOutline18,
+  IconTrash2Outline24,
+} from '@stagewise/icons';
 import { ChevronDownIcon } from 'lucide-react';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
+import { DndContext, closestCenter, type DragEndEvent } from '@dnd-kit/core';
+import {
+  SortableContext,
+  arrayMove,
+  useSortable,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
+import {
+  restrictToParentElement,
+  restrictToVerticalAxis,
+} from '@dnd-kit/modifiers';
+import { CSS } from '@dnd-kit/utilities';
 import { cn } from '@ui/utils';
 import type { AgentMessage } from '@shared/karton-contracts/ui/agent';
 import {
@@ -20,78 +36,149 @@ import { getMessageText } from './shared';
 
 export interface QueuedMessagesSectionProps {
   queuedMessages: AgentMessage[];
-  onRemoveMessage: (messageId: string) => Promise<void>;
-  onFlush: () => Promise<void>;
+  onRemoveMessage: (messageId: string) => void;
+  onSendMessage: (messageId: string) => void;
+  onMoveMessage: (messageId: string, toIndex: number) => void;
+}
+
+function SortableQueuedMessage({
+  queuedMsg,
+  showButtons,
+  onHover,
+  onRemoveMessage,
+  onSendMessage,
+}: {
+  queuedMsg: AgentMessage;
+  showButtons: boolean;
+  onHover: (messageId: string) => void;
+  onRemoveMessage: QueuedMessagesSectionProps['onRemoveMessage'];
+  onSendMessage: QueuedMessagesSectionProps['onSendMessage'];
+}) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: queuedMsg.id });
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={{ transform: CSS.Transform.toString(transform), transition }}
+      className={cn(
+        'relative flex w-full items-center rounded px-1 py-0.5 text-foreground hover:bg-surface-1',
+        isDragging && 'z-10 bg-surface-1 shadow-elevation-1',
+      )}
+      onMouseEnter={() => onHover(queuedMsg.id)}
+    >
+      <button
+        type="button"
+        aria-label="Reorder queued message"
+        className="flex size-5 shrink-0 cursor-grab touch-none items-center justify-center text-muted-foreground hover:text-foreground active:cursor-grabbing"
+        {...attributes}
+        {...listeners}
+      >
+        <IconGripDotsVerticalOutline18 className="size-3.5" />
+      </button>
+      <span
+        className={cn(
+          'inline-flex w-full items-center gap-0.5 overflow-x-hidden text-ellipsis whitespace-nowrap text-xs transition-[mask-image] duration-200',
+          showButtons
+            ? 'mask-[linear-gradient(to_left,transparent_0px,transparent_104px,black_136px)]'
+            : 'mask-[linear-gradient(to_left,transparent_0px,black_24px)]',
+        )}
+      >
+        {parseMessageSegments(getMessageText(queuedMsg)).map((seg) =>
+          seg.kind === 'text' ? (
+            seg.content
+          ) : (
+            <AttachmentLinkRouter
+              key={getAttachmentKey(seg.linkData)}
+              linkData={seg.linkData}
+            />
+          ),
+        )}
+      </span>
+      <div
+        className="absolute top-1/2 right-1 flex -translate-y-1/2 items-center"
+        hidden={!showButtons}
+      >
+        <Button
+          variant="ghost"
+          size="xs"
+          onClick={() => onSendMessage(queuedMsg.id)}
+        >
+          Send now
+          <IconArrowUpOutline24 className="size-3" />
+        </Button>
+        <Tooltip>
+          <TooltipTrigger>
+            <Button
+              aria-label="Remove from queue"
+              variant="ghost"
+              size="icon-xs"
+              onClick={() => onRemoveMessage(queuedMsg.id)}
+            >
+              <IconTrash2Outline24 className="size-3" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>Remove from queue</TooltipContent>
+        </Tooltip>
+      </div>
+    </div>
+  );
 }
 
 function MessageQueueSectionContent({
   queuedMessages,
   onRemoveMessage,
+  onSendMessage,
+  onMoveMessage,
 }: QueuedMessagesSectionProps) {
-  const [hoveredIndex, setHoveredIndex] = useState<number | null>(null);
+  const [hoveredMessageId, setHoveredMessageId] = useState<string | null>(null);
+  const [orderedMessages, setOrderedMessages] = useState(queuedMessages);
+
+  useEffect(() => setOrderedMessages(queuedMessages), [queuedMessages]);
+
+  const handleDragEnd = ({ active, over }: DragEndEvent) => {
+    if (!over || active.id === over.id) return;
+    const fromIndex = orderedMessages.findIndex(({ id }) => id === active.id);
+    const toIndex = orderedMessages.findIndex(({ id }) => id === over.id);
+    if (fromIndex < 0 || toIndex < 0) return;
+
+    setOrderedMessages(arrayMove(orderedMessages, fromIndex, toIndex));
+    onMoveMessage(String(active.id), toIndex);
+  };
 
   return (
-    <div className="pt-1" onMouseLeave={() => setHoveredIndex(null)}>
-      {queuedMessages.map((queuedMsg, index) => {
-        const isFirst = index === 0;
-        // Show buttons for first item when nothing is hovered, or when this specific item is hovered
-        const showButtons = isFirst
-          ? hoveredIndex === null || hoveredIndex === 0
-          : hoveredIndex === index;
-
-        return (
-          <div
-            key={queuedMsg.id}
-            className="relative flex w-full flex-row items-center rounded px-1 py-0.5 text-foreground hover:bg-surface-1 hover:text-hover-derived"
-            onMouseEnter={() => setHoveredIndex(index)}
-          >
-            <div className="flex size-5 shrink-0 items-center justify-center">
-              <div className="size-1 rounded-full bg-foreground" />
-            </div>
-            <span
-              className={cn(
-                'inline-flex w-full items-center gap-0.5 overflow-x-hidden text-ellipsis whitespace-nowrap text-xs transition-[mask-image] duration-200',
-                showButtons
-                  ? 'mask-[linear-gradient(to_left,transparent_0px,transparent_56px,black_88px)]'
-                  : 'mask-[linear-gradient(to_left,transparent_0px,black_24px)]',
-              )}
-            >
-              {parseMessageSegments(getMessageText(queuedMsg)).map((seg) =>
-                seg.kind === 'text' ? (
-                  seg.content
-                ) : (
-                  <AttachmentLinkRouter
-                    key={getAttachmentKey(seg.linkData)}
-                    linkData={seg.linkData}
-                  />
-                ),
-              )}
-            </span>
-            <div
-              className={cn(
-                'absolute top-1/2 right-1 -translate-y-1/2 flex-row items-center',
-                showButtons ? 'flex' : 'hidden',
-              )}
-            >
-              <Tooltip>
-                <TooltipTrigger>
-                  <Button
-                    variant="ghost"
-                    size="icon-xs"
-                    onClick={() => {
-                      void onRemoveMessage(queuedMsg.id);
-                    }}
-                  >
-                    <IconTrash2Outline24 className="size-3" />
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent>Remove from queue</TooltipContent>
-              </Tooltip>
-            </div>
-          </div>
-        );
-      })}
-    </div>
+    <DndContext
+      collisionDetection={closestCenter}
+      modifiers={[restrictToVerticalAxis, restrictToParentElement]}
+      onDragEnd={handleDragEnd}
+    >
+      <SortableContext
+        items={orderedMessages}
+        strategy={verticalListSortingStrategy}
+      >
+        <div className="pt-1" onMouseLeave={() => setHoveredMessageId(null)}>
+          {orderedMessages.map((queuedMsg, index) => (
+            <SortableQueuedMessage
+              key={queuedMsg.id}
+              queuedMsg={queuedMsg}
+              showButtons={
+                hoveredMessageId === queuedMsg.id ||
+                (index === 0 && hoveredMessageId === null)
+              }
+              onHover={setHoveredMessageId}
+              onRemoveMessage={onRemoveMessage}
+              onSendMessage={onSendMessage}
+            />
+          ))}
+        </div>
+      </SortableContext>
+    </DndContext>
   );
 }
 
@@ -103,27 +190,14 @@ export function MessageQueueSection(
   return {
     key: 'message-queue',
     trigger: (isOpen: boolean) => (
-      <div className="flex h-6 w-full flex-row items-center justify-between gap-2 pl-1.5 text-muted-foreground text-xs hover:text-foreground has-[button:hover]:text-muted-foreground">
-        <div className="flex flex-row items-center justify-start gap-2">
-          <ChevronDownIcon
-            className={cn(
-              'size-3 shrink-0 transition-transform duration-50',
-              isOpen && 'rotate-180',
-            )}
-          />
-          {`${props.queuedMessages.length} Queued`}
-        </div>
-        <Button
-          variant="ghost"
-          size="xs"
-          onClick={(e) => {
-            e.stopPropagation();
-            props.onFlush();
-          }}
-        >
-          Send now
-          <IconArrowUpOutline24 className="size-3" />
-        </Button>
+      <div className="flex h-6 w-full items-center gap-2 pl-1.5 text-muted-foreground text-xs hover:text-foreground">
+        <ChevronDownIcon
+          className={cn(
+            'size-3 shrink-0 transition-transform duration-50',
+            isOpen && 'rotate-180',
+          )}
+        />
+        {`${props.queuedMessages.length} Queued`}
       </div>
     ),
     scrollable: true,

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/footer-status-card/message-queue-section.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/footer-status-card/message-queue-section.tsx
@@ -68,7 +68,7 @@ function SortableQueuedMessage({
       ref={setNodeRef}
       style={{ transform: CSS.Transform.toString(transform), transition }}
       className={cn(
-        'relative flex w-full items-center rounded px-1 py-0.5 text-foreground hover:bg-surface-1',
+        'group/queue-item relative flex w-full items-center rounded px-1 py-0.5 text-foreground hover:bg-surface-1',
         isDragging && 'z-10 bg-surface-1 shadow-elevation-1',
       )}
       onMouseEnter={() => onHover(queuedMsg.id)}
@@ -87,7 +87,7 @@ function SortableQueuedMessage({
           'inline-flex w-full items-center gap-0.5 overflow-x-hidden text-ellipsis whitespace-nowrap text-xs transition-[mask-image] duration-200',
           showButtons
             ? 'mask-[linear-gradient(to_left,transparent_0px,transparent_104px,black_136px)]'
-            : 'mask-[linear-gradient(to_left,transparent_0px,black_24px)]',
+            : 'mask-[linear-gradient(to_left,transparent_0px,black_24px)] group-focus-within/queue-item:mask-[linear-gradient(to_left,transparent_0px,transparent_104px,black_136px)]',
         )}
       >
         {parseMessageSegments(getMessageText(queuedMsg)).map((seg) =>
@@ -102,8 +102,10 @@ function SortableQueuedMessage({
         )}
       </span>
       <div
-        className="absolute top-1/2 right-1 flex -translate-y-1/2 items-center"
-        hidden={!showButtons}
+        className={cn(
+          'absolute top-1/2 right-1 hidden -translate-y-1/2 items-center group-focus-within/queue-item:flex',
+          showButtons && 'flex',
+        )}
       >
         <Button
           variant="ghost"

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/panel-footer.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/panel-footer.tsx
@@ -104,7 +104,6 @@ import { useOpenSideChat } from '@ui/hooks/use-open-side-chat';
 
 // Stable empty arrays to avoid new-reference re-renders
 const EMPTY_HISTORY: AgentMessage[] = [];
-const EMPTY_QUEUE: (AgentMessage & { role: 'user' })[] = [];
 const EMPTY_WORKSPACE_ACTION_CONFIGS: ReadonlyMap<
   string,
   WorkspaceActionConfig
@@ -232,6 +231,12 @@ export const ChatPanelFooter = memo(function ChatPanelFooter({
   );
   const isWorkingRef = useRef(isWorking);
   isWorkingRef.current = isWorking;
+
+  const hasQueuedMessages = useKartonState((s) =>
+    openAgent
+      ? (s.agents.instances[openAgent]?.state.queuedMessages.length ?? 0) > 0
+      : false,
+  );
 
   // History & inputState are NEVER used during rendering — only inside
   // callbacks via refs.  We use a silent-subscription pattern: the
@@ -1061,10 +1066,10 @@ export const ChatPanelFooter = memo(function ChatPanelFooter({
     setCanSendMessage(false);
     if (openAgent) void setChatInputState(openAgent, JSON.stringify(emptyDoc));
 
-    // Dispatch event with message data for optimistic rendering
-    // Only dispatch when agent is NOT working - if working, the backend
-    // will queue the message instead of adding to history immediately
-    const didDispatchOptimisticMessage = !isWorkingRef.current;
+    // Only render optimistically when the backend will add the message to
+    // history immediately. Active work or an older queue entry will queue it.
+    const didDispatchOptimisticMessage =
+      !isWorkingRef.current && !hasQueuedMessages;
     if (didDispatchOptimisticMessage)
       window.dispatchEvent(
         new CustomEvent('chat-message-sent', {
@@ -1167,6 +1172,7 @@ export const ChatPanelFooter = memo(function ChatPanelFooter({
     interruptQuestionWithMessage,
     executePendingWorkspaceActions,
     setFileAttachments,
+    hasQueuedMessages,
   ]);
 
   const handleNextAttentionAgentClick = () => {
@@ -1238,12 +1244,6 @@ export const ChatPanelFooter = memo(function ChatPanelFooter({
     const max = maxTokens ?? 1;
     return Math.min(100, Math.round((used / max) * 100));
   }, [usedTokens, maxTokens]);
-
-  const queuedMessages = useKartonState((s) =>
-    openAgent
-      ? (s.agents.instances[openAgent]?.state.queuedMessages ?? EMPTY_QUEUE)
-      : EMPTY_QUEUE,
-  );
 
   const handlePromptHistoryNavigationRequest = useCallback(
     (direction: PromptHistoryDirection) => {
@@ -1952,7 +1952,7 @@ export const ChatPanelFooter = memo(function ChatPanelFooter({
             contextUsedPercentage={contextUsed}
             contextUsedKb={usedTokens ? usedTokens / 1000 : 0}
             contextMaxKb={maxTokens ? maxTokens / 1000 : 0}
-            hasQueuedMessages={(queuedMessages?.length ?? 0) > 0}
+            hasQueuedMessages={hasQueuedMessages}
             onFlushQueue={handleFlushQueue}
             onFocus={onInputFocus}
             onBlur={onInputBlur}

--- a/packages/agent-core/src/agents/base-agent-send-user-message.test.ts
+++ b/packages/agent-core/src/agents/base-agent-send-user-message.test.ts
@@ -13,7 +13,10 @@ const approvalMessage = {
   ],
 } as unknown as AgentMessage;
 
-function createTestAgent(queuedMessages: AgentMessage[] = []) {
+function createTestAgent(
+  queuedMessages: AgentMessage[] = [],
+  history: AgentMessage[] = [approvalMessage],
+) {
   return Object.assign(Object.create(ChatAgent.prototype), {
     instanceId: 'agent-1',
     runStep: vi.fn(),
@@ -21,7 +24,7 @@ function createTestAgent(queuedMessages: AgentMessage[] = []) {
     state: {
       get: () => ({
         isWorking: false,
-        history: [approvalMessage],
+        history,
         queuedMessages,
       }),
       commands: {
@@ -69,9 +72,24 @@ describe('BaseAgent.sendUserMessage', () => {
     const agent = createTestAgent([userMessage('queued-message')]);
     const commands = agent.state.commands;
 
-    await agent.sendUserMessage(userMessage('manual-message'));
+    const messageId = await agent.sendUserMessage(
+      userMessage('manual-message'),
+    );
 
     expect(commands.enqueueUserMessage).toHaveBeenCalledOnce();
+    expect(messageId).toBe(
+      commands.enqueueUserMessage.mock.calls[0]?.[0].message.id,
+    );
     expect(commands.appendHistoryMessage).not.toHaveBeenCalled();
+    expect(agent.runStep).not.toHaveBeenCalled();
+  });
+
+  it('resumes an idle queue when a new manual message arrives', async () => {
+    const agent = createTestAgent([userMessage('queued-message')], []);
+
+    await agent.sendUserMessage(userMessage('manual-message'));
+
+    expect(agent.state.commands.enqueueUserMessage).toHaveBeenCalledOnce();
+    expect(agent.runStep).toHaveBeenCalledOnce();
   });
 });

--- a/packages/agent-core/src/agents/base-agent-send-user-message.test.ts
+++ b/packages/agent-core/src/agents/base-agent-send-user-message.test.ts
@@ -2,54 +2,76 @@ import type { AgentMessage } from '@stagewise/agent-interface-internal';
 import { describe, expect, it, vi } from 'vitest';
 import { ChatAgent } from './chat/chat';
 
-describe('BaseAgent.sendUserMessage', () => {
-  it('queues a background message while a tool approval is pending', async () => {
-    const approvalMessage = {
-      id: 'assistant-message',
-      role: 'assistant',
-      parts: [
-        {
-          type: 'tool-createShellSession',
-          state: 'approval-requested',
-        },
-      ],
-    } as unknown as AgentMessage;
-    const enqueueUserMessage = vi.fn().mockReturnValue({
-      queuedModelId: 'test-model',
-      queueLengthAfter: 1,
-    });
-    const denyAllNonTerminalToolPartsInHistory = vi.fn();
-    const appendHistoryMessage = vi.fn();
-    const runStep = vi.fn();
-    const agent = Object.create(ChatAgent.prototype) as any;
-    agent.instanceId = 'agent-1';
-    agent.runStep = runStep;
-    agent.scheduleMemorySnapshotWrite = vi.fn();
-    agent.state = {
-      get: () => ({ isWorking: false, history: [approvalMessage] }),
+const approvalMessage = {
+  id: 'assistant-message',
+  role: 'assistant',
+  parts: [
+    {
+      type: 'tool-createShellSession',
+      state: 'approval-requested',
+    },
+  ],
+} as unknown as AgentMessage;
+
+function createTestAgent(queuedMessages: AgentMessage[] = []) {
+  return Object.assign(Object.create(ChatAgent.prototype), {
+    instanceId: 'agent-1',
+    runStep: vi.fn(),
+    scheduleMemorySnapshotWrite: vi.fn(),
+    state: {
+      get: () => ({
+        isWorking: false,
+        history: [approvalMessage],
+        queuedMessages,
+      }),
       commands: {
-        enqueueUserMessage,
-        denyAllNonTerminalToolPartsInHistory,
-        appendHistoryMessage,
+        enqueueUserMessage: vi.fn().mockReturnValue({
+          queuedModelId: 'test-model',
+          queueLengthAfter: queuedMessages.length + 1,
+        }),
+        denyAllNonTerminalToolPartsInHistory: vi.fn(),
+        appendHistoryMessage: vi.fn(),
       },
-    };
-    agent.host = {
+    },
+    host: {
       logger: { debug: vi.fn() },
       telemetry: { capture: vi.fn() },
-    };
+    },
+  });
+}
 
-    await agent.sendUserMessage(
-      {
-        id: 'watcher-message',
-        role: 'user',
-        parts: [{ type: 'text', text: 'Watcher triggered' }],
-      } as AgentMessage & { role: 'user' },
-      { queueIfBlocked: true },
-    );
+function userMessage(id: string) {
+  return {
+    id,
+    role: 'user',
+    parts: [{ type: 'text', text: id }],
+  } as AgentMessage & { role: 'user' };
+}
 
-    expect(enqueueUserMessage).toHaveBeenCalledOnce();
-    expect(denyAllNonTerminalToolPartsInHistory).not.toHaveBeenCalled();
-    expect(appendHistoryMessage).not.toHaveBeenCalled();
-    expect(runStep).not.toHaveBeenCalled();
+describe('BaseAgent.sendUserMessage', () => {
+  it('queues a background message while a tool approval is pending', async () => {
+    const agent = createTestAgent();
+    const commands = agent.state.commands;
+
+    await agent.sendUserMessage(userMessage('watcher-message'), {
+      queueIfBlocked: true,
+    });
+
+    expect(commands.enqueueUserMessage).toHaveBeenCalledOnce();
+    expect(
+      commands.denyAllNonTerminalToolPartsInHistory,
+    ).not.toHaveBeenCalled();
+    expect(commands.appendHistoryMessage).not.toHaveBeenCalled();
+    expect(agent.runStep).not.toHaveBeenCalled();
+  });
+
+  it('keeps a manual message queued when another message is waiting', async () => {
+    const agent = createTestAgent([userMessage('queued-message')]);
+    const commands = agent.state.commands;
+
+    await agent.sendUserMessage(userMessage('manual-message'));
+
+    expect(commands.enqueueUserMessage).toHaveBeenCalledOnce();
+    expect(commands.appendHistoryMessage).not.toHaveBeenCalled();
   });
 });

--- a/packages/agent-core/src/agents/base-agent.ts
+++ b/packages/agent-core/src/agents/base-agent.ts
@@ -802,7 +802,9 @@ export abstract class BaseAgent<
         queue_length_after: queueLengthAfter,
       });
 
-      return message.id;
+      if (!state.isWorking && this.canRunStep()) void this.runStep();
+
+      return id;
     }
 
     this.host.logger.debug(

--- a/packages/agent-core/src/agents/base-agent.ts
+++ b/packages/agent-core/src/agents/base-agent.ts
@@ -768,8 +768,6 @@ export abstract class BaseAgent<
    * @param message - The message to send to the agent
    * @param options.queueIfBlocked - Queue instead of interrupting unfinished tool interactions.
    *
-   * @note If the agent is waiting for one or more tool approvals or not every tool call has been finished, the message will be queued and sent once the current step is finished.
-   *
    * @note On send, the chat history is converted into model context with the following pipeline:
    *        `transformMessagesBeforeStep` -> `getSystemPrompt` -> `transformMessagesToModelMessages` -> `transformModelMessagesBeforeStep`.
    *
@@ -784,11 +782,12 @@ export abstract class BaseAgent<
 
     const msg = { ...message, id: id };
 
-    // Background messages must not interrupt pending approvals or other
-    // unfinished tool interactions. Explicit user messages keep their
-    // existing interrupt behavior unless the caller opts into queueing.
+    // Preserve queue order, and only let manual input interrupt a blocked
+    // interaction when no older message is waiting.
+    const state = this.state.get();
     if (
-      this.state.get().isWorking ||
+      state.isWorking ||
+      state.queuedMessages.length > 0 ||
       (options.queueIfBlocked && !this.canRunStep())
     ) {
       const { queuedModelId, queueLengthAfter } =
@@ -901,6 +900,13 @@ export abstract class BaseAgent<
     return;
   }
 
+  public async moveQueuedMessage(
+    messageId: string,
+    toIndex: number,
+  ): Promise<void> {
+    this.state.commands.moveQueuedMessage({ messageId, toIndex });
+  }
+
   /**
    * Clears/Empties the queue of the agent without sending any of the queued messages.
    */
@@ -918,18 +924,22 @@ export abstract class BaseAgent<
    *
    * @note DO NOT OVERRIDE
    */
-  public async flushQueue(): Promise<void> {
-    const flushedCount = this.state.get().queuedMessages.length;
+  public async flushQueue(messageId?: string): Promise<void> {
+    if (
+      messageId &&
+      !this.state.commands.moveQueuedMessage({ messageId, toIndex: 0 })
+    ) {
+      return;
+    }
+
+    const hasQueuedMessages = this.state.get().queuedMessages.length > 0;
 
     await this.internalStop('user-flushed-queue');
 
     // Let the runStep() at the end of this method handle popping the first queued message
 
-    if (flushedCount > 0) {
+    if (hasQueuedMessages) {
       this.scheduleMemorySnapshotWrite('queued-messages');
-    }
-
-    if (flushedCount > 0) {
       this.host.telemetry?.capture('agent-queue-flushed', {
         agent_type: this.agentType,
         agent_instance_id: this.instanceId,
@@ -938,8 +948,6 @@ export abstract class BaseAgent<
     }
 
     this.runStep();
-
-    return;
   }
 
   /**

--- a/packages/agent-core/src/services/agent-manager/agent-manager.ts
+++ b/packages/agent-core/src/services/agent-manager/agent-manager.ts
@@ -611,9 +611,12 @@ export class AgentManager extends DisposableService {
     this.wrapAgentRpc('agents.stop', async (instanceId: string) => {
       await this.stopAgent(instanceId);
     });
-    this.wrapAgentRpc('agents.flushQueue', async (instanceId: string) => {
-      await this.flushQueue(instanceId);
-    });
+    this.wrapAgentRpc(
+      'agents.flushQueue',
+      async (instanceId: string, messageId?: string) => {
+        await this.flushQueue(instanceId, messageId);
+      },
+    );
     this.wrapAgentRpc('agents.clearQueue', async (instanceId: string) => {
       await this.clearQueue(instanceId);
     });
@@ -621,6 +624,12 @@ export class AgentManager extends DisposableService {
       'agents.deleteQueuedMessage',
       async (instanceId: string, messageId: string) => {
         await this.deleteQueuedMessage(instanceId, messageId);
+      },
+    );
+    this.wrapAgentRpc(
+      'agents.moveQueuedMessage',
+      async (instanceId: string, messageId: string, toIndex: number) => {
+        await this.moveQueuedMessage(instanceId, messageId, toIndex);
       },
     );
     this.wrapAgentRpc(
@@ -1737,14 +1746,14 @@ export class AgentManager extends DisposableService {
   /**
    * Flush the queue of a specific agent
    */
-  public async flushQueue(instanceId: string) {
+  public async flushQueue(instanceId: string, messageId?: string) {
     const agent = this.activeAgents.get(instanceId);
 
     if (!agent) {
       throw new Error(`Agent with instance id ${instanceId} not found`);
     }
 
-    await agent.flushQueue();
+    await agent.flushQueue(messageId);
   }
 
   /**
@@ -1771,6 +1780,20 @@ export class AgentManager extends DisposableService {
     }
 
     await agent.deleteQueuedMessage(messageId);
+  }
+
+  public async moveQueuedMessage(
+    instanceId: string,
+    messageId: string,
+    toIndex: number,
+  ) {
+    const agent = this.activeAgents.get(instanceId);
+
+    if (!agent) {
+      throw new Error(`Agent with instance id ${instanceId} not found`);
+    }
+
+    await agent.moveQueuedMessage(messageId, toIndex);
   }
 
   /**

--- a/packages/agent-core/src/services/agent-manager/state-mutations/bind.test.ts
+++ b/packages/agent-core/src/services/agent-manager/state-mutations/bind.test.ts
@@ -49,6 +49,32 @@ describe('state-mutations/bind', () => {
     expect(store.get().agents.instances.a1?.state.title).toBe('renamed');
   });
 
+  it('moves a queued message to the selected index', () => {
+    const store = new AgentStore(emptySystemState());
+    upsertAgentInstance(
+      store,
+      'a1',
+      makeEnvelope({
+        ...minimalState(),
+        queuedMessages: ['first', 'second', 'third'].map(
+          (id) => ({ id }) as AgentMessage & { role: 'user' },
+        ),
+      }),
+    );
+
+    const found = bindStateMutations(store, 'a1').moveQueuedMessage({
+      messageId: 'second',
+      toIndex: 2,
+    });
+
+    expect(found).toBe(true);
+    expect(
+      store
+        .get()
+        .agents.instances.a1?.state.queuedMessages.map((message) => message.id),
+    ).toEqual(['first', 'third', 'second']);
+  });
+
   it('attachEnvState writes envState entries onto the target user message', () => {
     const store = new AgentStore(emptySystemState());
     const userMsg: AgentMessage = {

--- a/packages/agent-core/src/services/agent-manager/state-mutations/bind.ts
+++ b/packages/agent-core/src/services/agent-manager/state-mutations/bind.ts
@@ -19,6 +19,7 @@ import {
 import {
   clearQueuedMessages,
   enqueueUserMessage,
+  moveQueuedMessage,
   removeQueuedMessage,
 } from './queue';
 import {
@@ -81,6 +82,8 @@ export function bindStateMutations(store: AgentStore, agentInstanceId: string) {
       enqueueUserMessage(store, agentInstanceId, args),
     removeQueuedMessage: (args: Parameters<typeof removeQueuedMessage>[2]) =>
       removeQueuedMessage(store, agentInstanceId, args),
+    moveQueuedMessage: (args: Parameters<typeof moveQueuedMessage>[2]) =>
+      moveQueuedMessage(store, agentInstanceId, args),
     clearQueuedMessages: () => clearQueuedMessages(store, agentInstanceId),
 
     appendHistoryMessage: (args: Parameters<typeof appendHistoryMessage>[2]) =>

--- a/packages/agent-core/src/services/agent-manager/state-mutations/queue.ts
+++ b/packages/agent-core/src/services/agent-manager/state-mutations/queue.ts
@@ -38,6 +38,28 @@ export function removeQueuedMessage(
   });
 }
 
+export function moveQueuedMessage(
+  store: AgentStore,
+  agentInstanceId: string,
+  args: { messageId: string; toIndex: number },
+): boolean {
+  let found = false;
+  updateAgentInstanceState(store, agentInstanceId, (state) => {
+    const index = state.queuedMessages.findIndex(
+      (message) => message.id === args.messageId,
+    );
+    if (index < 0) return;
+
+    state.queuedMessages.splice(
+      args.toIndex,
+      0,
+      ...state.queuedMessages.splice(index, 1),
+    );
+    found = true;
+  });
+  return found;
+}
+
 export function clearQueuedMessages(
   store: AgentStore,
   agentInstanceId: string,


### PR DESCRIPTION
## Summary

- keep the existing behavior when an approval is pending and the queue is empty: a new user message interrupts the approval and is sent immediately
- when an approval is pending and messages are already queued, append new messages to the queue instead of letting them bypass older inputs
- allow users to send any queued message immediately with "Send now", interrupting the pending approval while leaving the remaining messages queued
- add drag-and-drop reordering

<img width="550" height="175" alt="image" src="https://github.com/user-attachments/assets/8afbbee4-dc48-4152-8b98-b16ce7683fe8" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core `sendUserMessage` / `flushQueue` ordering and interrupt semantics during approvals; mistakes could send the wrong message or stall the queue, though behavior is covered by new unit tests.
> 
> **Overview**
> **Improves agent message queue behavior** when the agent is busy or waiting on tool approval: new input is queued if anything is already waiting, instead of bypassing older queued messages. Pending approval with an empty queue still allows an immediate interrupt/send as before.
> 
> **Backend:** Adds `moveQueuedMessage` and optional `messageId` on `flushQueue` (promote that message to the front, then stop and process one item). Idle queues can auto-resume via `runStep` when a new message is enqueued. Karton/RPC contracts and state mutations are wired through; tests cover queue-when-busy and idle resume.
> 
> **UI:** The footer status queue uses drag-and-drop reorder, per-row **Send now** and remove, and drops the section-level flush. Optimistic `chat-message-sent` rendering is skipped when the agent is working or the queue is non-empty (chat input and `/implement` hook).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 858d004ed53cad6214add3afdc790c42193401b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves queued message handling to preserve input order during approvals and active work, adds per-message “Send now,” and enables drag-and-drop reordering. Also stops optimistic rendering when a queue exists to avoid chat/history mismatches.

- **New Features**
  - If an approval is pending and the queue is empty, a new user message still sends immediately; if the agent is working or the queue has items, new messages append.
  - Per-message “Send now” promotes a selected queued message using `agents.flushQueue(agentId, messageId?)`, keeping the rest queued.
  - Drag-and-drop reordering of queued messages via `agents.moveQueuedMessage`.

- **Bug Fixes**
  - Resume an idle queue when a new manual message arrives so queued items start processing.
  - Suppress optimistic rendering for both chat and Implement when working or when the queue has items.

<sup>Written for commit 858d004ed53cad6214add3afdc790c42193401b6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1528?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added drag-and-drop reordering for queued agent messages.
  * Added options to send an individual queued message immediately or remove it.
  * New messages preserve queue order while the agent is busy.
  * Queued messages resume processing automatically when the agent becomes available.

* **Bug Fixes**
  * Sending a queued message now targets only the selected message instead of the entire queue.

* **Tests**
  * Added coverage for queue ordering and queued message behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->