### PR TITLE
fix(stagewise): prioritize replies to active questions

### DIFF
--- a/apps/browser/src/backend/services/toolbox/tools/user-interaction/ask-user-questions.ts
+++ b/apps/browser/src/backend/services/toolbox/tools/user-interaction/ask-user-questions.ts
@@ -105,7 +105,7 @@ export function cancelQuestion(
 
   if (reason === 'user_sent_message') {
     // Return partial answers with a notice instead of marking as cancelled.
-    // The user's actual message is queued in the same step.
+    // The user's actual message is consumed by the immediate next step.
     deferred.resolve({
       completed: false,
       cancelled: false,

--- a/apps/browser/src/shared/karton-contracts/ui/index.ts
+++ b/apps/browser/src/shared/karton-contracts/ui/index.ts
@@ -1365,7 +1365,7 @@ export type KartonContract = {
         agentId: string,
         message: AgentMessage & { role: 'user' },
       ) => Promise<void>;
-      /** Queue a user message AND resolve a pending question in one atomic call. */
+      /** Stage a user message for the next step and resolve a question atomically. */
       interruptQuestionWithMessage: (
         agentId: string,
         questionId: string,

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/panel-footer.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/panel-footer.tsx
@@ -1128,8 +1128,8 @@ export const ChatPanelFooter = memo(function ChatPanelFooter({
 
       if (openAgent) {
         if (currentPendingQuestionId) {
-          // Atomic: queue message + resolve question in a single backend call.
-          // Include the current form draft so partial answers are preserved.
+          // Atomic: stage the message for the next model step and resolve the
+          // question. Include the current draft so partial answers survive.
           await interruptQuestionWithMessage(
             openAgent,
             currentPendingQuestionId,

--- a/packages/agent-core/src/agents/base-agent-send-user-message.test.ts
+++ b/packages/agent-core/src/agents/base-agent-send-user-message.test.ts
@@ -69,10 +69,13 @@ function createWorkingAgent() {
   agent.instanceId = 'agent-1';
   agent.state = {
     get: () => stateValue,
-    commands: { enqueueUserMessage },
+    commands: {
+      enqueueUserMessage,
+      setIsWorkingFalse: vi.fn(),
+    },
   };
   agent.host = {
-    logger: { debug: vi.fn() },
+    logger: { debug: vi.fn(), info: vi.fn() },
     telemetry: { capture: vi.fn() },
   };
 
@@ -180,5 +183,24 @@ describe('BaseAgent.sendUserMessage', () => {
         content: [],
       }),
     ).toEqual({ shouldRun: true, flushQueue: false });
+  });
+
+  it('flushes a prioritized message during interrupted-run recovery', async () => {
+    const { agent } = createWorkingAgent();
+    agent.internalStop = vi.fn().mockResolvedValue(undefined);
+    agent.runStep = vi.fn();
+
+    await agent.sendUserMessage(
+      {
+        id: 'client-message',
+        role: 'user',
+        parts: [{ type: 'text', text: 'Use these partial answers instead' }],
+      } as AgentMessage & { role: 'user' },
+      { flushQueueOnNextStep: true },
+    );
+    await agent.recoverInterruptedRun('system-resumed');
+
+    expect(agent.internalStop).toHaveBeenCalledWith('system-interrupted');
+    expect(agent.runStep).toHaveBeenCalledWith(false, true);
   });
 });

--- a/packages/agent-core/src/agents/base-agent-send-user-message.test.ts
+++ b/packages/agent-core/src/agents/base-agent-send-user-message.test.ts
@@ -43,6 +43,42 @@ function createTestAgent(
   });
 }
 
+function createWorkingAgent() {
+  const stateValue = {
+    isWorking: true,
+    history: [],
+    queuedMessages: [] as AgentMessage[],
+  };
+  const enqueueUserMessage = vi.fn(
+    ({
+      message,
+      position,
+    }: {
+      message: AgentMessage & { role: 'user' };
+      position?: 'front' | 'back';
+    }) => {
+      if (position === 'front') stateValue.queuedMessages.unshift(message);
+      else stateValue.queuedMessages.push(message);
+      return {
+        queuedModelId: 'test-model',
+        queueLengthAfter: stateValue.queuedMessages.length,
+      };
+    },
+  );
+  const agent = Object.create(ChatAgent.prototype) as any;
+  agent.instanceId = 'agent-1';
+  agent.state = {
+    get: () => stateValue,
+    commands: { enqueueUserMessage },
+  };
+  agent.host = {
+    logger: { debug: vi.fn() },
+    telemetry: { capture: vi.fn() },
+  };
+
+  return { agent, enqueueUserMessage };
+}
+
 function userMessage(id: string) {
   return {
     id,
@@ -91,5 +127,58 @@ describe('BaseAgent.sendUserMessage', () => {
 
     expect(agent.state.commands.enqueueUserMessage).toHaveBeenCalledOnce();
     expect(agent.runStep).toHaveBeenCalledOnce();
+  });
+
+  it('flushes a prioritized blocked message on the next tool continuation', async () => {
+    const { agent, enqueueUserMessage } = createWorkingAgent();
+
+    await agent.sendUserMessage(
+      {
+        id: 'client-message',
+        role: 'user',
+        parts: [{ type: 'text', text: 'Use these partial answers instead' }],
+      } as AgentMessage & { role: 'user' },
+      { flushQueueOnNextStep: true },
+    );
+
+    expect(enqueueUserMessage).toHaveBeenCalledWith({
+      message: expect.objectContaining({
+        role: 'user',
+        parts: [{ type: 'text', text: 'Use these partial answers instead' }],
+      }),
+      position: 'front',
+    });
+    expect(
+      agent.shouldRunNewStep({
+        finishReason: 'tool-calls',
+        toolCalls: [{ toolName: 'askUserQuestions' }],
+        content: [{ type: 'tool-approval-request' }],
+      }),
+    ).toEqual({ shouldRun: false, flushQueue: false });
+    expect(
+      agent.shouldRunNewStep({
+        finishReason: 'tool-calls',
+        toolCalls: [{ toolName: 'askUserQuestions' }],
+        content: [],
+      }),
+    ).toEqual({ shouldRun: true, flushQueue: true });
+  });
+
+  it('does not flush an ordinary queued message during a tool chain', async () => {
+    const { agent } = createWorkingAgent();
+
+    await agent.sendUserMessage({
+      id: 'client-message',
+      role: 'user',
+      parts: [{ type: 'text', text: 'Wait until the tool chain finishes' }],
+    } as AgentMessage & { role: 'user' });
+
+    expect(
+      agent.shouldRunNewStep({
+        finishReason: 'tool-calls',
+        toolCalls: [{ toolName: 'executeShellCommand' }],
+        content: [],
+      }),
+    ).toEqual({ shouldRun: true, flushQueue: false });
   });
 });

--- a/packages/agent-core/src/agents/base-agent.ts
+++ b/packages/agent-core/src/agents/base-agent.ts
@@ -1001,6 +1001,10 @@ export abstract class BaseAgent<
     reason: 'system-resumed' | 'event-loop-stalled',
   ): Promise<void> {
     const historyLengthBefore = this.state.get().history.length;
+    const prioritizedMessageId = this._queuedMessageToFlushOnNextStepId;
+    const shouldFlushPrioritizedMessage =
+      prioritizedMessageId !== null &&
+      this.state.get().queuedMessages[0]?.id === prioritizedMessageId;
 
     this.host.logger.info(
       `[BaseAgent:${this.instanceId}] Recovering interrupted run with synthetic continuation. reason=${reason}, historyLength=${historyLengthBefore}`,
@@ -1010,7 +1014,7 @@ export abstract class BaseAgent<
     this.state.commands.setIsWorkingFalse();
 
     this._pendingSyntheticContinuation = { reason };
-    void this.runStep(false, false);
+    void this.runStep(false, shouldFlushPrioritizedMessage);
   }
 
   /**

--- a/packages/agent-core/src/agents/base-agent.ts
+++ b/packages/agent-core/src/agents/base-agent.ts
@@ -439,6 +439,11 @@ export type BaseAgentConfig<TFinishToolOutputSchema extends z.ZodType | null> =
 
 export type MessageId = string;
 
+export type SendUserMessageOptions = {
+  queueIfBlocked?: boolean;
+  flushQueueOnNextStep?: boolean;
+};
+
 /**
  * Interface for the static (class) side of any agent.
  * This enables type-safe access to static properties like `config` and `agentType`
@@ -619,6 +624,14 @@ export abstract class BaseAgent<
     null;
 
   /**
+   * ID of a queued user message that must be consumed by the immediately
+   * following step. Used when free-form input resolves a blocking user
+   * question: the tool result and the user's message must reach the model
+   * together instead of letting the autonomous tool chain continue first.
+   */
+  private _queuedMessageToFlushOnNextStepId: string | null = null;
+
+  /**
    * Set only for runtime recovery after a suspend/resume or event-loop stall.
    * It appends a transient model-only `continue` user message for the next
    * step without writing anything to visible/persisted chat history.
@@ -767,6 +780,8 @@ export abstract class BaseAgent<
    * Send a message to the agent. If the agent is busy, the message will be queued.
    * @param message - The message to send to the agent
    * @param options.queueIfBlocked - Queue instead of interrupting unfinished tool interactions.
+   * @param options.flushQueueOnNextStep - Prioritize a blocked message and
+   * consume it in the immediately following step.
    *
    * @note On send, the chat history is converted into model context with the following pipeline:
    *        `transformMessagesBeforeStep` -> `getSystemPrompt` -> `transformMessagesToModelMessages` -> `transformModelMessagesBeforeStep`.
@@ -775,7 +790,7 @@ export abstract class BaseAgent<
    */
   public async sendUserMessage(
     message: AgentMessage & { role: 'user' },
-    options: { queueIfBlocked?: boolean } = {},
+    options: SendUserMessageOptions = {},
   ): Promise<MessageId> {
     // We override the message id with a random UUID to ensure it's unique.
     const id = crypto.randomUUID();
@@ -791,7 +806,14 @@ export abstract class BaseAgent<
       (options.queueIfBlocked && !this.canRunStep())
     ) {
       const { queuedModelId, queueLengthAfter } =
-        this.state.commands.enqueueUserMessage({ message: msg });
+        this.state.commands.enqueueUserMessage({
+          message: msg,
+          position: options.flushQueueOnNextStep ? 'front' : 'back',
+        });
+
+      if (options.flushQueueOnNextStep) {
+        this._queuedMessageToFlushOnNextStepId = msg.id;
+      }
 
       this.host.logger.debug(`[BaseAgent:${this.instanceId}] Queued message`);
 
@@ -899,6 +921,9 @@ export abstract class BaseAgent<
    */
   public async deleteQueuedMessage(messageId: string): Promise<void> {
     this.state.commands.removeQueuedMessage({ messageId });
+    if (this._queuedMessageToFlushOnNextStepId === messageId) {
+      this._queuedMessageToFlushOnNextStepId = null;
+    }
     return;
   }
 
@@ -914,6 +939,7 @@ export abstract class BaseAgent<
    */
   public async clearQueue(): Promise<void> {
     this.state.commands.clearQueuedMessages();
+    this._queuedMessageToFlushOnNextStepId = null;
     return;
   }
 
@@ -1656,6 +1682,10 @@ export abstract class BaseAgent<
       flushQueue,
     });
     if (flushedIndex !== undefined) {
+      const flushedMessage = this.state.get().history[flushedIndex];
+      if (flushedMessage?.id === this._queuedMessageToFlushOnNextStepId) {
+        this._queuedMessageToFlushOnNextStepId = null;
+      }
       this.scheduleMemorySnapshotWrite('queued-messages');
     }
     const queueFlushIndex = flushedIndex ?? -1;
@@ -1755,10 +1785,8 @@ export abstract class BaseAgent<
       return;
     }
 
-    let modelMessages: Awaited<
-      ReturnType<typeof this.generateContextForNewStep>
-    >;
-    let tools: Awaited<ReturnType<typeof this.getToolsForStep>>;
+    let modelMessages: ModelMessage[];
+    let tools: Partial<ToolSet>;
     let resolvedConfig: BaseAgentConfig<TFinishToolOutputSchema>;
     try {
       modelMessages = await this.generateContextForNewStep(
@@ -2516,7 +2544,16 @@ export abstract class BaseAgent<
       }
     }
 
-    const hasQueuedMessages = this.state.get().queuedMessages.length > 0;
+    const queuedMessages = this.state.get().queuedMessages;
+    const hasQueuedMessages = queuedMessages.length > 0;
+    if (
+      this._queuedMessageToFlushOnNextStepId !== null &&
+      !queuedMessages.some(
+        (message) => message.id === this._queuedMessageToFlushOnNextStepId,
+      )
+    ) {
+      this._queuedMessageToFlushOnNextStepId = null;
+    }
 
     // Check if the maximum number of steps has been reached
     if (this.config.maxSteps && stepsSinceLastMessage >= this.config.maxSteps) {
@@ -2554,6 +2591,13 @@ export abstract class BaseAgent<
         `[BaseAgent:${this.instanceId}] There are open tool approval requests`,
       );
       return { shouldRun: false, flushQueue: false };
+    }
+
+    if (
+      typeof this._queuedMessageToFlushOnNextStepId === 'string' &&
+      queuedMessages[0]?.id === this._queuedMessageToFlushOnNextStepId
+    ) {
+      return { shouldRun: true, flushQueue: true };
     }
 
     // We assume that approved tool calls are executed and results are attached,
@@ -3130,6 +3174,7 @@ export abstract class BaseAgent<
     this._pendingContinue = null;
     this._pendingSyntheticContinuation = null;
     this._pendingFallbackRetry = false;
+    this._queuedMessageToFlushOnNextStepId = null;
     try {
       this.stepAbortController?.abort();
     } catch {}

--- a/packages/agent-core/src/agents/index.ts
+++ b/packages/agent-core/src/agents/index.ts
@@ -21,6 +21,7 @@ export {
   type BaseAgentStatic,
   type AgentConfig,
   type MessageId,
+  type SendUserMessageOptions,
 } from './base-agent';
 export { ChatAgent } from './chat/chat';
 

--- a/packages/agent-core/src/services/agent-manager/agent-manager.create-handler.test.ts
+++ b/packages/agent-core/src/services/agent-manager/agent-manager.create-handler.test.ts
@@ -386,6 +386,47 @@ describe('AgentManager agents.create handler', () => {
   });
 });
 
+describe('AgentManager question interruption handler', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('prioritizes the message before resolving the pending question', async () => {
+    const sendUserMessageSpy = vi
+      .spyOn(AgentManager.prototype, 'sendUserMessage')
+      .mockResolvedValue(undefined);
+    const deps = createDeps();
+    const manager = buildManager(deps);
+    const message = {
+      id: 'message-1',
+      role: 'user',
+      parts: [{ type: 'text', text: 'Use my free-form answer' }],
+    } as any;
+    const draftAnswers = { framework: 'react' };
+
+    await deps.registry.dispatch<unknown[], void>(
+      'agents.interruptQuestionWithMessage',
+      { callerId: 'test' },
+      ['agent-1', 'question-1', message, draftAnswers],
+    );
+
+    expect(sendUserMessageSpy).toHaveBeenCalledWith('agent-1', message, {
+      flushQueueOnNextStep: true,
+    });
+    expect(deps.toolbox.cancelQuestion).toHaveBeenCalledWith(
+      'agent-1',
+      'question-1',
+      'user_sent_message',
+      draftAnswers,
+    );
+    expect(sendUserMessageSpy.mock.invocationCallOrder[0]).toBeLessThan(
+      deps.toolbox.cancelQuestion.mock.invocationCallOrder[0]!,
+    );
+
+    await manager.teardown();
+  });
+});
+
 describe('AgentManager agents.fork handler', () => {
   afterEach(() => {
     vi.restoreAllMocks();

--- a/packages/agent-core/src/services/agent-manager/agent-manager.create-handler.test.ts
+++ b/packages/agent-core/src/services/agent-manager/agent-manager.create-handler.test.ts
@@ -425,6 +425,34 @@ describe('AgentManager question interruption handler', () => {
 
     await manager.teardown();
   });
+
+  it('keeps the question pending when message staging fails', async () => {
+    vi.spyOn(AgentManager.prototype, 'sendUserMessage').mockRejectedValue(
+      new Error('staging failed'),
+    );
+    const deps = createDeps();
+    const manager = buildManager(deps);
+
+    await expect(
+      deps.registry.dispatch<unknown[], void>(
+        'agents.interruptQuestionWithMessage',
+        { callerId: 'test' },
+        [
+          'agent-1',
+          'question-1',
+          {
+            id: 'message-1',
+            role: 'user',
+            parts: [{ type: 'text', text: 'Use my free-form answer' }],
+          },
+          { framework: 'react' },
+        ],
+      ),
+    ).rejects.toThrow('staging failed');
+    expect(deps.toolbox.cancelQuestion).not.toHaveBeenCalled();
+
+    await manager.teardown();
+  });
 });
 
 describe('AgentManager agents.fork handler', () => {

--- a/packages/agent-core/src/services/agent-manager/agent-manager.ts
+++ b/packages/agent-core/src/services/agent-manager/agent-manager.ts
@@ -3,6 +3,7 @@ import type {
   BaseAgent,
   BaseAgentDependencies,
   BaseAgentToolboxView,
+  SendUserMessageOptions,
 } from '../../agents/base-agent';
 import type { AgentTypeRegistry } from '../../agents/agents-registry';
 import { toAgentsMap, type AgentsMap } from '../../agents/agents-map';
@@ -567,10 +568,13 @@ export class AgentManager extends DisposableService {
         message: AgentMessage & { role: 'user' },
         draftAnswers: Record<string, unknown>,
       ) => {
-        // Queue the message FIRST, then resolve the question — both in
-        // one backend call so there's no race between separate RPCs.
+        // Stage the message for the immediate next model step, then resolve
+        // the question. Keeping both actions in one command avoids a race
+        // between separate RPCs while preserving partial form answers.
         try {
-          await this.sendUserMessage(instanceId, message);
+          await this.sendUserMessage(instanceId, message, {
+            flushQueueOnNextStep: true,
+          });
         } finally {
           this.managerToolbox.cancelQuestion(
             instanceId,
@@ -1567,7 +1571,7 @@ export class AgentManager extends DisposableService {
   public async sendUserMessage(
     instanceId: string,
     message: AgentMessage & { role: 'user' },
-    options: { queueIfBlocked?: boolean } = {},
+    options: SendUserMessageOptions = {},
   ) {
     const agent = this.activeAgents.get(instanceId);
 

--- a/packages/agent-core/src/services/agent-manager/agent-manager.ts
+++ b/packages/agent-core/src/services/agent-manager/agent-manager.ts
@@ -571,18 +571,15 @@ export class AgentManager extends DisposableService {
         // Stage the message for the immediate next model step, then resolve
         // the question. Keeping both actions in one command avoids a race
         // between separate RPCs while preserving partial form answers.
-        try {
-          await this.sendUserMessage(instanceId, message, {
-            flushQueueOnNextStep: true,
-          });
-        } finally {
-          this.managerToolbox.cancelQuestion(
-            instanceId,
-            questionId,
-            'user_sent_message',
-            draftAnswers,
-          );
-        }
+        await this.sendUserMessage(instanceId, message, {
+          flushQueueOnNextStep: true,
+        });
+        this.managerToolbox.cancelQuestion(
+          instanceId,
+          questionId,
+          'user_sent_message',
+          draftAnswers,
+        );
       },
     );
     this.wrapAgentRpc(

--- a/packages/agent-core/src/services/agent-manager/state-mutations/queue.ts
+++ b/packages/agent-core/src/services/agent-manager/state-mutations/queue.ts
@@ -14,12 +14,19 @@ import { updateAgentInstanceState } from './internal';
 export function enqueueUserMessage(
   store: AgentStore,
   agentInstanceId: string,
-  args: { message: AgentMessage & { role: 'user' } },
+  args: {
+    message: AgentMessage & { role: 'user' };
+    position?: 'front' | 'back';
+  },
 ): { queuedModelId: string; queueLengthAfter: number } {
   let queuedModelId = 'unknown';
   let queueLengthAfter = 0;
   updateAgentInstanceState(store, agentInstanceId, (state) => {
-    state.queuedMessages.push(args.message);
+    if (args.position === 'front') {
+      state.queuedMessages.unshift(args.message);
+    } else {
+      state.queuedMessages.push(args.message);
+    }
     queuedModelId = state.activeModelId ?? 'unknown';
     queueLengthAfter = state.queuedMessages.length;
   });


### PR DESCRIPTION
## Summary

- treat free-form messages sent during an active question as immediate replies
- preserve partially completed question answers when resolving the question
- prioritize only the question reply while keeping existing queued messages for later

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes agent step scheduling and queue ordering during active tool runs; behavior is well-tested but affects core chat/tool-loop timing.
> 
> **Overview**
> When users type in chat while an **ask-user-questions** form is open, their message is now treated as an immediate reply instead of sitting behind the autonomous tool chain.
> 
> **`flushQueueOnNextStep`** on `sendUserMessage` enqueues that message at the **front** of the queue and marks it so the **next** model step flushes it into history (including after tool continuations and interrupted-run recovery). Ordinary queued messages still wait until the chain finishes. **`enqueueUserMessage`** gains optional `position: 'front' | 'back'`.
> 
> **`interruptQuestionWithMessage`** stages the free-form message with `flushQueueOnNextStep: true`, then resolves the question with draft answers—staging runs first, and the question stays pending if staging fails (no more `try/finally` that always cancelled). UI and contract copy describe this as staging for the next step rather than a generic queue.
> 
> Tests cover prioritized flush vs normal queue behavior, recovery, and the agent-manager interrupt handler ordering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 573f57b57d4fa5734a88c265f6d85ec924dd6ee6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * User messages submitted while an agent question is pending are now staged for the next model step and processed promptly.
  * Pending questions are resolved atomically while preserving the current draft response.
  * Prioritized messages are handled before other queued messages when appropriate.

* **Tests**
  * Added coverage for prioritized message handling, queue behavior, and question interruption workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->