### PR TITLE
fix: use fire-and-forget for update restart

### DIFF
--- a/apps/browser/src/ui/screens/main/_components/sidebar-auth-footer.tsx
+++ b/apps/browser/src/ui/screens/main/_components/sidebar-auth-footer.tsx
@@ -28,7 +28,9 @@ export function SidebarAuthFooter() {
   const toggleClosedLidSleep = useKartonProcedure(
     (p) => p.closedLidSleep.toggle,
   );
-  const quitAndInstall = useKartonProcedure((p) => p.autoUpdate.quitAndInstall);
+  const quitAndInstall = useKartonProcedure(
+    (p) => p.autoUpdate.quitAndInstall.fire,
+  );
 
   const appScreenMode = useKartonState((s) => s.appScreen.mode);
   const userAccount = useKartonState((s) => s.userAccount);

--- a/apps/browser/src/ui/screens/settings/sections/about-section.tsx
+++ b/apps/browser/src/ui/screens/settings/sections/about-section.tsx
@@ -50,7 +50,9 @@ function AppUpdateStatus() {
   const checkForUpdates = useKartonProcedure(
     (p) => p.autoUpdate.checkForUpdates,
   );
-  const quitAndInstall = useKartonProcedure((p) => p.autoUpdate.quitAndInstall);
+  const quitAndInstall = useKartonProcedure(
+    (p) => p.autoUpdate.quitAndInstall.fire,
+  );
 
   if (autoUpdate.status === 'unsupported') {
     return null;


### PR DESCRIPTION
## Summary

Fixes #1532.

The `Restart & Install` action was invoking `autoUpdate.quitAndInstall` through a normal Karton RPC call. Because `quitAndInstall()` causes Electron to shut down, the RPC client could be destroyed before the server response was sent, resulting in:

`TypeError: Object has been destroyed`

This changes both UI call sites to use Karton's fire-and-forget procedure API.

### Changes

* Use `autoUpdate.quitAndInstall.fire` in the sidebar update action.
* Use `autoUpdate.quitAndInstall.fire` in the About/Update settings action.
* No changes to the backend updater or Karton RPC implementation.

### Validation

* `pnpm exec tsc -p tsconfig.ui.json --noEmit` — passed
* `pnpm test` — all tests passed
* Biome checks — passed
* `git diff --check` — passed

The full browser typecheck is currently blocked by pre-existing TypeScript errors in `packages/agent-core/src/services/toolbox/universal-tools.ts`, unrelated to this change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Two-line UI wiring change only; no auth, data, or updater behavior changes.
> 
> **Overview**
> Fixes **Restart & Install** throwing `TypeError: Object has been destroyed` when Electron exits before the Karton RPC can return.
> 
> Both update UI entry points—the sidebar ready-to-install control and **About → Install Update & Restart**—now call `autoUpdate.quitAndInstall` via Karton's **`.fire`** fire-and-forget procedure instead of awaiting a normal RPC. No backend or updater logic changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a600daa69ea3deb13b6c55a4ea66673c4c325ba7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the update restart to a fire-and-forget call to prevent "Object has been destroyed" errors when Electron quits during Restart & Install. Both UI call sites now use `autoUpdate.quitAndInstall.fire`.

- **Bug Fixes**
  - Sidebar Restart & Install action uses `autoUpdate.quitAndInstall.fire`.
  - Settings > About update action uses `autoUpdate.quitAndInstall.fire`.

<sup>Written for commit a600daa69ea3deb13b6c55a4ea66673c4c325ba7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1535?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the app update installation flow from the sidebar and About settings.
  * Update installation actions now trigger reliably through the supported procedure interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->