### PR TITLE
feat(stagewise): support zooming chat images and Mermaid diagrams

### DIFF
--- a/apps/browser/package.json
+++ b/apps/browser/package.json
@@ -56,6 +56,7 @@
     "pdfjs-dist": "^5.7.284",
     "prosemirror-highlight": "^0.15.1",
     "react-virtuoso": "^4.18.7",
+    "react-zoom-pan-pinch": "^4.0.4",
     "sharp": "^0.34.5",
     "tiptap-markdown": "^0.9.0",
     "web-tree-sitter": "^0.26.6",

--- a/apps/browser/src/backend/main.ts
+++ b/apps/browser/src/backend/main.ts
@@ -69,6 +69,7 @@ import type { SkillDefinition, SkillDefinitionUI } from '@shared/skills';
 import { AssetCacheService } from './services/asset-cache';
 import { detectShell, resolveShellEnv } from '@stagewise/agent-shell';
 import path from 'node:path';
+import { createHash } from 'node:crypto';
 import { registerStartupUrlHandler } from './startup-url-events';
 import { requestAppDataReset } from './utils/app-data-reset';
 import { AgentPowerSaveBlockerService } from './services/agent-power-save-blocker';
@@ -886,6 +887,39 @@ export async function main({ launchOptions: { verbose } }: MainParameters) {
         agentInstanceId,
         options,
       ),
+  );
+  uiKarton.registerServerProcedureHandler(
+    'fileTree.openImageTab',
+    async (
+      _cid,
+      title: string,
+      sourceUrl: string,
+      mimeType: string,
+      agentInstanceId?: string | null,
+    ) => {
+      const id = createHash('sha256').update(sourceUrl).digest('hex');
+      const subtype =
+        mimeType === 'image/svg+xml' ? 'svg' : mimeType.split('/')[1];
+      const extension = subtype?.match(/^[a-z0-9]+$/i) ? subtype : 'img';
+      return windowLayoutService.openFileTab(
+        {
+          workspaceKey: 'media:',
+          relativePath: `${id}.${extension}`,
+          absolutePath: '',
+          kind: 'image',
+          mimeType,
+          size: 0,
+          displayName: title.trim() || 'Image',
+          sourceUrl,
+          readOnly: true,
+        },
+        agentInstanceId,
+        {
+          preview: true,
+          temporaryGroupKey: `media-preview:${agentInstanceId ?? 'global'}`,
+        },
+      );
+    },
   );
   uiKarton.registerServerProcedureHandler(
     'fileTree.promoteFileTab',

--- a/apps/browser/src/backend/services/window-layout/index.ts
+++ b/apps/browser/src/backend/services/window-layout/index.ts
@@ -75,6 +75,7 @@ const fileTabMetadataSchema = z.object({
   mimeType: z.string(),
   size: z.number(),
   displayName: z.string().optional(),
+  sourceUrl: z.string().optional(),
   readOnly: z.boolean().optional(),
   showDiff: z.boolean().optional(),
   diffStaged: z.boolean().optional(),
@@ -980,7 +981,7 @@ export class WindowLayoutService extends DisposableService {
   public promoteFileTab(tabId: string): void {
     this.uiKarton.setState((draft) => {
       const tab = draft.contentTabs.tabs[tabId];
-      if (tab?.type === 'file' && tab.file) {
+      if (tab?.type === 'file' && tab.file && !tab.file.sourceUrl) {
         tab.lifecycle = { kind: 'permanent' };
       }
     });
@@ -3047,9 +3048,11 @@ export class WindowLayoutService extends DisposableService {
       const contentTabsTabs = contentTabs.tabs;
       const allIds = this.getAllOrderedTabIds(contentTabs).filter((id) => {
         const tab = contentTabsTabs[id];
-        // Never persist temporary/preview file tabs — they are ephemeral by
-        // design and should not survive a restart.
-        if (tab?.type === 'file' && tab.lifecycle?.kind !== 'permanent')
+        // Preview tabs and direct media payloads are session-only.
+        if (
+          tab?.type === 'file' &&
+          (tab.lifecycle?.kind !== 'permanent' || tab.file?.sourceUrl)
+        )
           return false;
         return true;
       });

--- a/apps/browser/src/shared/karton-contracts/ui/index.ts
+++ b/apps/browser/src/shared/karton-contracts/ui/index.ts
@@ -699,6 +699,8 @@ export type FileTabMetadata = {
    * file name should be shown to the user.
    */
   displayName?: string;
+  /** Direct image URL for read-only media tabs that do not have a file path. */
+  sourceUrl?: string;
   /** When true, the tab content is read-only (e.g. attachment blobs). */
   readOnly?: boolean;
   /**
@@ -2025,6 +2027,12 @@ export type KartonContract = {
         displayName?: string,
         agentInstanceId?: string | null,
         options?: OpenFileTabOptions,
+      ) => Promise<string | null>;
+      openImageTab: (
+        title: string,
+        sourceUrl: string,
+        mimeType: string,
+        agentInstanceId?: string | null,
       ) => Promise<string | null>;
       promoteFileTab: (tabId: string) => Promise<void>;
       renameEntry: (

--- a/apps/browser/src/ui/components/file-preview/previews/image-expanded.tsx
+++ b/apps/browser/src/ui/components/file-preview/previews/image-expanded.tsx
@@ -1,16 +1,31 @@
 import type { FilePreviewProps } from '../types';
 import { cn } from '@ui/utils';
+import { useOpenImageTab } from '@ui/hooks/use-open-image-tab';
 
 export default function ImageExpanded({
   src,
   fileName,
+  mediaType,
   className,
 }: FilePreviewProps) {
+  const openImageTab = useOpenImageTab();
+
   return (
-    <img
-      src={src}
-      alt={fileName}
-      className={cn('max-h-56 max-w-72 rounded object-contain', className)}
-    />
+    <button
+      type="button"
+      className="cursor-pointer rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-solid"
+      aria-label={`Open ${fileName} in tab`}
+      onMouseDown={(event) => event.stopPropagation()}
+      onClick={(event) => {
+        event.stopPropagation();
+        openImageTab(fileName, src, mediaType);
+      }}
+    >
+      <img
+        src={src}
+        alt={fileName}
+        className={cn('max-h-56 max-w-72 rounded object-contain', className)}
+      />
+    </button>
   );
 }

--- a/apps/browser/src/ui/components/streamdown/index.tsx
+++ b/apps/browser/src/ui/components/streamdown/index.tsx
@@ -6,6 +6,7 @@ import { useOpenAgent } from '@ui/hooks/use-open-chat';
 import { CodeBlock } from '../ui/code-block';
 import { StreamingCodeBlock } from '../ui/streaming-code-block';
 import { Mermaid } from '../ui/mermaid';
+import { useOpenImageTab } from '@ui/hooks/use-open-image-tab';
 import {
   memo,
   type DetailedHTMLProps,
@@ -358,6 +359,7 @@ const CodeComponent = ({
         >
           <Mermaid
             chart={code}
+            openInTab
             config={{
               theme: 'default',
             }}
@@ -641,6 +643,7 @@ const ImgComponent = ({
   ...props
 }: DetailedHTMLProps<ImgHTMLAttributes<HTMLImageElement>, HTMLImageElement> &
   ExtraProps) => {
+  const openImageTab = useOpenImageTab();
   const downloadImage = useCallback(async () => {
     if (!src) return;
 
@@ -672,9 +675,9 @@ const ImgComponent = ({
   }, [src]);
 
   return (
-    <div className="my-2 flex flex-col gap-1" data-streamdown="image-wrapper">
+    <span className="my-2 flex flex-col gap-1" data-streamdown="image-wrapper">
       {/* Download control */}
-      <div className="flex items-center justify-end">
+      <span className="flex items-center justify-end">
         <Button
           variant="ghost"
           size="icon-xs"
@@ -683,17 +686,30 @@ const ImgComponent = ({
         >
           <DownloadIcon className="size-3" />
         </Button>
-      </div>
+      </span>
 
-      {/* Image */}
-      <img
-        className={cn('max-w-full rounded-lg', className)}
-        alt={alt ?? ''}
-        src={src}
-        data-streamdown="image"
-        {...props}
-      />
-    </div>
+      {src ? (
+        <button
+          type="button"
+          className="max-w-full cursor-pointer rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-solid"
+          aria-label={`Open ${alt || 'image'} in tab`}
+          onMouseDown={(event) => event.stopPropagation()}
+          onClick={(event) => {
+            event.preventDefault();
+            event.stopPropagation();
+            openImageTab(alt || 'Image', src);
+          }}
+        >
+          <img
+            className={cn('max-w-full rounded-lg', className)}
+            alt={alt ?? ''}
+            src={src}
+            data-streamdown="image"
+            {...props}
+          />
+        </button>
+      ) : null}
+    </span>
   );
 };
 

--- a/apps/browser/src/ui/components/ui/mermaid.tsx
+++ b/apps/browser/src/ui/components/ui/mermaid.tsx
@@ -3,6 +3,7 @@ import type { MermaidConfig } from 'mermaid';
 import { useEffect, useRef, useState } from 'react';
 import { cn } from '@ui/utils';
 import { getMermaidCache } from '@ui/hooks/use-mermaid-cache';
+import { useOpenImageTab } from '@ui/hooks/use-open-image-tab';
 
 const initializeMermaid = async (customConfig?: MermaidConfig) => {
   const defaultConfig: MermaidConfig = {
@@ -29,9 +30,16 @@ type MermaidProps = {
   chart: string;
   className?: string;
   config?: MermaidConfig;
+  openInTab?: boolean;
 };
 
-export const Mermaid = ({ chart, className, config }: MermaidProps) => {
+export const Mermaid = ({
+  chart,
+  className,
+  config,
+  openInTab = false,
+}: MermaidProps) => {
+  const openImageTab = useOpenImageTab();
   const cachedEntry = mermaidCache.get(chart, config);
 
   const [error, setError] = useState<string | null>(null);
@@ -42,7 +50,6 @@ export const Mermaid = ({ chart, className, config }: MermaidProps) => {
   const [lastValidSvg, setLastValidSvg] = useState<string>(
     cachedEntry?.svgHtml ?? '',
   );
-
   const mountedRef = useRef(true);
 
   useEffect(() => {
@@ -139,6 +146,40 @@ export const Mermaid = ({ chart, className, config }: MermaidProps) => {
   }
 
   const displaySvg = svgContent || lastValidSvg;
+
+  if (openInTab) {
+    return (
+      <button
+        type="button"
+        aria-label="Open Mermaid chart in tab"
+        className={cn(
+          'my-4 flex cursor-pointer justify-center rounded-md',
+          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-solid',
+          className,
+        )}
+        onMouseDown={(event) => event.stopPropagation()}
+        onClick={(event) => {
+          event.stopPropagation();
+          const svg = event.currentTarget.querySelector('svg');
+          if (!svg) return;
+          const exportedSvg = svg.cloneNode(true) as SVGSVGElement;
+          const { width, height } = svg.viewBox.baseVal;
+          if (width && height) {
+            exportedSvg.setAttribute('width', String(width));
+            exportedSvg.setAttribute('height', String(height));
+          }
+          openImageTab(
+            'Mermaid chart',
+            `data:image/svg+xml;charset=utf-8,${encodeURIComponent(
+              new XMLSerializer().serializeToString(exportedSvg),
+            )}`,
+            'image/svg+xml',
+          );
+        }}
+        dangerouslySetInnerHTML={{ __html: displaySvg }}
+      />
+    );
+  }
 
   return (
     <div

--- a/apps/browser/src/ui/components/ui/zoomable-viewport.tsx
+++ b/apps/browser/src/ui/components/ui/zoomable-viewport.tsx
@@ -1,0 +1,193 @@
+import {
+  type ReactZoomPanPinchProps,
+  type ReactZoomPanPinchRef,
+  TransformComponent,
+  TransformWrapper,
+} from 'react-zoom-pan-pinch';
+import {
+  type ComponentProps,
+  type ReactNode,
+  type WheelEvent,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
+import { HotkeyActions } from '@shared/hotkeys';
+import { useHotKeyListener } from '@ui/hooks/use-hotkey-listener';
+import { cn } from '@ui/utils';
+
+type UseZoomableViewportOptions = {
+  hotkeysEnabled?: boolean;
+  onInteract?: () => void;
+};
+
+export function useZoomableViewport({
+  hotkeysEnabled = false,
+  onInteract,
+}: UseZoomableViewportOptions = {}) {
+  const ref = useRef<ReactZoomPanPinchRef>(null);
+  const [scale, setScale] = useState(1);
+
+  const handleInteract = useCallback(() => onInteract?.(), [onInteract]);
+
+  const handleTransform = useCallback<
+    NonNullable<ReactZoomPanPinchProps['onTransform']>
+  >((_ref, state) => setScale(state.scale), []);
+
+  const zoomIn = useCallback(() => {
+    handleInteract();
+    ref.current?.zoomIn(0.25, 150);
+  }, [handleInteract]);
+
+  const zoomOut = useCallback(() => {
+    handleInteract();
+    ref.current?.zoomOut(0.25, 150);
+  }, [handleInteract]);
+
+  const resetZoom = useCallback(() => {
+    handleInteract();
+    ref.current?.centerView(1, 150);
+  }, [handleInteract]);
+
+  const fit = useCallback((animationTime: number) => {
+    const viewport = ref.current;
+    const wrapper = viewport?.instance.wrapperComponent;
+    const content = viewport?.instance.contentComponent;
+    if (!viewport || !wrapper || !content) return;
+    if (!wrapper.clientWidth || !wrapper.clientHeight) return;
+    if (!content.offsetWidth || !content.offsetHeight) return;
+
+    const scale = Math.max(
+      Math.min(
+        wrapper.clientWidth / content.offsetWidth,
+        wrapper.clientHeight / content.offsetHeight,
+        1,
+      ),
+      viewport.instance.setup.minScale,
+    );
+    viewport.centerView(scale, animationTime);
+  }, []);
+
+  const fitToView = useCallback(() => {
+    handleInteract();
+    fit(150);
+  }, [fit, handleInteract]);
+
+  useHotKeyListener(zoomIn, HotkeyActions.ZOOM_IN, hotkeysEnabled);
+  useHotKeyListener(zoomOut, HotkeyActions.ZOOM_OUT, hotkeysEnabled);
+  useHotKeyListener(resetZoom, HotkeyActions.ZOOM_RESET, hotkeysEnabled);
+
+  return {
+    ref,
+    scale,
+    zoomIn,
+    zoomOut,
+    resetZoom,
+    fitToView,
+    fit,
+    handleTransform,
+    handleInteract,
+  };
+}
+
+type ZoomableViewportController = ReturnType<typeof useZoomableViewport>;
+
+type ZoomableViewportProps = {
+  children: ReactNode;
+  controller: ZoomableViewportController;
+  className?: string;
+  wrapperProps?: ComponentProps<'div'> & {
+    [key: `data-${string}`]: string | undefined;
+  };
+};
+
+const hasZoomModifier = (keys: string[]) =>
+  keys.includes('Control') || keys.includes('Meta');
+
+const hasNoShiftModifier = (keys: string[]) => !keys.includes('Shift');
+
+export function ZoomableViewport({
+  children,
+  controller,
+  className,
+  wrapperProps,
+}: ZoomableViewportProps) {
+  useEffect(() => {
+    const content = controller.ref.current?.instance.contentComponent;
+    if (!content) return;
+
+    const fit = () => controller.fit(0);
+    const frame = requestAnimationFrame(fit);
+    content.addEventListener('load', fit, true);
+
+    return () => {
+      cancelAnimationFrame(frame);
+      content.removeEventListener('load', fit, true);
+    };
+  }, [controller.fit, controller.ref]);
+
+  const handleWheel = useCallback(
+    (event: WheelEvent<HTMLDivElement>) => {
+      if (!event.shiftKey) return;
+
+      const viewport = controller.ref.current;
+      if (!viewport) return;
+
+      event.preventDefault();
+      event.stopPropagation();
+      controller.handleInteract();
+
+      const { positionX, positionY, scale } = viewport.state;
+      viewport.setTransform(
+        positionX - (event.deltaX || event.deltaY),
+        positionY,
+        scale,
+        0,
+      );
+    },
+    [controller.handleInteract, controller.ref],
+  );
+
+  return (
+    <TransformWrapper
+      ref={controller.ref}
+      minScale={0.01}
+      maxScale={100}
+      limitToBounds={false}
+      centerOnInit
+      centerZoomedOut
+      autoAlignment={{ disabled: true }}
+      wheel={{
+        step: 0.004,
+        activationKeys: hasZoomModifier,
+      }}
+      trackPadPanning={{
+        disabled: false,
+        activationKeys: hasNoShiftModifier,
+      }}
+      panning={{
+        velocityDisabled: true,
+        allowMiddleClickPan: false,
+        allowRightClickPan: false,
+      }}
+      doubleClick={{ mode: 'toggle', step: 0.75 }}
+      onTransform={controller.handleTransform}
+      onPanningStart={controller.handleInteract}
+      onPinchStart={controller.handleInteract}
+      onZoomStart={controller.handleInteract}
+    >
+      <TransformComponent
+        wrapperClass={cn(
+          'cursor-grab touch-none select-none active:cursor-grabbing',
+          className,
+        )}
+        contentClass="will-change-transform"
+        wrapperStyle={{ width: '100%', height: '100%' }}
+        wrapperProps={{ ...wrapperProps, onWheel: handleWheel }}
+      >
+        {children}
+      </TransformComponent>
+    </TransformWrapper>
+  );
+}

--- a/apps/browser/src/ui/components/ui/zoomable-viewport.tsx
+++ b/apps/browser/src/ui/components/ui/zoomable-viewport.tsx
@@ -22,6 +22,8 @@ type UseZoomableViewportOptions = {
   onInteract?: () => void;
 };
 
+const FIT_PADDING = 24;
+
 export function useZoomableViewport({
   hotkeysEnabled = false,
   onInteract,
@@ -55,15 +57,25 @@ export function useZoomableViewport({
     const wrapper = viewport?.instance.wrapperComponent;
     const content = viewport?.instance.contentComponent;
     if (!viewport || !wrapper || !content) return;
-    if (!wrapper.clientWidth || !wrapper.clientHeight) return;
-    if (!content.offsetWidth || !content.offsetHeight) return;
+
+    const image = content.firstElementChild;
+    if (
+      image instanceof HTMLImageElement &&
+      image.naturalWidth &&
+      image.naturalHeight
+    ) {
+      image.style.width = `${image.naturalWidth}px`;
+      image.style.height = `${image.naturalHeight}px`;
+    }
+
+    const availableWidth = wrapper.clientWidth - FIT_PADDING * 2;
+    const availableHeight = wrapper.clientHeight - FIT_PADDING * 2;
+    const { offsetWidth, offsetHeight } = content;
+    if (availableWidth <= 0 || availableHeight <= 0) return;
+    if (!offsetWidth || !offsetHeight) return;
 
     const scale = Math.max(
-      Math.min(
-        wrapper.clientWidth / content.offsetWidth,
-        wrapper.clientHeight / content.offsetHeight,
-        1,
-      ),
+      Math.min(availableWidth / offsetWidth, availableHeight / offsetHeight, 1),
       viewport.instance.setup.minScale,
     );
     viewport.centerView(scale, animationTime);
@@ -77,6 +89,7 @@ export function useZoomableViewport({
   useHotKeyListener(zoomIn, HotkeyActions.ZOOM_IN, hotkeysEnabled);
   useHotKeyListener(zoomOut, HotkeyActions.ZOOM_OUT, hotkeysEnabled);
   useHotKeyListener(resetZoom, HotkeyActions.ZOOM_RESET, hotkeysEnabled);
+  useHotKeyListener(fitToView, HotkeyActions.CENTER_IMAGE, hotkeysEnabled);
 
   return {
     ref,

--- a/apps/browser/src/ui/hooks/use-open-image-tab.ts
+++ b/apps/browser/src/ui/hooks/use-open-image-tab.ts
@@ -1,0 +1,15 @@
+import { useCallback } from 'react';
+import { useKartonProcedure } from './use-karton';
+import { useOpenAgent } from './use-open-chat';
+
+export function useOpenImageTab() {
+  const [openAgent] = useOpenAgent();
+  const openImageTab = useKartonProcedure((p) => p.fileTree.openImageTab);
+
+  return useCallback(
+    (title: string, sourceUrl: string, mimeType = 'image/*') => {
+      void openImageTab(title, sourceUrl, mimeType, openAgent);
+    },
+    [openAgent, openImageTab],
+  );
+}

--- a/apps/browser/src/ui/screens/main/agent-chat/chat/_components/message-part-ui/file.tsx
+++ b/apps/browser/src/ui/screens/main/agent-chat/chat/_components/message-part-ui/file.tsx
@@ -2,9 +2,12 @@ import { FileIcon, ImageIcon } from 'lucide-react';
 import { openFileUrl } from '@ui/utils';
 import type { FileUIPart } from '@shared/karton-contracts/ui';
 import { Button } from '@stagewise/stage-ui/components/button';
+import { useOpenImageTab } from '@ui/hooks/use-open-image-tab';
 
 export const FilePart = ({ part }: { part: FileUIPart }) => {
+  const openImageTab = useOpenImageTab();
   const isImage = part.mediaType.startsWith('image/');
+  const fileName = part.filename ?? 'Generated file';
 
   return (
     <div className="-mx-1 rounded-xl">
@@ -14,7 +17,8 @@ export const FilePart = ({ part }: { part: FileUIPart }) => {
         data-image={isImage}
         className="group/file-part flex h-auto w-full flex-col items-center gap-1 rounded-xl text-foreground"
         onClick={() => {
-          void openFileUrl(part.url, part.filename);
+          if (isImage) openImageTab(fileName, part.url, part.mediaType);
+          else void openFileUrl(part.url, part.filename);
         }}
       >
         <div className="flex w-full shrink-0 flex-row items-center justify-start gap-1.5 group-data-[image=true]/file-part:text-muted-foreground">
@@ -23,17 +27,15 @@ export const FilePart = ({ part }: { part: FileUIPart }) => {
           ) : (
             <FileIcon className="size-3" />
           )}
-          <span className="flex-1 text-start text-xs">
-            {part.filename ?? 'Generated file'}
-          </span>
+          <span className="flex-1 text-start text-xs">{fileName}</span>
         </div>
-        {isImage && (
+        {isImage ? (
           <img
             src={part.url}
-            alt={part.filename ?? 'Generated file'}
+            alt={fileName}
             className="m-1 w-max rounded object-cover"
           />
-        )}
+        ) : null}
       </Button>
     </div>
   );

--- a/apps/browser/src/ui/screens/main/file-tree/file-preview-tab-content.tsx
+++ b/apps/browser/src/ui/screens/main/file-tree/file-preview-tab-content.tsx
@@ -16,6 +16,7 @@ import { useKartonProcedure, useKartonState } from '@ui/hooks/use-karton';
 import { cn } from '@ui/utils';
 import { useTabUIState } from '@ui/hooks/use-tab-ui-state';
 import type {
+  FileDiffContent,
   FilePreviewResult,
   FileStatResult,
   TabState,
@@ -29,7 +30,6 @@ import {
   type ReactElement,
 } from 'react';
 import { IconDatabaseFillDuo18 } from '@stagewise/icons';
-import type { FileDiffContent } from '@shared/karton-contracts/ui';
 import {
   Loader2Icon,
   MinusIcon,
@@ -58,8 +58,13 @@ import { useHotKeyListener } from '@ui/hooks/use-hotkey-listener';
 import { HotkeyCombo } from '@ui/components/hotkey-combo';
 import { FileIcon } from '@ui/components/file-icon';
 import { nativeFileManagerLabel } from '@shared/ide-url';
+import { inferMimeType } from '@shared/mime-utils';
 import { OpenInIdeMenu } from '@ui/components/open-in-ide-menu-items';
 import { Streamdown } from '@ui/components/streamdown';
+import {
+  useZoomableViewport,
+  ZoomableViewport,
+} from '@ui/components/ui/zoomable-viewport';
 import {
   type EditorActions,
   useFileEditorController,
@@ -962,6 +967,16 @@ function useFileCodeZoom(tabId: string, enabled = true) {
 
 type DiffMode = 'inline' | 'split';
 
+function getWorkspacePath(workspaceKey: string) {
+  const colonIndex = workspaceKey.indexOf(':');
+  return colonIndex < 0 ? workspaceKey : workspaceKey.slice(colonIndex + 1);
+}
+
+function isImagePath(filePath: string | undefined) {
+  if (!filePath) return false;
+  return inferMimeType(filePath).startsWith('image/');
+}
+
 function DiffEditorPreview({
   tab,
   tabId,
@@ -1030,12 +1045,7 @@ function DiffEditorPreview({
 
   // Extract the workspace path from the workspace key for the git diff
   // procedure (it expects a filesystem path, not a composite key).
-  const workspacePath = useMemo(() => {
-    const colonIdx = tab.workspaceKey.indexOf(':');
-    return colonIdx < 0
-      ? tab.workspaceKey
-      : tab.workspaceKey.slice(colonIdx + 1);
-  }, [tab.workspaceKey]);
+  const workspacePath = getWorkspacePath(tab.workspaceKey);
 
   // All save / dirty / undo-redo / conflict / unsaved-prompt / hotkey behavior
   // is shared with the plain source editor via this controller. The diff
@@ -1561,179 +1571,82 @@ function getCheckerboardStyle(background: SvgPreviewBackground) {
     : undefined;
 }
 
-function useImagePanAndZoom(tabId: string, enabled = true) {
-  const [zoom, setZoom] = useState(1);
-  const [pan, setPan] = useState({ x: 0, y: 0 });
-  const { tabUiState, setTabUiState } = useTabUIState();
-  const isTabContentFocused = tabUiState[tabId]?.focusedPanel === 'tab-content';
-  const panStateRef = useRef<{
-    pointerId: number | null;
-    startX: number;
-    startY: number;
-    originX: number;
-    originY: number;
-  }>({ pointerId: null, startX: 0, startY: 0, originX: 0, originY: 0 });
-
-  const markFocused = useCallback(() => {
-    setTabUiState(tabId, { focusedPanel: 'tab-content' });
-  }, [setTabUiState, tabId]);
-
-  const zoomBy = useCallback((delta: number) => {
-    setZoom((value) => Math.max(0.01, value + delta));
-  }, []);
-
-  const handleZoomIn = useCallback(() => {
-    if (!isTabContentFocused) return false;
-    zoomBy(0.25);
-  }, [isTabContentFocused, zoomBy]);
-
-  const handleZoomOut = useCallback(() => {
-    if (!isTabContentFocused) return false;
-    zoomBy(-0.25);
-  }, [isTabContentFocused, zoomBy]);
-
-  const handleZoomReset = useCallback(() => {
-    if (!isTabContentFocused) return false;
-    setZoom(1);
-  }, [isTabContentFocused]);
-
-  useHotKeyListener(handleZoomIn, HotkeyActions.ZOOM_IN, enabled);
-  useHotKeyListener(handleZoomOut, HotkeyActions.ZOOM_OUT, enabled);
-  useHotKeyListener(handleZoomReset, HotkeyActions.ZOOM_RESET, enabled);
-
-  const handleWheel = useCallback((event: React.WheelEvent) => {
-    if (!event.ctrlKey && !event.metaKey) return;
-    event.preventDefault();
-    const factor = Math.exp(-event.deltaY * 0.0035);
-    setZoom((value) => Math.max(0.01, value * factor));
-  }, []);
-
-  const handlePointerDown = useCallback(
-    (event: React.PointerEvent) => {
-      if (event.button !== 0) return;
-      event.preventDefault();
-      markFocused();
-      (event.currentTarget as HTMLElement).focus({ preventScroll: true });
-      panStateRef.current = {
-        pointerId: event.pointerId,
-        startX: event.clientX,
-        startY: event.clientY,
-        originX: pan.x,
-        originY: pan.y,
-      };
-      event.currentTarget.setPointerCapture(event.pointerId);
-    },
-    [markFocused, pan.x, pan.y],
-  );
-
-  const clearPanCapture = useCallback((event: React.PointerEvent) => {
-    if (panStateRef.current.pointerId !== event.pointerId) return;
-    panStateRef.current.pointerId = null;
-    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
-      event.currentTarget.releasePointerCapture(event.pointerId);
-    }
-  }, []);
-
-  const handlePointerMove = useCallback((event: React.PointerEvent) => {
-    const state = panStateRef.current;
-    if (state.pointerId !== event.pointerId) return;
-    if ((event.buttons & 1) === 0) {
-      panStateRef.current.pointerId = null;
-      return;
-    }
-    setPan({
-      x: state.originX + event.clientX - state.startX,
-      y: state.originY + event.clientY - state.startY,
-    });
-  }, []);
-
-  return {
-    zoom,
-    pan,
-    isPanned: pan.x !== 0 || pan.y !== 0,
-    setZoom,
-    setPan,
-    zoomBy,
-    handleWheel,
-    handlePointerDown,
-    handlePointerMove,
-    clearPanCapture,
-    markFocused,
-  };
+function getCanvasStyle(
+  background: SvgPreviewBackground,
+  customBackground: string,
+) {
+  return background === 'custom'
+    ? { backgroundColor: normalizeHexColor(customBackground, '#ffffff') }
+    : getCheckerboardStyle(background);
 }
 
 function ImagePreview({
-  preview,
-  blobUrl,
+  src,
+  alt,
+  openExternalPath,
   tabId,
 }: {
-  preview: FilePreviewResult;
-  blobUrl: string;
+  src: string;
+  alt: string;
+  openExternalPath?: string;
   tabId: string;
 }) {
   const [background, setBackground] =
     useState<ImagePreviewBackground>('default');
   const [customBackground, setCustomBackground] = useState('ffffff');
-  const {
-    zoom,
-    pan,
-    isPanned,
-    setZoom,
-    setPan,
-    zoomBy,
-    handleWheel,
-    handlePointerDown,
-    handlePointerMove,
-    clearPanCapture,
-    markFocused,
-  } = useImagePanAndZoom(tabId);
-  const normalizedCustomBackground = normalizeHexColor(
-    customBackground,
-    '#ffffff',
-  );
+  const { tabUiState, setTabUiState } = useTabUIState();
+  const isTabContentFocused = tabUiState[tabId]?.focusedPanel === 'tab-content';
+  const markFocused = useCallback(() => {
+    setTabUiState(tabId, { focusedPanel: 'tab-content' });
+  }, [setTabUiState, tabId]);
+  const zoomController = useZoomableViewport({
+    hotkeysEnabled: isTabContentFocused,
+    onInteract: markFocused,
+  });
+  const backgroundStyle = getCanvasStyle(background, customBackground);
   const [imageError, setImageError] = useState(false);
   return (
     <div className="flex size-full flex-col bg-background">
       <FileTabToolbar
         actions={null}
-        openExternalPath={getPreviewAbsolutePath(preview)}
+        openExternalPath={openExternalPath}
         right={
           <>
-            {isPanned ? (
-              <div className="flex items-center px-1">
-                <Button
-                  variant="ghost"
-                  size="icon-xs"
-                  aria-label="Center image"
-                  onClick={() => setPan({ x: 0, y: 0 })}
-                >
-                  <IconArrowsToCenterOutline18 className="size-4" />
-                </Button>
-              </div>
-            ) : null}
+            <div className="flex items-center px-1">
+              <Button
+                variant="ghost"
+                size="icon-xs"
+                aria-label="Fit image to view"
+                onClick={zoomController.fitToView}
+              >
+                <IconArrowsToCenterOutline18 className="size-4" />
+              </Button>
+            </div>
             <div className="flex items-center gap-0.5 px-1">
               <Button
                 variant="ghost"
                 size="icon-xs"
                 aria-label="Zoom out"
-                disabled={zoom <= 0.01}
-                onClick={() => zoomBy(-0.25)}
+                title="Zoom out"
+                onClick={zoomController.zoomOut}
               >
                 <MinusIcon className="size-4" />
               </Button>
               <button
                 type="button"
                 className="min-w-10 text-center text-muted-foreground text-xs hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-solid focus-visible:ring-inset"
-                onClick={() => setZoom(1)}
                 aria-label="Reset zoom"
+                title="Reset zoom"
+                onClick={zoomController.resetZoom}
               >
-                {Math.round(zoom * 100)}%
+                {Math.round(zoomController.scale * 100)}%
               </button>
               <Button
                 variant="ghost"
                 size="icon-xs"
                 aria-label="Zoom in"
-                onClick={() => zoomBy(0.25)}
+                title="Zoom in"
+                onClick={zoomController.zoomIn}
               >
                 <PlusIcon className="size-4" />
               </Button>
@@ -1801,46 +1714,38 @@ function ImagePreview({
         }
       />
       <div
-        className={`flex min-h-0 flex-1 touch-none select-none items-center justify-center overflow-hidden p-4 focus:outline-none focus-visible:outline-none focus-visible:ring-0 ${getPreviewBackgroundClassName(background)}`}
-        role="button"
-        tabIndex={0}
-        aria-label="Image preview canvas"
-        data-image-preview-canvas="true"
-        onFocus={markFocused}
-        onClick={markFocused}
-        onWheel={handleWheel}
-        onPointerDown={handlePointerDown}
-        onPointerMove={handlePointerMove}
-        onPointerUp={clearPanCapture}
-        onPointerCancel={clearPanCapture}
-        onLostPointerCapture={clearPanCapture}
-        style={
-          background === 'custom'
-            ? { backgroundColor: normalizedCustomBackground }
-            : getCheckerboardStyle(background)
-        }
+        className={`min-h-0 flex-1 ${getPreviewBackgroundClassName(background)}`}
+        style={backgroundStyle}
       >
-        {imageError ? (
-          <div className="flex flex-col items-center gap-2 text-muted-foreground">
-            <TriangleAlertIcon className="size-8" />
-            <span className="text-sm">Unable to render this image.</span>
-            <span className="text-xs">
-              The file may be corrupt or in an unsupported format.
-            </span>
-          </div>
-        ) : (
-          <img
-            src={blobUrl}
-            alt={preview.relativePath}
-            className="pointer-events-none max-h-none max-w-none object-contain"
-            draggable={false}
-            style={{
-              transform: `translate(${pan.x}px, ${pan.y}px) scale(${zoom})`,
-              transformOrigin: 'center',
-            }}
-            onError={() => setImageError(true)}
-          />
-        )}
+        <ZoomableViewport
+          controller={zoomController}
+          className="overflow-hidden focus:outline-none focus-visible:outline-none focus-visible:ring-0"
+          wrapperProps={{
+            role: 'region',
+            tabIndex: 0,
+            'aria-label': 'Image preview canvas',
+            'data-image-preview-canvas': 'true',
+            onFocus: markFocused,
+          }}
+        >
+          {imageError ? (
+            <div className="flex flex-col items-center gap-2 text-muted-foreground">
+              <TriangleAlertIcon className="size-8" />
+              <span className="text-sm">Unable to render this image.</span>
+              <span className="text-xs">
+                The file may be missing, corrupt, or unsupported.
+              </span>
+            </div>
+          ) : (
+            <img
+              src={src}
+              alt={alt}
+              className="pointer-events-none max-h-none max-w-none object-contain"
+              draggable={false}
+              onError={() => setImageError(true)}
+            />
+          )}
+        </ZoomableViewport>
       </div>
     </div>
   );
@@ -1913,10 +1818,7 @@ function SvgPreview({
   const cursorPosition = useSourceCursorPosition(editor);
   const actions = useEditorActions(tabId, editor, preview, text, setText);
   const previewBackgroundClassName = getPreviewBackgroundClassName(background);
-  const normalizedCustomBackground = normalizeHexColor(
-    customBackground,
-    '#ffffff',
-  );
+  const backgroundStyle = getCanvasStyle(background, customBackground);
   const normalizedCustomCurrentColor = normalizeHexColor(
     customCurrentColor,
     '#8b5cf6',
@@ -1951,7 +1853,10 @@ function SvgPreview({
   }, [dataUrl]);
 
   // Cmd/Ctrl+Shift+V toggles code/preview mode when the tab is focused.
-  const { tabUiState } = useTabUIState();
+  const { tabUiState, setTabUiState } = useTabUIState();
+  const markPreviewFocused = useCallback(() => {
+    setTabUiState(tabId, { focusedPanel: 'tab-content' });
+  }, [setTabUiState, tabId]);
   const modeRef = useRef(mode);
   modeRef.current = mode;
   const tabUiStateRef = useRef(tabUiState);
@@ -2003,19 +1908,12 @@ function SvgPreview({
     });
   }, [editor, sourceFontSize]);
 
-  const {
-    zoom,
-    pan,
-    isPanned,
-    setZoom,
-    setPan,
-    zoomBy,
-    handleWheel: handlePreviewWheel,
-    handlePointerDown,
-    handlePointerMove,
-    clearPanCapture,
-    markFocused,
-  } = useImagePanAndZoom(tabId, mode === 'preview');
+  const zoomController = useZoomableViewport({
+    hotkeysEnabled:
+      mode === 'preview' && tabUiState[tabId]?.focusedPanel === 'tab-content',
+    onInteract: markPreviewFocused,
+  });
+  const { scale: zoom } = zoomController;
 
   // Hotkeys scoped to this SVG tab when it has focus.
   const bgRef = useRef(background);
@@ -2023,13 +1921,13 @@ function SvgPreview({
   const fgRef = useRef(currentColorMode);
   fgRef.current = currentColorMode;
 
-  const handleCenterImage = useCallback(() => {
+  const handleFitImage = useCallback(() => {
     if (tabUiStateRef.current[tabId]?.focusedPanel !== 'tab-content')
       return false;
     if (modeRef.current !== 'preview') return false;
-    setPan({ x: 0, y: 0 });
-  }, [tabId, setPan]);
-  useHotKeyListener(handleCenterImage, HotkeyActions.CENTER_IMAGE);
+    zoomController.fitToView();
+  }, [tabId, zoomController.fitToView]);
+  useHotKeyListener(handleFitImage, HotkeyActions.CENTER_IMAGE);
 
   const handleCycleBg = useCallback(() => {
     if (tabUiStateRef.current[tabId]?.focusedPanel !== 'tab-content')
@@ -2063,17 +1961,17 @@ function SvgPreview({
         onInteract={markSourceFocused}
         right={
           <>
-            {mode === 'preview' && isPanned ? (
+            {mode === 'preview' ? (
               <div className="flex items-center pr-2 pl-1">
                 <ToolbarTooltip
-                  label="Center image"
+                  label="Fit image to view"
                   shortcut={HotkeyActions.CENTER_IMAGE}
                 >
                   <Button
                     variant="ghost"
                     size="icon-xs"
-                    aria-label="Center image"
-                    onClick={() => setPan({ x: 0, y: 0 })}
+                    aria-label="Fit image to view"
+                    onClick={zoomController.fitToView}
                   >
                     <IconArrowsToCenterOutline18 className="size-4" />
                   </Button>
@@ -2090,8 +1988,7 @@ function SvgPreview({
                     variant="ghost"
                     size="icon-xs"
                     aria-label="Zoom out"
-                    disabled={zoom <= 0.01}
-                    onClick={() => zoomBy(-0.25)}
+                    onClick={zoomController.zoomOut}
                   >
                     <MinusIcon className="size-4" />
                   </Button>
@@ -2103,7 +2000,7 @@ function SvgPreview({
                   <button
                     type="button"
                     className="min-w-10 cursor-pointer text-center text-muted-foreground text-xs hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-solid focus-visible:ring-inset"
-                    onClick={() => setZoom(1)}
+                    onClick={zoomController.resetZoom}
                     aria-label="Reset zoom"
                   >
                     {Math.round(zoom * 100)}%
@@ -2117,7 +2014,7 @@ function SvgPreview({
                     variant="ghost"
                     size="icon-xs"
                     aria-label="Zoom in"
-                    onClick={() => zoomBy(0.25)}
+                    onClick={zoomController.zoomIn}
                   >
                     <PlusIcon className="size-4" />
                   </Button>
@@ -2291,26 +2188,24 @@ function SvgPreview({
       {actions.externalChange ? (
         <ExternalChangeBanner actions={actions} />
       ) : null}
-      <div className="min-h-0 flex-1">
+      <div
+        className={cn(
+          'min-h-0 flex-1',
+          mode === 'preview' && previewBackgroundClassName,
+        )}
+        style={mode === 'preview' ? backgroundStyle : undefined}
+      >
         {mode === 'preview' ? (
-          <button
-            type="button"
-            className={`flex size-full touch-none select-none items-center justify-center overflow-hidden p-4 text-left focus:outline-none focus-visible:outline-none focus-visible:ring-0 ${previewBackgroundClassName}`}
-            aria-label="SVG preview canvas"
-            data-image-preview-canvas="true"
-            onFocus={markFocused}
-            onClick={markFocused}
-            onWheel={handlePreviewWheel}
-            onPointerDown={handlePointerDown}
-            onPointerMove={handlePointerMove}
-            onPointerUp={clearPanCapture}
-            onPointerCancel={clearPanCapture}
-            onLostPointerCapture={clearPanCapture}
-            style={
-              background === 'custom'
-                ? { backgroundColor: normalizedCustomBackground }
-                : getCheckerboardStyle(background)
-            }
+          <ZoomableViewport
+            controller={zoomController}
+            className="overflow-hidden text-left focus:outline-none focus-visible:outline-none focus-visible:ring-0"
+            wrapperProps={{
+              role: 'region',
+              tabIndex: 0,
+              'aria-label': 'SVG preview canvas',
+              'data-image-preview-canvas': 'true',
+              onFocus: markPreviewFocused,
+            }}
           >
             {imageError ? (
               <div className="flex flex-col items-center gap-2 text-muted-foreground">
@@ -2326,14 +2221,10 @@ function SvgPreview({
                 alt={preview.relativePath}
                 className="pointer-events-none max-h-none max-w-none object-contain"
                 draggable={false}
-                style={{
-                  transform: `translate(${pan.x}px, ${pan.y}px) scale(${zoom})`,
-                  transformOrigin: 'center',
-                }}
                 onError={() => setImageError(true)}
               />
             )}
-          </button>
+          </ZoomableViewport>
         ) : (
           <div
             className="size-full"
@@ -2635,6 +2526,22 @@ function MissingFileNotice() {
 }
 
 export function FilePreviewTabContent({ tab }: FilePreviewTabContentProps) {
+  const file = tab.file;
+  if (file?.sourceUrl) {
+    return (
+      <ImagePreview
+        key={file.sourceUrl}
+        src={file.sourceUrl}
+        alt={file.displayName ?? tab.title}
+        tabId={tab.id}
+      />
+    );
+  }
+
+  return <FileBackedPreviewTabContent tab={tab} />;
+}
+
+function FileBackedPreviewTabContent({ tab }: FilePreviewTabContentProps) {
   const getFilePreview = useKartonProcedure((p) => p.fileTree.getFilePreview);
   const getFileStat = useKartonProcedure((p) => p.fileTree.getFileStat);
   const clearFileNotice = useKartonProcedure((p) => p.browser.clearFileNotice);
@@ -2854,6 +2761,9 @@ export function FilePreviewTabContent({ tab }: FilePreviewTabContentProps) {
   }, [workspaceKey, relativePath, preview, recreateDeletedFile, revalidate]);
 
   const fileNotice = tab.fileNotice;
+  const isImageDiff = tab.file.kind === 'image' || tab.file.kind === 'svg';
+  const isBinaryDiff =
+    tab.file.kind === 'binary' || isImagePath(tab.file.diffOldPath);
 
   // File was deleted — keep showing cached content with the delete banner.
   // Don't show the MissingFileNotice; the user can still see/edit and
@@ -2873,8 +2783,9 @@ export function FilePreviewTabContent({ tab }: FilePreviewTabContentProps) {
           {cachedPreview ? (
             cachedPreview.kind === 'image' ? (
               <ImagePreview
-                preview={cachedPreview}
-                blobUrl={blobUrl}
+                src={blobUrl}
+                alt={cachedPreview.relativePath}
+                openExternalPath={getPreviewAbsolutePath(cachedPreview)}
                 tabId={tab.id}
               />
             ) : cachedPreview.kind === 'svg' ? (
@@ -2897,12 +2808,27 @@ export function FilePreviewTabContent({ tab }: FilePreviewTabContentProps) {
     );
   }
 
-  // Git diff view: bypass the regular file preview pipeline entirely.
-  // The DiffEditorPreview loads its own content and is read-only.
+  // Git diff views bypass the regular preview pipeline. Images show the
+  // current workspace file; other binary files avoid feeding bytes to Monaco.
   if (tab.file?.showDiff) {
     return (
       <div className="absolute inset-0 z-10 flex flex-col bg-background">
-        <DiffEditorPreview tab={tab.file} tabId={tab.id} />
+        {isImageDiff ? (
+          <ImagePreview
+            src={blobUrl}
+            alt={tab.file.relativePath}
+            openExternalPath={tab.file.absolutePath}
+            tabId={tab.id}
+          />
+        ) : isBinaryDiff ? (
+          <BinaryPreview
+            workspaceKey={tab.file.workspaceKey}
+            relativePath={tab.file.relativePath}
+            revealInFolder={revealInFolder}
+          />
+        ) : (
+          <DiffEditorPreview tab={tab.file} tabId={tab.id} />
+        )}
       </div>
     );
   }
@@ -2956,7 +2882,12 @@ export function FilePreviewTabContent({ tab }: FilePreviewTabContentProps) {
             )}
           </div>
         ) : preview.kind === 'image' ? (
-          <ImagePreview preview={preview} blobUrl={blobUrl} tabId={tab.id} />
+          <ImagePreview
+            src={blobUrl}
+            alt={preview.relativePath}
+            openExternalPath={getPreviewAbsolutePath(preview)}
+            tabId={tab.id}
+          />
         ) : preview.kind === 'svg' ? (
           <SvgPreview preview={preview} tabId={tab.id} />
         ) : preview.kind === 'text' && isMarkdownPath(preview.relativePath) ? (

--- a/apps/browser/src/ui/screens/main/file-tree/file-preview-tab-content.tsx
+++ b/apps/browser/src/ui/screens/main/file-tree/file-preview-tab-content.tsx
@@ -1580,6 +1580,64 @@ function getCanvasStyle(
     : getCheckerboardStyle(background);
 }
 
+function ZoomControls({
+  controller,
+}: {
+  controller: ReturnType<typeof useZoomableViewport>;
+}) {
+  return (
+    <>
+      <div className="flex items-center px-1">
+        <ToolbarTooltip
+          label="Fit image to view"
+          shortcut={HotkeyActions.CENTER_IMAGE}
+        >
+          <Button
+            variant="ghost"
+            size="icon-xs"
+            aria-label="Fit image to view"
+            onClick={controller.fitToView}
+          >
+            <IconArrowsToCenterOutline18 className="size-4" />
+          </Button>
+        </ToolbarTooltip>
+      </div>
+      <div className="flex items-center gap-0.5 px-1">
+        <ToolbarTooltip label="Zoom out" shortcut={HotkeyActions.ZOOM_OUT}>
+          <Button
+            variant="ghost"
+            size="icon-xs"
+            aria-label="Zoom out"
+            onClick={controller.zoomOut}
+          >
+            <MinusIcon className="size-4" />
+          </Button>
+        </ToolbarTooltip>
+        <ToolbarTooltip label="Reset zoom" shortcut={HotkeyActions.ZOOM_RESET}>
+          <button
+            type="button"
+            className="min-w-10 cursor-pointer text-center text-muted-foreground text-xs hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-solid focus-visible:ring-inset"
+            aria-label="Reset zoom"
+            onClick={controller.resetZoom}
+          >
+            {Math.round(controller.scale * 100)}%
+          </button>
+        </ToolbarTooltip>
+        <ToolbarTooltip label="Zoom in" shortcut={HotkeyActions.ZOOM_IN}>
+          <Button
+            variant="ghost"
+            size="icon-xs"
+            aria-label="Zoom in"
+            onClick={controller.zoomIn}
+          >
+            <PlusIcon className="size-4" />
+          </Button>
+        </ToolbarTooltip>
+      </div>
+    </>
+  );
+}
+
 function ImagePreview({
   src,
   alt,
@@ -1612,45 +1670,7 @@ function ImagePreview({
         openExternalPath={openExternalPath}
         right={
           <>
-            <div className="flex items-center px-1">
-              <Button
-                variant="ghost"
-                size="icon-xs"
-                aria-label="Fit image to view"
-                onClick={zoomController.fitToView}
-              >
-                <IconArrowsToCenterOutline18 className="size-4" />
-              </Button>
-            </div>
-            <div className="flex items-center gap-0.5 px-1">
-              <Button
-                variant="ghost"
-                size="icon-xs"
-                aria-label="Zoom out"
-                title="Zoom out"
-                onClick={zoomController.zoomOut}
-              >
-                <MinusIcon className="size-4" />
-              </Button>
-              <button
-                type="button"
-                className="min-w-10 text-center text-muted-foreground text-xs hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-solid focus-visible:ring-inset"
-                aria-label="Reset zoom"
-                title="Reset zoom"
-                onClick={zoomController.resetZoom}
-              >
-                {Math.round(zoomController.scale * 100)}%
-              </button>
-              <Button
-                variant="ghost"
-                size="icon-xs"
-                aria-label="Zoom in"
-                title="Zoom in"
-                onClick={zoomController.zoomIn}
-              >
-                <PlusIcon className="size-4" />
-              </Button>
-            </div>
+            <ZoomControls controller={zoomController} />
             <div className="h-5 w-px bg-border-subtle" />
             <div className="flex items-center px-1">
               <Popover>
@@ -1913,21 +1933,12 @@ function SvgPreview({
       mode === 'preview' && tabUiState[tabId]?.focusedPanel === 'tab-content',
     onInteract: markPreviewFocused,
   });
-  const { scale: zoom } = zoomController;
 
   // Hotkeys scoped to this SVG tab when it has focus.
   const bgRef = useRef(background);
   bgRef.current = background;
   const fgRef = useRef(currentColorMode);
   fgRef.current = currentColorMode;
-
-  const handleFitImage = useCallback(() => {
-    if (tabUiStateRef.current[tabId]?.focusedPanel !== 'tab-content')
-      return false;
-    if (modeRef.current !== 'preview') return false;
-    zoomController.fitToView();
-  }, [tabId, zoomController.fitToView]);
-  useHotKeyListener(handleFitImage, HotkeyActions.CENTER_IMAGE);
 
   const handleCycleBg = useCallback(() => {
     if (tabUiStateRef.current[tabId]?.focusedPanel !== 'tab-content')
@@ -1962,64 +1973,7 @@ function SvgPreview({
         right={
           <>
             {mode === 'preview' ? (
-              <div className="flex items-center pr-2 pl-1">
-                <ToolbarTooltip
-                  label="Fit image to view"
-                  shortcut={HotkeyActions.CENTER_IMAGE}
-                >
-                  <Button
-                    variant="ghost"
-                    size="icon-xs"
-                    aria-label="Fit image to view"
-                    onClick={zoomController.fitToView}
-                  >
-                    <IconArrowsToCenterOutline18 className="size-4" />
-                  </Button>
-                </ToolbarTooltip>
-              </div>
-            ) : null}
-            {mode === 'preview' ? (
-              <div className="flex items-center gap-0.5 px-1">
-                <ToolbarTooltip
-                  label="Zoom out"
-                  shortcut={HotkeyActions.ZOOM_OUT}
-                >
-                  <Button
-                    variant="ghost"
-                    size="icon-xs"
-                    aria-label="Zoom out"
-                    onClick={zoomController.zoomOut}
-                  >
-                    <MinusIcon className="size-4" />
-                  </Button>
-                </ToolbarTooltip>
-                <ToolbarTooltip
-                  label="Reset zoom"
-                  shortcut={HotkeyActions.ZOOM_RESET}
-                >
-                  <button
-                    type="button"
-                    className="min-w-10 cursor-pointer text-center text-muted-foreground text-xs hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-solid focus-visible:ring-inset"
-                    onClick={zoomController.resetZoom}
-                    aria-label="Reset zoom"
-                  >
-                    {Math.round(zoom * 100)}%
-                  </button>
-                </ToolbarTooltip>
-                <ToolbarTooltip
-                  label="Zoom in"
-                  shortcut={HotkeyActions.ZOOM_IN}
-                >
-                  <Button
-                    variant="ghost"
-                    size="icon-xs"
-                    aria-label="Zoom in"
-                    onClick={zoomController.zoomIn}
-                  >
-                    <PlusIcon className="size-4" />
-                  </Button>
-                </ToolbarTooltip>
-              </div>
+              <ZoomControls controller={zoomController} />
             ) : null}
             {mode === 'preview' ? (
               <>

--- a/apps/browser/src/ui/screens/main/file-tree/file-tree-diff-view.tsx
+++ b/apps/browser/src/ui/screens/main/file-tree/file-tree-diff-view.tsx
@@ -1,17 +1,13 @@
 import { Virtuoso } from 'react-virtuoso';
 import { cn } from '@ui/utils';
 import { getBaseName } from '@shared/path-utils';
-import type { MountedWorkspaceGitDiffSummary } from '@shared/karton-contracts/ui';
+import type {
+  MountedWorkspaceGitDiffEntry,
+  MountedWorkspaceGitDiffSummary,
+} from '@shared/karton-contracts/ui';
 import { DiffLineStats } from '@ui/components/diff-line-stats';
 
-type DiffRow = {
-  path: string;
-  added: number;
-  deleted: number;
-  changeType: 'modified' | 'added' | 'deleted' | 'renamed' | 'untracked';
-  oldPath?: string;
-  staged: boolean;
-};
+type DiffRow = MountedWorkspaceGitDiffEntry;
 
 const CHANGE_LABELS: Record<DiffRow['changeType'], string> = {
   modified: 'M',

--- a/apps/browser/src/ui/screens/main/file-tree/file-tree-sidebar.tsx
+++ b/apps/browser/src/ui/screens/main/file-tree/file-tree-sidebar.tsx
@@ -176,10 +176,6 @@ export function FileTreeSidebar() {
       : null;
   });
 
-  const _getFileDiffContent = useKartonProcedure(
-    (p) => p.toolbox.getFileDiffContent,
-  );
-
   const handleDiffOpenFile = useCallback(
     (path: string, staged: boolean, oldPath?: string) => {
       if (!selectedWorkspaceKey) return;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -254,6 +254,9 @@ importers:
       react-virtuoso:
         specifier: ^4.18.7
         version: 4.18.7(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      react-zoom-pan-pinch:
+        specifier: ^4.0.4
+        version: 4.0.4(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       sharp:
         specifier: ^0.34.5
         version: 0.34.5
@@ -9906,6 +9909,13 @@ packages:
     peerDependencies:
       react: ^18.0.0 || ^19.0.0
       react-dom: ^18.0.0 || ^19.0.0
+
+  react-zoom-pan-pinch@4.0.4:
+    resolution: {integrity: sha512-P0D7lfNHyJCNuUozoVdt0WNWcQ34ZbbD71B8pb+UtF7Th8MKBnxYiPApDfPZZmr+Gk0l0WmGTXL8R36JirHcQQ==}
+    engines: {node: '>=8', npm: '>=5'}
+    peerDependencies:
+      react: '*'
+      react-dom: '*'
 
   react@19.2.3:
     resolution: {integrity: sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==}
@@ -21566,6 +21576,11 @@ snapshots:
       react-dom: 19.2.3(react@19.2.3)
 
   react-window@2.2.7(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+    dependencies:
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+
+  react-zoom-pan-pinch@4.0.4(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)


### PR DESCRIPTION
## Summary

- extend existing image and SVG preview tabs with shared zoom and pan controls
- open chat images, generated images, and Mermaid diagrams through the existing preview-tab flow
- preserve native media size and only scale down oversized content with viewport padding
- support dragging, trackpad scrolling, Shift+scroll, modifier-wheel zoom, fit, reset, and zoom hotkeys
- correctly render dimensionless SVGs and Mermaid diagrams
- show the current workspace image for image diffs instead of binary data in Monaco

<img width="887" height="1069" alt="image" src="https://github.com/user-attachments/assets/cbbbdf26-28e5-4c74-aaa1-550c3f1936c8" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit d0645dbf4e2553ca9e0f4bd64620975356ab2819. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds zoomable media tabs for images and Mermaid diagrams, with consistent zoom/pan controls across previews and diffs. Chat and generated images now open in preview tabs instead of inline-only views, improving readability and navigation.

- **New Features**
  - Shared zoom/pan UI using `react-zoom-pan-pinch` (drag, trackpad pan, Shift+scroll, modifier+wheel zoom, double‑click toggle, fit, reset, zoom hotkeys).
  - Open chat/Streamdown images and Mermaid charts in tabs via `fileTree.openImageTab` and `useOpenImageTab`.
  - Preserve native media size; only scale down oversized content with viewport padding.
  - Media preview tabs are session-only (not persisted or promotable).

- **Bug Fixes**
  - Correct sizing for dimensionless SVGs and Mermaid diagrams.
  - Git diffs: show current workspace image for image diffs and avoid rendering raw binary blobs in the editor.

<sup>Written for commit d0645dbf4e2553ca9e0f4bd64620975356ab2819. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1540?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Images and Mermaid diagrams can now be opened in dedicated tabs.
  - Image and SVG previews support zooming, panning, fitting, and keyboard interactions.
  - Image previews include improved accessibility and focus behavior.
  - Image and binary file differences now use dedicated preview experiences.

- **Bug Fixes**
  - Temporary and direct-media tabs are excluded from persistent tab state.
  - Image previews now preserve source information and display reliable filenames.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->