### PR TITLE
fix(website): rewrite infra engineer career copy to remove AI-sounding phrasing

### DIFF
--- a/apps/website/content/career/working-student-infrastructure-engineer-bielefeld.mdx
+++ b/apps/website/content/career/working-student-infrastructure-engineer-bielefeld.mdx
@@ -19,7 +19,7 @@ You'll:
 - Monitor, debug, and resolve infrastructure incidents
 - Help shape our infrastructure architecture and tooling decisions
 
-If you're the kind of person who has strong opinions about Ingress controllers, gets excited about a clean `values.yaml`, and treats bare-metal servers with the same respect as managed cloud services, you'll feel right at home.
+Infrastructure is the stuff nobody thinks about until it breaks. We want the person who thinks about it before it does — someone to design and build that foundation from the ground up, alongside the founding team. Not just keeping things running, but deciding what gets built and how, so the whole operation has something solid to stand on from day one. It's quiet work, but it's what everything else depends on.
 
 ## Who We're Looking For
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Marketing copy only on a single career MDX page; no application logic or infrastructure changes.
> 
> **Overview**
> Updates the **“What You'll Do”** section on the Bielefeld infrastructure working-student career page (`working-student-infrastructure-engineer-bielefeld.mdx`).
> 
> **Removed** the closing paragraph that leaned on insider jokes (Ingress controllers, `values.yaml`, bare metal vs cloud) and a “you'll feel right at home” tone.
> 
> **Added** a replacement that frames infrastructure as foundational work: thinking ahead before things break, designing and building alongside the founding team, and owning what gets built—not only operations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 915acbb68b57340f24ca86363c8e2f0de1075aa9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rewrote the Infrastructure Engineer (Working Student, Bielefeld) career page copy to replace AI-sounding phrasing with clear, grounded language. The new paragraph emphasizes proactive ownership and role impact, improving tone and clarity for candidates.

<sup>Written for commit 915acbb68b57340f24ca86363c8e2f0de1075aa9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1530?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the infrastructure engineering working student job description to emphasize proactively designing and building infrastructure alongside the founding team.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->