### PR TITLE
fix(stagewise): make plan viewer and overlay scrollbars immediately scrollable

### DIFF
--- a/apps/browser/src/pages/routes/plan/$filename.tsx
+++ b/apps/browser/src/pages/routes/plan/$filename.tsx
@@ -41,8 +41,13 @@ function PlanPage() {
         const text = await response.text();
         if (cancelled) return;
 
-        setContent(text);
-        setRevision((r) => r + 1);
+        setContent((prev) => {
+          if (prev !== text) {
+            setRevision((r) => r + 1);
+            return text;
+          }
+          return prev;
+        });
       } catch (e) {
         if (!cancelled) setError(String(e));
       }
@@ -84,6 +89,7 @@ function PlanPage() {
 
   return (
     <OverlayScrollbar
+      defer={false}
       className="h-screen w-full bg-background p-8 text-foreground text-sm"
       contentClassName="flex justify-center"
     >

--- a/apps/browser/src/pages/routes/plan/$filename.tsx
+++ b/apps/browser/src/pages/routes/plan/$filename.tsx
@@ -12,7 +12,10 @@ export const Route = createFileRoute('/plan/$filename')({
 
 function PlanPage() {
   const { filename } = Route.useParams();
-  const [content, setContent] = useState<string | null>(null);
+  const [{ content, revision }, setPlanState] = useState<{
+    content: string | null;
+    revision: number;
+  }>({ content: null, revision: 0 });
   const [error, setError] = useState<string | null>(null);
 
   const fetchUrl = `plans://plans/${filename}`;
@@ -24,10 +27,6 @@ function PlanPage() {
   const planMeta = useKartonState((s) => {
     return s.plans.find((p) => p.filename === filename);
   });
-
-  // Revision counter bumped on external changes to force editor remount
-  // so the read-only editor picks up the latest content.
-  const [revision, setRevision] = useState(0);
 
   // Fetch file content. Runs on initial load and whenever planMeta changes
   // (i.e. the backend detected a file change on disk).
@@ -41,10 +40,12 @@ function PlanPage() {
         const text = await response.text();
         if (cancelled) return;
 
-        setContent((prev) => {
-          if (prev !== text) {
-            setRevision((r) => r + 1);
-            return text;
+        setPlanState((prev) => {
+          if (prev.content !== text) {
+            return {
+              content: text,
+              revision: prev.content === null ? 0 : prev.revision + 1,
+            };
           }
           return prev;
         });

--- a/apps/browser/src/pages/routes/preview/$appId.tsx
+++ b/apps/browser/src/pages/routes/preview/$appId.tsx
@@ -3,7 +3,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { sendThemeToIframe } from '@shared/iframe-theme';
 import { useIframeAppBridge } from '@pages/lib/iframe-app-bridge';
 
-interface PreviewSearch {
+export interface PreviewSearch {
   agentId?: string;
   pluginId?: string;
   t?: string;

--- a/apps/browser/tsconfig.pages.json
+++ b/apps/browser/tsconfig.pages.json
@@ -20,7 +20,7 @@
     "resolveJsonModule": true,
     "noUncheckedIndexedAccess": true
   },
-  "include": ["src/pages", "forge.env.d.ts", "src/shared", "src/ui"],
+  "include": ["src/pages", "forge.env.d.ts", "src/shared", "src/ui", "src/types"],
   "exclude": [
     "**/*.stories.tsx",
     "**/*.stories.ts",

--- a/packages/stage-ui/src/components/overlay-scrollbar.tsx
+++ b/packages/stage-ui/src/components/overlay-scrollbar.tsx
@@ -53,7 +53,10 @@ export interface OverlayScrollbarProps {
   onUpdated?: (instance: OverlayScrollbars) => void;
   /** Called when the instance is initialized */
   onInitialized?: (instance: OverlayScrollbars) => void;
-  /** Defer initialization until idle (defaults to false for immediate scrollability) */
+  /**
+   * Defer initialization until idle (defaults to false for immediate
+   * scrollability).
+   */
   defer?: boolean;
   /** The HTML element to use for the root */
   element?: 'div' | 'section' | 'article' | 'main' | 'aside' | 'nav';

--- a/packages/stage-ui/src/components/overlay-scrollbar.tsx
+++ b/packages/stage-ui/src/components/overlay-scrollbar.tsx
@@ -53,7 +53,7 @@ export interface OverlayScrollbarProps {
   onUpdated?: (instance: OverlayScrollbars) => void;
   /** Called when the instance is initialized */
   onInitialized?: (instance: OverlayScrollbars) => void;
-  /** Defer initialization until idle */
+  /** Defer initialization until idle (defaults to false for immediate scrollability) */
   defer?: boolean;
   /** The HTML element to use for the root */
   element?: 'div' | 'section' | 'article' | 'main' | 'aside' | 'nav';
@@ -121,7 +121,7 @@ export const OverlayScrollbar = forwardRef<
     onScroll,
     onUpdated,
     onInitialized,
-    defer = true,
+    defer = false,
     element = 'div',
     'aria-label': ariaLabel,
     onViewportRef,


### PR DESCRIPTION
## Summary
Closes #1399

Fixes an issue where the plan viewer tab was unscrollable for 3+ seconds upon opening.

### Root Cause
`OverlayScrollbar` in `@stagewise/stage-ui` had `defer = true` enabled by default. This delegated scrollbar initialization to `requestIdleCallback`. When opening a plan, ProseMirror/TipTap editor initialization and Shiki syntax highlighting kept the main thread active, preventing `requestIdleCallback` from firing for several seconds and leaving the container without initialized scroll listeners or viewport elements.

### Changes
- Set `defer = false` by default on `OverlayScrollbar` in `@stagewise/stage-ui` so scrollbars and viewport listeners initialize immediately upon mounting.
- Explicitly set `defer={false}` on `PlanPage`'s `OverlayScrollbar`.
- In `PlanPage`, only increment the editor `revision` counter (which forces a remount) when fetched file content text actually differs.
- Included `src/types` in `tsconfig.pages.json` and exported `PreviewSearch` to ensure clean TypeScript compilation across pages.

## Verification
- `pnpm -F stagewise typecheck` passed (ui, backend, preload, storybook).
- `pnpm --dir apps/browser exec tsc -p tsconfig.pages.json --noEmit` passed.
- `pnpm -F stagewise test` passed (90 test files, 1,092 tests passing).
- `pnpm biome check` passed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the plan viewer and all overlay scrollbars immediately scrollable by initializing on mount. Previously, initialization deferred to idle and the plan tab stayed unscrollable for several seconds; now it initializes synchronously with a small mount cost.

- In `@stagewise/stage-ui`, change `OverlayScrollbar` default `defer` to false. If you need deferred init, pass `defer={true}`.
- Plan page: set `defer={false}` and make content updates pure—only update state when text changes and increment editor `revision` on content changes (skip initial load) to avoid unnecessary remounts.
- Export `PreviewSearch` and include `src/types` in `tsconfig.pages.json` for page type-safety.

<sup>Written for commit 25f783221ce3a6b7d691fd74b0f9bceaa597b969. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stagewise-io/stagewise/pull/1552?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI scrolling and plan refresh behavior only; default defer change is app-wide but callers can still pass defer={true}.
> 
> **Overview**
> Fixes the plan tab staying **unscrollable for several seconds** after open by changing **`OverlayScrollbar`** so **`defer` defaults to `false`**, initializing scrollbars on mount instead of waiting on **`requestIdleCallback`** (which was starved by TipTap/Shiki on the plan page).
> 
> On the **plan route**, content and editor **`revision`** are updated together: **`revision` only increases when fetched markdown text changes**, avoiding pointless **`MarkdownEditor`** remounts when **`planMeta`** refetches the same file. The plan shell also sets **`defer={false}`** explicitly.
> 
> Small TS hygiene: **`PreviewSearch`** is exported from the preview route and **`src/types`** is added to **`tsconfig.pages.json`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25f783221ce3a6b7d691fd74b0f9bceaa597b969. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented unnecessary editor revisions when plan content has not changed.
  * Updated overlay scrollbars to initialize immediately by default for more consistent scrolling behavior.

* **Documentation**
  * Clarified the default behavior of deferred scrollbar initialization.

* **Internal Improvements**
  * Expanded TypeScript coverage for shared type definitions.
  * Made preview search parameters available for reuse, supporting more consistent preview behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->