### PR TITLE
fix(stagewise): remove hidden context menu items

### DIFF
--- a/apps/browser/src/backend/services/window-layout/utils/context-menu-web-content.ts
+++ b/apps/browser/src/backend/services/window-layout/utils/context-menu-web-content.ts
@@ -67,6 +67,7 @@ export class ContextMenuWebContent {
 
     const allItems: MenuItem[] = allItems2D.reduce((acc, curr) => {
       const visibleItems = curr.filter((item) => item.visible !== false);
+      if (visibleItems.at(-1)?.type === 'separator') visibleItems.pop();
       if (visibleItems.length === 0) return acc;
       if (acc.length > 0) acc.push({ type: 'separator' });
       acc.push(...visibleItems);

--- a/apps/browser/src/backend/services/window-layout/utils/context-menu-web-content.ts
+++ b/apps/browser/src/backend/services/window-layout/utils/context-menu-web-content.ts
@@ -66,9 +66,10 @@ export class ContextMenuWebContent {
     ];
 
     const allItems: MenuItem[] = allItems2D.reduce((acc, curr) => {
-      if (curr.length === 0) return acc;
+      const visibleItems = curr.filter((item) => item.visible !== false);
+      if (visibleItems.length === 0) return acc;
       if (acc.length > 0) acc.push({ type: 'separator' });
-      acc.push(...curr);
+      acc.push(...visibleItems);
       return acc;
     }, [] as MenuItem[]);
 


### PR DESCRIPTION
## Summary

* filter invisible Electron context menu items before determining whether a menu group is empty
* prevent orphaned and duplicate separators in the Windows context menu

Fixes stagewise-io/stagewise#1536

---

> [!NOTE]
> **Low Risk**<br>Localized change to Electron context menu template assembly with no auth, data, or security impact.
>
> **Overview**<br>Fixes **Windows web context menus** showing entries that should be hidden and leaving **extra or duplicate separators** between groups.
>
> When flattening menu sections, the builder now **drops items with** `visible: false`, treats a section as empty only after that filter, **strips a trailing separator** from a section if nothing follows it, and inserts separators only between non-empty visible groups.
>
> Reviewed by [Cursor Bugbot](<https://cursor.com/bugbot>) for commit 8fc08ed0ab5a0af60195eea59c452bcea3dc35ae. Bugbot is set up for automated code reviews on this repo. Configure [here](<https://www.cursor.com/dashboard/bugbot>).

---

## Summary by cubic

Filters out hidden Electron context menu items before grouping and trims trailing separators within groups. Skips empty groups and only inserts separators between non‑empty groups, fixing orphaned, duplicate, and trailing separators in the Windows context menu (fixes stagewise-io/stagewise#1536).

Written for commit 8fc08ed0ab5a0af60195eea59c452bcea3dc35ae. Summary will update on new commits.

![Review in cubic](https://camo.githubusercontent.com/bd9efce2efa0a4d0a92a581dc73a4b2dc621085d3ac789eccf3330c974d2dae0/68747470733a2f2f7777772e63756269632e6465762f627574746f6e732f7265766965772d696e2d63756269632d6461726b2e737667)

## Summary by CodeRabbit

* **Bug Fixes**
  * Hidden context-menu items are no longer displayed.
  * Empty menu groups are omitted correctly, preventing unnecessary separators or blank sections.