### PR TITLE
feat(stagewise): support Codex worktree setup scripts

### DIFF
--- a/apps/browser/package.json
+++ b/apps/browser/package.json
@@ -57,6 +57,7 @@
     "prosemirror-highlight": "^0.15.1",
     "react-virtuoso": "^4.18.7",
     "sharp": "^0.34.5",
+    "smol-toml": "^1.7.1",
     "tiptap-markdown": "^0.9.0",
     "web-tree-sitter": "^0.26.6",
     "yauzl": "^3.3.0"

--- a/apps/browser/src/backend/services/codex-worktree-setup.ts
+++ b/apps/browser/src/backend/services/codex-worktree-setup.ts
@@ -1,0 +1,20 @@
+import fs from 'node:fs/promises';
+import { parse } from 'smol-toml';
+
+export const CODEX_WORKTREE_SETUP_CONFIG_RELATIVE_PATH =
+  '.codex/environments/environment.toml';
+
+type CodexSetupConfig = { script?: string } & Partial<
+  Record<'darwin' | 'linux' | 'win32', { script?: string }>
+>;
+
+export async function readCodexSetupScript(
+  configPath: string,
+  platform: NodeJS.Platform,
+): Promise<string | null> {
+  const config = parse(await fs.readFile(configPath, 'utf8'));
+  const setup = config.setup as CodexSetupConfig | undefined;
+  const platformKey =
+    platform === 'darwin' || platform === 'win32' ? platform : 'linux';
+  return setup?.[platformKey]?.script?.trim() || setup?.script?.trim() || null;
+}

--- a/apps/browser/src/backend/services/toolbox/services/mount-manager/worktree-setup-runner.test.ts
+++ b/apps/browser/src/backend/services/toolbox/services/mount-manager/worktree-setup-runner.test.ts
@@ -56,21 +56,27 @@ function metadata(mainWorktreePath: string, workspacePath: string) {
 }
 
 async function writeSetupScript(worktreePath: string, content = 'exit 0') {
-  const scriptPath = path.join(worktreePath, '.stagewise', 'worktree-setup.sh');
+  const scriptPath = path.join(worktreePath, '.stagewise/worktree-setup.sh');
   await fs.mkdir(path.dirname(scriptPath), { recursive: true });
   await fs.writeFile(scriptPath, content);
   return scriptPath;
 }
 
 async function writePowerShellScript(worktreePath: string, content = 'exit 0') {
-  const scriptPath = path.join(
-    worktreePath,
-    '.stagewise',
-    'worktree-setup.ps1',
-  );
+  const scriptPath = path.join(worktreePath, '.stagewise/worktree-setup.ps1');
   await fs.mkdir(path.dirname(scriptPath), { recursive: true });
   await fs.writeFile(scriptPath, content);
   return scriptPath;
+}
+
+async function writeCodexFixture(worktreePath: string, content: string) {
+  const configPath = path.join(
+    worktreePath,
+    '.codex/environments/environment.toml',
+  );
+  await fs.mkdir(path.dirname(configPath), { recursive: true });
+  await fs.writeFile(configPath, content);
+  return configPath;
 }
 
 function createProcess() {
@@ -113,6 +119,25 @@ function createRunner(deps: TestRunnerDeps) {
   });
 }
 
+function createRunnerHarness(overrides: Partial<TestRunnerDeps> = {}) {
+  const { state, uiKarton } = createKarton();
+  const child = createProcess();
+  const spawnProcess = vi.fn<NonNullable<TestRunnerDeps['spawnProcess']>>(
+    () => child,
+  );
+  const runner = createRunner({
+    logger: { warn: vi.fn() } as unknown as Logger,
+    telemetryService: {
+      captureException: vi.fn(),
+    } as unknown as TelemetryService,
+    uiKarton,
+    resolvedEnvPromise: Promise.resolve(null),
+    spawnProcess,
+    ...overrides,
+  });
+  return { child, runner, spawnProcess, state };
+}
+
 describe('mergeEnv', () => {
   it('lets overrides replace base entries that differ only in case', () => {
     // Simulates Windows: process.env exposes a stale `Path`, the resolved
@@ -138,17 +163,7 @@ describe('WorktreeSetupRunner', () => {
     const mainWorktreePath = path.join(tempDir, 'main');
     const workspacePath = path.join(tempDir, 'worktree');
     await fs.mkdir(workspacePath, { recursive: true });
-    const { state, uiKarton } = createKarton();
-    const spawnProcess = vi.fn();
-    const runner = createRunner({
-      logger: { warn: vi.fn() } as unknown as Logger,
-      telemetryService: {
-        captureException: vi.fn(),
-      } as unknown as TelemetryService,
-      uiKarton,
-      resolvedEnvPromise: Promise.resolve(null),
-      spawnProcess,
-    });
+    const { runner, spawnProcess, state } = createRunnerHarness();
 
     await runner.start(metadata(mainWorktreePath, workspacePath));
 
@@ -161,18 +176,7 @@ describe('WorktreeSetupRunner', () => {
     const workspacePath = path.join(tempDir, 'worktree');
     await fs.mkdir(workspacePath, { recursive: true });
     const scriptPath = await writeSetupScript(mainWorktreePath);
-    const child = createProcess();
-    const { state, uiKarton } = createKarton();
-    const spawnProcess = vi.fn(() => child);
-    const runner = createRunner({
-      logger: { warn: vi.fn() } as unknown as Logger,
-      telemetryService: {
-        captureException: vi.fn(),
-      } as unknown as TelemetryService,
-      uiKarton,
-      resolvedEnvPromise: Promise.resolve(null),
-      spawnProcess,
-    });
+    const { child, runner, spawnProcess, state } = createRunnerHarness();
 
     await runner.start(metadata(mainWorktreePath, workspacePath));
 
@@ -190,6 +194,91 @@ describe('WorktreeSetupRunner', () => {
 
     child.emit('close', 0);
     runner.teardown();
+  });
+
+  it('falls back to the Codex setup config in the main worktree', async () => {
+    const mainWorktreePath = path.join(tempDir, 'main');
+    const workspacePath = path.join(tempDir, 'worktree');
+    await fs.mkdir(workspacePath, { recursive: true });
+    const configPath = await writeCodexFixture(
+      mainWorktreePath,
+      "[setup]\nscript = 'pnpm install'\n[setup.darwin]\nscript = '   '\n",
+    );
+    const { child, runner, spawnProcess, state } = createRunnerHarness();
+
+    await runner.start(metadata(mainWorktreePath, workspacePath));
+
+    expect(spawnProcess).toHaveBeenCalledWith(
+      'bash',
+      ['-xeo', 'pipefail', '-c', 'pnpm install'],
+      {
+        cwd: workspacePath,
+        env: expect.objectContaining({
+          CODEX_SOURCE_TREE_PATH: mainWorktreePath,
+          CODEX_WORKTREE_PATH: workspacePath,
+          STAGEWISE_TARGET_WORKTREE_PATH: workspacePath,
+        }),
+        stdio: ['ignore', 'pipe', 'pipe'],
+      },
+    );
+    expect(state.workspaceGitSetup.runsByPath[workspacePath]).toMatchObject({
+      scriptPath: configPath,
+      status: 'running',
+    });
+
+    child.emit('close', 0);
+  });
+
+  it('prefers the stagewise setup script over the Codex config', async () => {
+    const mainWorktreePath = path.join(tempDir, 'main');
+    const workspacePath = path.join(tempDir, 'worktree');
+    await fs.mkdir(workspacePath, { recursive: true });
+    const scriptPath = await writeSetupScript(mainWorktreePath);
+    await writeCodexFixture(workspacePath, "[setup]\nscript = 'codex setup'\n");
+    const { child, runner, spawnProcess } = createRunnerHarness();
+
+    await runner.start(metadata(mainWorktreePath, workspacePath));
+
+    expect(spawnProcess).toHaveBeenCalledWith(
+      '/bin/sh',
+      [scriptPath],
+      expect.objectContaining({
+        env: expect.not.objectContaining({
+          CODEX_WORKTREE_PATH: expect.any(String),
+        }),
+      }),
+    );
+
+    child.emit('close', 0);
+  });
+
+  it('uses the platform-specific Codex setup command on Windows', async () => {
+    const mainWorktreePath = path.join(tempDir, 'main');
+    const workspacePath = path.join(tempDir, 'worktree');
+    await fs.mkdir(workspacePath, { recursive: true });
+    await writeCodexFixture(
+      workspacePath,
+      "[setup]\nscript = 'default setup'\n[setup.win32]\nscript = 'windows setup'\n",
+    );
+    const { child, runner, spawnProcess } = createRunnerHarness({
+      resolvePowerShellCommand: () => 'powershell.exe',
+      platform: 'win32',
+    });
+
+    await runner.start(metadata(mainWorktreePath, workspacePath));
+
+    expect(spawnProcess).toHaveBeenCalledWith(
+      'powershell.exe',
+      [
+        '-NoProfile',
+        '-NonInteractive',
+        '-Command',
+        'windows setup\nexit $LASTEXITCODE',
+      ],
+      expect.objectContaining({ cwd: workspacePath }),
+    );
+
+    child.emit('close', 0);
   });
 
   it('spawns the setup script with expected cwd and environment', async () => {

--- a/apps/browser/src/backend/services/toolbox/services/mount-manager/worktree-setup-runner.ts
+++ b/apps/browser/src/backend/services/toolbox/services/mount-manager/worktree-setup-runner.ts
@@ -9,7 +9,10 @@ import {
   variantForPlatform,
 } from '@shared/worktree-setup';
 import { sanitizeEnv } from '@stagewise/agent-shell';
-import { parse } from 'smol-toml';
+import {
+  CODEX_WORKTREE_SETUP_CONFIG_RELATIVE_PATH,
+  readCodexSetupScript,
+} from '@/services/codex-worktree-setup';
 import type { KartonService } from '@/services/karton';
 import type { Logger } from '@/services/logger';
 import type { TelemetryService } from '@/services/telemetry';
@@ -17,9 +20,6 @@ import type { TelemetryService } from '@/services/telemetry';
 const WORKTREE_SETUP_TIMEOUT_MS = 20 * 60 * 1000;
 const OUTPUT_TAIL_MAX_LENGTH = 12_000;
 const OUTPUT_UPDATE_INTERVAL_MS = 150;
-const CODEX_WORKTREE_SETUP_CONFIG_RELATIVE_PATH =
-  '.codex/environments/environment.toml';
-
 const WORKTREE_SETUP_TIMEOUT_MESSAGE = 'Worktree setup timed out.';
 
 const EXPECTED_FAILURE_MESSAGES = new Set([
@@ -137,10 +137,6 @@ type ActiveRun = {
   settled: boolean;
 };
 
-type CodexSetupConfig = { script?: string } & Partial<
-  Record<'darwin' | 'linux' | 'win32', { script?: string }>
->;
-
 function appendTail(current: string, chunk: Buffer): string {
   const next = current + chunk.toString('utf8');
   if (next.length <= OUTPUT_TAIL_MAX_LENGTH) return next;
@@ -194,14 +190,7 @@ export class WorktreeSetupRunner {
       );
       if (!sourcePath) return;
       try {
-        const config = parse(await fs.readFile(sourcePath, 'utf8'));
-        const setup = config.setup as CodexSetupConfig | undefined;
-        const platformKey =
-          this.platform === 'darwin' || this.platform === 'win32'
-            ? this.platform
-            : 'linux';
-        inlineScript =
-          setup?.[platformKey]?.script?.trim() || setup?.script?.trim() || null;
+        inlineScript = await readCodexSetupScript(sourcePath, this.platform);
       } catch (error) {
         this.logger.warn(
           '[WorktreeSetupRunner] Failed to read Codex setup config',

--- a/apps/browser/src/backend/services/toolbox/services/mount-manager/worktree-setup-runner.ts
+++ b/apps/browser/src/backend/services/toolbox/services/mount-manager/worktree-setup-runner.ts
@@ -9,6 +9,7 @@ import {
   variantForPlatform,
 } from '@shared/worktree-setup';
 import { sanitizeEnv } from '@stagewise/agent-shell';
+import { parse } from 'smol-toml';
 import type { KartonService } from '@/services/karton';
 import type { Logger } from '@/services/logger';
 import type { TelemetryService } from '@/services/telemetry';
@@ -16,6 +17,8 @@ import type { TelemetryService } from '@/services/telemetry';
 const WORKTREE_SETUP_TIMEOUT_MS = 20 * 60 * 1000;
 const OUTPUT_TAIL_MAX_LENGTH = 12_000;
 const OUTPUT_UPDATE_INTERVAL_MS = 150;
+const CODEX_WORKTREE_SETUP_CONFIG_RELATIVE_PATH =
+  '.codex/environments/environment.toml';
 
 const WORKTREE_SETUP_TIMEOUT_MESSAGE = 'Worktree setup timed out.';
 
@@ -134,6 +137,10 @@ type ActiveRun = {
   settled: boolean;
 };
 
+type CodexSetupConfig = { script?: string } & Partial<
+  Record<'darwin' | 'linux' | 'win32', { script?: string }>
+>;
+
 function appendTail(current: string, chunk: Buffer): string {
   const next = current + chunk.toString('utf8');
   if (next.length <= OUTPUT_TAIL_MAX_LENGTH) return next;
@@ -177,20 +184,32 @@ export class WorktreeSetupRunner {
 
     const variant = variantForPlatform(this.platform);
     const relativeScriptPath = WORKTREE_SETUP_SCRIPT_RELATIVE_PATHS[variant];
-    const workspaceScriptPath = path.join(
-      metadata.workspacePath,
-      relativeScriptPath,
-    );
-    const mainWorktreeScriptPath = path.join(
-      metadata.mainWorktreePath,
-      relativeScriptPath,
-    );
-    const scriptPath = (await this.pathExists(workspaceScriptPath))
-      ? workspaceScriptPath
-      : (await this.pathExists(mainWorktreeScriptPath))
-        ? mainWorktreeScriptPath
-        : null;
-    if (!scriptPath) return;
+    let sourcePath = await this.findSetupFile(metadata, relativeScriptPath);
+    let inlineScript: string | null = null;
+
+    if (!sourcePath) {
+      sourcePath = await this.findSetupFile(
+        metadata,
+        CODEX_WORKTREE_SETUP_CONFIG_RELATIVE_PATH,
+      );
+      if (!sourcePath) return;
+      try {
+        const config = parse(await fs.readFile(sourcePath, 'utf8'));
+        const setup = config.setup as CodexSetupConfig | undefined;
+        const platformKey =
+          this.platform === 'darwin' || this.platform === 'win32'
+            ? this.platform
+            : 'linux';
+        inlineScript =
+          setup?.[platformKey]?.script?.trim() || setup?.script?.trim() || null;
+      } catch (error) {
+        this.logger.warn(
+          '[WorktreeSetupRunner] Failed to read Codex setup config',
+          { sourcePath, error },
+        );
+      }
+      if (!inlineScript) return;
+    }
 
     const runId = randomUUID();
     const startedAt = Date.now();
@@ -200,7 +219,7 @@ export class WorktreeSetupRunner {
         workspacePath: metadata.workspacePath,
         sourceWorktreePath: metadata.sourceWorktreePath,
         mainWorktreePath: metadata.mainWorktreePath,
-        scriptPath,
+        scriptPath: sourcePath,
         status: 'running',
         startedAt,
         finishedAt: null,
@@ -304,25 +323,29 @@ export class WorktreeSetupRunner {
       STAGEWISE_SOURCE_WORKTREE_PATH: metadata.sourceWorktreePath,
       STAGEWISE_TARGET_WORKTREE_PATH: metadata.workspacePath,
       STAGEWISE_MAIN_WORKTREE_PATH: metadata.mainWorktreePath,
+      ...(inlineScript !== null
+        ? {
+            CODEX_SOURCE_TREE_PATH: metadata.sourceWorktreePath,
+            CODEX_WORKTREE_PATH: metadata.workspacePath,
+          }
+        : {}),
     });
 
-    const [command, commandArgs] =
-      variant === 'powershell'
-        ? ([
-            this.resolvePowerShellCommand(env),
-            [
-              '-NoProfile',
-              '-NonInteractive',
-              '-ExecutionPolicy',
-              'Bypass',
-              '-File',
-              scriptPath,
-            ],
-          ] as const)
-        : (['/bin/sh', [scriptPath]] as const);
+    let command = inlineScript ? 'bash' : '/bin/sh';
+    let commandArgs = inlineScript
+      ? ['-xeo', 'pipefail', '-c', inlineScript]
+      : [sourcePath];
+
+    if (variant === 'powershell') {
+      command = this.resolvePowerShellCommand(env);
+      const actionArgs = inlineScript
+        ? ['-Command', `${inlineScript}\nexit $LASTEXITCODE`]
+        : ['-ExecutionPolicy', 'Bypass', '-File', sourcePath];
+      commandArgs = ['-NoProfile', '-NonInteractive', ...actionArgs];
+    }
 
     try {
-      activeRun.child = this.spawnProcess(command, [...commandArgs], {
+      activeRun.child = this.spawnProcess(command, commandArgs, {
         cwd: metadata.workspacePath,
         env,
         stdio: ['ignore', 'pipe', 'pipe'],
@@ -395,6 +418,20 @@ export class WorktreeSetupRunner {
     } catch {
       return false;
     }
+  }
+
+  private async findSetupFile(
+    metadata: WorktreeSetupMetadata,
+    relativePath: string,
+  ): Promise<string | null> {
+    for (const rootPath of [
+      metadata.workspacePath,
+      metadata.mainWorktreePath,
+    ]) {
+      const targetPath = path.join(rootPath, relativePath);
+      if (await this.pathExists(targetPath)) return targetPath;
+    }
+    return null;
   }
 
   private updateOutput(

--- a/apps/browser/src/backend/services/worktree-setup-settings.test.ts
+++ b/apps/browser/src/backend/services/worktree-setup-settings.test.ts
@@ -129,7 +129,32 @@ async function createManagedWorktree(relativePath = 'repo-hash/feature-a') {
   return await fs.realpath(worktreePath);
 }
 
+async function writeCodexSetupConfig(content: string) {
+  const configPath = path.join(
+    repoPath,
+    '.codex/environments/environment.toml',
+  );
+  await fs.mkdir(path.dirname(configPath), { recursive: true });
+  await fs.writeFile(configPath, content);
+}
+
 describe('WorktreeSetupSettingsService', () => {
+  it('reports a usable Codex setup config', async () => {
+    await writeCodexSetupConfig('[setup]\nscript = "pnpm install"\n');
+
+    const result = await createService().service.listRepositories();
+
+    expect(result.repositories[0]?.hasCodexSetupScript).toBe(true);
+  });
+
+  it('does not report a Codex config without a setup script', async () => {
+    await writeCodexSetupConfig('[setup]\n');
+
+    const result = await createService().service.listRepositories();
+
+    expect(result.repositories[0]?.hasCodexSetupScript).toBe(false);
+  });
+
   it('rejects setup script saves for unknown repositories', async () => {
     const { service } = createService({ recentPaths: [] });
 

--- a/apps/browser/src/backend/services/worktree-setup-settings.ts
+++ b/apps/browser/src/backend/services/worktree-setup-settings.ts
@@ -3,6 +3,10 @@ import path from 'node:path';
 import type { GitService } from '@/services/git';
 import type { Logger } from '@/services/logger';
 import type { UserExperienceService } from '@/services/experience';
+import {
+  CODEX_WORKTREE_SETUP_CONFIG_RELATIVE_PATH,
+  readCodexSetupScript,
+} from '@/services/codex-worktree-setup';
 import { getWorktreesDir } from '@/utils/paths';
 import type {
   DeleteWorktreeSetupWorktreeResult,
@@ -339,12 +343,28 @@ export class WorktreeSetupSettingsService {
       mainWorktreePath,
       repositoryId,
       scripts,
+      hasCodexSetupScript: await this.hasCodexSetupScript(
+        path.join(mainWorktreePath, CODEX_WORKTREE_SETUP_CONFIG_RELATIVE_PATH),
+      ),
       managedWorktrees: this.filterManagedWorktreesForRepository(
         mainWorktreePath,
         repositoryId,
         managedWorktrees,
       ),
     };
+  }
+
+  private async hasCodexSetupScript(configPath: string): Promise<boolean> {
+    try {
+      return Boolean(await readCodexSetupScript(configPath, process.platform));
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+        this.logger.debug(
+          `[WorktreeSetupSettings] Failed to read Codex setup config ${configPath}: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+      return false;
+    }
   }
 
   private async readScriptContent(scriptPath: string): Promise<string | null> {

--- a/apps/browser/src/shared/karton-contracts/ui/index.ts
+++ b/apps/browser/src/shared/karton-contracts/ui/index.ts
@@ -221,6 +221,7 @@ export type WorktreeSetupRepositorySettings = {
   mainWorktreePath: string;
   repositoryId: string | null;
   scripts: Record<WorktreeSetupScriptVariant, WorktreeSetupScriptFile>;
+  hasCodexSetupScript: boolean;
   managedWorktrees: WorktreeSetupManagedWorktree[];
 };
 

--- a/apps/browser/src/ui/screens/settings/sections/agent-settings.worktree-setup.tsx
+++ b/apps/browser/src/ui/screens/settings/sections/agent-settings.worktree-setup.tsx
@@ -37,6 +37,7 @@ import {
 } from '@shared/worktree-setup';
 import {
   IconBranchOutOutline18,
+  IconCircleInfoOutline18,
   IconCircleQuestionOutline18,
   IconTrashOutline18,
 } from '@stagewise/icons';
@@ -452,6 +453,16 @@ function RepositoryDetails({
             </FileContextMenu>
           </div>
         </div>
+        {repository.hasCodexSetupScript && (
+          <div className="flex items-start gap-2 rounded-md bg-info-background/45 p-2 text-info-foreground text-xs leading-snug ring-1 ring-info-solid/20">
+            <IconCircleInfoOutline18 className="mt-0.5 size-3.5 shrink-0" />
+            <p>
+              <span className="font-medium">Codex setup detected.</span> It is
+              configured in the main worktree for this platform and may be used
+              as a fallback when creating worktrees.
+            </p>
+          </div>
+        )}
         <Tabs
           value={activeVariant}
           onValueChange={(value) =>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -257,6 +257,9 @@ importers:
       sharp:
         specifier: ^0.34.5
         version: 0.34.5
+      smol-toml:
+        specifier: ^1.7.1
+        version: 1.7.1
       tiptap-markdown:
         specifier: ^0.9.0
         version: 0.9.0(@tiptap/core@3.23.1(@tiptap/pm@3.23.1))
@@ -10378,6 +10381,10 @@ packages:
   smart-buffer@4.2.0:
     resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
     engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
+
+  smol-toml@1.7.1:
+    resolution: {integrity: sha512-PPlsspAZ4jbMBu5DMFhfUGDQLu/vrL4SyBROVS37x8ynnVmFIs1VPBz1Co8Xks3TvpIaZXmU85y4DrQ+UyVFoQ==}
+    engines: {node: '>= 18'}
 
   socks-proxy-agent@7.0.0:
     resolution: {integrity: sha512-Fgl0YPZ902wEsAyiQ+idGd1A7rSFx/ayC1CQVMw5P+EQx2V0SgpGtf6OKFhVjPflPUl9YMmEOnmfjCdMUsygww==}
@@ -22211,6 +22218,8 @@ snapshots:
       is-fullwidth-code-point: 4.0.0
 
   smart-buffer@4.2.0: {}
+
+  smol-toml@1.7.1: {}
 
   socks-proxy-agent@7.0.0:
     dependencies:


### PR DESCRIPTION
## Summary

- fall back to `.codex/environments/environment.toml` when no stagewise worktree setup script exists
- support default and platform-specific Codex setup commands
- provide the expected `CODEX_SOURCE_TREE_PATH` and `CODEX_WORKTREE_PATH` environment variables

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Extends worktree setup to parse and execute commands from Codex TOML configs, which affects post-create shell execution paths across platforms.
> 
> **Overview**
> Adds **Codex worktree setup fallback**: when no `.stagewise` setup script exists, the runner now reads `.codex/environments/environment.toml` and runs its setup command.
> 
> Stagewise scripts still take precedence. Codex configs support a default `[setup].script` plus platform-specific overrides (`darwin` / `linux` / `win32`). Inline commands run via `bash -c` (or PowerShell `-Command` on Windows) and receive `CODEX_SOURCE_TREE_PATH` / `CODEX_WORKTREE_PATH`.
> 
> Settings also surface a `hasCodexSetupScript` flag and an info banner when a usable Codex config is detected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25a3780f81e139256b7ca148e1aac9d906b9f947. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds fallback support for Codex worktree setup via `.codex/environments/environment.toml` when no `.stagewise` script exists, and shows detection in repository settings.

- **New Features**
  - Prefer `.stagewise/worktree-setup.*`; otherwise read the Codex config from the workspace or main worktree
  - Execute inline `[setup].script` or `[setup.<platform>].script` (bash on Unix; PowerShell on Windows) and set `CODEX_*` env vars for Codex runs
  - Indicate “Codex setup detected” in repository settings when a usable config is present

- **Dependencies**
  - Added `smol-toml` for TOML parsing

<sup>Written for commit 25a3780f81e139256b7ca148e1aac9d906b9f947. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1546?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Codex TOML environment setup.
  * Setup supports shared and platform-specific scripts, including Windows PowerShell commands.
  * Inline setup scripts receive Codex worktree environment variables.
  * Repository settings now indicate when a Codex setup script is detected and available as a worktree fallback.

* **Bug Fixes**
  * Improved fallback behavior and handling when setup scripts are unavailable.

* **Tests**
  * Expanded coverage for fallback behavior, script precedence, and Windows commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->