### PR TITLE
fix(stagewise): guard destroyed window on second instance

### DIFF
--- a/apps/browser/src/backend/main.ts
+++ b/apps/browser/src/backend/main.ts
@@ -1454,6 +1454,7 @@ function openIncomingUrl(
     }
     return;
   }
+  if (!windowLayoutService.getBaseWindow()) return;
   logger.debug(`[Main] Opening incoming URL: ${describeIncomingUrl(url)}`);
   void windowLayoutService.openUrlInNewTab(url);
 }

--- a/apps/browser/src/backend/services/window-layout/index.ts
+++ b/apps/browser/src/backend/services/window-layout/index.ts
@@ -660,7 +660,7 @@ export class WindowLayoutService extends DisposableService {
     });
 
     app.on('second-instance', () => {
-      if (this.baseWindow) {
+      if (this.baseWindow && !this.baseWindow.isDestroyed()) {
         if (this.baseWindow.isMinimized()) this.baseWindow.restore();
         this.baseWindow.focus();
       }


### PR DESCRIPTION
## Summary

- Prevent access to a destroyed `BaseWindow` when a second instance starts
- Fix the `Object has been destroyed` error during “Restart & Install”

Fixes #1532

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small defensive checks in Electron main-process URL and second-instance paths; no auth or data changes.
> 
> **Overview**
> Fixes **"Object has been destroyed"** when a second app instance runs while the main window is gone or tearing down (e.g. **Restart & Install**).
> 
> On **`second-instance`**, restore/focus only runs if `baseWindow` exists and **`!isDestroyed()`**. **`openIncomingUrl`** bails out before **`openUrlInNewTab`** when **`getBaseWindow()`** is null (that helper already treats destroyed windows as absent).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1c75e5a6c4eef98b72cf75ba67cecf8395a4e16. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Guard against accessing a destroyed `BaseWindow` when a second instance starts and when handling incoming URLs. Prevents the "Object has been destroyed" error during Restart & Install and deep link handling.

<sup>Written for commit f1c75e5a6c4eef98b72cf75ba67cecf8395a4e16. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1547?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of app launches when the main window is unavailable or has been closed.
  * Prevented attempts to restore or focus a destroyed window.
  * Prevented non-authentication links from opening without an available main window.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->