### PR TITLE
feat(stagewise): passkey sign-in in the preview browser

### DIFF
--- a/apps/browser/src/backend/services/window-layout/browsing-tab-controller.ts
+++ b/apps/browser/src/backend/services/window-layout/browsing-tab-controller.ts
@@ -49,6 +49,8 @@ import { TabErrorHandler } from './tab-error-handler';
 import { TabPermissionHandler } from './tab-permission-handler';
 import { SessionPermissionRegistry } from './tab-permission-handler/session-registry';
 import { TabAuthenticationHandler } from './tab-authentication-handler';
+import { TabPasskeyAuthenticator } from './tab-passkey-authenticator';
+import { PersistedPasskeyCredentialStore } from './tab-passkey-authenticator/credential-store';
 import type {
   PermissionRequest,
   AuthenticationRequest,
@@ -265,6 +267,9 @@ export class BrowsingTabController extends EventEmitter<TabControllerEventMap> {
   // Authentication handling
   private authenticationHandler: TabAuthenticationHandler | null = null;
 
+  // WebAuthn / passkey support
+  private passkeyAuthenticator: TabPasskeyAuthenticator | null = null;
+
   constructor(
     id: string,
     parentWindow: BaseWindow,
@@ -412,6 +417,7 @@ export class BrowsingTabController extends EventEmitter<TabControllerEventMap> {
     this.setupErrorHandler();
     this.setupPermissionHandler();
     this.setupAuthenticationHandler();
+    this.setupPasskeyAuthenticator();
 
     // Initialize zoom percentage from Electron's current zoom factor
     // This ensures we reflect any persisted zoom from previous sessions
@@ -1330,6 +1336,12 @@ export class BrowsingTabController extends EventEmitter<TabControllerEventMap> {
     if (this.authenticationHandler) {
       this.authenticationHandler.destroy();
       this.authenticationHandler = null;
+    }
+
+    // Clean up passkey authenticator
+    if (this.passkeyAuthenticator) {
+      this.passkeyAuthenticator.destroy();
+      this.passkeyAuthenticator = null;
     }
 
     // Only detach debugger if webContents is still alive
@@ -2579,6 +2591,23 @@ export class BrowsingTabController extends EventEmitter<TabControllerEventMap> {
    */
   public cancelAuth(requestId: string): void {
     this.authenticationHandler?.cancelAuth(requestId);
+  }
+
+  // =========================================================================
+  // Passkey / WebAuthn Handling
+  // =========================================================================
+
+  /**
+   * Gives the tab a virtual authenticator so WebAuthn requests resolve instead
+   * of hanging forever. See TabPasskeyAuthenticator for why this is needed.
+   */
+  private setupPasskeyAuthenticator() {
+    this.passkeyAuthenticator = new TabPasskeyAuthenticator(
+      this.webContentsView.webContents,
+      PersistedPasskeyCredentialStore.getInstance(this.logger),
+      this.logger,
+    );
+    void this.passkeyAuthenticator.install();
   }
 
   // =========================================================================

--- a/apps/browser/src/backend/services/window-layout/index.ts
+++ b/apps/browser/src/backend/services/window-layout/index.ts
@@ -22,6 +22,12 @@ import type { PageTransition } from '@shared/karton-contracts/pages-api/types';
 import type { UserPreferences } from '@shared/karton-contracts/ui/shared-types';
 import { UIController } from './ui-controller';
 import {
+  authorizeCeremony,
+  shouldUseLocalAuthenticator,
+  SystemPasskeyRelay,
+} from './system-passkey-relay';
+import { PersistedPasskeyCredentialStore } from './tab-passkey-authenticator/credential-store';
+import {
   BrowsingTabController,
   type ConsoleLogEntry,
   type GetConsoleLogsOptions,
@@ -456,6 +462,9 @@ export class WindowLayoutService extends DisposableService {
   private uiZoomPreferenceListener:
     | ((newPrefs: UserPreferences, oldPrefs: UserPreferences) => void)
     | null = null;
+
+  /** Runs WebAuthn ceremonies in a real browser on behalf of browsing tabs. */
+  private passkeyRelay: SystemPasskeyRelay | null = null;
   private readonly attachments: AttachmentsService;
 
   private constructor(
@@ -746,6 +755,9 @@ export class WindowLayoutService extends DisposableService {
     }
 
     ipcMain.removeHandler('request-turnstile-token');
+    ipcMain.removeHandler('passkey-relay-ceremony');
+    void this.passkeyRelay?.teardown();
+    this.passkeyRelay = null;
 
     app.applicationMenu = null;
 
@@ -1207,6 +1219,98 @@ export class WindowLayoutService extends DisposableService {
     );
     this.logger.debug(
       '[WindowLayoutService] Listening for turnstile proxy requests',
+    );
+
+    // Passkey relay: run WebAuthn ceremonies in a real browser, so pages in the
+    // preview browser can use the passkeys already on this machine.
+    this.passkeyRelay = new SystemPasskeyRelay(this.logger);
+    ipcMain.handle(
+      'passkey-relay-ceremony',
+      // Everything in `request` comes from a web page, so nothing about its
+      // shape is promised; `authorizeCeremony` is what decides it is usable.
+      async (event, request: { kind?: unknown; options?: unknown }) => {
+        const relay = this.passkeyRelay;
+        if (!relay?.available) return { ok: false, error: 'NoSystemBrowser' };
+        // Asking before finding out the browser is taken would spend a prompt
+        // on a ceremony that cannot run.
+        if (relay.running) return { ok: false, error: 'RelayBusy' };
+
+        const frame = event.senderFrame;
+        const allowed = authorizeCeremony({
+          kind: request?.kind,
+          inBrowsingSession:
+            event.sender.session ===
+            session.fromPartition('persist:browser-content'),
+          isMainFrame: Boolean(frame) && frame === event.sender.mainFrame,
+          frameOrigin: frame?.origin ?? null,
+        });
+        if (!allowed.ok) {
+          this.logger.debug(
+            `[SystemPasskeyRelay] Refused a ceremony: ${allowed.error}`,
+          );
+          return allowed;
+        }
+
+        // A passkey registered inside the preview browser lives in this tab's
+        // virtual authenticator, and the tab can answer for it without opening
+        // anything or asking the user anything.
+        if (
+          shouldUseLocalAuthenticator(
+            request.options,
+            allowed.origin,
+            PersistedPasskeyCredentialStore.getInstance(this.logger).list(),
+          )
+        ) {
+          this.logger.debug(
+            `[SystemPasskeyRelay] ${allowed.origin} has a passkey in this tab; not relaying`,
+          );
+          return { ok: false, error: 'UseLocalAuthenticator' };
+        }
+
+        // Relaying opens a browser outside the app and can return an assertion
+        // for a real account, so the site asks first, on the same terms as any
+        // other capability a page can reach for.
+        const permitted =
+          await SessionPermissionRegistry.getInstance()?.requestPasskeyRelay(
+            event.sender.id,
+            allowed.origin,
+          );
+        if (!permitted) {
+          this.logger.debug(
+            `[SystemPasskeyRelay] ${allowed.origin} was not permitted to use system passkeys`,
+          );
+          return { ok: false, error: 'PermissionDenied' };
+        }
+
+        this.logger.debug(
+          `[SystemPasskeyRelay] Running get for ${allowed.origin}`,
+        );
+        // If the tab is gone there is no one left to hand the assertion to, and
+        // the helper window would sit there until the ceremony timed out.
+        const abandon = () => relay.cancel();
+        event.sender.once('destroyed', abandon);
+        let result: Awaited<ReturnType<typeof relay.run>>;
+        try {
+          result = await relay.run(allowed.origin, request.options);
+        } finally {
+          try {
+            event.sender.removeListener('destroyed', abandon);
+          } catch {
+            // The tab took its emitter with it.
+          }
+        }
+        this.logger.debug(
+          `[SystemPasskeyRelay] get for ${allowed.origin}: ${
+            result.ok ? 'credential returned' : result.error
+          }`,
+        );
+        return result;
+      },
+    );
+    this.logger.debug(
+      `[WindowLayoutService] Passkey relay browser: ${
+        this.passkeyRelay.browserName ?? 'none found'
+      }`,
     );
   }
 

--- a/apps/browser/src/backend/services/window-layout/index.ts
+++ b/apps/browser/src/backend/services/window-layout/index.ts
@@ -150,6 +150,14 @@ type PasskeyCeremony = {
   senderId: number;
   requestId: number | null;
   cancelled: boolean;
+  /**
+   * Resolves when the page gives up. A permission prompt has no way to be
+   * withdrawn, so without this the handler would sit on one nobody is waiting
+   * for — holding the relay against every other tab until someone happened to
+   * answer it.
+   */
+  abandoned: Promise<void>;
+  abandon: () => void;
 };
 
 const LEGACY_DIFF_REVIEW_URL_PREFIX = 'stagewise://internal/diff-review/';
@@ -1294,34 +1302,43 @@ export class WindowLayoutService extends DisposableService {
         // tab asking meanwhile is told the relay is taken rather than being
         // prompted for a ceremony that cannot run, and a page that gives up
         // while the prompt is open has something to cancel.
+        let abandon = () => {};
+        const abandoned = new Promise<void>((resolve) => {
+          abandon = resolve;
+        });
         const ceremony: PasskeyCeremony = {
           senderId: event.sender.id,
           requestId: typeof request.id === 'number' ? request.id : null,
           cancelled: false,
+          abandoned,
+          abandon,
         };
         this.passkeyCeremony = ceremony;
         try {
           // Relaying opens a browser outside the app and can return an
           // assertion for a real account, so the site asks first, on the same
           // terms as any other capability a page can reach for.
-          const permitted =
-            await SessionPermissionRegistry.getInstance()?.requestPasskeyRelay(
+          const permitted = await Promise.race([
+            SessionPermissionRegistry.getInstance()?.requestPasskeyRelay(
               event.sender.id,
               allowed.origin,
-            );
-          if (!permitted) {
-            this.logger.debug(
-              `[SystemPasskeyRelay] ${allowed.origin} was not permitted to use system passkeys`,
-            );
-            return { ok: false, error: 'PermissionDenied' };
-          }
-          // Answering a prompt the page stopped waiting on would open a helper
-          // window for a ceremony nobody is left to receive.
+            ),
+            ceremony.abandoned.then(() => false),
+          ]);
+          // Asked before the refusal, because the race answers false for both
+          // and only one of the two is the user's own answer. Going ahead would
+          // open a helper window for a ceremony nobody is left to receive.
           if (ceremony.cancelled) {
             this.logger.debug(
               `[SystemPasskeyRelay] ${allowed.origin} gave up while the prompt was open`,
             );
             return { ok: false, error: 'Cancelled' };
+          }
+          if (!permitted) {
+            this.logger.debug(
+              `[SystemPasskeyRelay] ${allowed.origin} was not permitted to use system passkeys`,
+            );
+            return { ok: false, error: 'PermissionDenied' };
           }
 
           this.logger.debug(
@@ -1330,16 +1347,16 @@ export class WindowLayoutService extends DisposableService {
           // If the tab is gone — closed, or simply moved on to another page —
           // there is no one left to hand the assertion to, and the helper
           // window would sit there until the ceremony timed out.
-          const abandon = () => relay.cancel();
-          event.sender.once('destroyed', abandon);
-          event.sender.once('did-navigate', abandon);
+          const stopOnTabGone = () => relay.cancel();
+          event.sender.once('destroyed', stopOnTabGone);
+          event.sender.once('did-navigate', stopOnTabGone);
           let result: Awaited<ReturnType<typeof relay.run>>;
           try {
             result = await relay.run(allowed.origin, request.options);
           } finally {
             try {
-              event.sender.removeListener('destroyed', abandon);
-              event.sender.removeListener('did-navigate', abandon);
+              event.sender.removeListener('destroyed', stopOnTabGone);
+              event.sender.removeListener('did-navigate', stopOnTabGone);
             } catch {
               // The tab took its emitter with it.
             }
@@ -1370,6 +1387,7 @@ export class WindowLayoutService extends DisposableService {
       if (ceremony.requestId !== requestId) return;
       this.logger.debug('[SystemPasskeyRelay] The page abandoned its ceremony');
       ceremony.cancelled = true;
+      ceremony.abandon();
       this.passkeyRelay?.cancel();
     });
     this.logger.debug(

--- a/apps/browser/src/backend/services/window-layout/index.ts
+++ b/apps/browser/src/backend/services/window-layout/index.ts
@@ -137,6 +137,21 @@ const tabStateSchema = z.object({
 
 type PersistedTabState = z.infer<typeof tabStateSchema>;
 
+/**
+ * The passkey ceremony currently holding the relay.
+ *
+ * The relay runs one ceremony at a time, so this doubles as the lock: it is
+ * claimed before the permission prompt goes up and released when the request
+ * that claimed it is done. `requestId` is the page's own id for the request,
+ * which is what tells a cancel meant for this ceremony from one left over from
+ * an earlier `get()` in the same tab.
+ */
+type PasskeyCeremony = {
+  senderId: number;
+  requestId: number | null;
+  cancelled: boolean;
+};
+
 const LEGACY_DIFF_REVIEW_URL_PREFIX = 'stagewise://internal/diff-review/';
 
 /**
@@ -465,8 +480,8 @@ export class WindowLayoutService extends DisposableService {
 
   /** Runs WebAuthn ceremonies in a real browser on behalf of browsing tabs. */
   private passkeyRelay: SystemPasskeyRelay | null = null;
-  /** The tab whose ceremony is running, and the only one that may cancel it. */
-  private passkeyRelayOwner: number | null = null;
+  /** The one ceremony in flight, and the only request that may cancel it. */
+  private passkeyCeremony: PasskeyCeremony | null = null;
   private readonly attachments: AttachmentsService;
 
   private constructor(
@@ -761,7 +776,7 @@ export class WindowLayoutService extends DisposableService {
     ipcMain.removeAllListeners('passkey-relay-cancel');
     void this.passkeyRelay?.teardown();
     this.passkeyRelay = null;
-    this.passkeyRelayOwner = null;
+    this.passkeyCeremony = null;
 
     app.applicationMenu = null;
 
@@ -1232,12 +1247,16 @@ export class WindowLayoutService extends DisposableService {
       'passkey-relay-ceremony',
       // Everything in `request` comes from a web page, so nothing about its
       // shape is promised; `authorizeCeremony` is what decides it is usable.
-      async (event, request: { kind?: unknown; options?: unknown }) => {
+      async (
+        event,
+        request: { kind?: unknown; options?: unknown; id?: unknown },
+      ) => {
         const relay = this.passkeyRelay;
         if (!relay?.available) return { ok: false, error: 'NoSystemBrowser' };
         // Asking before finding out the browser is taken would spend a prompt
         // on a ceremony that cannot run.
-        if (relay.running) return { ok: false, error: 'RelayBusy' };
+        if (relay.running || this.passkeyCeremony)
+          return { ok: false, error: 'RelayBusy' };
 
         const frame = event.senderFrame;
         const allowed = authorizeCeremony({
@@ -1271,58 +1290,86 @@ export class WindowLayoutService extends DisposableService {
           return { ok: false, error: 'UseLocalAuthenticator' };
         }
 
-        // Relaying opens a browser outside the app and can return an assertion
-        // for a real account, so the site asks first, on the same terms as any
-        // other capability a page can reach for.
-        const permitted =
-          await SessionPermissionRegistry.getInstance()?.requestPasskeyRelay(
-            event.sender.id,
-            allowed.origin,
-          );
-        if (!permitted) {
-          this.logger.debug(
-            `[SystemPasskeyRelay] ${allowed.origin} was not permitted to use system passkeys`,
-          );
-          return { ok: false, error: 'PermissionDenied' };
-        }
-
-        this.logger.debug(
-          `[SystemPasskeyRelay] Running get for ${allowed.origin}`,
-        );
-        // If the tab is gone — closed, or simply moved on to another page —
-        // there is no one left to hand the assertion to, and the helper window
-        // would sit there until the ceremony timed out.
-        const abandon = () => relay.cancel();
-        event.sender.once('destroyed', abandon);
-        event.sender.once('did-navigate', abandon);
-        this.passkeyRelayOwner = event.sender.id;
-        let result: Awaited<ReturnType<typeof relay.run>>;
+        // Claimed before the prompt goes up, not after it comes back: a second
+        // tab asking meanwhile is told the relay is taken rather than being
+        // prompted for a ceremony that cannot run, and a page that gives up
+        // while the prompt is open has something to cancel.
+        const ceremony: PasskeyCeremony = {
+          senderId: event.sender.id,
+          requestId: typeof request.id === 'number' ? request.id : null,
+          cancelled: false,
+        };
+        this.passkeyCeremony = ceremony;
         try {
-          result = await relay.run(allowed.origin, request.options);
-        } finally {
-          this.passkeyRelayOwner = null;
-          try {
-            event.sender.removeListener('destroyed', abandon);
-            event.sender.removeListener('did-navigate', abandon);
-          } catch {
-            // The tab took its emitter with it.
+          // Relaying opens a browser outside the app and can return an
+          // assertion for a real account, so the site asks first, on the same
+          // terms as any other capability a page can reach for.
+          const permitted =
+            await SessionPermissionRegistry.getInstance()?.requestPasskeyRelay(
+              event.sender.id,
+              allowed.origin,
+            );
+          if (!permitted) {
+            this.logger.debug(
+              `[SystemPasskeyRelay] ${allowed.origin} was not permitted to use system passkeys`,
+            );
+            return { ok: false, error: 'PermissionDenied' };
           }
+          // Answering a prompt the page stopped waiting on would open a helper
+          // window for a ceremony nobody is left to receive.
+          if (ceremony.cancelled) {
+            this.logger.debug(
+              `[SystemPasskeyRelay] ${allowed.origin} gave up while the prompt was open`,
+            );
+            return { ok: false, error: 'Cancelled' };
+          }
+
+          this.logger.debug(
+            `[SystemPasskeyRelay] Running get for ${allowed.origin}`,
+          );
+          // If the tab is gone — closed, or simply moved on to another page —
+          // there is no one left to hand the assertion to, and the helper
+          // window would sit there until the ceremony timed out.
+          const abandon = () => relay.cancel();
+          event.sender.once('destroyed', abandon);
+          event.sender.once('did-navigate', abandon);
+          let result: Awaited<ReturnType<typeof relay.run>>;
+          try {
+            result = await relay.run(allowed.origin, request.options);
+          } finally {
+            try {
+              event.sender.removeListener('destroyed', abandon);
+              event.sender.removeListener('did-navigate', abandon);
+            } catch {
+              // The tab took its emitter with it.
+            }
+          }
+          this.logger.debug(
+            `[SystemPasskeyRelay] get for ${allowed.origin}: ${
+              result.ok ? 'credential returned' : result.error
+            }`,
+          );
+          return result;
+        } finally {
+          if (this.passkeyCeremony === ceremony) this.passkeyCeremony = null;
         }
-        this.logger.debug(
-          `[SystemPasskeyRelay] get for ${allowed.origin}: ${
-            result.ok ? 'credential returned' : result.error
-          }`,
-        );
-        return result;
       },
     );
     // A page that gives up on its own request — an AbortController firing, a
     // sign-in button the user clicked away from — should not leave the helper
-    // window open, holding the relay against every other tab. Only the tab the
-    // ceremony belongs to may end it.
-    ipcMain.on('passkey-relay-cancel', (event) => {
-      if (this.passkeyRelayOwner !== event.sender.id) return;
+    // window open, holding the relay against every other tab.
+    ipcMain.on('passkey-relay-cancel', (event, requestId: unknown) => {
+      const ceremony = this.passkeyCeremony;
+      if (!ceremony || ceremony.senderId !== event.sender.id) return;
+      // Only a main frame can start a ceremony, so only a main frame may end
+      // one: the preload runs in subframes too, and they share this sender.
+      if (event.senderFrame !== event.sender.mainFrame) return;
+      // The id the page gave the request it is abandoning. Without it, a
+      // cancel left over from an earlier `get()` in the same tab would stop
+      // whatever ceremony happens to be running now.
+      if (ceremony.requestId !== requestId) return;
       this.logger.debug('[SystemPasskeyRelay] The page abandoned its ceremony');
+      ceremony.cancelled = true;
       this.passkeyRelay?.cancel();
     });
     this.logger.debug(

--- a/apps/browser/src/backend/services/window-layout/index.ts
+++ b/apps/browser/src/backend/services/window-layout/index.ts
@@ -465,6 +465,8 @@ export class WindowLayoutService extends DisposableService {
 
   /** Runs WebAuthn ceremonies in a real browser on behalf of browsing tabs. */
   private passkeyRelay: SystemPasskeyRelay | null = null;
+  /** The tab whose ceremony is running, and the only one that may cancel it. */
+  private passkeyRelayOwner: number | null = null;
   private readonly attachments: AttachmentsService;
 
   private constructor(
@@ -756,8 +758,10 @@ export class WindowLayoutService extends DisposableService {
 
     ipcMain.removeHandler('request-turnstile-token');
     ipcMain.removeHandler('passkey-relay-ceremony');
+    ipcMain.removeAllListeners('passkey-relay-cancel');
     void this.passkeyRelay?.teardown();
     this.passkeyRelay = null;
+    this.passkeyRelayOwner = null;
 
     app.applicationMenu = null;
 
@@ -1285,16 +1289,21 @@ export class WindowLayoutService extends DisposableService {
         this.logger.debug(
           `[SystemPasskeyRelay] Running get for ${allowed.origin}`,
         );
-        // If the tab is gone there is no one left to hand the assertion to, and
-        // the helper window would sit there until the ceremony timed out.
+        // If the tab is gone — closed, or simply moved on to another page —
+        // there is no one left to hand the assertion to, and the helper window
+        // would sit there until the ceremony timed out.
         const abandon = () => relay.cancel();
         event.sender.once('destroyed', abandon);
+        event.sender.once('did-navigate', abandon);
+        this.passkeyRelayOwner = event.sender.id;
         let result: Awaited<ReturnType<typeof relay.run>>;
         try {
           result = await relay.run(allowed.origin, request.options);
         } finally {
+          this.passkeyRelayOwner = null;
           try {
             event.sender.removeListener('destroyed', abandon);
+            event.sender.removeListener('did-navigate', abandon);
           } catch {
             // The tab took its emitter with it.
           }
@@ -1307,6 +1316,15 @@ export class WindowLayoutService extends DisposableService {
         return result;
       },
     );
+    // A page that gives up on its own request — an AbortController firing, a
+    // sign-in button the user clicked away from — should not leave the helper
+    // window open, holding the relay against every other tab. Only the tab the
+    // ceremony belongs to may end it.
+    ipcMain.on('passkey-relay-cancel', (event) => {
+      if (this.passkeyRelayOwner !== event.sender.id) return;
+      this.logger.debug('[SystemPasskeyRelay] The page abandoned its ceremony');
+      this.passkeyRelay?.cancel();
+    });
     this.logger.debug(
       `[WindowLayoutService] Passkey relay browser: ${
         this.passkeyRelay.browserName ?? 'none found'

--- a/apps/browser/src/backend/services/window-layout/system-passkey-relay.test.ts
+++ b/apps/browser/src/backend/services/window-layout/system-passkey-relay.test.ts
@@ -164,8 +164,45 @@ describe('shouldUseLocalAuthenticator', () => {
     ).toBe(true);
   });
 
-  it('survives junk from the page without claiming a local passkey', () => {
-    expect(shouldUseLocalAuthenticator(null, 'not a url', stored)).toBe(false);
+  it('keeps an rpId the origin is not under away from the helper browser', () => {
+    // The native call rejects this with a SecurityError. Relaying it would open
+    // a window instead, and the difference between the two answers would tell
+    // evil.example whether this machine holds a passkey for the other site.
+    expect(
+      shouldUseLocalAuthenticator(
+        { rpId: 'webauthn.io' },
+        'https://evil.example',
+        stored,
+      ),
+    ).toBe(true);
+    expect(
+      shouldUseLocalAuthenticator(
+        { rpId: 'github.com' },
+        'https://evil.example',
+        stored,
+      ),
+    ).toBe(true);
+    // A subdomain claiming its parent is what WebAuthn allows, and it still
+    // relays when the tab holds nothing for that relying party.
+    expect(
+      shouldUseLocalAuthenticator(
+        { rpId: 'github.com' },
+        'https://login.github.com',
+        stored,
+      ),
+    ).toBe(false);
+    expect(
+      shouldUseLocalAuthenticator(
+        { rpId: 'example.com' },
+        'https://notexample.com',
+        stored,
+      ),
+    ).toBe(true);
+  });
+
+  it('survives junk from the page without opening a helper browser', () => {
+    // An origin that is not a URL is nothing to point a window at either.
+    expect(shouldUseLocalAuthenticator(null, 'not a url', stored)).toBe(true);
     expect(
       shouldUseLocalAuthenticator(
         { rpId: 'webauthn.io', allowCredentials: [null, 7, {}] },

--- a/apps/browser/src/backend/services/window-layout/system-passkey-relay.test.ts
+++ b/apps/browser/src/backend/services/window-layout/system-passkey-relay.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it } from 'vitest';
+import {
+  authorizeCeremony,
+  shouldUseLocalAuthenticator,
+} from './system-passkey-relay';
+
+/**
+ * A relayed ceremony produces a real assertion for a real account, so the rules
+ * about who may ask for one are the part of this feature that must not rot.
+ */
+describe('authorizeCeremony', () => {
+  const valid = {
+    kind: 'get' as const,
+    inBrowsingSession: true,
+    isMainFrame: true,
+    frameOrigin: 'https://github.com',
+  };
+
+  it('allows a main-frame request from a browsing tab', () => {
+    expect(authorizeCeremony(valid)).toEqual({
+      ok: true,
+      origin: 'https://github.com',
+    });
+  });
+
+  it('refuses a subframe, so an iframe cannot use the page that embeds it', () => {
+    // The override reaches every frame, and taking the origin from the tab
+    // would let a third-party frame mint an assertion for the top-level site.
+    expect(
+      authorizeCeremony({
+        ...valid,
+        isMainFrame: false,
+        frameOrigin: 'https://ads.example.com',
+      }),
+    ).toEqual({ ok: false, error: 'NotAMainFrame' });
+  });
+
+  it('refuses anything outside the browsing session', () => {
+    expect(authorizeCeremony({ ...valid, inBrowsingSession: false })).toEqual({
+      ok: false,
+      error: 'NotABrowsingTab',
+    });
+  });
+
+  it('refuses origins the helper browser must never be pointed at', () => {
+    for (const frameOrigin of [
+      'null', // sandboxed iframe
+      'file:///Users/someone',
+      'stagewise://internal',
+      'javascript:alert(1)',
+      '',
+      null,
+    ]) {
+      expect(authorizeCeremony({ ...valid, frameOrigin })).toEqual({
+        ok: false,
+        error: 'BadOrigin',
+      });
+    }
+  });
+
+  it('refuses registration, which belongs to the tab authenticator', () => {
+    // Relaying a create would put a passkey in the user's real keychain, and
+    // on every device it syncs to, for a page they may only be testing.
+    expect(authorizeCeremony({ ...valid, kind: 'create' })).toEqual({
+      ok: false,
+      error: 'BadRequest',
+    });
+  });
+
+  it('refuses anything that is not a get', () => {
+    for (const kind of ['store', 'preventSilentAccess', undefined, null, 7]) {
+      expect(authorizeCeremony({ ...valid, kind })).toEqual({
+        ok: false,
+        error: 'BadRequest',
+      });
+    }
+  });
+
+  it('checks the request shape before trusting any of its other fields', () => {
+    // A bad kind from a frame that also fails every other check should still
+    // be refused, never allowed through on a technicality.
+    expect(
+      authorizeCeremony({
+        kind: 'nonsense',
+        inBrowsingSession: false,
+        isMainFrame: false,
+        frameOrigin: null,
+      }).ok,
+    ).toBe(false);
+  });
+});
+
+/**
+ * Getting this wrong is what makes the feature annoying rather than unsafe: a
+ * passkey registered inside the preview browser would send the user to a helper
+ * window that cannot possibly hold it.
+ */
+describe('shouldUseLocalAuthenticator', () => {
+  const stored = [
+    { credentialId: 'abc-_123', rpId: 'webauthn.io' },
+    { credentialId: 'other', rpId: 'example.com' },
+  ];
+
+  it('keeps a discoverable request local when the tab holds a passkey', () => {
+    expect(
+      shouldUseLocalAuthenticator(
+        { rpId: 'webauthn.io' },
+        'https://webauthn.io',
+        stored,
+      ),
+    ).toBe(true);
+  });
+
+  it('relays when the tab holds nothing for the relying party', () => {
+    expect(
+      shouldUseLocalAuthenticator(
+        { rpId: 'github.com' },
+        'https://github.com',
+        stored,
+      ),
+    ).toBe(false);
+  });
+
+  it('falls back to the origin host when the site omits rpId', () => {
+    expect(shouldUseLocalAuthenticator({}, 'https://webauthn.io', stored)).toBe(
+      true,
+    );
+    expect(shouldUseLocalAuthenticator({}, 'https://github.com', stored)).toBe(
+      false,
+    );
+  });
+
+  it('matches an allowCredentials entry the tab actually holds', () => {
+    expect(
+      shouldUseLocalAuthenticator(
+        { rpId: 'webauthn.io', allowCredentials: [{ id: 'abc-_123' }] },
+        'https://webauthn.io',
+        stored,
+      ),
+    ).toBe(true);
+  });
+
+  it('relays when the site asks only for credentials the tab lacks', () => {
+    expect(
+      shouldUseLocalAuthenticator(
+        {
+          rpId: 'webauthn.io',
+          allowCredentials: [{ id: 'a-system-passkey' }],
+        },
+        'https://webauthn.io',
+        stored,
+      ),
+    ).toBe(false);
+  });
+
+  it('compares ids across base64 and base64url spellings', () => {
+    // CDP hands back standard base64; the page sends base64url.
+    expect(
+      shouldUseLocalAuthenticator(
+        { rpId: 'webauthn.io', allowCredentials: [{ id: 'abc-_123' }] },
+        'https://webauthn.io',
+        [{ credentialId: 'abc+/123=', rpId: 'webauthn.io' }],
+      ),
+    ).toBe(true);
+  });
+
+  it('survives junk from the page without claiming a local passkey', () => {
+    expect(shouldUseLocalAuthenticator(null, 'not a url', stored)).toBe(false);
+    expect(
+      shouldUseLocalAuthenticator(
+        { rpId: 'webauthn.io', allowCredentials: [null, 7, {}] },
+        'https://webauthn.io',
+        stored,
+      ),
+    ).toBe(false);
+  });
+});

--- a/apps/browser/src/backend/services/window-layout/system-passkey-relay.ts
+++ b/apps/browser/src/backend/services/window-layout/system-passkey-relay.ts
@@ -212,6 +212,8 @@ export class SystemPasskeyRelay extends DisposableService {
   >();
   /** Each ceremony owns the helper browser, so only one may run at a time. */
   private busy = false;
+  /** Set by `cancel`, cleared by the next `run`. See `cancel`. */
+  private cancelled = false;
   private readonly profileRoot: string;
   private profile: string | null = null;
   private ceremonyCount = 0;
@@ -257,6 +259,7 @@ export class SystemPasskeyRelay extends DisposableService {
     if (this.busy) return { ok: false, error: 'RelayBusy' };
 
     this.busy = true;
+    this.cancelled = false;
     try {
       return await this.runCeremony(origin, optionsJson);
     } finally {
@@ -270,9 +273,16 @@ export class SystemPasskeyRelay extends DisposableService {
    * Closing the helper browser drops the CDP socket, which fails the pending
    * evaluation and lets the ceremony unwind normally. Used when the tab that
    * asked for the sign-in goes away and nobody is left to finish it.
+   *
+   * Stopping the browser is not enough on its own: for most of a ceremony's
+   * life there is no browser to stop yet, or none that answers. The flag is
+   * what the waiting loops check, so a cancel during the launch is not simply
+   * lost — and does not leave them polling something already killed.
    */
   public cancel(): void {
-    if (this.busy) this.stopBrowser();
+    if (!this.busy) return;
+    this.cancelled = true;
+    this.stopBrowser();
   }
 
   private async runCeremony(
@@ -311,6 +321,9 @@ export class SystemPasskeyRelay extends DisposableService {
     this.stopBrowser();
 
     const port = await freePort();
+    // Picking a port is a trip through the event loop, and a cancel landing in
+    // it would have found no browser to stop.
+    if (this.cancelled) throw new Error('cancelled');
     // A profile of its own, thrown away after the ceremony: whatever the
     // relying party's page leaves behind — cookies, storage, cache — goes with
     // it, and nothing touches the user's real browser session. Passkeys live in
@@ -355,7 +368,9 @@ export class SystemPasskeyRelay extends DisposableService {
 
     const deadline = Date.now() + LAUNCH_TIMEOUT_MS;
     let pageSocketUrl: string | null = null;
-    while (Date.now() < deadline && !pageSocketUrl) {
+    // A cancel kills the browser, so without the flag this would go on polling
+    // a dead port for the whole launch timeout, holding the relay all the while.
+    while (Date.now() < deadline && !pageSocketUrl && !this.cancelled) {
       await sleep(200);
       try {
         const res = await fetch(`http://127.0.0.1:${port}/json/list`);
@@ -370,6 +385,7 @@ export class SystemPasskeyRelay extends DisposableService {
         // Not listening yet.
       }
     }
+    if (this.cancelled) throw new Error('cancelled');
     if (!pageSocketUrl) throw new Error('helper browser never opened a page');
 
     await this.connect(pageSocketUrl);
@@ -381,7 +397,7 @@ export class SystemPasskeyRelay extends DisposableService {
    * is actually on, so the ceremony must not start until it has arrived there.
    */
   private async waitForOrigin(origin: string): Promise<void> {
-    for (let attempt = 0; attempt < 60; attempt++) {
+    for (let attempt = 0; attempt < 60 && !this.cancelled; attempt++) {
       const evaluated = (await this.send('Runtime.evaluate', {
         expression: 'location.origin',
         returnByValue: true,
@@ -494,6 +510,9 @@ export class SystemPasskeyRelay extends DisposableService {
   }
 
   protected onTeardown(): void {
+    // Same reason the loops check it during a cancel: a ceremony in flight
+    // while the app shuts down should stop, not keep polling a dead browser.
+    this.cancelled = true;
     this.stopBrowser();
     try {
       rmSync(this.profileRoot, { recursive: true, force: true });

--- a/apps/browser/src/backend/services/window-layout/system-passkey-relay.ts
+++ b/apps/browser/src/backend/services/window-layout/system-passkey-relay.ts
@@ -407,10 +407,12 @@ export class SystemPasskeyRelay extends DisposableService {
       this.pending.delete(message.id);
     };
     socket.onclose = () => {
-      this.failPending('socket closed');
       // Same reason as the child process: a close arriving after the next
-      // ceremony has connected must not drop that ceremony's socket.
-      if (this.socket === socket) this.socket = null;
+      // ceremony has connected belongs to the old socket, and must touch
+      // neither the handle nor the commands the new one has in flight.
+      if (this.socket !== socket) return;
+      this.failPending('socket closed');
+      this.socket = null;
     };
     this.socket = socket;
   }

--- a/apps/browser/src/backend/services/window-layout/system-passkey-relay.ts
+++ b/apps/browser/src/backend/services/window-layout/system-passkey-relay.ts
@@ -1,0 +1,465 @@
+import { spawn, type ChildProcess } from 'node:child_process';
+import { existsSync, rmSync } from 'node:fs';
+import { createServer } from 'node:net';
+import path from 'node:path';
+import { app, screen } from 'electron';
+import { DisposableService } from '../disposable';
+import type { Logger } from '../logger';
+
+/** Ceremonies wait on a human — scanning a QR code takes a while. */
+const CEREMONY_TIMEOUT_MS = 180_000;
+const LAUNCH_TIMEOUT_MS = 20_000;
+const WINDOW = { width: 520, height: 680 };
+
+/**
+ * Browsers that ship a real platform authenticator, most preferred first.
+ * Any Chromium with a remote debugging port will do; Chrome is just the one
+ * most likely to be installed and signed in.
+ */
+function browserCandidates(): string[] {
+  if (process.platform === 'darwin') {
+    return [
+      '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+      '/Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary',
+      '/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge',
+      '/Applications/Brave Browser.app/Contents/MacOS/Brave Browser',
+      '/Applications/Chromium.app/Contents/MacOS/Chromium',
+    ];
+  }
+  if (process.platform === 'win32') {
+    const roots = [
+      process.env.PROGRAMFILES,
+      process.env['PROGRAMFILES(X86)'],
+      process.env.LOCALAPPDATA,
+    ].filter((r): r is string => Boolean(r));
+    return roots.flatMap((root) => [
+      path.join(root, 'Google/Chrome/Application/chrome.exe'),
+      path.join(root, 'Microsoft/Edge/Application/msedge.exe'),
+    ]);
+  }
+  return [
+    '/usr/bin/google-chrome',
+    '/usr/bin/google-chrome-stable',
+    '/usr/bin/microsoft-edge',
+    '/usr/bin/chromium',
+    '/usr/bin/chromium-browser',
+  ];
+}
+
+function findBrowser(): string | null {
+  return browserCandidates().find((p) => existsSync(p)) ?? null;
+}
+
+async function freePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = createServer();
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      const port = typeof address === 'object' && address ? address.port : 0;
+      server.close(() => (port ? resolve(port) : reject(new Error('no port'))));
+    });
+  });
+}
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+export type RelayResult =
+  | { ok: true; credential: unknown }
+  | { ok: false; error: string };
+
+/**
+ * Decides whether a ceremony request may run, and for which origin.
+ *
+ * Kept separate from the IPC plumbing because this is the security boundary:
+ * it is what stops a third-party iframe from obtaining an assertion for the
+ * page that embeds it.
+ */
+export function authorizeCeremony(request: {
+  kind: unknown;
+  inBrowsingSession: boolean;
+  isMainFrame: boolean;
+  frameOrigin: string | null;
+}): { ok: true; origin: string } | { ok: false; error: string } {
+  // Only sign-ins are relayed. Registering through the helper browser would
+  // write a passkey into the user's real keychain — and syncing it to every
+  // device they own — for what is usually a page they are only testing.
+  // Registration stays with the tab's own virtual authenticator.
+  if (request.kind !== 'get') return { ok: false, error: 'BadRequest' };
+
+  // Only browsing tabs relay; the app's own UI has no business here.
+  if (!request.inBrowsingSession)
+    return { ok: false, error: 'NotABrowsingTab' };
+
+  // The override is injected into every frame and the preload runs in
+  // subframes, so a third-party iframe can reach the handler. Answering it
+  // with the tab's origin would hand that iframe an assertion for the page
+  // embedding it — what the `publickey-credentials-get` permissions policy
+  // exists to prevent.
+  if (!request.isMainFrame) return { ok: false, error: 'NotAMainFrame' };
+
+  // An opaque origin reports "null"; nothing but a real web origin may become
+  // a URL the helper browser is pointed at.
+  const origin = request.frameOrigin ?? '';
+  if (!origin.startsWith('https://') && !origin.startsWith('http://'))
+    return { ok: false, error: 'BadOrigin' };
+
+  return { ok: true, origin };
+}
+
+/** CDP reports credential ids as standard base64; pages send base64url. */
+function normalizeCredentialId(id: string): string {
+  return id.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+/**
+ * Whether the tab's own virtual authenticator already holds the passkey the
+ * page is asking for, in which case there is nothing to relay.
+ *
+ * A passkey registered inside the preview browser is the one the page means,
+ * and it is the whole point of the virtual authenticator. Opening a window onto
+ * the user's real passkeys to look for it would find nothing, so this decides
+ * from what is actually stored rather than by letting a lookup fail first.
+ */
+export function shouldUseLocalAuthenticator(
+  options: unknown,
+  origin: string,
+  stored: readonly { credentialId: string; rpId: string }[],
+): boolean {
+  const request = (options ?? {}) as {
+    rpId?: unknown;
+    allowCredentials?: unknown;
+  };
+
+  let rpId = typeof request.rpId === 'string' ? request.rpId : null;
+  if (!rpId) {
+    try {
+      rpId = new URL(origin).hostname;
+    } catch {
+      return false;
+    }
+  }
+
+  const local = stored.filter((credential) => credential.rpId === rpId);
+  if (local.length === 0) return false;
+
+  // An empty or absent list means any discoverable credential for the relying
+  // party will do, and we hold one.
+  const allowed = request.allowCredentials;
+  if (!Array.isArray(allowed) || allowed.length === 0) return true;
+
+  const ids = new Set(local.map((c) => normalizeCredentialId(c.credentialId)));
+  return allowed.some(
+    (descriptor: unknown) =>
+      typeof (descriptor as { id?: unknown })?.id === 'string' &&
+      ids.has(normalizeCredentialId((descriptor as { id: string }).id)),
+  );
+}
+
+/** Runs inside the helper browser, on the relying party's own origin. */
+const CEREMONY_SCRIPT = `(async (optionsJson) => {
+  try {
+    const options = PublicKeyCredential.parseRequestOptionsFromJSON(optionsJson);
+    const credential = await navigator.credentials.get({ publicKey: options });
+    if (!credential) return { ok: false, error: 'NotAllowedError' };
+    return { ok: true, credential: credential.toJSON() };
+  } catch (err) {
+    return { ok: false, error: err && err.name ? err.name : String(err) };
+  }
+})`;
+
+/**
+ * Runs a WebAuthn ceremony in a real browser so the preview tab can use the
+ * passkeys already on this machine.
+ *
+ * Electron ships Chromium's WebAuthn implementation with no platform
+ * authenticator behind it, and the native one added in Electron 41
+ * (`app.configureWebAuthn`) only reaches device-bound Secure Enclave
+ * credentials, needs a `keychain-access-groups` entitlement, and does not exist
+ * on the version we build against. The virtual authenticator covers registering
+ * a passkey inside the preview browser, but it cannot see a passkey that
+ * already lives in iCloud Keychain or on a phone.
+ *
+ * A real browser can see all of them. So the ceremony is forwarded to one: a
+ * throwaway profile is opened on the relying party's own origin, the ceremony
+ * runs there over CDP, and the resulting assertion comes back to the preview
+ * tab. The assertion is signed over the challenge the site issued and over that
+ * same origin, so the site verifies it exactly as if it had been produced here.
+ * Only the ceremony is relayed — cookies, storage and the session stay in the
+ * preview browser. Only sign-ins are relayed, too: see `authorizeCeremony`.
+ *
+ * The helper browser exists only for the length of one ceremony. Its remote
+ * debugging port has no authentication, so keeping it open between sign-ins
+ * would leave a window for any other local process to drive it.
+ */
+export class SystemPasskeyRelay extends DisposableService {
+  private readonly logger: Logger;
+  private readonly browserPath: string | null;
+
+  private child: ChildProcess | null = null;
+  private socket: WebSocket | null = null;
+  private nextId = 0;
+  private readonly pending = new Map<
+    number,
+    (message: Record<string, unknown>) => void
+  >();
+  /** Each ceremony owns the helper browser, so only one may run at a time. */
+  private busy = false;
+  private readonly profileRoot: string;
+  private profile: string | null = null;
+  private ceremonyCount = 0;
+
+  constructor(logger: Logger) {
+    super();
+    this.logger = logger;
+    this.browserPath = findBrowser();
+    this.profileRoot = path.join(
+      app.getPath('userData'),
+      'passkey-relay-profiles',
+      String(process.pid),
+    );
+  }
+
+  /** Whether a browser capable of running the ceremony exists on this machine. */
+  public get available(): boolean {
+    return this.browserPath !== null;
+  }
+
+  public get browserName(): string | null {
+    return this.browserPath ? path.basename(this.browserPath) : null;
+  }
+
+  /** Whether a ceremony already owns the helper browser. */
+  public get running(): boolean {
+    return this.busy;
+  }
+
+  /**
+   * Runs one ceremony for `origin` and returns the credential as JSON.
+   *
+   * `optionsJson` is the site's own `PublicKeyCredentialRequestOptions` with the
+   * binary fields base64url-encoded, which is the shape
+   * `parseRequestOptionsFromJSON` expects on the other side.
+   */
+  public async run(origin: string, optionsJson: unknown): Promise<RelayResult> {
+    if (this.disposed) return { ok: false, error: 'RelayUnavailable' };
+    if (!this.browserPath) return { ok: false, error: 'NoSystemBrowser' };
+    // Queueing instead would let a window appear minutes later, over whatever
+    // the user had moved on to. The caller falls back to the tab's own
+    // authenticator, and a second attempt costs one more click.
+    if (this.busy) return { ok: false, error: 'RelayBusy' };
+
+    this.busy = true;
+    try {
+      return await this.runCeremony(origin, optionsJson);
+    } finally {
+      this.busy = false;
+    }
+  }
+
+  /**
+   * Abandons the ceremony in flight, if any.
+   *
+   * Closing the helper browser drops the CDP socket, which fails the pending
+   * evaluation and lets the ceremony unwind normally. Used when the tab that
+   * asked for the sign-in goes away and nobody is left to finish it.
+   */
+  public cancel(): void {
+    if (this.busy) this.stopBrowser();
+  }
+
+  private async runCeremony(
+    origin: string,
+    optionsJson: unknown,
+  ): Promise<RelayResult> {
+    try {
+      await this.launch(origin);
+      await this.waitForOrigin(origin);
+
+      const evaluated = (await this.send('Runtime.evaluate', {
+        expression: `${CEREMONY_SCRIPT}(${JSON.stringify(optionsJson)})`,
+        awaitPromise: true,
+        returnByValue: true,
+        userGesture: true,
+        timeout: CEREMONY_TIMEOUT_MS,
+      })) as { result?: { value?: RelayResult } };
+
+      return evaluated.result?.value ?? { ok: false, error: 'NoResult' };
+    } catch (err) {
+      this.logger.warn(`[SystemPasskeyRelay] Ceremony failed: ${err}`);
+      return { ok: false, error: 'RelayUnavailable' };
+    } finally {
+      this.stopBrowser();
+    }
+  }
+
+  /**
+   * Opens the helper browser directly on `origin` and attaches to its page.
+   *
+   * `--app` gives a window without tabs or an omnibox, so what the user sees is
+   * a sign-in dialog rather than a second browser appearing from nowhere.
+   */
+  private async launch(origin: string): Promise<void> {
+    if (!this.browserPath) throw new Error('no system browser');
+    this.stopBrowser();
+
+    const port = await freePort();
+    // A profile of its own, thrown away after the ceremony: whatever the
+    // relying party's page leaves behind — cookies, storage, cache — goes with
+    // it, and nothing touches the user's real browser session. Passkeys live in
+    // the OS keychain or on a phone rather than in the profile, so starting
+    // from empty still reaches every one of them.
+    //
+    // The path is scoped to this process because a second stagewise sharing it
+    // would hit Chrome's profile lock: the launch would hand off to the running
+    // copy and exit, leaving nothing listening on the port we just picked.
+    this.profile = path.join(this.profileRoot, String(++this.ceremonyCount));
+    const bounds = screen.getPrimaryDisplay().workArea;
+
+    this.child = spawn(
+      this.browserPath,
+      [
+        `--app=${origin}`,
+        `--remote-debugging-port=${port}`,
+        `--user-data-dir=${this.profile}`,
+        `--window-size=${WINDOW.width},${WINDOW.height}`,
+        `--window-position=${Math.round(bounds.x + (bounds.width - WINDOW.width) / 2)},${Math.round(bounds.y + (bounds.height - WINDOW.height) / 2)}`,
+        '--no-first-run',
+        '--no-default-browser-check',
+        '--no-service-autorun',
+        '--disable-background-networking',
+        '--disable-sync',
+      ],
+      { stdio: 'ignore', detached: false },
+    );
+    this.child.on('exit', () => {
+      this.child = null;
+    });
+
+    const deadline = Date.now() + LAUNCH_TIMEOUT_MS;
+    let pageSocketUrl: string | null = null;
+    while (Date.now() < deadline && !pageSocketUrl) {
+      await sleep(200);
+      try {
+        const res = await fetch(`http://127.0.0.1:${port}/json/list`);
+        const targets = (await res.json()) as {
+          type?: string;
+          webSocketDebuggerUrl?: string;
+        }[];
+        pageSocketUrl =
+          targets.find((t) => t.type === 'page' && t.webSocketDebuggerUrl)
+            ?.webSocketDebuggerUrl ?? null;
+      } catch {
+        // Not listening yet.
+      }
+    }
+    if (!pageSocketUrl) throw new Error('helper browser never opened a page');
+
+    await this.connect(pageSocketUrl);
+    this.logger.debug(`[SystemPasskeyRelay] Helper browser ready on ${origin}`);
+  }
+
+  /**
+   * The helper browser will only mint an assertion for the origin its document
+   * is actually on, so the ceremony must not start until it has arrived there.
+   */
+  private async waitForOrigin(origin: string): Promise<void> {
+    for (let attempt = 0; attempt < 60; attempt++) {
+      const evaluated = (await this.send('Runtime.evaluate', {
+        expression: 'location.origin',
+        returnByValue: true,
+      }).catch(() => null)) as { result?: { value?: string } } | null;
+      if (evaluated?.result?.value === origin) return;
+      await sleep(250);
+    }
+    throw new Error(`helper browser never reached ${origin}`);
+  }
+
+  private async connect(debuggerUrl: string): Promise<void> {
+    const socket = new WebSocket(debuggerUrl);
+    await new Promise<void>((resolve, reject) => {
+      socket.onopen = () => resolve();
+      socket.onerror = () => reject(new Error('CDP socket failed'));
+    });
+    socket.onmessage = (event) => {
+      const message = JSON.parse(String(event.data)) as {
+        id?: number;
+      } & Record<string, unknown>;
+      if (typeof message.id !== 'number') return;
+      this.pending.get(message.id)?.(message);
+      this.pending.delete(message.id);
+    };
+    socket.onclose = () => {
+      for (const resolve of this.pending.values())
+        resolve({ error: { message: 'socket closed' } });
+      this.pending.clear();
+      this.socket = null;
+    };
+    this.socket = socket;
+  }
+
+  private send(
+    method: string,
+    params: Record<string, unknown> = {},
+  ): Promise<unknown> {
+    const socket = this.socket;
+    if (!socket || socket.readyState !== WebSocket.OPEN)
+      return Promise.reject(new Error('helper browser not connected'));
+
+    const id = ++this.nextId;
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        reject(new Error(`${method} timed out`));
+      }, CEREMONY_TIMEOUT_MS + 10_000);
+
+      this.pending.set(id, (message) => {
+        clearTimeout(timer);
+        const error = message.error as { message?: string } | undefined;
+        if (error) reject(new Error(error.message ?? method));
+        else resolve(message.result);
+      });
+      socket.send(JSON.stringify({ id, method, params }));
+    });
+  }
+
+  private stopBrowser(): void {
+    try {
+      this.socket?.close();
+    } catch {
+      // Already gone.
+    }
+    this.socket = null;
+    this.pending.clear();
+    if (this.child && !this.child.killed) this.child.kill();
+    this.child = null;
+    this.discardProfile();
+  }
+
+  /**
+   * Removes the profile the ceremony ran in, so the relying party's cookies and
+   * storage do not outlive the sign-in that created them.
+   */
+  private discardProfile(): void {
+    const profile = this.profile;
+    this.profile = null;
+    if (!profile) return;
+    try {
+      rmSync(profile, { recursive: true, force: true });
+    } catch (err) {
+      // Chrome may still be releasing files; the whole root goes at teardown.
+      this.logger.debug(
+        `[SystemPasskeyRelay] Could not remove the helper profile yet: ${err}`,
+      );
+    }
+  }
+
+  protected onTeardown(): void {
+    this.stopBrowser();
+    try {
+      rmSync(this.profileRoot, { recursive: true, force: true });
+    } catch {
+      // Nothing left to clean up on the next run either way.
+    }
+  }
+}

--- a/apps/browser/src/backend/services/window-layout/system-passkey-relay.ts
+++ b/apps/browser/src/backend/services/window-layout/system-passkey-relay.ts
@@ -131,14 +131,21 @@ export function shouldUseLocalAuthenticator(
     allowCredentials?: unknown;
   };
 
-  let rpId = typeof request.rpId === 'string' ? request.rpId : null;
-  if (!rpId) {
-    try {
-      rpId = new URL(origin).hostname;
-    } catch {
-      return false;
-    }
+  let host: string;
+  try {
+    host = new URL(origin).hostname;
+  } catch {
+    // Nothing to open a window onto; leave it with the native call.
+    return true;
   }
+
+  const rpId = typeof request.rpId === 'string' ? request.rpId : host;
+  // WebAuthn only lets a page claim an rpId its own origin sits under, and the
+  // native call rejects anything else with a SecurityError. Relaying one of
+  // those instead would open a window and turn the choice of path into an
+  // oracle: a page could ask with someone else's rpId and learn from the
+  // answer whether this machine holds a passkey for that site.
+  if (host !== rpId && !host.endsWith(`.${rpId}`)) return true;
 
   const local = stored.filter((credential) => credential.rpId === rpId);
   if (local.length === 0) return false;
@@ -316,7 +323,7 @@ export class SystemPasskeyRelay extends DisposableService {
     this.profile = path.join(this.profileRoot, String(++this.ceremonyCount));
     const bounds = screen.getPrimaryDisplay().workArea;
 
-    this.child = spawn(
+    const child = spawn(
       this.browserPath,
       [
         `--app=${origin}`,
@@ -332,9 +339,19 @@ export class SystemPasskeyRelay extends DisposableService {
       ],
       { stdio: 'ignore', detached: false },
     );
-    this.child.on('exit', () => {
-      this.child = null;
+    this.child = child;
+    // A ChildProcess with no 'error' listener rethrows, and a browser that
+    // cannot be executed at all would take the main process down with it.
+    child.on('error', (err) => {
+      this.logger.warn(
+        `[SystemPasskeyRelay] Helper browser could not be started: ${err}`,
+      );
+      this.forgetChild(child);
     });
+    // Only if this is still the current child: a late exit from the previous
+    // ceremony's browser would otherwise drop the handle to this one, and its
+    // window would outlive every ceremony after it.
+    child.on('exit', () => this.forgetChild(child));
 
     const deadline = Date.now() + LAUNCH_TIMEOUT_MS;
     let pageSocketUrl: string | null = null;
@@ -390,12 +407,32 @@ export class SystemPasskeyRelay extends DisposableService {
       this.pending.delete(message.id);
     };
     socket.onclose = () => {
-      for (const resolve of this.pending.values())
-        resolve({ error: { message: 'socket closed' } });
-      this.pending.clear();
-      this.socket = null;
+      this.failPending('socket closed');
+      // Same reason as the child process: a close arriving after the next
+      // ceremony has connected must not drop that ceremony's socket.
+      if (this.socket === socket) this.socket = null;
     };
     this.socket = socket;
+  }
+
+  /**
+   * Fails every command still in flight.
+   *
+   * The stored callbacks reject on an `error` member, so this is what unwinds a
+   * ceremony whose browser has gone away. Waiting for `onclose` to do it would
+   * not work: the socket closes a turn later, by which point `stopBrowser` has
+   * already emptied the map, and the ceremony would sit on the `send` timeout —
+   * holding the relay busy, and every other tab with it, for three minutes.
+   */
+  private failPending(reason: string): void {
+    for (const settle of this.pending.values())
+      settle({ error: { message: reason } });
+    this.pending.clear();
+  }
+
+  /** Drops the handle to `child`, unless a later ceremony has replaced it. */
+  private forgetChild(child: ChildProcess): void {
+    if (this.child === child) this.child = null;
   }
 
   private send(
@@ -430,7 +467,7 @@ export class SystemPasskeyRelay extends DisposableService {
       // Already gone.
     }
     this.socket = null;
-    this.pending.clear();
+    this.failPending('helper browser stopped');
     if (this.child && !this.child.killed) this.child.kill();
     this.child = null;
     this.discardProfile();

--- a/apps/browser/src/backend/services/window-layout/tab-passkey-authenticator/credential-store.ts
+++ b/apps/browser/src/backend/services/window-layout/tab-passkey-authenticator/credential-store.ts
@@ -13,7 +13,7 @@ export const storedPasskeyCredentialSchema = z.object({
   credentialId: z.string(),
   rpId: z.string(),
   isResidentCredential: z.boolean(),
-  /** Base64 PKCS#8 private key. Persisted encrypted via safeStorage. */
+  /** Base64 PKCS#8 private key. */
   privateKey: z.string(),
   userHandle: z.string().optional(),
   signCount: z.number(),
@@ -44,7 +44,8 @@ export interface PasskeyCredentialStore {
  * `persist:browser-content` session, so this is a single process-wide store.
  *
  * Private keys are written through safeStorage, matching how the app persists
- * its other credentials.
+ * its other credentials — which also means they fall back to plaintext on
+ * systems where no OS keyring is available.
  */
 export class PersistedPasskeyCredentialStore implements PasskeyCredentialStore {
   private static instance: PersistedPasskeyCredentialStore | null = null;

--- a/apps/browser/src/backend/services/window-layout/tab-passkey-authenticator/credential-store.ts
+++ b/apps/browser/src/backend/services/window-layout/tab-passkey-authenticator/credential-store.ts
@@ -1,0 +1,95 @@
+import { z } from 'zod';
+import type { Logger } from '../../logger';
+import {
+  readPersistedDataSync,
+  writePersistedDataSync,
+} from '../../../utils/persisted-data';
+
+/**
+ * A credential held by the virtual authenticator, in the shape CDP's
+ * `WebAuthn.Credential` type uses. All binary fields are base64.
+ */
+export const storedPasskeyCredentialSchema = z.object({
+  credentialId: z.string(),
+  rpId: z.string(),
+  isResidentCredential: z.boolean(),
+  /** Base64 PKCS#8 private key. Persisted encrypted via safeStorage. */
+  privateKey: z.string(),
+  userHandle: z.string().optional(),
+  signCount: z.number(),
+});
+
+export type StoredPasskeyCredential = z.infer<
+  typeof storedPasskeyCredentialSchema
+>;
+
+const passkeyFileSchema = z.object({
+  credentials: z.array(storedPasskeyCredentialSchema),
+});
+
+/**
+ * Read/write access to the passkeys the preview browser has registered.
+ */
+export interface PasskeyCredentialStore {
+  list(): StoredPasskeyCredential[];
+  save(credential: StoredPasskeyCredential): void;
+}
+
+/**
+ * Stores passkeys registered inside the preview browser.
+ *
+ * The virtual authenticator is destroyed whenever the debugger detaches or the
+ * tab navigates cross-origin, and a fresh one starts empty, so credentials have
+ * to live here rather than in Chromium. Tabs share the
+ * `persist:browser-content` session, so this is a single process-wide store.
+ *
+ * Private keys are written through safeStorage, matching how the app persists
+ * its other credentials.
+ */
+export class PersistedPasskeyCredentialStore implements PasskeyCredentialStore {
+  private static instance: PersistedPasskeyCredentialStore | null = null;
+
+  private readonly logger: Logger;
+  private credentials: StoredPasskeyCredential[];
+
+  private constructor(logger: Logger) {
+    this.logger = logger;
+    this.credentials = readPersistedDataSync(
+      'passkeys',
+      passkeyFileSchema,
+      { credentials: [] },
+      { encrypt: true },
+    ).credentials;
+  }
+
+  public static getInstance(logger: Logger): PersistedPasskeyCredentialStore {
+    if (!PersistedPasskeyCredentialStore.instance) {
+      PersistedPasskeyCredentialStore.instance =
+        new PersistedPasskeyCredentialStore(logger);
+    }
+    return PersistedPasskeyCredentialStore.instance;
+  }
+
+  public list(): StoredPasskeyCredential[] {
+    return this.credentials;
+  }
+
+  public save(credential: StoredPasskeyCredential): void {
+    const index = this.credentials.findIndex(
+      (c) => c.credentialId === credential.credentialId,
+    );
+    if (index >= 0) this.credentials[index] = credential;
+    else this.credentials.push(credential);
+
+    try {
+      writePersistedDataSync(
+        'passkeys',
+        passkeyFileSchema,
+        { credentials: this.credentials },
+        { encrypt: true },
+      );
+    } catch (err) {
+      this.logger.error(`[PasskeyCredentialStore] Failed to persist: ${err}`);
+    }
+  }
+}

--- a/apps/browser/src/backend/services/window-layout/tab-passkey-authenticator/index.test.ts
+++ b/apps/browser/src/backend/services/window-layout/tab-passkey-authenticator/index.test.ts
@@ -180,6 +180,28 @@ describe('TabPasskeyAuthenticator', () => {
     authenticator.destroy();
   });
 
+  it('reinstalls after DevTools closes', async () => {
+    const wc = createWebContents();
+    const { store } = createStore();
+
+    const authenticator = new TabPasskeyAuthenticator(
+      wc,
+      store,
+      logger as never,
+    );
+    await authenticator.install();
+    expect(callsFor(wc, 'WebAuthn.addVirtualAuthenticator')).toHaveLength(1);
+
+    // Closing DevTools disables the virtual authenticator environment without
+    // detaching the debugger or navigating, so nothing else triggers a rebuild.
+    wc.emit('devtools-closed');
+    await vi.waitFor(() =>
+      expect(callsFor(wc, 'WebAuthn.addVirtualAuthenticator')).toHaveLength(2),
+    );
+
+    authenticator.destroy();
+  });
+
   it('reinstalls after a cross-origin navigation but not a same-origin one', async () => {
     const wc = createWebContents('https://app.example.com/login');
     const { store } = createStore();

--- a/apps/browser/src/backend/services/window-layout/tab-passkey-authenticator/index.test.ts
+++ b/apps/browser/src/backend/services/window-layout/tab-passkey-authenticator/index.test.ts
@@ -36,10 +36,12 @@ function createWebContents(url = 'https://app.example.com/login') {
   // reinstall which forgets to clean up is a test failure, not a silent one.
   let live: string | null = null;
   let nextId = 1;
+  let gate: Promise<void> | null = null;
   const dbg = Object.assign(new EventEmitter(), {
     isAttached: vi.fn(() => true),
     attach: vi.fn(),
     sendCommand: vi.fn(async (method: string, params?: unknown) => {
+      if (gate) await gate;
       if (method === 'WebAuthn.addVirtualAuthenticator') {
         if (live)
           throw new Error(
@@ -57,6 +59,17 @@ function createWebContents(url = 'https://app.example.com/login') {
       return {};
     }),
     liveAuthenticatorId: () => live,
+    /** Holds every CDP command open until the returned function is called. */
+    blockCommands: () => {
+      let release!: () => void;
+      gate = new Promise<void>((resolve) => {
+        release = () => {
+          gate = null;
+          resolve();
+        };
+      });
+      return release;
+    },
   });
   const wc = Object.assign(new EventEmitter(), {
     debugger: dbg,
@@ -254,6 +267,32 @@ describe('TabPasskeyAuthenticator', () => {
 
     // stored credentials get seeded onto the replacement too
     expect(callsFor(wc, 'WebAuthn.addCredential')).toHaveLength(2);
+
+    authenticator.destroy();
+  });
+
+  it('runs a reinstall requested while an install is still in flight', async () => {
+    const wc = createWebContents();
+    const { store } = createStore();
+
+    const authenticator = new TabPasskeyAuthenticator(
+      wc,
+      store,
+      logger as never,
+    );
+
+    const release = wc.debugger.blockCommands();
+    const inFlight = authenticator.install();
+    // The tab loses the authenticator this install is still building, so the
+    // finished one is stale the moment it lands.
+    wc.emit('did-navigate', {}, 'https://other.example.org/');
+    release();
+    await inFlight;
+
+    await vi.waitFor(() =>
+      expect(callsFor(wc, 'WebAuthn.addVirtualAuthenticator')).toHaveLength(2),
+    );
+    expect(logger.error).not.toHaveBeenCalled();
 
     authenticator.destroy();
   });

--- a/apps/browser/src/backend/services/window-layout/tab-passkey-authenticator/index.test.ts
+++ b/apps/browser/src/backend/services/window-layout/tab-passkey-authenticator/index.test.ts
@@ -36,6 +36,7 @@ function createWebContents(url = 'https://app.example.com/login') {
   // reinstall which forgets to clean up is a test failure, not a silent one.
   let live: string | null = null;
   let nextId = 1;
+  let nextScriptId = 1;
   let gate: Promise<void> | null = null;
   const dbg = Object.assign(new EventEmitter(), {
     isAttached: vi.fn(() => true),
@@ -50,6 +51,8 @@ function createWebContents(url = 'https://app.example.com/login') {
         live = `auth-${nextId++}`;
         return { authenticatorId: live };
       }
+      if (method === 'Page.addScriptToEvaluateOnNewDocument')
+        return { identifier: `script-${nextScriptId++}` };
       if (method === 'WebAuthn.removeVirtualAuthenticator') {
         const { authenticatorId } = params as { authenticatorId: string };
         if (live !== authenticatorId)
@@ -211,6 +214,43 @@ describe('TabPasskeyAuthenticator', () => {
     await vi.waitFor(() =>
       expect(callsFor(wc, 'WebAuthn.addVirtualAuthenticator')).toHaveLength(2),
     );
+
+    authenticator.destroy();
+  });
+
+  it('installs the main-world override that reaches the system passkeys', async () => {
+    const wc = createWebContents();
+    const { store } = createStore();
+
+    const authenticator = new TabPasskeyAuthenticator(
+      wc,
+      store,
+      logger as never,
+    );
+    await authenticator.install();
+
+    // A preload cannot reach the main world and a <script> element is blocked
+    // by a strict script-src, so this has to arrive over CDP.
+    const added = callsFor(wc, 'Page.addScriptToEvaluateOnNewDocument');
+    expect(added).toHaveLength(1);
+    expect((added[0]?.[1] as { source: string }).source).toContain(
+      '__stagewisePasskeyRequest',
+    );
+    // …and again for the document already on screen.
+    expect(callsFor(wc, 'Runtime.evaluate')).toHaveLength(1);
+
+    // The registration dies with the CDP session, so a reinstall has to drop
+    // the stale one rather than stack a second override.
+    wc.debugger.emit('detach');
+    await vi.waitFor(() =>
+      expect(
+        callsFor(wc, 'Page.addScriptToEvaluateOnNewDocument'),
+      ).toHaveLength(2),
+    );
+    expect(
+      callsFor(wc, 'Page.removeScriptToEvaluateOnNewDocument'),
+    ).toHaveLength(1);
+    expect(logger.error).not.toHaveBeenCalled();
 
     authenticator.destroy();
   });

--- a/apps/browser/src/backend/services/window-layout/tab-passkey-authenticator/index.test.ts
+++ b/apps/browser/src/backend/services/window-layout/tab-passkey-authenticator/index.test.ts
@@ -1,0 +1,257 @@
+import { EventEmitter } from 'node:events';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { TabPasskeyAuthenticator } from './index';
+import type {
+  PasskeyCredentialStore,
+  StoredPasskeyCredential,
+} from './credential-store';
+
+vi.mock('electron', () => ({}));
+
+const logger = {
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+};
+
+function createStore(initial: StoredPasskeyCredential[] = []) {
+  const credentials = [...initial];
+  const store: PasskeyCredentialStore = {
+    list: vi.fn(() => credentials),
+    save: vi.fn((credential: StoredPasskeyCredential) => {
+      const index = credentials.findIndex(
+        (c) => c.credentialId === credential.credentialId,
+      );
+      if (index >= 0) credentials[index] = credential;
+      else credentials.push(credential);
+    }),
+  };
+  return { store, credentials };
+}
+
+function createWebContents(url = 'https://app.example.com/login') {
+  // Chrome permits exactly one internal authenticator per CDP session; adding a
+  // second without removing the first fails. The mock enforces that so a
+  // reinstall which forgets to clean up is a test failure, not a silent one.
+  let live: string | null = null;
+  let nextId = 1;
+  const dbg = Object.assign(new EventEmitter(), {
+    isAttached: vi.fn(() => true),
+    attach: vi.fn(),
+    sendCommand: vi.fn(async (method: string, params?: unknown) => {
+      if (method === 'WebAuthn.addVirtualAuthenticator') {
+        if (live)
+          throw new Error(
+            'Chrome only supports one internal authenticator per environment',
+          );
+        live = `auth-${nextId++}`;
+        return { authenticatorId: live };
+      }
+      if (method === 'WebAuthn.removeVirtualAuthenticator') {
+        const { authenticatorId } = params as { authenticatorId: string };
+        if (live !== authenticatorId)
+          throw new Error('Could not find a Virtual Authenticator matching ID');
+        live = null;
+      }
+      return {};
+    }),
+    liveAuthenticatorId: () => live,
+  });
+  const wc = Object.assign(new EventEmitter(), {
+    debugger: dbg,
+    isDestroyed: vi.fn(() => false),
+    getURL: vi.fn(() => url),
+  });
+  return wc as unknown as Electron.WebContents & {
+    debugger: typeof dbg;
+    emit: EventEmitter['emit'];
+  };
+}
+
+const sentMethods = (wc: ReturnType<typeof createWebContents>) =>
+  wc.debugger.sendCommand.mock.calls.map((c) => c[0] as string);
+
+const callsFor = (wc: ReturnType<typeof createWebContents>, method: string) =>
+  wc.debugger.sendCommand.mock.calls.filter((c) => c[0] === method);
+
+const sampleCredential: StoredPasskeyCredential = {
+  credentialId: 'Y3JlZC1pZA==',
+  rpId: 'app.example.com',
+  isResidentCredential: true,
+  privateKey: 'cHJpdmF0ZS1rZXk=',
+  userHandle: 'dXNlci1oYW5kbGU=',
+  signCount: 3,
+};
+
+describe('TabPasskeyAuthenticator', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('installs a virtual authenticator so WebAuthn requests can complete', async () => {
+    const wc = createWebContents();
+    const { store } = createStore();
+
+    const authenticator = new TabPasskeyAuthenticator(
+      wc,
+      store,
+      logger as never,
+    );
+    await authenticator.install();
+
+    expect(sentMethods(wc)).toContain('WebAuthn.enable');
+    expect(sentMethods(wc)).toContain('WebAuthn.addVirtualAuthenticator');
+
+    const [, enableParams] = callsFor(wc, 'WebAuthn.enable')[0]!;
+    // Chromium's native WebAuthn UI is not compiled into Electron, so the
+    // request would hang waiting for a dialog that can never render.
+    expect(enableParams).toMatchObject({ enableUI: false });
+
+    const [, addParams] = callsFor(wc, 'WebAuthn.addVirtualAuthenticator')[0]!;
+    expect(addParams).toMatchObject({
+      options: {
+        transport: 'internal',
+        hasResidentKey: true,
+        hasUserVerification: true,
+        automaticPresenceSimulation: true,
+        isUserVerified: true,
+      },
+    });
+  });
+
+  it('seeds previously stored credentials onto the new authenticator', async () => {
+    const wc = createWebContents();
+    const { store } = createStore([sampleCredential]);
+
+    await new TabPasskeyAuthenticator(wc, store, logger as never).install();
+
+    const added = callsFor(wc, 'WebAuthn.addCredential');
+    expect(added).toHaveLength(1);
+    expect(added[0]![1]).toMatchObject({
+      authenticatorId: 'auth-1',
+      credential: sampleCredential,
+    });
+  });
+
+  it('persists credentials created and asserted by the page', async () => {
+    const wc = createWebContents();
+    const { store, credentials } = createStore();
+
+    const authenticator = new TabPasskeyAuthenticator(
+      wc,
+      store,
+      logger as never,
+    );
+    await authenticator.install();
+
+    wc.debugger.emit('message', {}, 'WebAuthn.credentialAdded', {
+      authenticatorId: 'auth-1',
+      credential: sampleCredential,
+    });
+    expect(credentials).toEqual([sampleCredential]);
+
+    wc.debugger.emit('message', {}, 'WebAuthn.credentialAsserted', {
+      authenticatorId: 'auth-1',
+      credential: { ...sampleCredential, signCount: 4 },
+    });
+    expect(credentials).toEqual([{ ...sampleCredential, signCount: 4 }]);
+  });
+
+  it('reinstalls after the debugger detaches and reattaches', async () => {
+    const wc = createWebContents();
+    const { store } = createStore();
+
+    const authenticator = new TabPasskeyAuthenticator(
+      wc,
+      store,
+      logger as never,
+    );
+    await authenticator.install();
+    expect(callsFor(wc, 'WebAuthn.addVirtualAuthenticator')).toHaveLength(1);
+
+    // Detaching destroys the virtual authenticator; re-enabling alone does not
+    // bring it back, so the authenticator has to be added again.
+    wc.debugger.emit('detach');
+    await vi.waitFor(() =>
+      expect(callsFor(wc, 'WebAuthn.addVirtualAuthenticator')).toHaveLength(2),
+    );
+
+    authenticator.destroy();
+  });
+
+  it('reinstalls after a cross-origin navigation but not a same-origin one', async () => {
+    const wc = createWebContents('https://app.example.com/login');
+    const { store } = createStore();
+
+    const authenticator = new TabPasskeyAuthenticator(
+      wc,
+      store,
+      logger as never,
+    );
+    await authenticator.install();
+
+    wc.emit('did-navigate', {}, 'https://app.example.com/dashboard');
+    await vi.waitFor(() =>
+      expect(callsFor(wc, 'WebAuthn.addVirtualAuthenticator')).toHaveLength(1),
+    );
+
+    wc.emit('did-navigate', {}, 'https://other.example.org/');
+    await vi.waitFor(() =>
+      expect(callsFor(wc, 'WebAuthn.addVirtualAuthenticator')).toHaveLength(2),
+    );
+
+    authenticator.destroy();
+  });
+
+  it('removes the previous authenticator before adding its replacement', async () => {
+    const wc = createWebContents();
+    const { store } = createStore([sampleCredential]);
+
+    const authenticator = new TabPasskeyAuthenticator(
+      wc,
+      store,
+      logger as never,
+    );
+    await authenticator.install();
+    const first = wc.debugger.liveAuthenticatorId();
+    expect(first).toBe('auth-1');
+
+    wc.emit('did-navigate', {}, 'https://other.example.org/');
+    await vi.waitFor(() =>
+      expect(callsFor(wc, 'WebAuthn.addVirtualAuthenticator')).toHaveLength(2),
+    );
+
+    // Chrome refuses a second internal authenticator, so the reinstall must
+    // drop the old one first or the tab is left with no working authenticator.
+    expect(callsFor(wc, 'WebAuthn.removeVirtualAuthenticator')[0]![1]).toEqual({
+      authenticatorId: first,
+    });
+    expect(wc.debugger.liveAuthenticatorId()).toBe('auth-2');
+    expect(logger.error).not.toHaveBeenCalled();
+
+    // stored credentials get seeded onto the replacement too
+    expect(callsFor(wc, 'WebAuthn.addCredential')).toHaveLength(2);
+
+    authenticator.destroy();
+  });
+
+  it('does not send CDP commands once destroyed', async () => {
+    const wc = createWebContents();
+    const { store } = createStore();
+
+    const authenticator = new TabPasskeyAuthenticator(
+      wc,
+      store,
+      logger as never,
+    );
+    await authenticator.install();
+    authenticator.destroy();
+
+    const before = wc.debugger.sendCommand.mock.calls.length;
+    wc.emit('did-navigate', {}, 'https://other.example.org/');
+    await authenticator.install();
+
+    expect(wc.debugger.sendCommand.mock.calls.length).toBe(before);
+  });
+});

--- a/apps/browser/src/backend/services/window-layout/tab-passkey-authenticator/index.ts
+++ b/apps/browser/src/backend/services/window-layout/tab-passkey-authenticator/index.ts
@@ -54,6 +54,8 @@ export class TabPasskeyAuthenticator {
   private destroyed = false;
   /** In-flight install, so overlapping triggers don't add two authenticators. */
   private installing: Promise<void> | null = null;
+  /** A trigger arrived mid-install, so the one being built is already stale. */
+  private reinstallQueued = false;
 
   private readonly boundHandleDetach: () => void;
   private readonly boundHandleMessage: (
@@ -91,12 +93,22 @@ export class TabPasskeyAuthenticator {
 
   /**
    * Installs the virtual authenticator and seeds it with stored credentials.
-   * Safe to call repeatedly; a no-op while one is already installed.
+   * Safe to call repeatedly; calls made during an install are coalesced into a
+   * single follow-up run.
    */
   public async install(): Promise<void> {
-    if (this.installing) return this.installing;
+    if (this.installing) {
+      // Whatever this install ends up with was already destroyed by the event
+      // that got us here, so it has to run again rather than be waited on.
+      this.reinstallQueued = true;
+      return this.installing;
+    }
     this.installing = this.doInstall().finally(() => {
       this.installing = null;
+      if (this.reinstallQueued) {
+        this.reinstallQueued = false;
+        void this.install();
+      }
     });
     return this.installing;
   }

--- a/apps/browser/src/backend/services/window-layout/tab-passkey-authenticator/index.ts
+++ b/apps/browser/src/backend/services/window-layout/tab-passkey-authenticator/index.ts
@@ -1,4 +1,5 @@
 import type { WebContents } from 'electron';
+import { PASSKEY_RELAY_MAIN_WORLD_SCRIPT } from '@shared/passkey-relay-script';
 import type { Logger } from '../../logger';
 import {
   type PasskeyCredentialStore,
@@ -56,6 +57,8 @@ export class TabPasskeyAuthenticator {
   private installing: Promise<void> | null = null;
   /** A trigger arrived mid-install, so the one being built is already stale. */
   private reinstallQueued = false;
+  /** Registration id of the main-world relay override, per CDP session. */
+  private relayScriptId: string | null = null;
 
   private readonly boundHandleDetach: () => void;
   private readonly boundHandleMessage: (
@@ -170,12 +173,61 @@ export class TabPasskeyAuthenticator {
         }
       }
 
+      await this.installRelayOverride(dbg);
+
       this.logger.debug(
         `[TabPasskeyAuthenticator] Installed ${authenticatorId} with ${this.store.list().length} credential(s)`,
       );
     } catch (err) {
       this.authenticatorId = null;
       this.logger.error(`[TabPasskeyAuthenticator] Install failed: ${err}`);
+    }
+  }
+
+  /**
+   * Hands the page's own JavaScript context an override of
+   * `navigator.credentials` that routes ceremonies to the system passkey relay.
+   *
+   * This goes through CDP rather than the preload script because a preload
+   * cannot reach the main world, and the `<script>` element trick the stealth
+   * overrides use is blocked outright by a strict `script-src` — which is
+   * exactly the kind of site people sign in to.
+   *
+   * The registration is per CDP session, so it is renewed on every reinstall
+   * alongside the authenticator itself.
+   */
+  private async installRelayOverride(
+    dbg: WebContents['debugger'],
+  ): Promise<void> {
+    try {
+      await dbg.sendCommand('Page.enable');
+      if (this.relayScriptId) {
+        await dbg
+          .sendCommand('Page.removeScriptToEvaluateOnNewDocument', {
+            identifier: this.relayScriptId,
+          })
+          .catch(() => {
+            // Gone with the previous session.
+          });
+        this.relayScriptId = null;
+      }
+
+      const { identifier } = (await dbg.sendCommand(
+        'Page.addScriptToEvaluateOnNewDocument',
+        { source: PASSKEY_RELAY_MAIN_WORLD_SCRIPT },
+      )) as { identifier: string };
+      this.relayScriptId = identifier;
+
+      // That only covers documents loaded from here on, and a reinstall often
+      // happens with a page already sitting there. The script guards itself
+      // against running twice.
+      await dbg.sendCommand('Runtime.evaluate', {
+        expression: PASSKEY_RELAY_MAIN_WORLD_SCRIPT,
+      });
+    } catch (err) {
+      this.logger.warn(
+        `[TabPasskeyAuthenticator] Could not install relay override: ${err}`,
+      );
     }
   }
 

--- a/apps/browser/src/backend/services/window-layout/tab-passkey-authenticator/index.ts
+++ b/apps/browser/src/backend/services/window-layout/tab-passkey-authenticator/index.ts
@@ -40,8 +40,9 @@ const VIRTUAL_AUTHENTICATOR_OPTIONS = {
  * Chromium still enforces the usual origin/RP-ID binding on top of it.
  *
  * The authenticator is bound to the tab's CDP session, so it is lost on
- * debugger detach and on cross-origin navigation (both measured); it is
- * reinstalled on each, with the stored credentials seeded back in.
+ * debugger detach, on cross-origin navigation and when DevTools closes (all
+ * measured); it is reinstalled on each, with the stored credentials seeded
+ * back in.
  */
 export class TabPasskeyAuthenticator {
   private readonly webContents: WebContents;
@@ -64,6 +65,7 @@ export class TabPasskeyAuthenticator {
     event: Electron.Event,
     url: string,
   ) => void;
+  private readonly boundHandleDevToolsClosed: () => void;
 
   constructor(
     webContents: WebContents,
@@ -79,10 +81,12 @@ export class TabPasskeyAuthenticator {
     this.boundHandleMessage = (_event, method, params) =>
       this.handleCdpMessage(method, params);
     this.boundHandleDidNavigate = (_event, url) => this.handleDidNavigate(url);
+    this.boundHandleDevToolsClosed = () => this.handleDevToolsClosed();
 
     this.webContents.debugger.on('detach', this.boundHandleDetach);
     this.webContents.debugger.on('message', this.boundHandleMessage);
     this.webContents.on('did-navigate', this.boundHandleDidNavigate);
+    this.webContents.on('devtools-closed', this.boundHandleDevToolsClosed);
   }
 
   /**
@@ -172,6 +176,17 @@ export class TabPasskeyAuthenticator {
     void this.install();
   }
 
+  /**
+   * Closing DevTools disables the virtual authenticator environment for the
+   * whole session — `WebAuthn.getCredentials` then fails with "The Virtual
+   * Authenticator Environment has not been enabled for this session". The
+   * debugger stays attached and no `detach` fires, so nothing else notices.
+   */
+  private handleDevToolsClosed(): void {
+    if (this.destroyed) return;
+    void this.install();
+  }
+
   private handleDidNavigate(url: string): void {
     const origin = this.originOf(url);
     if (origin === this.currentOrigin) return;
@@ -232,5 +247,6 @@ export class TabPasskeyAuthenticator {
     this.webContents.debugger.off('detach', this.boundHandleDetach);
     this.webContents.debugger.off('message', this.boundHandleMessage);
     this.webContents.off('did-navigate', this.boundHandleDidNavigate);
+    this.webContents.off('devtools-closed', this.boundHandleDevToolsClosed);
   }
 }

--- a/apps/browser/src/backend/services/window-layout/tab-passkey-authenticator/index.ts
+++ b/apps/browser/src/backend/services/window-layout/tab-passkey-authenticator/index.ts
@@ -1,0 +1,236 @@
+import type { WebContents } from 'electron';
+import type { Logger } from '../../logger';
+import {
+  type PasskeyCredentialStore,
+  type StoredPasskeyCredential,
+  storedPasskeyCredentialSchema,
+} from './credential-store';
+
+/**
+ * Options for the software authenticator installed into each tab.
+ *
+ * `transport: 'internal'` makes it look like a platform authenticator, which is
+ * what sites gate the "use a passkey" path on. Chromium's own passkey UI lives
+ * in `//chrome` and is not compiled into Electron, so there is no dialog to
+ * drive user presence and verification — both are simulated instead.
+ */
+const VIRTUAL_AUTHENTICATOR_OPTIONS = {
+  protocol: 'ctap2',
+  ctap2Version: 'ctap2_1',
+  transport: 'internal',
+  hasResidentKey: true,
+  hasUserVerification: true,
+  automaticPresenceSimulation: true,
+  isUserVerified: true,
+  defaultBackupEligibility: true,
+  defaultBackupState: true,
+} as const;
+
+/**
+ * Makes WebAuthn work in a browsing tab.
+ *
+ * Electron ships Chromium's WebAuthn implementation but none of the platform
+ * authenticator integrations, so `navigator.credentials.create()` finds no
+ * authenticator, never resolves and never rejects — the page's own `timeout` is
+ * not applied either, so a passkey login just hangs forever.
+ *
+ * Attaching a CDP virtual authenticator gives those requests something to talk
+ * to. It is a software authenticator: it can only see credentials registered
+ * inside the preview browser, never the real passkeys on the machine, and
+ * Chromium still enforces the usual origin/RP-ID binding on top of it.
+ *
+ * The authenticator is bound to the tab's CDP session, so it is lost on
+ * debugger detach and on cross-origin navigation (both measured); it is
+ * reinstalled on each, with the stored credentials seeded back in.
+ */
+export class TabPasskeyAuthenticator {
+  private readonly webContents: WebContents;
+  private readonly store: PasskeyCredentialStore;
+  private readonly logger: Logger;
+
+  private authenticatorId: string | null = null;
+  private currentOrigin: string;
+  private destroyed = false;
+  /** In-flight install, so overlapping triggers don't add two authenticators. */
+  private installing: Promise<void> | null = null;
+
+  private readonly boundHandleDetach: () => void;
+  private readonly boundHandleMessage: (
+    event: Electron.Event,
+    method: string,
+    params: unknown,
+  ) => void;
+  private readonly boundHandleDidNavigate: (
+    event: Electron.Event,
+    url: string,
+  ) => void;
+
+  constructor(
+    webContents: WebContents,
+    store: PasskeyCredentialStore,
+    logger: Logger,
+  ) {
+    this.webContents = webContents;
+    this.store = store;
+    this.logger = logger;
+    this.currentOrigin = this.originOf(webContents.getURL());
+
+    this.boundHandleDetach = () => this.handleDetach();
+    this.boundHandleMessage = (_event, method, params) =>
+      this.handleCdpMessage(method, params);
+    this.boundHandleDidNavigate = (_event, url) => this.handleDidNavigate(url);
+
+    this.webContents.debugger.on('detach', this.boundHandleDetach);
+    this.webContents.debugger.on('message', this.boundHandleMessage);
+    this.webContents.on('did-navigate', this.boundHandleDidNavigate);
+  }
+
+  /**
+   * Installs the virtual authenticator and seeds it with stored credentials.
+   * Safe to call repeatedly; a no-op while one is already installed.
+   */
+  public async install(): Promise<void> {
+    if (this.installing) return this.installing;
+    this.installing = this.doInstall().finally(() => {
+      this.installing = null;
+    });
+    return this.installing;
+  }
+
+  private async doInstall(): Promise<void> {
+    if (this.destroyed) return;
+    if (this.webContents.isDestroyed()) return;
+
+    const dbg = this.webContents.debugger;
+    if (!dbg.isAttached()) {
+      try {
+        dbg.attach('1.3');
+      } catch (err) {
+        // DevTools holds the only debugger connection while it is open. Leave
+        // the authenticator uninstalled; the next navigation retries.
+        this.logger.debug(
+          `[TabPasskeyAuthenticator] Cannot attach debugger: ${err}`,
+        );
+        return;
+      }
+    }
+
+    try {
+      await dbg.sendCommand('WebAuthn.enable', { enableUI: false });
+
+      // Chrome allows exactly one internal authenticator per CDP session, so a
+      // replacement can only be added once the previous one is gone. Detach
+      // destroys it for us; a cross-origin navigation does not.
+      const previous = this.authenticatorId;
+      this.authenticatorId = null;
+      if (previous) {
+        try {
+          await dbg.sendCommand('WebAuthn.removeVirtualAuthenticator', {
+            authenticatorId: previous,
+          });
+        } catch {
+          // Already destroyed with the old CDP session; nothing to release.
+        }
+      }
+
+      const { authenticatorId } = (await dbg.sendCommand(
+        'WebAuthn.addVirtualAuthenticator',
+        { options: VIRTUAL_AUTHENTICATOR_OPTIONS },
+      )) as { authenticatorId: string };
+
+      if (this.destroyed) return;
+      this.authenticatorId = authenticatorId;
+
+      for (const credential of this.store.list()) {
+        try {
+          await dbg.sendCommand('WebAuthn.addCredential', {
+            authenticatorId,
+            credential,
+          });
+        } catch (err) {
+          this.logger.warn(
+            `[TabPasskeyAuthenticator] Failed to restore credential for ${credential.rpId}: ${err}`,
+          );
+        }
+      }
+
+      this.logger.debug(
+        `[TabPasskeyAuthenticator] Installed ${authenticatorId} with ${this.store.list().length} credential(s)`,
+      );
+    } catch (err) {
+      this.authenticatorId = null;
+      this.logger.error(`[TabPasskeyAuthenticator] Install failed: ${err}`);
+    }
+  }
+
+  /**
+   * Detach destroys the virtual authenticator. Re-enabling the domain alone
+   * does not bring it back, so install a fresh one.
+   */
+  private handleDetach(): void {
+    if (this.destroyed) return;
+    void this.install();
+  }
+
+  private handleDidNavigate(url: string): void {
+    const origin = this.originOf(url);
+    if (origin === this.currentOrigin) return;
+
+    // A cross-origin navigation swaps the render frame and takes the
+    // authenticator with it.
+    this.currentOrigin = origin;
+    void this.install();
+  }
+
+  private handleCdpMessage(method: string, params: unknown): void {
+    if (
+      method !== 'WebAuthn.credentialAdded' &&
+      method !== 'WebAuthn.credentialAsserted'
+    )
+      return;
+
+    const payload = params as {
+      authenticatorId?: string;
+      credential?: unknown;
+    };
+    if (payload?.authenticatorId !== this.authenticatorId) return;
+
+    const existing = this.findStored(payload.credential);
+    const parsed = storedPasskeyCredentialSchema.safeParse({
+      ...existing,
+      ...(payload.credential as Record<string, unknown>),
+    });
+    if (!parsed.success) {
+      this.logger.warn(
+        `[TabPasskeyAuthenticator] Ignoring unparsable credential from ${method}`,
+      );
+      return;
+    }
+
+    this.store.save(parsed.data);
+  }
+
+  /** Existing record for an incoming credential, to fill in omitted fields. */
+  private findStored(credential: unknown): StoredPasskeyCredential | undefined {
+    const credentialId = (credential as { credentialId?: unknown })
+      ?.credentialId;
+    if (typeof credentialId !== 'string') return undefined;
+    return this.store.list().find((c) => c.credentialId === credentialId);
+  }
+
+  private originOf(url: string): string {
+    try {
+      return new URL(url).origin;
+    } catch {
+      return '';
+    }
+  }
+
+  public destroy(): void {
+    this.destroyed = true;
+    this.authenticatorId = null;
+    this.webContents.debugger.off('detach', this.boundHandleDetach);
+    this.webContents.debugger.off('message', this.boundHandleMessage);
+    this.webContents.off('did-navigate', this.boundHandleDidNavigate);
+  }
+}

--- a/apps/browser/src/backend/services/window-layout/tab-permission-handler/index.ts
+++ b/apps/browser/src/backend/services/window-layout/tab-permission-handler/index.ts
@@ -784,6 +784,9 @@ export class TabPermissionHandler {
       'speaker-selection': 'speaker-selection',
       'storage-access': 'storage-access',
       'top-level-storage-access': 'storage-access',
+      // Not an Electron permission: raised by the passkey relay before it runs
+      // a WebAuthn ceremony in a browser outside the app.
+      passkey: 'passkey',
     };
     return mapping[permission] || null;
   }

--- a/apps/browser/src/backend/services/window-layout/tab-permission-handler/session-registry.ts
+++ b/apps/browser/src/backend/services/window-layout/tab-permission-handler/session-registry.ts
@@ -61,6 +61,7 @@ function mapToConfigurablePermission(
     'speaker-selection': 'speaker-selection',
     'storage-access': 'storage-access',
     'top-level-storage-access': 'storage-access', // variant maps to storage-access
+    passkey: 'passkey',
   };
   return mapping[permission] ?? null;
 }
@@ -355,6 +356,45 @@ export class SessionPermissionRegistry {
     this.logger.debug(
       '[SessionPermissionRegistry] Session handlers registered',
     );
+  }
+
+  /**
+   * Asks the user whether `origin` may use the passkeys stored on this machine.
+   *
+   * WebAuthn is not an Electron permission, so this request never passes through
+   * `setPermissionRequestHandler` — but relaying a ceremony opens a browser
+   * outside the app and can produce an assertion for a real account, so it gets
+   * the same stored Allow/Block/Ask treatment and the same prompt as any other
+   * capability a page can reach for.
+   */
+  public async requestPasskeyRelay(
+    webContentsId: number,
+    origin: string,
+  ): Promise<boolean> {
+    const setting = this.preferencesService?.getPermissionSetting(
+      origin,
+      'passkey',
+    );
+    if (setting === PermissionSetting.Allow) return true;
+    if (setting === PermissionSetting.Block) {
+      this.logger.debug(
+        `[SessionPermissionRegistry] Auto-blocking passkey relay for ${origin} (stored preference)`,
+      );
+      return false;
+    }
+
+    const handler = this.handlers.get(webContentsId);
+    if (!handler) {
+      // No handler registered - reject for security, as the request handler does.
+      this.logger.debug(
+        `[SessionPermissionRegistry] No handler for passkey relay request (webContents: ${webContentsId})`,
+      );
+      return false;
+    }
+
+    return new Promise<boolean>((resolve) => {
+      handler.handlePermissionRequest('passkey', {}, resolve);
+    });
   }
 
   /**

--- a/apps/browser/src/backend/utils/paths.ts
+++ b/apps/browser/src/backend/utils/paths.ts
@@ -36,6 +36,7 @@ export type JsonName =
   | 'identity'
   | 'auth-session'
   | 'credentials'
+  | 'passkeys'
   | 'preferences'
   | 'recently-opened-workspaces'
   | 'onboarding-state'

--- a/apps/browser/src/shared/karton-contracts/ui/index.ts
+++ b/apps/browser/src/shared/karton-contracts/ui/index.ts
@@ -463,7 +463,8 @@ export type PermissionRequestType =
   | 'midi'
   | 'idle-detection'
   | 'speaker-selection'
-  | 'storage-access';
+  | 'storage-access'
+  | 'passkey';
 
 /** Media types for camera/microphone distinction */
 export type MediaType = 'video' | 'audio'; // video = camera, audio = microphone
@@ -500,7 +501,8 @@ export interface SimplePermissionRequest extends BasePermissionRequest {
     | 'midi'
     | 'idle-detection'
     | 'speaker-selection'
-    | 'storage-access';
+    | 'storage-access'
+    | 'passkey';
 }
 
 /** Bluetooth device info for UI display */

--- a/apps/browser/src/shared/karton-contracts/ui/shared-types.ts
+++ b/apps/browser/src/shared/karton-contracts/ui/shared-types.ts
@@ -1210,6 +1210,7 @@ const defaultPermissionsForUserPrefs = {
     'idle-detection': 0 as const,
     'speaker-selection': 0 as const,
     'storage-access': 0 as const,
+    passkey: 0 as const,
   },
   exceptions: {
     media: {},
@@ -1226,6 +1227,7 @@ const defaultPermissionsForUserPrefs = {
     'idle-detection': {},
     'speaker-selection': {},
     'storage-access': {},
+    passkey: {},
   },
 };
 
@@ -1385,6 +1387,7 @@ export const configurablePermissionTypes = [
   'idle-detection',
   'speaker-selection',
   'storage-access',
+  'passkey',
 ] as const;
 
 export type ConfigurablePermissionType =
@@ -1424,6 +1427,7 @@ export const defaultPermissionSettingsSchema = z.object({
   'idle-detection': z.enum(PermissionSetting).default(PermissionSetting.Ask),
   'speaker-selection': z.enum(PermissionSetting).default(PermissionSetting.Ask),
   'storage-access': z.enum(PermissionSetting).default(PermissionSetting.Ask),
+  passkey: z.enum(PermissionSetting).default(PermissionSetting.Ask),
 });
 
 export type DefaultPermissionSettings = z.infer<
@@ -1462,6 +1466,7 @@ export const hostPermissionOverridesSchema = z.object({
   'storage-access': z
     .record(z.string(), hostPermissionExceptionSchema)
     .default({}),
+  passkey: z.record(z.string(), hostPermissionExceptionSchema).default({}),
 });
 
 export type HostPermissionOverrides = z.infer<
@@ -1484,6 +1489,7 @@ export const defaultPermissionSettings: DefaultPermissionSettings = {
   'idle-detection': PermissionSetting.Ask,
   'speaker-selection': PermissionSetting.Ask,
   'storage-access': PermissionSetting.Ask,
+  passkey: PermissionSetting.Ask,
 };
 
 /** Default empty host overrides */
@@ -1502,6 +1508,7 @@ export const defaultHostPermissionOverrides: HostPermissionOverrides = {
   'idle-detection': {},
   'speaker-selection': {},
   'storage-access': {},
+  passkey: {},
 };
 
 /**

--- a/apps/browser/src/shared/passkey-relay-script.test.ts
+++ b/apps/browser/src/shared/passkey-relay-script.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from 'vitest';
+import { PASSKEY_RELAY_MAIN_WORLD_SCRIPT } from './passkey-relay-script';
+
+/**
+ * The override runs as a string inside the page, where neither the compiler nor
+ * the rest of this test suite can see it. What matters here is the one decision
+ * it makes: whether a request is relayed to the helper browser or left to the
+ * tab's own authenticator. Getting that wrong either opens a browser window the
+ * user never asked for, or drops fields the ceremony needs.
+ */
+function install() {
+  const listeners = new Set<(event: unknown) => void>();
+  const posted: Record<string, unknown>[] = [];
+  const nativeCalls: unknown[] = [];
+
+  class FakePublicKeyCredential {}
+  const window = {
+    PublicKeyCredential: FakePublicKeyCredential,
+    addEventListener: (_type: string, fn: (event: unknown) => void) =>
+      listeners.add(fn),
+    removeEventListener: (_type: string, fn: (event: unknown) => void) =>
+      listeners.delete(fn),
+    postMessage: (data: Record<string, unknown>) => posted.push(data),
+  };
+  const navigator = {
+    credentials: {
+      get: async (arg: unknown) => {
+        nativeCalls.push(arg);
+        return 'native';
+      },
+    },
+  };
+
+  new Function(
+    'window',
+    'navigator',
+    'PublicKeyCredential',
+    PASSKEY_RELAY_MAIN_WORLD_SCRIPT,
+  )(window, navigator, FakePublicKeyCredential);
+
+  return { window, navigator, posted, nativeCalls };
+}
+
+const request = (extra: Record<string, unknown> = {}) => ({
+  publicKey: { challenge: new Uint8Array([1, 2, 3]), ...extra },
+});
+
+describe('the main-world credentials.get override', () => {
+  it('relays an ordinary sign-in', async () => {
+    const page = install();
+    void page.navigator.credentials.get(request());
+    await Promise.resolve();
+    expect(page.posted.some((m) => m.__stagewisePasskeyRequest)).toBe(true);
+    expect(page.nativeCalls).toHaveLength(0);
+  });
+
+  it('leaves mediation that asked for no UI to the tab authenticator', async () => {
+    // Opening a browser window for autofill, or for a request that promised to
+    // be silent, would be an ambush.
+    for (const mediation of ['conditional', 'silent']) {
+      const page = install();
+      await page.navigator.credentials.get({ ...request(), mediation });
+      expect(page.posted).toHaveLength(0);
+      expect(page.nativeCalls).toHaveLength(1);
+    }
+  });
+
+  it('leaves a nested binary extension to the tab authenticator', async () => {
+    // prf.eval.first is a BufferSource two levels down. Relaying it would hand
+    // JSON.stringify an ArrayBuffer, which flattens to {} — the ceremony would
+    // run without the extension the site asked for and quietly return the
+    // wrong assertion.
+    const page = install();
+    await page.navigator.credentials.get(
+      request({
+        extensions: { prf: { eval: { first: new Uint8Array([9]) } } },
+      }),
+    );
+    expect(page.posted).toHaveLength(0);
+    expect(page.nativeCalls).toHaveLength(1);
+  });
+
+  it('still relays extensions that carry no binary', async () => {
+    const page = install();
+    void page.navigator.credentials.get(
+      request({
+        extensions: { appid: 'https://example.com', credProps: true },
+      }),
+    );
+    await Promise.resolve();
+    expect(page.posted.some((m) => m.__stagewisePasskeyRequest)).toBe(true);
+  });
+
+  it('gives up on a ceremony the page aborts while it is running', async () => {
+    const page = install();
+    const controller = new AbortController();
+    const result = page.navigator.credentials.get({
+      ...request(),
+      signal: controller.signal,
+    });
+    await Promise.resolve();
+    expect(page.posted.some((m) => m.__stagewisePasskeyRequest)).toBe(true);
+
+    controller.abort();
+    // The helper window has to close with it, and the request falls back to the
+    // native call, which is what rejects with the AbortError the page expects.
+    expect(page.posted.some((m) => m.__stagewisePasskeyCancel)).toBe(true);
+    await expect(result).resolves.toBe('native');
+    expect(page.nativeCalls).toHaveLength(1);
+  });
+
+  it('does not wrap itself twice', async () => {
+    const page = install();
+    const wrapped = page.navigator.credentials.get;
+    new Function(
+      'window',
+      'navigator',
+      'PublicKeyCredential',
+      PASSKEY_RELAY_MAIN_WORLD_SCRIPT,
+    )(page.window, page.navigator, page.window.PublicKeyCredential);
+    expect(page.navigator.credentials.get).toBe(wrapped);
+  });
+});

--- a/apps/browser/src/shared/passkey-relay-script.ts
+++ b/apps/browser/src/shared/passkey-relay-script.ts
@@ -1,0 +1,154 @@
+/**
+ * Main-world override of `navigator.credentials.get`, handing WebAuthn sign-ins
+ * to the main process so pages can use the passkeys already on this machine.
+ *
+ * Only sign-ins are overridden. `navigator.credentials.create` is left alone:
+ * registration belongs to the tab's own virtual authenticator, which is what
+ * keeps a page under test from writing a passkey into the user's real keychain.
+ *
+ * This has to reach the page's own JavaScript context, which a preload script
+ * cannot do directly — and injecting a `<script>` element is blocked outright
+ * by any site with a strict `script-src` (github.com among them). So it is
+ * installed over CDP with `Page.addScriptToEvaluateOnNewDocument`, which runs
+ * in the main world ahead of page scripts and is not subject to CSP.
+ *
+ * The isolated-world half of the bridge lives in
+ * `web-content-preload/passkey-relay.ts`.
+ */
+export const PASSKEY_RELAY_MAIN_WORLD_SCRIPT = `(() => {
+  if (!window.PublicKeyCredential || !navigator.credentials) return;
+  // Injected both on new documents and into the live one, so it must be safe
+  // to run twice — otherwise the second run would wrap the first wrapper.
+  if (window.__stagewisePasskeyRelay) return;
+  window.__stagewisePasskeyRelay = true;
+
+  const nativeGet = navigator.credentials.get.bind(navigator.credentials);
+
+  const toB64 = (value) => {
+    const view = value instanceof ArrayBuffer
+      ? new Uint8Array(value)
+      : new Uint8Array(value.buffer, value.byteOffset, value.byteLength);
+    let binary = '';
+    for (let i = 0; i < view.length; i++) binary += String.fromCharCode(view[i]);
+    return btoa(binary).replace(/\\+/g, '-').replace(/\\//g, '_').replace(/=+$/, '');
+  };
+
+  const toBuffer = (value) => {
+    const padded = value.replace(/-/g, '+').replace(/_/g, '/');
+    const binary = atob(padded);
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+    return bytes.buffer;
+  };
+
+  const isBinary = (value) =>
+    value instanceof ArrayBuffer || ArrayBuffer.isView(value);
+
+  // The JSON shape parseRequestOptionsFromJSON expects on the other side.
+  const serialize = (options) => {
+    const out = { ...options, challenge: toB64(options.challenge) };
+    if (options.allowCredentials)
+      out.allowCredentials = options.allowCredentials.map(
+        (entry) => ({ ...entry, id: toB64(entry.id) }),
+      );
+    return out;
+  };
+
+  const revive = (json) => {
+    const source = json.response || {};
+    const response = {};
+    for (const key of Object.keys(source)) {
+      response[key] = typeof source[key] === 'string'
+        ? toBuffer(source[key])
+        : source[key];
+    }
+    if (source.authenticatorData)
+      response.getAuthenticatorData = () => toBuffer(source.authenticatorData);
+
+    const credential = {
+      id: json.id,
+      rawId: toBuffer(json.rawId || json.id),
+      type: json.type || 'public-key',
+      authenticatorAttachment: json.authenticatorAttachment ?? null,
+      response,
+      getClientExtensionResults: () => json.clientExtensionResults || {},
+      toJSON: () => json,
+    };
+    // Own properties shadow the native accessors, but sites that check
+    // \`instanceof PublicKeyCredential\` should still see one.
+    try { Object.setPrototypeOf(credential, PublicKeyCredential.prototype); } catch {}
+    return credential;
+  };
+
+  let nextId = 0;
+  const relay = (options) => new Promise((resolve) => {
+    const id = ++nextId;
+    let acknowledged = false;
+    const settle = (value) => {
+      window.removeEventListener('message', onMessage);
+      resolve(value);
+    };
+    const onMessage = (event) => {
+      if (event.source !== window) return;
+      const data = event.data;
+      if (!data || data.id !== id) return;
+      if (data.__stagewisePasskeyAck) { acknowledged = true; return; }
+      if (!data.__stagewisePasskeyResult) return;
+      settle(data.result);
+    };
+    window.addEventListener('message', onMessage);
+    // Overriding navigator.credentials with nothing behind it would hang every
+    // WebAuthn call forever — the exact bug this is here to fix. A ceremony can
+    // legitimately take minutes, so the deadline is on the bridge acknowledging
+    // the request, not on the ceremony finishing.
+    setTimeout(() => { if (!acknowledged) settle(null); }, 2000);
+    window.postMessage(
+      { __stagewisePasskeyRequest: true, id, kind: 'get', options }, '*',
+    );
+  });
+
+  // Why a request was left to the tab's own authenticator, or null to relay it.
+  const skipReason = (arg) => {
+    if (!arg || !arg.publicKey) return 'not-a-webauthn-request';
+    // Autofill runs on page load with no user intent behind it — opening a
+    // browser window for that would be an ambush.
+    if (arg.mediation === 'conditional') return 'conditional-mediation';
+    // An abort the page can still trigger has to stay with the native call,
+    // which is the only thing that knows how to honour the signal.
+    if (arg.signal && arg.signal.aborted) return 'already-aborted';
+    const options = arg.publicKey;
+    if (options.extensions && Object.values(options.extensions).some(isBinary))
+      return 'binary-extensions';
+    if (!options.challenge) return 'incomplete-options';
+    return null;
+  };
+
+  const log = (message) => {
+    try { console.debug('[stagewise passkey] ' + message); } catch {}
+  };
+
+  navigator.credentials.get = async function (arg) {
+    const skip = skipReason(arg);
+    if (skip) {
+      log('get handled by the tab authenticator: ' + skip);
+      return nativeGet(arg);
+    }
+
+    log('get relayed to the system browser');
+    let result;
+    try {
+      result = await relay(serialize(arg.publicKey));
+    } catch (err) {
+      log('get could not be serialized: ' + err);
+      return nativeGet(arg);
+    }
+    if (result && result.ok) return revive(result.credential);
+
+    // Anything else — no bridge, no browser, the user said no, a passkey this
+    // tab already holds — leaves the request where it would have gone anyway.
+    log('get relay declined: ' + (result ? result.error : 'no-bridge'));
+    if (result && result.error === 'NotAllowedError')
+      throw new DOMException('The operation was cancelled.', 'NotAllowedError');
+    return nativeGet(arg);
+  };
+})();`;

--- a/apps/browser/src/shared/passkey-relay-script.ts
+++ b/apps/browser/src/shared/passkey-relay-script.ts
@@ -44,6 +44,14 @@ export const PASSKEY_RELAY_MAIN_WORLD_SCRIPT = `(() => {
   const isBinary = (value) =>
     value instanceof ArrayBuffer || ArrayBuffer.isView(value);
 
+  // Extensions nest — \`prf.eval.first\` is a BufferSource two levels down, and
+  // JSON.stringify would flatten it to {} on the way to the helper browser.
+  const hasBinary = (value, depth) => {
+    if (isBinary(value)) return true;
+    if (!value || typeof value !== 'object' || depth > 4) return false;
+    return Object.values(value).some((inner) => hasBinary(inner, depth + 1));
+  };
+
   // The JSON shape parseRequestOptionsFromJSON expects on the other side.
   const serialize = (options) => {
     const out = { ...options, challenge: toB64(options.challenge) };
@@ -81,12 +89,20 @@ export const PASSKEY_RELAY_MAIN_WORLD_SCRIPT = `(() => {
   };
 
   let nextId = 0;
-  const relay = (options) => new Promise((resolve) => {
+  const relay = (options, signal) => new Promise((resolve) => {
     const id = ++nextId;
     let acknowledged = false;
     const settle = (value) => {
       window.removeEventListener('message', onMessage);
+      if (signal) signal.removeEventListener('abort', onAbort);
       resolve(value);
+    };
+    // A ceremony the page has given up on has to stop waiting on the user, and
+    // the helper window has to go with it — otherwise it sits there holding the
+    // relay for every other tab until the ceremony times out.
+    const onAbort = () => {
+      window.postMessage({ __stagewisePasskeyCancel: true, id }, '*');
+      settle(null);
     };
     const onMessage = (event) => {
       if (event.source !== window) return;
@@ -97,6 +113,7 @@ export const PASSKEY_RELAY_MAIN_WORLD_SCRIPT = `(() => {
       settle(data.result);
     };
     window.addEventListener('message', onMessage);
+    if (signal) signal.addEventListener('abort', onAbort);
     // Overriding navigator.credentials with nothing behind it would hang every
     // WebAuthn call forever — the exact bug this is here to fix. A ceremony can
     // legitimately take minutes, so the deadline is on the bridge acknowledging
@@ -112,12 +129,15 @@ export const PASSKEY_RELAY_MAIN_WORLD_SCRIPT = `(() => {
     if (!arg || !arg.publicKey) return 'not-a-webauthn-request';
     // Autofill runs on page load with no user intent behind it — opening a
     // browser window for that would be an ambush.
-    if (arg.mediation === 'conditional') return 'conditional-mediation';
-    // An abort the page can still trigger has to stay with the native call,
-    // which is the only thing that knows how to honour the signal.
+    // 'silent' is the same bargain: no UI was asked for, so opening one is
+    // never the right answer.
+    if (arg.mediation === 'conditional' || arg.mediation === 'silent')
+      return arg.mediation + '-mediation';
+    // Already over before it began; the native call is what rejects with the
+    // AbortError the page is waiting for.
     if (arg.signal && arg.signal.aborted) return 'already-aborted';
     const options = arg.publicKey;
-    if (options.extensions && Object.values(options.extensions).some(isBinary))
+    if (options.extensions && hasBinary(options.extensions, 0))
       return 'binary-extensions';
     if (!options.challenge) return 'incomplete-options';
     return null;
@@ -137,7 +157,7 @@ export const PASSKEY_RELAY_MAIN_WORLD_SCRIPT = `(() => {
     log('get relayed to the system browser');
     let result;
     try {
-      result = await relay(serialize(arg.publicKey));
+      result = await relay(serialize(arg.publicKey), arg.signal);
     } catch (err) {
       log('get could not be serialized: ' + err);
       return nativeGet(arg);

--- a/apps/browser/src/ui/screens/main/content/_components/control-buttons/resource-requests.tsx
+++ b/apps/browser/src/ui/screens/main/content/_components/control-buttons/resource-requests.tsx
@@ -21,6 +21,7 @@ import {
   IconConnection2Outline18,
   IconCheckOutline18,
   IconBanOutline18,
+  IconKey2Outline18,
 } from '@stagewise/icons';
 import { IconBluetoothOutline24 } from '@stagewise/icons';
 import { IconUsbOutline24 } from '@stagewise/icons';
@@ -67,6 +68,7 @@ const ICON_COLORS: Record<string, string> = {
   'idle-detection': 'text-violet-600 dark:text-violet-300',
   'speaker-selection': 'text-cyan-600 dark:text-cyan-300',
   'storage-access': 'text-amber-600 dark:text-amber-300',
+  passkey: 'text-emerald-600 dark:text-emerald-300',
 };
 
 function PermissionIcon({
@@ -110,6 +112,8 @@ function PermissionIcon({
       return <IconSpeakerOutline18 className={cn} />;
     case 'storage-access':
       return <IconHardDriveOutline18 className={cn} />;
+    case 'passkey':
+      return <IconKey2Outline18 className={cn} />;
     default:
       return <IconConnection2Outline18 className={cn} />;
   }
@@ -162,6 +166,8 @@ function getRequestDescription(request: PermissionRequest): string {
       return 'wants to select audio output';
     case 'storage-access':
       return 'wants storage access';
+    case 'passkey':
+      return 'wants to sign in with a passkey saved on this device';
     case 'bluetooth':
       return 'wants to connect to a Bluetooth device';
     case 'hid':
@@ -189,6 +195,7 @@ const SIMPLE_REQUEST_TYPES = [
   'idle-detection',
   'speaker-selection',
   'storage-access',
+  'passkey',
 ];
 
 function isSimpleRequest(request: PermissionRequest): boolean {

--- a/apps/browser/src/ui/screens/settings/sections/browsing-settings-section.tsx
+++ b/apps/browser/src/ui/screens/settings/sections/browsing-settings-section.tsx
@@ -427,6 +427,7 @@ const permissionTypeLabels: Record<ConfigurablePermissionType, string> = {
   'idle-detection': 'Idle Detection',
   'speaker-selection': 'Speaker Selection',
   'storage-access': 'Storage Access',
+  passkey: 'Passkeys',
 };
 
 /** Human-readable labels for permission settings */

--- a/apps/browser/src/ui/screens/settings/sections/website-permissions-section.tsx
+++ b/apps/browser/src/ui/screens/settings/sections/website-permissions-section.tsx
@@ -29,6 +29,7 @@ const permissionTypeLabels: Record<ConfigurablePermissionType, string> = {
   'idle-detection': 'Idle Detection',
   'speaker-selection': 'Speaker Selection',
   'storage-access': 'Storage Access',
+  passkey: 'Passkeys',
 };
 
 /** Human-readable labels for permission settings */

--- a/apps/browser/src/web-content-preload/index.ts
+++ b/apps/browser/src/web-content-preload/index.ts
@@ -1,4 +1,5 @@
 import { injectStealthOverrides } from './stealth';
+import { installPasskeyRelayBridge } from './passkey-relay';
 import { contextBridge, ipcRenderer } from 'electron';
 import { createElement, StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
@@ -10,6 +11,9 @@ import { shouldChromeConsumeEvent } from './utils';
 
 // Inject stealth overrides into the main world before any page scripts run
 injectStealthOverrides();
+
+// Carry WebAuthn ceremonies out to the passkeys already on this machine
+installPasskeyRelayBridge();
 
 declare global {
   interface Window {

--- a/apps/browser/src/web-content-preload/passkey-relay.ts
+++ b/apps/browser/src/web-content-preload/passkey-relay.ts
@@ -29,9 +29,11 @@ export function installPasskeyRelayBridge(): void {
       options?: unknown;
     } | null;
     // The page aborted its own request, so the helper window has nothing left
-    // to hand its answer to.
+    // to hand its answer to. The id goes with it: only the ceremony that
+    // request started may be the one this ends.
     if (data?.__stagewisePasskeyCancel) {
-      ipcRenderer.send('passkey-relay-cancel');
+      if (typeof data.id === 'number')
+        ipcRenderer.send('passkey-relay-cancel', data.id);
       return;
     }
     if (!data?.__stagewisePasskeyRequest || typeof data.id !== 'number') return;
@@ -48,6 +50,7 @@ export function installPasskeyRelayBridge(): void {
 
     ipcRenderer
       .invoke('passkey-relay-ceremony', {
+        id,
         kind: data.kind,
         options: data.options,
       })

--- a/apps/browser/src/web-content-preload/passkey-relay.ts
+++ b/apps/browser/src/web-content-preload/passkey-relay.ts
@@ -1,0 +1,50 @@
+import { ipcRenderer } from 'electron';
+
+/**
+ * Isolated-world half of the passkey relay: carries ceremony requests from the
+ * page's own JavaScript context to the main process and the result back.
+ *
+ * The main-world override that produces those requests cannot be installed from
+ * here — a `<script>` element is blocked by any strict `script-src` — so it is
+ * injected over CDP instead. See `@shared/passkey-relay-script`.
+ *
+ * The page can watch and forge these messages, but the only credentials it can
+ * reach that way are its own, which it could already request directly.
+ */
+export function installPasskeyRelayBridge(): void {
+  try {
+    if (window.location.protocol === 'stagewise:') return;
+    if (!window.isSecureContext) return;
+  } catch {
+    return;
+  }
+
+  window.addEventListener('message', (event: MessageEvent) => {
+    if (event.source !== window) return;
+    const data = event.data as {
+      __stagewisePasskeyRequest?: boolean;
+      id?: number;
+      kind?: 'create' | 'get';
+      options?: unknown;
+    } | null;
+    if (!data?.__stagewisePasskeyRequest || typeof data.id !== 'number') return;
+
+    const id = data.id;
+    const reply = (result: unknown) => {
+      window.postMessage({ __stagewisePasskeyResult: true, id, result }, '*');
+    };
+
+    // A ceremony can take minutes, so the override cannot use a plain timeout
+    // to tell "still waiting on the user" from "no bridge here at all". This
+    // says the request landed; without it the override falls back.
+    window.postMessage({ __stagewisePasskeyAck: true, id }, '*');
+
+    ipcRenderer
+      .invoke('passkey-relay-ceremony', {
+        kind: data.kind,
+        options: data.options,
+      })
+      .then(reply)
+      .catch(() => reply({ ok: false, error: 'RelayUnavailable' }));
+  });
+}

--- a/apps/browser/src/web-content-preload/passkey-relay.ts
+++ b/apps/browser/src/web-content-preload/passkey-relay.ts
@@ -23,10 +23,17 @@ export function installPasskeyRelayBridge(): void {
     if (event.source !== window) return;
     const data = event.data as {
       __stagewisePasskeyRequest?: boolean;
+      __stagewisePasskeyCancel?: boolean;
       id?: number;
       kind?: 'create' | 'get';
       options?: unknown;
     } | null;
+    // The page aborted its own request, so the helper window has nothing left
+    // to hand its answer to.
+    if (data?.__stagewisePasskeyCancel) {
+      ipcRenderer.send('passkey-relay-cancel');
+      return;
+    }
     if (!data?.__stagewisePasskeyRequest || typeof data.id !== 'number') return;
 
     const id = data.id;


### PR DESCRIPTION
# Passkey Sign-In via System Authenticators

Passkey sign-in now works in the preview browser using passkeys that already exist on the machine — iCloud Keychain, password managers, or a phone over hybrid transport.

Verified end to end against **GitHub** and **Discord** using real accounts, real passkeys, and real sessions.

## Demo

<img width="1544" height="707" alt="Screenshot 2026-08-13 at 12 27 28 PM" src="https://github.com/user-attachments/assets/7e3f739e-ecf3-49da-ab92-a858609c222e" />


---

## Problem

Electron includes Chromium's WebAuthn implementation, but not its platform authenticator integrations.

When a site calls `navigator.credentials.get()` inside a preview tab, Electron finds no authenticator. The request can hang indefinitely without resolving or rejecting.

A CDP virtual authenticator fixes the hang, but only knows about credentials created inside the preview browser. It cannot access passkeys already stored in the OS keychain, a password manager, or on a phone.

So real-account passkey sign-in still did not work.

## Solution

Authentication ceremonies can now be relayed to an installed Chromium-based browser that has access to system authenticators.

The flow is:

1. Open a temporary Chromium profile on the relying party's origin in a chromeless `--app` window.
2. Run the WebAuthn ceremony there over CDP.
3. The user completes their normal Touch ID, password-manager, or phone flow.
4. Return the assertion to the preview tab's `navigator.credentials.get()` call.

The challenge and origin remain those supplied by the site, so the relying party verifies the assertion normally.

Only the WebAuthn ceremony is relayed. **Cookies, storage, and the authenticated session remain inside the preview browser.**

The helper browser exists for one ceremony, is terminated in `finally`, and its temporary profile is deleted afterwards.

## Local vs System Authenticator

Registration remains local to the preview browser.

Relaying `navigator.credentials.create()` would create a real passkey in the user's system keychain and potentially sync it across their devices for a site they may only be testing.

Therefore:

- `credentials.get()` may use the system relay.
- `credentials.create()` always uses the preview browser's virtual authenticator.

If the preview browser already has a matching credential, `shouldUseLocalAuthenticator()` keeps the ceremony local and no helper browser is opened.

## Permission

System passkey access is exposed as a `passkey` website permission with per-origin:

- Ask
- Allow
- Block

The default is **Ask**.

Nothing is relayed until the user grants permission.

## Security

- **Main frame only:** subframe requests are rejected.
- **Origin from `senderFrame`:** not inferred from the tab.
- **HTTP(S) only:** opaque, `file://`, `stagewise://`, `javascript:` and other invalid origins are rejected.
- **Browsing sessions only:** requests from the app UI are rejected.
- **Authentication only:** registration and unsupported ceremony kinds are rejected.
- **RP ID validation stays in Chromium:** the helper runs on the relying party's origin, so Chromium enforces the RP ID relationship.
- **Ephemeral helper browser:** no persistent debugging endpoint, cookies, cache, or profile.
- **No shell invocation** when launching the helper browser.

`authorizeCeremony()` and `shouldUseLocalAuthenticator()` are pure functions so these decisions can be tested directly.

## Tests

**24 tests** under:

`apps/browser/src/backend/services/window-layout/`

### `system-passkey-relay.test.ts`

Covers:

- subframe rejection
- non-browsing-session rejection
- invalid origin schemes
- registration rejection
- unsupported ceremony kinds
- local vs system authenticator selection
- base64 and base64url credential IDs
- malformed page input

### `tab-passkey-authenticator/index.test.ts`

Covers:

- virtual authenticator lifecycle
- reinstall behavior
- WebAuthn override injection

## Manual Verification

Verified against:

- `github.com`
- `discord.com`

Also verified:

- cancelling the helper window fails cleanly instead of hanging
- denying the `passkey` permission does not break the page
- fixes #1435 

## Known Limits

- Requires an installed Chromium-based browser: Chrome, Edge, Brave, or Chromium.
- Windows and Linux browser discovery paths are implemented but not yet manually exercised.
- `PublicKeyCredential.signalAllAcceptedCredentials()` is not relayed.
- Passkey registration is intentionally not relayed.

## Follow-up

`stealth.ts` currently injects overrides using a `<script>` element. Sites with strict `script-src`, including GitHub and Discord, block that injection.

This has the same CSP limitation solved here through CDP injection, but is intentionally left out of this PR and can be addressed separately.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches authentication (WebAuthn assertions, permission prompts, spawning a local Chromium with remote debugging) and stores virtual passkey private keys; security relies heavily on `authorizeCeremony` and ceremony locking staying correct.
> 
> **Overview**
> Adds **passkey / WebAuthn sign-in** in preview browsing tabs so `navigator.credentials.get()` can complete with **preview-registered** passkeys or **OS-stored** passkeys (keychain, password manager, phone).
> 
> Each tab gets a **CDP virtual authenticator** (`TabPasskeyAuthenticator`) so WebAuthn no longer hangs; credentials registered in the preview are **encrypted and persisted** (`passkeys` store) and re-seeded after navigation or debugger lifecycle events. **`credentials.create` stays local**—only sign-in may be relayed.
> 
> For system passkeys, a **main-world `credentials.get` override** (CDP-injected, CSP-safe) and preload **IPC bridge** forward ceremonies to **`SystemPasskeyRelay`**, which runs **`get` only** in a **short-lived Chromium helper** on the site’s origin via CDP, then returns the assertion to the tab. **Registration and non-`get` kinds are rejected**; **main-frame browsing tabs** with valid **http(s)** origins only; **one ceremony at a time** with **cancel / abandon** when the tab navigates or the page aborts.
> 
> Relaying requires a new **`passkey` site permission** (Ask/Allow/Block, UI prompts and settings). **`shouldUseLocalAuthenticator`** skips the helper when the tab already holds a matching credential; **`authorizeCeremony`** gates IPC.
> 
> **Tests** cover authorization, local-vs-relay routing, authenticator lifecycle, and the relay script’s routing rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2393554e20f35bca266b2ca1107e889110cad836. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added passkey sign-in support for websites in the browser.
  * Passkeys can be securely stored and reused across browsing sessions.
  * Added permission prompts and settings to allow, block, or ask about passkey access.
  * Added fallback support through an installed browser when needed.
  * Added clear passkey indicators and messaging in permission requests.

* **Bug Fixes**
  * Improved handling of navigation, cancellation, unavailable authenticators, and interrupted passkey requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->