### PR TITLE
feat(stagewise): add external skills onboarding step

### DIFF
--- a/apps/browser/src/backend/services/telemetry.test.ts
+++ b/apps/browser/src/backend/services/telemetry.test.ts
@@ -230,8 +230,8 @@ describe('onboarding funnel telemetry schemas', () => {
         'onboarding-step-viewed',
         {
           onboarding_run_id: 'run-1',
-          step: 'configure-providers',
-          previous_step: 'login',
+          step: 'configure-skills',
+          previous_step: 'configure-providers',
           visit_index: 1,
           elapsed_ms_since_start: 12.5,
         },

--- a/apps/browser/src/backend/services/telemetry.ts
+++ b/apps/browser/src/backend/services/telemetry.ts
@@ -73,6 +73,7 @@ const providerInstanceTypeIdSchema = z.enum(providerInstanceTypeIds);
 const onboardingStepSchema = z.enum([
   'login',
   'configure-providers',
+  'configure-skills',
   'personalization',
 ]);
 const nonNegativeNumberSchema = z.number().nonnegative();

--- a/apps/browser/src/backend/services/toolbox/index.ts
+++ b/apps/browser/src/backend/services/toolbox/index.ts
@@ -1084,10 +1084,25 @@ export class ToolboxService
     const gen = ++this.globalSkillsRebuildGeneration;
     const mounts = getGlobalSkillsMounts();
     const perMount = await Promise.all(
-      mounts.map(async (m) => ({
-        mount: m,
-        skills: await discoverSkills(m.skillsPath ?? m.absolutePath),
-      })),
+      mounts.map(async (mount) => {
+        try {
+          return {
+            mount,
+            skills: await discoverSkills(
+              mount.skillsPath ?? mount.absolutePath,
+            ),
+          };
+        } catch (error) {
+          this.logger.warn(
+            `[ToolboxService] Failed to discover global skills from ${mount.prefix}`,
+            { error },
+          );
+          this.report(error as Error, 'rebuildGlobalSkillsIndex', {
+            mountPrefix: mount.prefix,
+          });
+          return { mount, skills: [] };
+        }
+      }),
     );
     if (gen !== this.globalSkillsRebuildGeneration) return;
 

--- a/apps/browser/src/backend/services/toolbox/index.ts
+++ b/apps/browser/src/backend/services/toolbox/index.ts
@@ -1046,9 +1046,6 @@ export class ToolboxService
         draft.skills = cmds.map(toSkillDefinitionUI);
       });
     }
-    // Always populate the global skills index for the Settings UI,
-    // even before any agent is created.
-    void this.rebuildGlobalSkillsIndex();
   }
 
   /**
@@ -1475,7 +1472,8 @@ export class ToolboxService
       );
     }
 
-    // Start watching global skills directories (~/.stagewise/skills, ~/.agents/skills)
+    // Populate the index before onboarding can inspect it, then keep it current.
+    await this.rebuildGlobalSkillsIndex();
     this.startGlobalSkillsWatchers();
 
     const fileDiffHandler = createFileDiffHandler({

--- a/apps/browser/src/shared/global-skill-prefixes.ts
+++ b/apps/browser/src/shared/global-skill-prefixes.ts
@@ -1,3 +1,33 @@
+export const EXTERNAL_GLOBAL_SKILL_SOURCES = [
+  {
+    prefix: 'globalskills-codex',
+    label: 'Codex',
+    directory: '~/.codex/skills',
+  },
+  {
+    prefix: 'globalskills-claude',
+    label: 'Claude Code',
+    directory: '~/.claude/skills',
+  },
+] as const;
+
+export type ExternalGlobalSkillSourcePrefix =
+  (typeof EXTERNAL_GLOBAL_SKILL_SOURCES)[number]['prefix'];
+
+export const GLOBAL_SKILL_SOURCES = [
+  {
+    prefix: 'globalskills-sw',
+    label: 'Stagewise',
+    directory: '~/.stagewise/skills',
+  },
+  {
+    prefix: 'globalskills-agents',
+    label: 'Agents',
+    directory: '~/.agents/skills',
+  },
+  ...EXTERNAL_GLOBAL_SKILL_SOURCES,
+] as const;
+
 /**
  * Mount prefixes for global skill directories that are always enabled
  * (not gated by user preference). Stagewise and Agents dirs are core

--- a/apps/browser/src/shared/karton-contracts/ui/telemetry.ts
+++ b/apps/browser/src/shared/karton-contracts/ui/telemetry.ts
@@ -9,6 +9,7 @@ import type {
 export type OnboardingStep =
   | 'login'
   | 'configure-providers'
+  | 'configure-skills'
   | 'personalization';
 export type OnboardingNavigationAction = 'next' | 'back' | 'skip' | 'finish';
 export type OnboardingProviderKind =

--- a/apps/browser/src/ui/screens/onboarding/index.test.tsx
+++ b/apps/browser/src/ui/screens/onboarding/index.test.tsx
@@ -1,13 +1,19 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { AppState } from '@shared/karton-contracts/ui';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
   track: vi.fn(),
   setHasSeenOnboardingFlow: vi.fn(),
+  updatePreferences: vi.fn(),
   markCurrentReleaseNotesSeen: vi.fn(),
   state: {
     userAccount: { status: 'unauthenticated' },
-    preferences: { providerInstances: [] as unknown[] },
+    preferences: {
+      providerInstances: [] as unknown[],
+      agent: { enabledGlobalSkillDirs: [] as string[] },
+    },
+    globalSkills: [] as AppState['globalSkills'],
   },
 }));
 
@@ -22,6 +28,7 @@ vi.mock('@ui/hooks/use-karton', () => ({
       userExperience: {
         setHasSeenOnboardingFlow: mocks.setHasSeenOnboardingFlow,
       },
+      preferences: { update: mocks.updatePreferences },
     }),
   ),
 }));
@@ -90,21 +97,23 @@ vi.mock('./steps/07-theme', () => ({
     </div>
   ),
 }));
-
 import { OnboardingWizard } from './index';
 
 function callsFor(eventName: string) {
   return mocks.track.mock.calls.filter(([name]) => name === eventName);
 }
 
-describe('OnboardingWizard telemetry', () => {
+describe('OnboardingWizard', () => {
   beforeEach(() => {
     mocks.track.mockReset();
     mocks.track.mockResolvedValue(undefined);
     mocks.setHasSeenOnboardingFlow.mockReset();
+    mocks.updatePreferences.mockReset();
+    mocks.updatePreferences.mockResolvedValue(undefined);
     mocks.markCurrentReleaseNotesSeen.mockReset();
     mocks.state.userAccount.status = 'unauthenticated';
     mocks.state.preferences.providerInstances = [];
+    mocks.state.globalSkills = [];
     vi.spyOn(globalThis.crypto, 'randomUUID').mockReturnValue(
       '00000000-0000-4000-8000-000000000001',
     );
@@ -254,5 +263,26 @@ describe('OnboardingWizard telemetry', () => {
         }),
       }),
     );
+  });
+
+  it('routes through skill configuration when external skills are detected', async () => {
+    mocks.state.globalSkills = [
+      {
+        name: 'review',
+        description: 'Review code',
+        mountPrefix: 'globalskills-codex',
+      },
+    ];
+    render(<OnboardingWizard />);
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Skip login' }));
+    fireEvent.click(
+      await screen.findByRole('button', { name: 'Provider next skipped' }),
+    );
+    expect(await screen.findByText('Use your existing skills')).toBeTruthy();
+    fireEvent.click(await screen.findByRole('button', { name: 'Next' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Theme back' }));
+
+    expect(await screen.findByText('Use your existing skills')).toBeTruthy();
   });
 });

--- a/apps/browser/src/ui/screens/onboarding/index.tsx
+++ b/apps/browser/src/ui/screens/onboarding/index.tsx
@@ -18,20 +18,28 @@ import { useTrack } from '@ui/hooks/use-track';
 import { cn } from '@ui/utils';
 import { StepLogin } from './steps/01-login';
 import type { OnboardingAuthCompletion } from './steps/01-login';
+import type {
+  OnboardingNavigationAction,
+  OnboardingStep,
+} from '@shared/karton-contracts/ui/telemetry';
 import {
   StepConfigureProviders,
   type ProviderStepSummary,
 } from './steps/06-configure-providers';
+import {
+  StepConfigureSkills,
+  hasDetectedExternalSkills,
+  type ExternalSkillSourceSelection,
+} from './steps/07-configure-skills';
 import { StepTheme } from './steps/07-theme';
 
-type ScreenId = 'login' | 'configure-providers' | 'personalization';
-type NavigationAction = 'next' | 'back' | 'skip' | 'finish';
-
 export function OnboardingWizard() {
-  const [screen, setScreen] = useState<ScreenId>('login');
+  const [screen, setScreen] = useState<OnboardingStep>('login');
   const [onboardingRunId] = useState(() => crypto.randomUUID());
   const [authCompletion, setAuthCompletion] =
     useState<OnboardingAuthCompletion | null>(null);
+  const [skillSourceSelection, setSkillSourceSelection] =
+    useState<ExternalSkillSourceSelection>({});
   const providerSummaryRef = useRef<ProviderStepSummary | null>(null);
   const personalizationChangedRef = useRef(false);
   const track = useTrack();
@@ -39,17 +47,21 @@ export function OnboardingWizard() {
   const connectedProviderCount = useKartonState(
     (s) => s.preferences.providerInstances?.length ?? 0,
   );
+  const hasExternalSkills = useKartonState((s) =>
+    hasDetectedExternalSkills(s.globalSkills),
+  );
   const runStartedAtRef = useRef(performance.now());
   const stepEnteredAtRef = useRef(runStartedAtRef.current);
-  const currentStepRef = useRef<ScreenId>('login');
-  const previousStepRef = useRef<ScreenId | undefined>(undefined);
-  const visitCountsRef = useRef<Record<ScreenId, number>>({
+  const currentStepRef = useRef<OnboardingStep>('login');
+  const previousStepRef = useRef<OnboardingStep | undefined>(undefined);
+  const visitCountsRef = useRef<Record<OnboardingStep, number>>({
     login: 0,
     'configure-providers': 0,
+    'configure-skills': 0,
     personalization: 0,
   });
   const startedTrackedRef = useRef(false);
-  const lastViewedStepRef = useRef<ScreenId | null>(null);
+  const lastViewedStepRef = useRef<OnboardingStep | null>(null);
   const setHasSeenOnboardingFlow = useKartonProcedure(
     (p) => p.userExperience.setHasSeenOnboardingFlow,
   );
@@ -82,7 +94,7 @@ export function OnboardingWizard() {
   }, [authStatus, connectedProviderCount, onboardingRunId, screen, track]);
 
   const navigate = useCallback(
-    (next: ScreenId, action: NavigationAction) => {
+    (next: OnboardingStep, action: OnboardingNavigationAction) => {
       const current = currentStepRef.current;
       void track('onboarding-step-exited', {
         onboarding_run_id: onboardingRunId,
@@ -156,14 +168,39 @@ export function OnboardingWizard() {
                   summary.provider_step_skipped,
               };
             }}
-            onNext={() => navigate('personalization', 'next')}
+            onNext={() =>
+              navigate(
+                hasExternalSkills ? 'configure-skills' : 'personalization',
+                'next',
+              )
+            }
             onBack={() => navigate('login', 'back')}
+          />
+        )}
+        {screen === 'configure-skills' && (
+          <StepConfigureSkills
+            selection={skillSourceSelection}
+            onSelectionChange={(prefix, enabled) =>
+              setSkillSourceSelection((current) => ({
+                ...current,
+                [prefix]: enabled,
+              }))
+            }
+            onNext={() => navigate('personalization', 'next')}
+            onBack={() => navigate('configure-providers', 'back')}
           />
         )}
         {screen === 'personalization' && (
           <StepTheme
             onNext={complete}
-            onBack={() => navigate('configure-providers', 'back')}
+            onBack={() =>
+              navigate(
+                previousStepRef.current === 'configure-skills'
+                  ? 'configure-skills'
+                  : 'configure-providers',
+                'back',
+              )
+            }
             onPersonalizationChanged={() => {
               personalizationChangedRef.current = true;
             }}
@@ -195,9 +232,15 @@ export function OnboardingBottomNav({
 }
 
 /** Back button styled consistently across screens. */
-export function BackButton({ onClick }: { onClick: () => void }) {
+export function BackButton({
+  onClick,
+  disabled,
+}: {
+  onClick: () => void;
+  disabled?: boolean;
+}) {
   return (
-    <Button variant="ghost" size="sm" onClick={onClick}>
+    <Button variant="ghost" size="sm" onClick={onClick} disabled={disabled}>
       <IconArrowLeftFill18 className="size-4" />
       Back
     </Button>

--- a/apps/browser/src/ui/screens/onboarding/steps/07-configure-skills.test.tsx
+++ b/apps/browser/src/ui/screens/onboarding/steps/07-configure-skills.test.tsx
@@ -1,0 +1,145 @@
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  updatePreferences: vi.fn(),
+  state: {
+    globalSkills: [
+      {
+        name: 'codex-skill-one',
+        description: 'First Codex skill',
+        mountPrefix: 'globalskills-codex',
+      },
+      {
+        name: 'codex-skill-two',
+        description: 'Second Codex skill',
+        mountPrefix: 'globalskills-codex',
+      },
+      {
+        name: 'stagewise-skill',
+        description: 'Stagewise skill',
+        mountPrefix: 'globalskills-sw',
+      },
+    ],
+    preferences: {
+      agent: {
+        enabledGlobalSkillDirs: [] as string[],
+      },
+    },
+  },
+}));
+
+vi.mock('@ui/hooks/use-karton', () => ({
+  useKartonState: vi.fn((selector) => selector(mocks.state)),
+  useKartonProcedure: vi.fn((selector) =>
+    selector({ preferences: { update: mocks.updatePreferences } }),
+  ),
+}));
+
+import {
+  StepConfigureSkills,
+  type ExternalSkillSourceSelection,
+} from './07-configure-skills';
+
+function renderStep(selection: ExternalSkillSourceSelection = {}) {
+  const onNext = vi.fn();
+  render(
+    <StepConfigureSkills
+      selection={selection}
+      onSelectionChange={vi.fn()}
+      onNext={onNext}
+      onBack={vi.fn()}
+    />,
+  );
+  return { onNext };
+}
+
+describe('StepConfigureSkills', () => {
+  beforeEach(() => {
+    mocks.updatePreferences.mockReset();
+    mocks.updatePreferences.mockResolvedValue(undefined);
+    mocks.state.preferences.agent.enabledGlobalSkillDirs = [];
+  });
+
+  it('shows only detected external sources and enables them by default', () => {
+    renderStep();
+
+    expect(screen.getByText('~/.codex/skills · 2 skills')).toBeTruthy();
+    expect(screen.queryByText('Claude Code')).toBeNull();
+    expect(
+      screen
+        .getByRole('switch', { name: 'Use Codex skills' })
+        .getAttribute('aria-checked'),
+    ).toBe('true');
+  });
+
+  it('persists detected sources before continuing', async () => {
+    const { onNext } = renderStep();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Next' }));
+
+    await waitFor(() => {
+      expect(mocks.updatePreferences).toHaveBeenCalledWith([
+        {
+          op: 'replace',
+          path: ['agent', 'enabledGlobalSkillDirs'],
+          value: ['globalskills-codex'],
+        },
+      ]);
+    });
+    expect(onNext).toHaveBeenCalledOnce();
+  });
+
+  it('respects a disabled selection and preserves unrelated sources', async () => {
+    mocks.state.preferences.agent.enabledGlobalSkillDirs = [
+      'globalskills-codex',
+      'globalskills-custom',
+    ];
+
+    renderStep({ 'globalskills-codex': false });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Next' }));
+
+    await waitFor(() => {
+      expect(mocks.updatePreferences).toHaveBeenCalledWith([
+        {
+          op: 'replace',
+          path: ['agent', 'enabledGlobalSkillDirs'],
+          value: ['globalskills-custom'],
+        },
+      ]);
+    });
+  });
+
+  it('locks navigation while preferences are being saved', async () => {
+    let finishSaving!: () => void;
+    mocks.updatePreferences.mockReturnValue(
+      new Promise<void>((resolve) => {
+        finishSaving = resolve;
+      }),
+    );
+    const { onNext } = renderStep();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Next' }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: 'Back' }).hasAttribute('disabled'),
+      ).toBe(true);
+    });
+    expect(
+      screen
+        .getByRole('button', { name: 'Saving...' })
+        .hasAttribute('disabled'),
+    ).toBe(true);
+
+    await act(async () => finishSaving());
+    expect(onNext).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/browser/src/ui/screens/onboarding/steps/07-configure-skills.tsx
+++ b/apps/browser/src/ui/screens/onboarding/steps/07-configure-skills.tsx
@@ -1,0 +1,140 @@
+import { Switch } from '@stagewise/stage-ui/components/switch';
+import {
+  EXTERNAL_GLOBAL_SKILL_SOURCES,
+  type ExternalGlobalSkillSourcePrefix,
+} from '@shared/global-skill-prefixes';
+import type { AppState } from '@shared/karton-contracts/ui';
+import { useKartonProcedure, useKartonState } from '@ui/hooks/use-karton';
+import { useState } from 'react';
+import { BackButton, NextButton, OnboardingBottomNav } from '../index';
+
+export type ExternalSkillSourceSelection = Partial<
+  Record<ExternalGlobalSkillSourcePrefix, boolean>
+>;
+
+type GlobalSkill = AppState['globalSkills'][number];
+
+export function hasDetectedExternalSkills(skills: GlobalSkill[]): boolean {
+  return EXTERNAL_GLOBAL_SKILL_SOURCES.some((source) =>
+    skills.some((skill) => skill.mountPrefix === source.prefix),
+  );
+}
+
+export function StepConfigureSkills({
+  selection,
+  onSelectionChange,
+  onNext,
+  onBack,
+}: {
+  selection: ExternalSkillSourceSelection;
+  onSelectionChange: (
+    prefix: ExternalGlobalSkillSourcePrefix,
+    enabled: boolean,
+  ) => void;
+  onNext: () => void;
+  onBack: () => void;
+}) {
+  const globalSkills = useKartonState((s) => s.globalSkills);
+  const enabledGlobalSkillDirs = useKartonState(
+    (s) => s.preferences.agent.enabledGlobalSkillDirs,
+  );
+  const updatePreferences = useKartonProcedure((p) => p.preferences.update);
+  const [isSaving, setIsSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+
+  const detectedSources = EXTERNAL_GLOBAL_SKILL_SOURCES.flatMap((source) => {
+    const skillCount = globalSkills.filter(
+      (skill) => skill.mountPrefix === source.prefix,
+    ).length;
+    return skillCount > 0 ? [{ ...source, skillCount }] : [];
+  });
+
+  async function handleNext() {
+    setIsSaving(true);
+    setSaveError(null);
+
+    const nextEnabledDirs = [
+      ...enabledGlobalSkillDirs.filter(
+        (prefix) => !detectedSources.some((source) => source.prefix === prefix),
+      ),
+      ...detectedSources.flatMap((source) =>
+        selection[source.prefix] !== false ? [source.prefix] : [],
+      ),
+    ];
+
+    try {
+      await updatePreferences([
+        {
+          op: 'replace',
+          path: ['agent', 'enabledGlobalSkillDirs'],
+          value: nextEnabledDirs,
+        },
+      ]);
+      onNext();
+    } catch {
+      setSaveError('Could not save your skill sources. Please try again.');
+      setIsSaving(false);
+    }
+  }
+
+  return (
+    <>
+      <div className="app-no-drag flex flex-1 flex-col items-center justify-center overflow-hidden px-8 py-8">
+        <div className="flex w-full max-w-xl flex-col gap-8">
+          <div className="flex flex-col items-center gap-2 text-center">
+            <h1 className="font-medium text-foreground text-xl">
+              Use your existing skills
+            </h1>
+            <p className="max-w-md text-muted-foreground text-sm">
+              We found skills from other coding agents. Enable the sources you
+              want stagewise to use.
+            </p>
+          </div>
+
+          <div className="divide-y divide-border-subtle overflow-hidden rounded-lg border border-derived bg-surface-1">
+            {detectedSources.map((source) => (
+              <div key={source.prefix} className="flex items-center gap-4 p-4">
+                <div className="min-w-0 flex-1">
+                  <p className="font-medium text-foreground text-sm">
+                    {source.label}
+                  </p>
+                  <p className="text-muted-foreground text-xs">
+                    {source.directory} · {source.skillCount}{' '}
+                    {source.skillCount === 1 ? 'skill' : 'skills'}
+                  </p>
+                </div>
+                <Switch
+                  checked={selection[source.prefix] !== false}
+                  onCheckedChange={(enabled) =>
+                    onSelectionChange(source.prefix, enabled)
+                  }
+                  size="sm"
+                  aria-label={`Use ${source.label} skills`}
+                />
+              </div>
+            ))}
+          </div>
+
+          {saveError ? (
+            <p
+              role="alert"
+              className="text-center text-error-foreground text-xs"
+            >
+              {saveError}
+            </p>
+          ) : null}
+        </div>
+      </div>
+      <OnboardingBottomNav
+        left={<BackButton onClick={onBack} disabled={isSaving} />}
+        right={
+          <NextButton
+            onClick={() => void handleNext()}
+            label={isSaving ? 'Saving...' : 'Next'}
+            disabled={isSaving}
+          />
+        }
+      />
+    </>
+  );
+}

--- a/apps/browser/src/ui/screens/settings/sections/skills-context-section.tsx
+++ b/apps/browser/src/ui/screens/settings/sections/skills-context-section.tsx
@@ -18,7 +18,10 @@ import {
 } from '@stagewise/stage-ui/components/tooltip';
 import type { RefObject } from 'react';
 import { SettingsScrollTabs } from '../_components/settings-scroll-tabs';
-import { ALWAYS_ENABLED_GLOBAL_SKILL_PREFIXES } from '@shared/global-skill-prefixes';
+import {
+  ALWAYS_ENABLED_GLOBAL_SKILL_PREFIXES,
+  GLOBAL_SKILL_SOURCES,
+} from '@shared/global-skill-prefixes';
 
 // =============================================================================
 // Vertical overflow detection (like useIsTruncated but for height)
@@ -236,37 +239,6 @@ function WorkspaceDetails({ mount }: { mount: MountEntry }) {
 // Global Skills Section
 // =============================================================================
 
-/** Mount prefixes that are always enabled (not toggleable in the UI). */
-/** Display metadata for each global skill directory. */
-const GLOBAL_SKILL_DIR_META: Record<string, { label: string; dir: string }> = {
-  'globalskills-sw': { label: 'Stagewise', dir: '~/.stagewise/skills' },
-  'globalskills-agents': { label: 'Agents', dir: '~/.agents/skills' },
-  'globalskills-codex': { label: 'Codex', dir: '~/.codex/skills' },
-  'globalskills-claude': { label: 'Claude Code', dir: '~/.claude/skills' },
-};
-
-/** Stable ordering for global skill directory display. */
-const GLOBAL_SKILL_DIR_ORDER = [
-  'globalskills-sw',
-  'globalskills-agents',
-  'globalskills-codex',
-  'globalskills-claude',
-] as const;
-
-/**
- * Lookup metadata for a global skill dir prefix. Throws if the prefix
- * is not in `GLOBAL_SKILL_DIR_META` — all callers use
- * `GLOBAL_SKILL_DIR_ORDER` so the key is always valid.
- */
-function getGlobalSkillDirMeta(prefix: string): {
-  label: string;
-  dir: string;
-} {
-  const meta = GLOBAL_SKILL_DIR_META[prefix];
-  if (!meta) throw new Error(`Unknown global skill dir prefix: ${prefix}`);
-  return meta;
-}
-
 type GlobalSkillEntry = AppState['globalSkills'][number];
 
 function GlobalSkillsDetails() {
@@ -338,8 +310,8 @@ function GlobalSkillsDetails() {
 
   return (
     <div className="space-y-8">
-      {GLOBAL_SKILL_DIR_ORDER.map((prefix) => {
-        const meta = getGlobalSkillDirMeta(prefix);
+      {GLOBAL_SKILL_SOURCES.map((source, index) => {
+        const prefix = source.prefix;
         const isAlwaysEnabled =
           ALWAYS_ENABLED_GLOBAL_SKILL_PREFIXES.has(prefix);
         const dirEnabled =
@@ -348,9 +320,7 @@ function GlobalSkillsDetails() {
 
         return (
           <div key={prefix}>
-            {prefix !== GLOBAL_SKILL_DIR_ORDER[0] && (
-              <hr className="border-derived-subtle border-t" />
-            )}
+            {index > 0 && <hr className="border-derived-subtle border-t" />}
             <section className="space-y-3 pt-8 first:pt-0">
               {/* Header with inline dir toggle next to name */}
               <div
@@ -373,7 +343,7 @@ function GlobalSkillsDetails() {
               >
                 <div className="flex items-center gap-3">
                   <h3 className="font-medium text-foreground text-lg">
-                    {meta.label} skills
+                    {source.label} skills
                   </h3>
                   {!isAlwaysEnabled && (
                     <div onClick={(e) => e.stopPropagation()}>
@@ -388,7 +358,7 @@ function GlobalSkillsDetails() {
                   )}
                 </div>
                 <p className="text-muted-foreground text-sm">
-                  {meta.dir}
+                  {source.directory}
                   {skills.length > 0 &&
                     ` · ${skills.length} skill${skills.length === 1 ? '' : 's'}`}
                 </p>


### PR DESCRIPTION
## Summary

- detect existing Codex and Claude Code skills during startup
- conditionally show a skill-source step during onboarding
- enable detected sources by default and persist the user's selection

<img width="1682" height="1010" alt="image" src="https://github.com/user-attachments/assets/1afc0a62-2877-492c-b032-ffe47324203e" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to onboarding routing, preferences for optional skill directories, and startup indexing resilience—no auth or security-sensitive paths.
> 
> **Overview**
> Adds a conditional **configure-skills** onboarding step when Codex or Claude Code skills show up in `globalSkills`, so users can opt into those directories before personalization.
> 
> The wizard branches after providers (skills step only when external skills are detected), back from theme returns to skills when that step ran, and telemetry/contracts include the new `configure-skills` step. **StepConfigureSkills** lists detected external sources (on by default), writes `preferences.agent.enabledGlobalSkillDirs` on Next (preserving unrelated prefixes), and disables navigation while saving.
> 
> **Toolbox** now **awaits** `rebuildGlobalSkillsIndex()` during startup so onboarding can read the index early; per-mount discovery errors are caught instead of failing the whole index. Global skill source labels/paths are centralized in `GLOBAL_SKILL_SOURCES` / `EXTERNAL_GLOBAL_SKILL_SOURCES` and reused in Settings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0730a1285b8b9e74704164d4ea5a6090a058f6c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an onboarding step to detect external global skills (Codex, Claude Code) and let users enable them. Makes skill discovery non-blocking and updates telemetry, settings, and indexing to support this flow.

- New Features
  - Detect existing Codex and Claude Code skills at startup and show a "Configure skills" step when found.
  - Enable detected sources by default; persist user choices to `preferences.agent.enabledGlobalSkillDirs`.
  - Add telemetry step `configure-skills` with enter/exit events and routing.
  - Disable Back/Next while saving; show an error if saving fails. Tests cover routing, persistence, and saving behavior.

- Bug Fixes
  - Prevent global skill discovery from blocking startup; populate the index before onboarding, keep it current with watchers, and handle per-mount discovery errors with logging and reporting.

<sup>Written for commit 0730a1285b8b9e74704164d4ea5a6090a058f6c7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1539?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an onboarding step for configuring detected external skills.
  - View available skill sources, see skill counts, and enable or disable sources.
  - Selections are saved to preferences while preserving existing skill directories.
  - Added support for external skill sources from Codex and Claude Code.
  - Updated Settings to display global skill sources consistently.

- **Bug Fixes**
  - Improved skill indexing during startup and prevented unnecessary rebuilds.
  - Added clearer navigation handling while skill preferences are being saved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->