### PR TITLE
feat(stagewise): add chat archiving

### DIFF
--- a/apps/browser/src/backend/services/agent-manager/agent-manager.ts
+++ b/apps/browser/src/backend/services/agent-manager/agent-manager.ts
@@ -36,6 +36,7 @@ const AGENT_RPC_COMMANDS = [
   'agents.promoteSideChat',
   'agents.discardSideChat',
   'agents.resume',
+  'agents.unarchive',
   'agents.sendUserMessage',
   'agents.interruptQuestionWithMessage',
   'agents.sendToolApprovalResponse',

--- a/apps/browser/src/backend/services/agent-manager/history-workspace-enrichment.test.ts
+++ b/apps/browser/src/backend/services/agent-manager/history-workspace-enrichment.test.ts
@@ -20,6 +20,7 @@ function makeEntry(
     messageCount: 0,
     parentAgentInstanceId: null,
     unread: false,
+    archivedAt: null,
     mountedWorkspaces,
   };
 }

--- a/apps/browser/src/shared/karton-contracts/ui/index.ts
+++ b/apps/browser/src/shared/karton-contracts/ui/index.ts
@@ -1351,11 +1351,13 @@ export type KartonContract = {
       discardSideChat: (agentId: string) => Promise<void>;
       resume: (agentId: string) => Promise<void>;
       archive: (agentId: string) => Promise<void>;
+      unarchive: (agentId: string) => Promise<void>;
       delete: (agentId: string) => Promise<void>;
       getAgentsHistoryList: (
         offset: number,
         limit: number,
         searchString?: string,
+        archived?: boolean,
       ) => Promise<AgentHistoryEntry[]>;
       getAgentHistoryEntriesByIds: (
         ids: string[],

--- a/apps/browser/src/shared/settings-route.ts
+++ b/apps/browser/src/shared/settings-route.ts
@@ -8,6 +8,7 @@ export type SettingsSection =
   | 'personalization'
   | 'browsing'
   | 'history'
+  | 'archived-agents'
   | 'website-permissions'
   | 'clear-data'
   | 'account'
@@ -27,6 +28,7 @@ export const SETTINGS_SECTION_LABELS: Record<SettingsSection, string> = {
   personalization: 'Personalization',
   browsing: 'General',
   history: 'History',
+  'archived-agents': 'Archived chats',
   'website-permissions': 'Website Permissions',
   'clear-data': 'Clear data',
   account: 'Account',

--- a/apps/browser/src/ui/screens/main/_components/shared-agent-context-menu.tsx
+++ b/apps/browser/src/ui/screens/main/_components/shared-agent-context-menu.tsx
@@ -3,6 +3,7 @@ import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { cn } from '@stagewise/stage-ui/lib/utils';
 import { useKartonProcedure, useKartonState } from '@ui/hooks/use-karton';
 import { IconTrash2Outline24 } from '@stagewise/icons';
+import { ArchiveIcon } from 'lucide-react';
 import {
   IconCopyOutline18,
   IconCopyIdOutline18,
@@ -105,6 +106,8 @@ export interface SharedAgentContextMenuHostProps {
   onForkRequest: (id: string) => void;
   /** Persistently mark the selected chat unread. */
   onMarkAsUnreadRequest: (id: string) => void;
+  /** Stop the agent and move it out of the normal chat list. */
+  onArchiveRequest: (id: string) => void;
   /** User picked "Permanently delete" — caller is expected to show a confirm dialog.
    * Cursor coordinates are forwarded so the confirm popover can anchor
    * right above the click position. */
@@ -117,6 +120,7 @@ export const SharedAgentContextMenuHost = memo(
     onClose,
     onForkRequest,
     onMarkAsUnreadRequest,
+    onArchiveRequest,
     onDeleteRequest,
   }: SharedAgentContextMenuHostProps) {
     const revealWorkingDirectory = useKartonProcedure(
@@ -256,6 +260,15 @@ export const SharedAgentContextMenuHost = memo(
                   <span>{isPinned ? 'Unpin' : 'Pin globally'}</span>
                 </AgentMenuItem>
               )}
+              <AgentMenuItem
+                onClick={() => {
+                  onArchiveRequest(agentId);
+                  onClose();
+                }}
+              >
+                <ArchiveIcon className="size-3.5 shrink-0" />
+                <span>Archive</span>
+              </AgentMenuItem>
               {canDelete !== false && (
                 <AgentMenuItem
                   onClick={() => {

--- a/apps/browser/src/ui/screens/main/_lib/agent-list-model.test.ts
+++ b/apps/browser/src/ui/screens/main/_lib/agent-list-model.test.ts
@@ -41,6 +41,7 @@ describe('agent list workspace model', () => {
           messageCount: 1,
           parentAgentInstanceId: null,
           unread: true,
+          archivedAt: null,
         },
       ],
       pendingRemovals: new Set(),

--- a/apps/browser/src/ui/screens/main/sidebar/agents-list/index.tsx
+++ b/apps/browser/src/ui/screens/main/sidebar/agents-list/index.tsx
@@ -689,6 +689,7 @@ export function AgentsList() {
   const createAgent = useKartonProcedure((p) => p.agents.create);
   const forkAgent = useKartonProcedure((p) => p.agents.fork);
   const resumeAgent = useKartonProcedure((p) => p.agents.resume);
+  const archiveAgent = useKartonProcedure((p) => p.agents.archive);
   const setLastOpenAgentId = useKartonProcedure(
     (p) => p.browser.setLastOpenAgentId,
   );
@@ -1212,11 +1213,10 @@ export function AgentsList() {
   // Bumped by `handleShowMore` when the visible count exceeds it.
   const fetchLimitRef = useRef(INITIAL_HISTORY_FETCH);
 
-  // Fetch history once on startup (after first agent is active).
+  // Fetch history once on startup.
   const historyFetchedRef = useRef(false);
   useEffect(() => {
     if (historyFetchedRef.current) return;
-    if (activeAgentIds.length === 0) return;
     historyFetchedRef.current = true;
     getAgentsHistoryList(0, fetchLimitRef.current)
       .then((entries) => {
@@ -1226,7 +1226,7 @@ export function AgentsList() {
         console.error('Failed to fetch agent history:', err);
         historyFetchedRef.current = false;
       });
-  }, [activeAgentIds, getAgentsHistoryList]);
+  }, [getAgentsHistoryList]);
 
   // Clean up pending removals once the backend has confirmed removal.
   const prevPendingSizeRef = useRef(0);
@@ -1282,6 +1282,10 @@ export function AgentsList() {
     string[] | null
   >(null);
   const displayedPinnedAgentIds = optimisticPinnedAgentIds ?? pinnedAgentIds;
+  const displayedPinnedAgentIdsRef = useRef(displayedPinnedAgentIds);
+  displayedPinnedAgentIdsRef.current = displayedPinnedAgentIds;
+  const openAgentRef = useRef(openAgent);
+  openAgentRef.current = openAgent;
 
   const updatePinnedAgentIds = useCallback(
     async (
@@ -1326,6 +1330,38 @@ export function AgentsList() {
     (id: string) =>
       updatePinnedAgentIds((ids) => ids.filter((value) => value !== id)),
     [updatePinnedAgentIds],
+  );
+
+  const handleArchive = useCallback(
+    async (id: string) => {
+      addPendingRemoval(id);
+
+      try {
+        await archiveAgent(id);
+        if (openAgentRef.current === id) void setLastOpenAgentId(null);
+        setPinnedHistoryList((current) =>
+          current.filter((entry) => entry.id !== id),
+        );
+        setHistoryList((current) => current.filter((entry) => entry.id !== id));
+        await updatePinnedAgentIds(
+          (ids) => ids.filter((value) => value !== id),
+          displayedPinnedAgentIdsRef.current,
+        ).catch((err) => {
+          console.error('Failed to unpin archived agent:', err);
+        });
+      } catch (err) {
+        console.error('Failed to archive agent:', err);
+      } finally {
+        removePendingRemoval(id);
+      }
+    },
+    [
+      addPendingRemoval,
+      archiveAgent,
+      removePendingRemoval,
+      setLastOpenAgentId,
+      updatePinnedAgentIds,
+    ],
   );
 
   const handleTogglePinned = useCallback(
@@ -2596,6 +2632,7 @@ export function AgentsList() {
         onClose={handleCtxMenuClose}
         onForkRequest={handleFork}
         onMarkAsUnreadRequest={handleMarkAsUnread}
+        onArchiveRequest={handleArchive}
         onDeleteRequest={handleCtxDeleteRequest}
       />
       <DeleteConfirmPopover

--- a/apps/browser/src/ui/screens/settings/content.tsx
+++ b/apps/browser/src/ui/screens/settings/content.tsx
@@ -13,6 +13,7 @@ import { AccountSection } from './sections/account-section';
 import { AboutSection } from './sections/about-section';
 import { HistorySection } from './sections/history-section';
 import { WorktreeSetupSection } from './sections/agent-settings.worktree-setup';
+import { ArchivedAgentsSection } from './sections/archived-agents-section';
 
 export function SettingsContent() {
   const settingsRoute = useKartonState((s) => s.appScreen.settingsRoute);
@@ -45,5 +46,7 @@ export function SettingsContent() {
       return <AboutSection />;
     case 'history':
       return <HistorySection />;
+    case 'archived-agents':
+      return <ArchivedAgentsSection />;
   }
 }

--- a/apps/browser/src/ui/screens/settings/sections/archived-agents-section.tsx
+++ b/apps/browser/src/ui/screens/settings/sections/archived-agents-section.tsx
@@ -16,7 +16,7 @@ import { getBaseName } from '@shared/path-utils';
 import { FolderIcon, Loader2Icon, SearchIcon, Trash2Icon } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 
-const ARCHIVED_PAGE_SIZE = 100;
+const ARCHIVED_PAGE_SIZE = 25;
 
 export function ArchivedAgentsSection() {
   const getArchivedAgents = useKartonProcedure(
@@ -42,7 +42,6 @@ export function ArchivedAgentsSection() {
 
     const loadEntries = async () => {
       setLoading(true);
-      setEntries([]);
       try {
         const nextEntries = await getArchivedAgents(
           0,
@@ -140,7 +139,7 @@ export function ArchivedAgentsSection() {
           ) : null}
 
           <div className="overflow-hidden rounded-xl border border-border-subtle bg-surface-1">
-            {loading ? (
+            {loading && entries.length === 0 ? (
               <div className="flex min-h-40 items-center justify-center gap-2 text-muted-foreground text-sm">
                 <Loader2Icon className="size-5 animate-spin" />
                 <span>Loading archived chats</span>

--- a/apps/browser/src/ui/screens/settings/sections/archived-agents-section.tsx
+++ b/apps/browser/src/ui/screens/settings/sections/archived-agents-section.tsx
@@ -1,0 +1,273 @@
+import { Button } from '@stagewise/stage-ui/components/button';
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@stagewise/stage-ui/components/dialog';
+import { Input } from '@stagewise/stage-ui/components/input';
+import { OverlayScrollbar } from '@stagewise/stage-ui/components/overlay-scrollbar';
+import type { AgentHistoryEntry } from '@shared/karton-contracts/ui/agent';
+import { useKartonProcedure } from '@ui/hooks/use-karton';
+import { getBaseName } from '@shared/path-utils';
+import { FolderIcon, Loader2Icon, SearchIcon, Trash2Icon } from 'lucide-react';
+import { useEffect, useRef, useState } from 'react';
+
+const ARCHIVED_PAGE_SIZE = 100;
+
+export function ArchivedAgentsSection() {
+  const getArchivedAgents = useKartonProcedure(
+    (p) => p.agents.getAgentsHistoryList,
+  );
+  const unarchiveAgent = useKartonProcedure((p) => p.agents.unarchive);
+  const deleteAgent = useKartonProcedure((p) => p.agents.delete);
+
+  const [searchQuery, setSearchQuery] = useState('');
+  const [limit, setLimit] = useState(ARCHIVED_PAGE_SIZE);
+  const [entries, setEntries] = useState<AgentHistoryEntry[]>([]);
+  const [hasMore, setHasMore] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [pendingId, setPendingId] = useState<string | null>(null);
+  const [deleteTargetId, setDeleteTargetId] = useState<string | null>(null);
+  const [reloadToken, setReloadToken] = useState(0);
+  const removedIds = useRef(new Set<string>());
+  const query = searchQuery.trim();
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const loadEntries = async () => {
+      setLoading(true);
+      setEntries([]);
+      try {
+        const nextEntries = await getArchivedAgents(
+          0,
+          limit + 1,
+          query || undefined,
+          true,
+        );
+        if (cancelled) return;
+        setEntries(
+          nextEntries
+            .filter((entry) => !removedIds.current.has(entry.id))
+            .slice(0, limit),
+        );
+        setHasMore(nextEntries.length > limit);
+        setError(null);
+      } catch (cause) {
+        if (cancelled) return;
+        console.error('Failed to load archived chats:', cause);
+        setError('Failed to load archived chats.');
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+
+    void loadEntries();
+    return () => {
+      cancelled = true;
+    };
+  }, [getArchivedAgents, limit, query, reloadToken]);
+
+  async function runEntryMutation(
+    id: string,
+    mutate: () => Promise<unknown>,
+    fallbackError: string,
+  ) {
+    removedIds.current.add(id);
+    setPendingId(id);
+    setError(null);
+    try {
+      await mutate();
+      setEntries((current) => current.filter((entry) => entry.id !== id));
+    } catch (cause) {
+      removedIds.current.delete(id);
+      console.error(fallbackError, cause);
+      setError(fallbackError);
+      setReloadToken((current) => current + 1);
+    } finally {
+      setPendingId(null);
+    }
+  }
+
+  async function handleDelete() {
+    if (!deleteTargetId) return;
+    setDeleteTargetId(null);
+
+    await runEntryMutation(
+      deleteTargetId,
+      () => deleteAgent(deleteTargetId),
+      'Failed to permanently delete the chat.',
+    );
+  }
+
+  return (
+    <>
+      <OverlayScrollbar className="h-full" contentClassName="px-6 pt-24 pb-24">
+        <div className="mx-auto max-w-4xl space-y-6">
+          <div className="space-y-1">
+            <h1 className="font-semibold text-foreground text-xl">
+              Archived chats
+            </h1>
+            <p className="text-muted-foreground text-sm">
+              Archived agents are stopped and hidden from your chat list.
+            </p>
+          </div>
+
+          <div className="relative">
+            <Input
+              aria-label="Search archived chats"
+              placeholder="Search archived chats"
+              value={searchQuery}
+              onValueChange={(value) => {
+                setSearchQuery(value);
+                setLimit(ARCHIVED_PAGE_SIZE);
+              }}
+              debounce={250}
+              className="max-w-none pl-8"
+            />
+            <SearchIcon className="pointer-events-none absolute top-1/2 left-2.5 size-4 -translate-y-1/2 text-subtle-foreground" />
+          </div>
+
+          {error && entries.length > 0 ? (
+            <div className="rounded-lg bg-error-background px-3 py-2 text-error-foreground text-sm">
+              {error}
+            </div>
+          ) : null}
+
+          <div className="overflow-hidden rounded-xl border border-border-subtle bg-surface-1">
+            {loading ? (
+              <div className="flex min-h-40 items-center justify-center gap-2 text-muted-foreground text-sm">
+                <Loader2Icon className="size-5 animate-spin" />
+                <span>Loading archived chats</span>
+              </div>
+            ) : entries.length === 0 && !hasMore ? (
+              <div className="flex min-h-40 items-center justify-center px-6 text-center text-muted-foreground text-sm">
+                <p>
+                  {error
+                    ? 'Couldn’t load archived chats. Please try again.'
+                    : query
+                      ? 'No matching archived chats.'
+                      : 'Chats you archive will appear here.'}
+                </p>
+              </div>
+            ) : (
+              <div className="divide-y divide-border-subtle">
+                {entries.map((entry) => {
+                  const workspace = entry.mountedWorkspaces?.[0];
+                  const archivedAt = new Date(
+                    entry.archivedAt ?? entry.lastMessageAt,
+                  ).toLocaleString(undefined, {
+                    dateStyle: 'medium',
+                    timeStyle: 'short',
+                  });
+                  return (
+                    <div
+                      key={entry.id}
+                      className="flex min-h-16 items-center gap-4 px-4 py-3 hover:bg-hover-derived"
+                    >
+                      <div className="min-w-0 flex-1">
+                        <p className="truncate font-medium text-foreground text-sm">
+                          {entry.title || 'Untitled chat'}
+                        </p>
+                        <div className="mt-0.5 flex min-w-0 items-center gap-2 text-muted-foreground text-xs">
+                          <span>{archivedAt}</span>
+                          {workspace ? (
+                            <>
+                              <span aria-hidden="true">·</span>
+                              <span className="flex min-w-0 items-center gap-1">
+                                <FolderIcon className="size-3 shrink-0" />
+                                <span className="truncate">
+                                  {getBaseName(workspace.path) ||
+                                    workspace.path}
+                                </span>
+                              </span>
+                            </>
+                          ) : null}
+                        </div>
+                      </div>
+                      <Button
+                        variant="ghost"
+                        size="icon-xs"
+                        aria-label={`Permanently delete ${entry.title || 'Untitled chat'}`}
+                        disabled={pendingId !== null}
+                        onClick={() => setDeleteTargetId(entry.id)}
+                      >
+                        <Trash2Icon className="size-3.5" />
+                      </Button>
+                      <Button
+                        variant="secondary"
+                        size="xs"
+                        disabled={pendingId !== null}
+                        onClick={() =>
+                          void runEntryMutation(
+                            entry.id,
+                            () => unarchiveAgent(entry.id),
+                            'Failed to unarchive the chat.',
+                          )
+                        }
+                      >
+                        {pendingId === entry.id ? (
+                          <Loader2Icon className="size-3.5 animate-spin" />
+                        ) : null}
+                        Unarchive
+                      </Button>
+                    </div>
+                  );
+                })}
+                {hasMore ? (
+                  <div className="flex justify-center p-3">
+                    <Button
+                      variant="secondary"
+                      size="sm"
+                      disabled={pendingId !== null}
+                      onClick={() =>
+                        setLimit((current) => current + ARCHIVED_PAGE_SIZE)
+                      }
+                    >
+                      Show more
+                    </Button>
+                  </div>
+                ) : null}
+              </div>
+            )}
+          </div>
+        </div>
+      </OverlayScrollbar>
+
+      <Dialog
+        open={deleteTargetId !== null}
+        onOpenChange={(open) => {
+          if (!open) setDeleteTargetId(null);
+        }}
+      >
+        <DialogContent>
+          <DialogClose />
+          <DialogHeader>
+            <DialogTitle>Permanently delete chat?</DialogTitle>
+            <DialogDescription>
+              This deletes the chat history and attachments. This action cannot
+              be undone.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="destructive" size="sm" onClick={handleDelete}>
+              Delete permanently
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => setDeleteTargetId(null)}
+            >
+              Cancel
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/apps/browser/src/ui/screens/settings/settings-route.tsx
+++ b/apps/browser/src/ui/screens/settings/settings-route.tsx
@@ -11,6 +11,7 @@ import {
   UserIcon,
   InfoIcon,
   PaletteIcon,
+  ArchiveIcon,
 } from 'lucide-react';
 import type { SettingsSection, SettingsRoute } from '@shared/settings-route';
 import { SETTINGS_SECTION_LABELS } from '@shared/settings-route';
@@ -53,6 +54,10 @@ export const SETTINGS_NAV_GROUPS: SettingsNavGroup[] = [
       {
         section: 'plugins',
         icon: <PuzzleIcon className="size-4 shrink-0" />,
+      },
+      {
+        section: 'archived-agents',
+        icon: <ArchiveIcon className="size-4 shrink-0" />,
       },
     ],
   },

--- a/packages/agent-core/src/agents/base-agent-reporting.test.ts
+++ b/packages/agent-core/src/agents/base-agent-reporting.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it, vi } from 'vitest';
+import { ChatAgent } from './chat/chat';
+
+describe('BaseAgent error reporting', () => {
+  it('does not surface state or telemetry failures', () => {
+    const captureException = vi.fn();
+    const agent = Object.create(ChatAgent.prototype) as any;
+    agent.instanceId = 'archived-agent';
+    agent.state = {
+      get: () => {
+        throw new Error('missing agent instance');
+      },
+    };
+    agent.host = { telemetry: { captureException } };
+
+    expect(() =>
+      agent.report(new Error('late callback'), 'updateTitle'),
+    ).not.toThrow();
+
+    agent.state.get = () => ({ activeModelId: 'test-model' });
+    captureException.mockImplementation(() => {
+      throw new Error('telemetry unavailable');
+    });
+    expect(() =>
+      agent.report(new Error('step failed'), 'runStep'),
+    ).not.toThrow();
+  });
+});

--- a/packages/agent-core/src/agents/base-agent.ts
+++ b/packages/agent-core/src/agents/base-agent.ts
@@ -3544,15 +3544,19 @@ export abstract class BaseAgent<
     operation: string,
     extra?: Record<string, unknown>,
   ) {
-    this.host.telemetry?.captureException(error, {
-      service: 'base-agent',
-      operation,
-      modelId: this.state.get().activeModelId,
-      agentType: this.agentType,
-      instanceId: this.instanceId,
-      ...BaseAgent.extractApiErrorContext(error),
-      ...extra,
-    });
+    try {
+      this.host.telemetry?.captureException(error, {
+        service: 'base-agent',
+        operation,
+        modelId: this.state.get().activeModelId,
+        agentType: this.agentType,
+        instanceId: this.instanceId,
+        ...BaseAgent.extractApiErrorContext(error),
+        ...extra,
+      });
+    } catch {
+      // Reporting must not surface teardown-state or telemetry failures.
+    }
   }
 
   /**

--- a/packages/agent-core/src/services/agent-manager/agent-manager.create-handler.test.ts
+++ b/packages/agent-core/src/services/agent-manager/agent-manager.create-handler.test.ts
@@ -24,13 +24,19 @@ function createDeps() {
     getLastChatWorkspacePaths: vi.fn(async () => null),
     getLastChatModelSelection: vi.fn(async () => null),
     getAgentHistoryEntries: vi.fn(async () => []),
+    getChildAgentInstanceIds: vi.fn(async () => []),
+    deleteAgentInstance: vi.fn(async () => {}),
     updateAgentUnread: vi.fn(async () => {}),
     setAgentArchived: vi.fn(async () => {}),
+  };
+  const attachments = {
+    deleteAgentBlobs: vi.fn(async () => {}),
   };
   return {
     registry: new CommandRegistry(),
     toolbox,
     persistenceDb,
+    attachments,
     agentStore: {
       get: vi.fn(() => ({ agents: { instances: {} }, toolbox: {} })),
       update: vi.fn(),
@@ -50,7 +56,7 @@ function buildManager(deps: ReturnType<typeof createDeps>) {
     state: { store: deps.agentStore as any },
     storage: {
       persistenceDb: deps.persistenceDb as any,
-      attachments: {} as any,
+      attachments: deps.attachments as any,
       fileReadCache: {} as any,
     },
     tools: {
@@ -121,6 +127,24 @@ describe('AgentManager unread handlers', () => {
       'active',
       true,
     );
+  });
+});
+
+describe('AgentManager agents.delete handler', () => {
+  it('completes after attachment cleanup fails', async () => {
+    const deps = createDeps();
+    deps.attachments.deleteAgentBlobs.mockRejectedValueOnce(
+      new Error('filesystem unavailable'),
+    );
+    const manager = buildManager(deps);
+
+    await deps.registry.dispatch<unknown[], void>(
+      'agents.delete',
+      { callerId: 'test' },
+      ['agent-1'],
+    );
+    expect(deps.attachments.deleteAgentBlobs).toHaveBeenCalledWith('agent-1');
+    await manager.teardown();
   });
 });
 

--- a/packages/agent-core/src/services/agent-manager/agent-manager.create-handler.test.ts
+++ b/packages/agent-core/src/services/agent-manager/agent-manager.create-handler.test.ts
@@ -23,7 +23,9 @@ function createDeps() {
   const persistenceDb = {
     getLastChatWorkspacePaths: vi.fn(async () => null),
     getLastChatModelSelection: vi.fn(async () => null),
+    getAgentHistoryEntries: vi.fn(async () => []),
     updateAgentUnread: vi.fn(async () => {}),
+    setAgentArchived: vi.fn(async () => {}),
   };
   return {
     registry: new CommandRegistry(),
@@ -235,6 +237,19 @@ describe('AgentManager agents.create handler', () => {
     await manager.teardown();
   });
 
+  it('does not resume archived agents', async () => {
+    const deps = createDeps();
+    (deps.persistenceDb as any).getStoredAgentInstanceById = vi.fn(
+      async () => ({ archivedAt: new Date() }),
+    );
+    const manager = buildManager(deps);
+
+    await expect(manager.resumeAgent('archived')).rejects.toThrow(
+      'must be unarchived before it can be resumed',
+    );
+    await manager.teardown();
+  });
+
   it('uses the provider instance when updating an active model', async () => {
     const deps = createDeps();
     const has = vi.fn(
@@ -436,16 +451,38 @@ describe('AgentManager agents.archive handler', () => {
     vi.restoreAllMocks();
   });
 
-  it('finalizes pending edits before tearing down the agent', async () => {
+  it('persists finalized state before tearing down the agent', async () => {
     const deps = createDeps();
+    deps.agentStore.get.mockReturnValue({
+      agents: {
+        instances: {
+          'agent-1': { parentAgentInstanceId: null, sideChatParentId: null },
+          'side-chat': {
+            parentAgentInstanceId: null,
+            sideChatParentId: 'agent-1',
+          },
+        },
+      },
+      toolbox: {},
+    });
     const manager = buildManager(deps);
+    const persistAgentState = vi
+      .spyOn(manager as any, 'persistAgentState')
+      .mockResolvedValue(undefined);
     const agent = {
       stop: vi.fn(async () => {}),
       reportErrorToParent: vi.fn(async () => {}),
       onTeardown: vi.fn(async () => {}),
       agentType: AgentTypes.CHAT,
     };
+    const sideChat = {
+      ...agent,
+      stop: vi.fn(async () => {}),
+      reportErrorToParent: vi.fn(async () => {}),
+      onTeardown: vi.fn(async () => {}),
+    };
     (manager as any).activeAgents.set('agent-1', agent);
+    (manager as any).activeAgents.set('side-chat', sideChat);
     await flush();
 
     await deps.registry.dispatch<unknown[], void>(
@@ -459,7 +496,64 @@ describe('AgentManager agents.archive handler', () => {
     );
     expect(
       deps.toolbox.finalizePendingEditsForAgent.mock.invocationCallOrder[0],
+    ).toBeLessThan(persistAgentState.mock.invocationCallOrder[0]!);
+    expect(persistAgentState).toHaveBeenCalledWith('agent-1');
+    expect(persistAgentState.mock.invocationCallOrder[0]).toBeLessThan(
+      deps.persistenceDb.setAgentArchived.mock.invocationCallOrder[0]!,
+    );
+    expect(deps.persistenceDb.setAgentArchived).toHaveBeenCalledTimes(1);
+    expect(deps.persistenceDb.setAgentArchived).toHaveBeenCalledWith(
+      'agent-1',
+      true,
+    );
+    expect(deps.persistenceDb.setAgentArchived).not.toHaveBeenCalledWith(
+      'side-chat',
+      true,
+    );
+    expect(sideChat.onTeardown).toHaveBeenCalledTimes(1);
+    expect(
+      deps.persistenceDb.setAgentArchived.mock.invocationCallOrder[0],
     ).toBeLessThan(agent.onTeardown.mock.invocationCallOrder[0]!);
+    await manager.teardown();
+  });
+
+  it.each([
+    ['agents.archive', true],
+    ['agents.unarchive', false],
+  ] as const)('updates persisted archive state for %s', async (command, value) => {
+    const deps = createDeps();
+    const manager = buildManager(deps);
+
+    await deps.registry.dispatch<unknown[], void>(
+      command,
+      { callerId: 'test' },
+      ['agent-1'],
+    );
+
+    expect(deps.persistenceDb.setAgentArchived).toHaveBeenCalledWith(
+      'agent-1',
+      value,
+    );
+    await manager.teardown();
+  });
+
+  it('queries archived history separately', async () => {
+    const deps = createDeps();
+    const manager = buildManager(deps);
+
+    await deps.registry.dispatch<unknown[], unknown>(
+      'agents.getAgentsHistoryList',
+      { callerId: 'test' },
+      [0, 101, ' chat ', true],
+    );
+
+    expect(deps.persistenceDb.getAgentHistoryEntries).toHaveBeenCalledWith(
+      101,
+      0,
+      [],
+      '%chat%',
+      true,
+    );
     await manager.teardown();
   });
 });

--- a/packages/agent-core/src/services/agent-manager/agent-manager.ts
+++ b/packages/agent-core/src/services/agent-manager/agent-manager.ts
@@ -656,9 +656,12 @@ export class AgentManager extends DisposableService {
     this.wrapAgentRpc('agents.delete', async (instanceId: string) => {
       await this.deleteAgent(instanceId);
     });
-    this.wrapAgentRpc('agents.archive', async (instanceId: string) => {
-      await this.archiveAgent(instanceId);
-    });
+    this.wrapAgentRpc('agents.archive', (instanceId: string) =>
+      this.archiveAgent(instanceId, true),
+    );
+    this.wrapAgentRpc('agents.unarchive', (instanceId: string) =>
+      this.persistenceDb.setAgentArchived(instanceId, false),
+    );
     this.wrapAgentRpc('agents.markAsRead', async (instanceId: string) => {
       await this.updateUnread(instanceId, false);
     });
@@ -733,9 +736,12 @@ export class AgentManager extends DisposableService {
     );
     this.wrapAgentRpc(
       'agents.getAgentsHistoryList',
-      async (offset: number, limit: number, searchString?: string) => {
-        return await this.getAgentsHistoryList(offset, limit, searchString);
-      },
+      (
+        offset: number,
+        limit: number,
+        searchString?: string,
+        archived?: boolean,
+      ) => this.getAgentsHistoryList(offset, limit, searchString, archived),
     );
     this.wrapAgentRpc(
       'agents.getAgentHistoryEntriesByIds',
@@ -1224,6 +1230,11 @@ export class AgentManager extends DisposableService {
     if (!agent) {
       throw new Error(`Agent with instance id ${instanceId} not found`);
     }
+    if (agent.archivedAt) {
+      throw new Error(
+        `Agent with instance id ${instanceId} is archived and must be unarchived before it can be resumed`,
+      );
+    }
 
     // Right now, we don't allow resuming sub-agents (because persisted agents stop all their tools calls anyway when they arew stopped and resumed - including any child agents).
     if (agent.parentAgentInstanceId) {
@@ -1303,10 +1314,6 @@ export class AgentManager extends DisposableService {
 
     if (!agent || !agentState) {
       throw new Error(`Agent with instance id ${instanceId} not found`);
-    }
-
-    if (agentState.history.length === 0) {
-      // We don't persist empty agents.
     }
 
     const mountedWorkspaces =
@@ -1484,7 +1491,7 @@ export class AgentManager extends DisposableService {
 
     // Permanently remove on-disk attachment blobs (archive intentionally
     // preserves them so a resumed agent can still access its attachments).
-    void this.attachments.deleteAgentBlobs(instanceId);
+    await this.attachments.deleteAgentBlobs(instanceId);
 
     this.host.telemetry?.capture('agent-deleted', {
       agent_type: agentType,
@@ -1496,12 +1503,18 @@ export class AgentManager extends DisposableService {
    * Stops an agent and deletes it's active instance while keeping the persisted state intact - must be resumed when it should be opened again.
    * @param instanceId The agent instance that should be archived (stopped and only persistence kept)
    */
-  private async archiveAgent(instanceId: string) {
+  private async archiveAgent(
+    instanceId: string,
+    persistState = false,
+    markArchived = persistState,
+  ) {
     this.logger.debug(`[AgentManager] Archiving agent. ID: ${instanceId}`);
     // Stop this agent and all child agents
     const agent = this.activeAgents.get(instanceId);
 
     if (!agent) {
+      if (markArchived)
+        await this.persistenceDb.setAgentArchived(instanceId, true);
       return;
     }
 
@@ -1526,11 +1539,13 @@ export class AgentManager extends DisposableService {
     const childAgentInstanceIds =
       this.getActiveChildAgentInstanceIds(instanceId);
     for (const childAgentInstanceId of childAgentInstanceIds) {
-      const childAgent = this.activeAgents.get(childAgentInstanceId);
-      await childAgent?.onTeardown();
-      await this.archiveAgent(childAgentInstanceId);
+      await this.archiveAgent(childAgentInstanceId, persistState, false);
     }
 
+    if (persistState) await this.persistAgentState(instanceId);
+    if (markArchived) {
+      await this.persistenceDb.setAgentArchived(instanceId, true);
+    }
     await agent.onTeardown();
 
     // Clear the active agents map.
@@ -1876,6 +1891,7 @@ export class AgentManager extends DisposableService {
     offset: number,
     limit: number,
     searchString?: string,
+    archived = false,
   ): Promise<AgentHistoryEntry[]> {
     const entries = await this.persistenceDb.getAgentHistoryEntries(
       limit,
@@ -1884,6 +1900,7 @@ export class AgentManager extends DisposableService {
       searchString && searchString.trim().length > 0
         ? `%${searchString.trim()}%`
         : undefined,
+      archived,
     );
     return this.enrichHistoryEntries
       ? await this.enrichHistoryEntries(entries)

--- a/packages/agent-core/src/services/agent-manager/agent-manager.ts
+++ b/packages/agent-core/src/services/agent-manager/agent-manager.ts
@@ -1491,7 +1491,14 @@ export class AgentManager extends DisposableService {
 
     // Permanently remove on-disk attachment blobs (archive intentionally
     // preserves them so a resumed agent can still access its attachments).
-    await this.attachments.deleteAgentBlobs(instanceId);
+    try {
+      await this.attachments.deleteAgentBlobs(instanceId);
+    } catch (error) {
+      this.logger.error(
+        `[AgentManager] Failed to delete attachment blobs for agent ${instanceId}`,
+        error,
+      );
+    }
 
     this.host.telemetry?.capture('agent-deleted', {
       agent_type: agentType,

--- a/packages/agent-core/src/services/agent-persistence/db.ts
+++ b/packages/agent-core/src/services/agent-persistence/db.ts
@@ -8,6 +8,7 @@ import {
   desc,
   asc,
   isNull,
+  isNotNull,
   eq,
   sql,
   gte,
@@ -173,6 +174,7 @@ export class AgentPersistenceDB {
    * @param offset The offset to fetch the agents from
    * @param excludeIds The ids of the agents to exclude from the fetch
    * @param titleLike The title to filter the agents by (optional, case-insensitive)
+   * @param archived Whether to fetch archived instead of active agents
    *
    * @note This method will not fetch any agents that have a parent agent instance.
    *
@@ -183,6 +185,7 @@ export class AgentPersistenceDB {
     offset: number,
     excludeIds: string[],
     titleLike?: string,
+    archived = false,
   ): Promise<AgentHistoryEntry[]> {
     const results = await this._db
       .select({
@@ -193,6 +196,7 @@ export class AgentPersistenceDB {
         messageCount: sql<number>`(SELECT COUNT(*) FROM agentMessages WHERE agent_instance_id = ${schema.agentInstances.id})`,
         parentAgentInstanceId: schema.agentInstances.parentAgentInstanceId,
         unread: schema.agentInstances.unread,
+        archivedAt: schema.agentInstances.archivedAt,
         mountedWorkspaces: schema.agentInstances.mountedWorkspaces,
       })
       .from(schema.agentInstances)
@@ -207,7 +211,9 @@ export class AgentPersistenceDB {
       // making them silently missing from groups like "Yesterday" until
       // the user clicked "Show more".
       .orderBy(
-        desc(schema.agentInstances.unread),
+        archived
+          ? desc(schema.agentInstances.archivedAt)
+          : desc(schema.agentInstances.unread),
         desc(schema.agentInstances.lastMessageAt),
       )
       .limit(limit)
@@ -216,6 +222,9 @@ export class AgentPersistenceDB {
         and(
           notInArray(schema.agentInstances.id, excludeIds),
           rootChatFilter,
+          archived
+            ? isNotNull(schema.agentInstances.archivedAt)
+            : isNull(schema.agentInstances.archivedAt),
           titleLike
             ? sql`lower(${schema.agentInstances.title}) like lower(${titleLike})`
             : undefined,
@@ -257,10 +266,17 @@ export class AgentPersistenceDB {
         messageCount: sql<number>`(SELECT COUNT(*) FROM agentMessages WHERE agent_instance_id = ${schema.agentInstances.id})`,
         parentAgentInstanceId: schema.agentInstances.parentAgentInstanceId,
         unread: schema.agentInstances.unread,
+        archivedAt: schema.agentInstances.archivedAt,
         mountedWorkspaces: schema.agentInstances.mountedWorkspaces,
       })
       .from(schema.agentInstances)
-      .where(and(inArray(schema.agentInstances.id, ids), rootChatFilter));
+      .where(
+        and(
+          inArray(schema.agentInstances.id, ids),
+          rootChatFilter,
+          isNull(schema.agentInstances.archivedAt),
+        ),
+      );
 
     this._logger.debug(
       `[AgentPersistenceDB] Fetched agent history entries by ids`,
@@ -446,6 +462,7 @@ export class AgentPersistenceDB {
       this._logger.error(
         `[AgentPersistenceDB] Failed to store agent instance: ${(error as Error).message}, ${(error as Error).stack}`,
       );
+      throw error;
     }
   }
 
@@ -594,6 +611,19 @@ export class AgentPersistenceDB {
     }
   }
 
+  public async setAgentArchived(id: string, archived: boolean): Promise<void> {
+    this._logger.debug(
+      `[AgentPersistenceDB] ${archived ? 'Archiving' : 'Unarchiving'} agent: ${id}`,
+    );
+    const result = await this._db
+      .update(schema.agentInstances)
+      .set({ archivedAt: archived ? new Date() : null })
+      .where(eq(schema.agentInstances.id, id));
+    if ((result as unknown as { rowsAffected: number }).rowsAffected === 0) {
+      throw new Error(`Agent with instance id ${id} not found`);
+    }
+  }
+
   /**
    * Updates unread state without hydrating the agent.
    */
@@ -677,24 +707,14 @@ export class AgentPersistenceDB {
       await this.deleteAgentInstance(childAgentInstanceId);
     }
 
-    // Delete associated messages first
-    await this._db
-      .delete(schema.agentMessages)
-      .where(eq(schema.agentMessages.agentInstanceId, id))
-      .catch((error) => {
-        this._logger.error(
-          `[AgentPersistenceDB] Failed to delete agent messages: ${error}`,
-        );
-      });
-
-    await this._db
-      .delete(schema.agentInstances)
-      .where(eq(schema.agentInstances.id, id))
-      .catch((error) => {
-        this._logger.error(
-          `[AgentPersistenceDB] Failed to delete agent instance: ${error}`,
-        );
-      });
+    await this._db.transaction(async (tx) => {
+      await tx
+        .delete(schema.agentMessages)
+        .where(eq(schema.agentMessages.agentInstanceId, id));
+      await tx
+        .delete(schema.agentInstances)
+        .where(eq(schema.agentInstances.id, id));
+    });
 
     // Clean up dirty-tracking state
     this._lastPersistedIds.delete(id);

--- a/packages/agent-core/src/services/agent-persistence/migrations/index.ts
+++ b/packages/agent-core/src/services/agent-persistence/migrations/index.ts
@@ -11,6 +11,7 @@ import { up as v010Up } from './v010-add-active-provider-instance-id';
 import { up as v011Up } from './v011-add-side-chats';
 import { up as v012Up } from './v012-add-marked-unread';
 import { up as v013Up } from './v013-rename-marked-unread';
+import { up as v014Up } from './v014-add-agent-archiving';
 
 const registry: MigrationScript[] = [
   { version: 2, name: 'add-mounted-workspaces', up: v002Up },
@@ -25,7 +26,8 @@ const registry: MigrationScript[] = [
   { version: 11, name: 'add-side-chats', up: v011Up },
   { version: 12, name: 'add-marked-unread', up: v012Up },
   { version: 13, name: 'rename-marked-unread', up: v013Up },
+  { version: 14, name: 'add-agent-archiving', up: v014Up },
 ];
-const schemaVersion = 13;
+const schemaVersion = 14;
 
 export { registry, schemaVersion };

--- a/packages/agent-core/src/services/agent-persistence/migrations/v014-add-agent-archiving.ts
+++ b/packages/agent-core/src/services/agent-persistence/migrations/v014-add-agent-archiving.ts
@@ -1,0 +1,7 @@
+import { sql } from 'drizzle-orm';
+import type { MigrationScript } from '@stagewise/agent-core/migrate-database';
+
+/** Persist whether a top-level chat was explicitly archived by the user. */
+export const up: MigrationScript['up'] = async (db) => {
+  await db.run(sql`ALTER TABLE agentInstances ADD COLUMN archived_at INTEGER`);
+};

--- a/packages/agent-core/src/services/agent-persistence/schema.sql
+++ b/packages/agent-core/src/services/agent-persistence/schema.sql
@@ -1,4 +1,4 @@
--- VERSION: 13
+-- VERSION: 14
 
 CREATE TABLE IF NOT EXISTS meta(
   key LONGVARCHAR NOT NULL UNIQUE PRIMARY KEY,
@@ -23,7 +23,8 @@ CREATE TABLE IF NOT EXISTS agentInstances(
   input_state TEXT NOT NULL,
   used_tokens INTEGER NOT NULL,
   mounted_workspaces TEXT,
-  tool_approval_mode TEXT NOT NULL DEFAULT 'alwaysAsk'
+  tool_approval_mode TEXT NOT NULL DEFAULT 'alwaysAsk',
+  archived_at INTEGER
 );
 
 CREATE INDEX IF NOT EXISTS agentInstances_created_at_index ON agentInstances(created_at);

--- a/packages/agent-core/src/services/agent-persistence/schema.ts
+++ b/packages/agent-core/src/services/agent-persistence/schema.ts
@@ -125,6 +125,7 @@ export const agentInstances = sqliteTable(
     toolApprovalMode: toolApprovalMode('tool_approval_mode')
       .notNull()
       .$defaultFn(() => DEFAULT_TOOL_APPROVAL_MODE),
+    archivedAt: integer('archived_at', { mode: 'timestamp' }),
   },
   (table) => [
     primaryKey({ columns: [table.id] }),

--- a/packages/agent-core/src/services/attachments/service.ts
+++ b/packages/agent-core/src/services/attachments/service.ts
@@ -22,7 +22,7 @@ import {
  * Each attachment is identified by `(agentId, attachmentId)` and stored at
  * `host.agentAttachmentPath(agentId, attachmentId)`. Writes go through a
  * temp-then-rename dance for atomicity. Per-agent cleanup is exposed via
- * `deleteAgentBlobs()`; the agent-manager fires it when an agent is hard
+ * `deleteAgentBlobs()`; the agent-manager calls it when an agent is hard
  * deleted (archive intentionally preserves blobs so a resumed agent can
  * still read its attachments).
  *

--- a/packages/agent-core/src/types/agent.ts
+++ b/packages/agent-core/src/types/agent.ts
@@ -143,6 +143,7 @@ export type AgentHistoryEntry = {
   messageCount: number;
   parentAgentInstanceId: string | null;
   unread: boolean;
+  archivedAt: Date | null;
   mountedWorkspaces?: AgentHistoryWorkspaceEntry[] | null;
 };
 


### PR DESCRIPTION
## Summary

- add persistent chat archiving from the sidebar context menu
- stop archived agents and hide them from the regular chat history
- add an Archived chats settings section with search, pagination, unarchive, and permanent deletion
- add the `archived_at` database field and v14 migration
- prevent archived chats from being resumed before unarchiving

<img width="375" height="421" alt="image" src="https://github.com/user-attachments/assets/f259827a-8ae1-448a-8d81-0fa59a846a36" />
<img width="1069" height="569" alt="image" src="https://github.com/user-attachments/assets/6d9555af-9b20-4569-a754-88cd4e0056d1" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes agent lifecycle, SQLite persistence, and history queries; migration is additive and behavior is covered by new tests, but archive/delete ordering affects stored chat data.
> 
> **Overview**
> **Chat archiving** lets users stop a chat and hide it from the normal sidebar list while keeping history on disk. Archive is available from the shared agent context menu; the sidebar calls `agents.archive`, optimistically removes the row, unpins if needed, and clears the last-open agent when appropriate.
> 
> **Archived chats** live under Settings → **Archived chats**, with search, pagination, **Unarchive**, and permanent delete (with confirmation). History listing gains an `archived` filter on `getAgentsHistoryList`; only non-archived chats appear in the main list. **Resume** is rejected until the chat is unarchived via `agents.unarchive`.
> 
> **Backend:** schema v14 adds `archived_at`; archive persists agent state, sets the flag, tears down active instances (including side chats without marking them archived separately), and excludes archived rows from default history queries. Permanent delete now awaits attachment blob removal and deletes messages/instances in a transaction. `BaseAgent.report` no longer throws on telemetry/state errors during teardown. Sidebar history loads on startup without waiting for an active agent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8a4314337099071dbf0259a1e6d44105a7b2741. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds persistent chat archiving with an Archived chats settings page. Archived chats are stopped, hidden from the main list, and can be unarchived or permanently deleted.

- **New Features**
  - Archive chats from the sidebar context menu; archived chats are stopped and removed from history and pinned lists.
  - Settings > Archived chats: search, pagination, unarchive, and permanent delete.
  - Prevents resuming archived chats until they are unarchived.
  - RPC updates in `karton` UI contract: `agents.unarchive(agentId)` and `agents.getAgentsHistoryList(offset, limit, search?, archived?)`.
  - Keeps attachments on archive; permanent delete uses a DB transaction, removes messages and blobs, and tolerates attachment cleanup failures. Hardens error reporting to avoid telemetry issues after archiving.

- **Migration**
  - Bumps `@stagewise/agent-core` schema to v14; adds `archived_at` to `agentInstances`. Run DB migrations.

<sup>Written for commit 3bdabe672df175ec103855f98f01b9970bf3af56. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1531?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added chat archiving and unarchiving from the chat menu.
  * Added an **Archived chats** settings section with search, pagination, unarchiving, and permanent deletion.
  * Archived chats are hidden from active lists and cannot be resumed until restored.
* **Bug Fixes**
  * Improved cleanup reliability when deleting chats and attachments.
  * Prevented reporting or telemetry errors from disrupting agent shutdown.
* **Database**
  * Added storage and migration support for archived chat status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->