### PR TITLE
feat(stagewise): support importing OpenCode Go subscription

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Connect any of the following subscriptions with a single API key to unlock all m
 | Qwen Coding Plan | [Alibaba DashScope](https://dashscope.console.aliyun.com) | Qwen 3-Coder 30B-A3B, Qwen 3-32B | [Get API key](https://dashscope.console.aliyun.com/apiKey) |
 | MiniMax          | [MiniMax](https://platform.minimax.io) | MiniMax M3, MiniMax M2.7 | [Get API key](https://platform.minimax.io/user-center/basic-information/interface-key) |
 | Xiaomi MiMo      | [Xiaomi MiMo](https://platform.xiaomimimo.com) | MiMo-V2.5-Pro, MiMo-V2.5               | [Get API key](https://platform.xiaomimimo.com/#/console/plan-manage) |
+| OpenCode Go      | [OpenCode](https://opencode.ai/go) | GLM 5.2, Kimi K3, DeepSeek V4 Pro, Qwen3.7 Plus, MiniMax M3 | [Get API key](https://opencode.ai/auth) |
 | Mistral          | [Mistral](https://console.mistral.ai) | Mistral Medium 3.5, Mistral Large 3, Mistral Small 4, Codestral | [Get API key](https://console.mistral.ai/api-keys) |
 
 ### Bring Your Own API Key

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Connect any of the following subscriptions with a single API key to unlock all m
 | Qwen Coding Plan | [Alibaba DashScope](https://dashscope.console.aliyun.com) | Qwen 3-Coder 30B-A3B, Qwen 3-32B | [Get API key](https://dashscope.console.aliyun.com/apiKey) |
 | MiniMax          | [MiniMax](https://platform.minimax.io) | MiniMax M3, MiniMax M2.7 | [Get API key](https://platform.minimax.io/user-center/basic-information/interface-key) |
 | Xiaomi MiMo      | [Xiaomi MiMo](https://platform.xiaomimimo.com) | MiMo-V2.5-Pro, MiMo-V2.5               | [Get API key](https://platform.xiaomimimo.com/#/console/plan-manage) |
-| OpenCode Go      | [OpenCode](https://opencode.ai/go) | GLM 5.2, Kimi K3, DeepSeek V4 Pro, Qwen3.7 Plus, MiniMax M3 | [Get API key](https://opencode.ai/auth) |
+| OpenCode Go      | [OpenCode](https://opencode.ai/go) | GLM 5.2, Kimi K3, DeepSeek V4 Pro, Qwen 3.7 Plus, MiniMax M3 | [Get API key](https://opencode.ai/auth) |
 | Mistral          | [Mistral](https://console.mistral.ai) | Mistral Medium 3.5, Mistral Large 3, Mistral Small 4, Codestral | [Get API key](https://console.mistral.ai/api-keys) |
 
 ### Bring Your Own API Key

--- a/apps/browser/src/backend/agents/providers/official-api.ts
+++ b/apps/browser/src/backend/agents/providers/official-api.ts
@@ -55,6 +55,7 @@ const VENDOR_TO_API_SPEC: Record<ModelProvider, ApiSpec> = {
   'xiaomi-mimo': 'openai-chat-completions',
   mistral: 'openai-chat-completions',
   'x-ai': 'openai-chat-completions',
+  opencode: 'openai-chat-completions',
 };
 
 /**
@@ -75,6 +76,7 @@ const VENDOR_VALIDATION_MODEL: Partial<Record<ModelProvider, string>> = {
   'x-ai': 'grok-3-mini',
   openai: 'gpt-4o-mini',
   google: 'gemini-2.0-flash',
+  opencode: 'mimo-v2.5',
 };
 
 // ============================================================================
@@ -525,6 +527,9 @@ export const mistralApiType: ProviderType<OfficialApiConfig> =
 export const xAiApiType: ProviderType<OfficialApiConfig> =
   createOpenAICompatibleApiType('x-ai');
 
+export const opencodeApiType: ProviderType<OfficialApiConfig> =
+  createOpenAICompatibleApiType('opencode');
+
 // ============================================================================
 // Registry of all official-api types, keyed by vendor
 // ============================================================================
@@ -544,6 +549,7 @@ export const OFFICIAL_API_TYPES: Record<
   'xiaomi-mimo': xiaomiMimoApiType,
   mistral: mistralApiType,
   'x-ai': xAiApiType,
+  opencode: opencodeApiType,
 };
 
 export const VENDOR_API_SPECS = VENDOR_TO_API_SPEC;

--- a/apps/browser/src/backend/agents/providers/opencode/local-auth.test.ts
+++ b/apps/browser/src/backend/agents/providers/opencode/local-auth.test.ts
@@ -1,0 +1,77 @@
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  authFilePath,
+  getLocalOpenCodeApiKey,
+  parseOpenCodeAuthCredentials,
+} from './local-auth';
+
+describe('parseOpenCodeAuthCredentials', () => {
+  it('parses the OpenCode Go api credential', () => {
+    const credentials = parseOpenCodeAuthCredentials(
+      JSON.stringify({
+        'opencode-go': { type: 'api', key: 'go-key' },
+        opencode: { type: 'api', key: 'zen-key' },
+      }),
+    );
+    expect(credentials['opencode-go']).toEqual({ type: 'api', key: 'go-key' });
+  });
+
+  it('returns an empty map for malformed JSON', () => {
+    expect(parseOpenCodeAuthCredentials('not-json')).toEqual({});
+  });
+
+  it('preserves oauth-style credentials without a key', () => {
+    const credentials = parseOpenCodeAuthCredentials(
+      JSON.stringify({
+        anthropic: { type: 'oauth', access: 'token', refresh: 'refresh' },
+      }),
+    );
+    expect(credentials.anthropic?.type).toBe('oauth');
+  });
+});
+
+describe('authFilePath', () => {
+  it('uses XDG_DATA_HOME when provided', () => {
+    expect(authFilePath({ XDG_DATA_HOME: '/data' })).toBe(
+      '/data/opencode/auth.json',
+    );
+  });
+
+  it('falls back to the XDG default under the home directory', () => {
+    expect(authFilePath({})).toBe(
+      join(homedir(), '.local', 'share', 'opencode', 'auth.json'),
+    );
+  });
+});
+
+describe('getLocalOpenCodeApiKey', () => {
+  it('resolves the key for an api credential', async () => {
+    await expect(
+      getLocalOpenCodeApiKey('opencode-go', {
+        OPENCODE_AUTH_CONTENT: JSON.stringify({
+          'opencode-go': { type: 'api', key: 'go-key' },
+        }),
+      }),
+    ).resolves.toBe('go-key');
+  });
+
+  it('never returns a non-api credential', async () => {
+    await expect(
+      getLocalOpenCodeApiKey('anthropic', {
+        OPENCODE_AUTH_CONTENT: JSON.stringify({
+          anthropic: { type: 'oauth', access: 'token' },
+        }),
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('resolves to undefined when the provider is absent', async () => {
+    await expect(
+      getLocalOpenCodeApiKey('opencode-go', {
+        OPENCODE_AUTH_CONTENT: '{}',
+      }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/apps/browser/src/backend/agents/providers/opencode/local-auth.test.ts
+++ b/apps/browser/src/backend/agents/providers/opencode/local-auth.test.ts
@@ -74,4 +74,14 @@ describe('getLocalOpenCodeApiKey', () => {
       }),
     ).resolves.toBeUndefined();
   });
+
+  it('rejects an api credential whose key is not a string', async () => {
+    await expect(
+      getLocalOpenCodeApiKey('opencode-go', {
+        OPENCODE_AUTH_CONTENT: JSON.stringify({
+          'opencode-go': { type: 'api', key: { nested: true } },
+        }),
+      }),
+    ).resolves.toBeUndefined();
+  });
 });

--- a/apps/browser/src/backend/agents/providers/opencode/local-auth.ts
+++ b/apps/browser/src/backend/agents/providers/opencode/local-auth.ts
@@ -1,0 +1,71 @@
+import { readFile } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { resolveAcpEnvironment } from '../../acp/adapter';
+
+export interface OpenCodeAuthCredential {
+  type?: string;
+  key?: string;
+}
+
+/**
+ * Resolving the login-shell environment spawns a shell, so it is memoized
+ * for the process lifetime — detection runs on every render of a plan card.
+ */
+let environmentPromise: Promise<NodeJS.ProcessEnv> | undefined;
+
+function resolveEnvironment(): Promise<NodeJS.ProcessEnv> {
+  environmentPromise ??= resolveAcpEnvironment().then((shellEnv) => ({
+    ...process.env,
+    ...(shellEnv ?? {}),
+  }));
+  return environmentPromise;
+}
+
+export function authFilePath(env: NodeJS.ProcessEnv): string {
+  const dataHome = env.XDG_DATA_HOME || join(homedir(), '.local', 'share');
+  return join(dataHome, 'opencode', 'auth.json');
+}
+
+/** Parse the OpenCode CLI auth.json contents into a credential map. */
+export function parseOpenCodeAuthCredentials(
+  contents: string,
+): Record<string, OpenCodeAuthCredential> {
+  try {
+    const parsed = JSON.parse(contents) as Record<
+      string,
+      OpenCodeAuthCredential
+    >;
+    return parsed ?? {};
+  } catch {
+    return {};
+  }
+}
+
+async function readOpenCodeAuthCredentials(
+  env: NodeJS.ProcessEnv,
+): Promise<Record<string, OpenCodeAuthCredential>> {
+  try {
+    const contents = env.OPENCODE_AUTH_CONTENT
+      ? env.OPENCODE_AUTH_CONTENT
+      : await readFile(authFilePath(env), 'utf8');
+    return parseOpenCodeAuthCredentials(contents);
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Resolve a stored API key for a provider ID (e.g. `opencode-go`).
+ * Falls back to the memoized login-shell environment when none is given.
+ */
+export async function getLocalOpenCodeApiKey(
+  providerId: string,
+  env?: NodeJS.ProcessEnv,
+): Promise<string | undefined> {
+  const credentials = await readOpenCodeAuthCredentials(
+    env ?? (await resolveEnvironment()),
+  );
+  const credential = credentials[providerId];
+  return credential?.type === 'api' ? credential.key : undefined;
+}

--- a/apps/browser/src/backend/agents/providers/opencode/local-auth.ts
+++ b/apps/browser/src/backend/agents/providers/opencode/local-auth.ts
@@ -67,5 +67,8 @@ export async function getLocalOpenCodeApiKey(
     env ?? (await resolveEnvironment()),
   );
   const credential = credentials[providerId];
-  return credential?.type === 'api' ? credential.key : undefined;
+  // auth.json is user-controlled: a valid JSON file can hold a non-string key.
+  return credential?.type === 'api' && typeof credential.key === 'string'
+    ? credential.key
+    : undefined;
 }

--- a/apps/browser/src/backend/agents/providers/opencode/usage.ts
+++ b/apps/browser/src/backend/agents/providers/opencode/usage.ts
@@ -1,8 +1,5 @@
-import { readFile } from 'node:fs/promises';
-import { homedir } from 'node:os';
-import { join } from 'node:path';
 import type { ProviderUsageLimits } from '@shared/karton-contracts/ui/shared-types';
-import { resolveAcpEnvironment } from '../../acp/adapter';
+import { getLocalOpenCodeApiKey } from './local-auth';
 
 interface OpenCodeUsageResponse {
   usage?: {
@@ -17,28 +14,6 @@ interface OpenCodeUsageWindow {
 }
 
 let pendingUsage: Promise<ProviderUsageLimits> | undefined;
-let environmentPromise: Promise<NodeJS.ProcessEnv | null> | undefined;
-
-function authFilePath(env: NodeJS.ProcessEnv): string {
-  const dataHome = env.XDG_DATA_HOME || join(homedir(), '.local', 'share');
-  return join(dataHome, 'opencode', 'auth.json');
-}
-
-async function readApiKey(env: NodeJS.ProcessEnv): Promise<string | undefined> {
-  try {
-    const contents = env.OPENCODE_AUTH_CONTENT
-      ? env.OPENCODE_AUTH_CONTENT
-      : await readFile(authFilePath(env), 'utf8');
-    const auth = JSON.parse(contents) as Record<
-      string,
-      { type?: string; key?: string }
-    >;
-    const credential = auth['opencode-go'];
-    return credential?.type === 'api' ? credential.key : undefined;
-  } catch {
-    return undefined;
-  }
-}
 
 export function formatOpenCodeUsage(
   response: OpenCodeUsageResponse,
@@ -54,9 +29,7 @@ export function formatOpenCodeUsage(
 }
 
 async function readOpenCodeUsageLimits(): Promise<ProviderUsageLimits> {
-  environmentPromise ??= resolveAcpEnvironment();
-  const shellEnv = (await environmentPromise) ?? {};
-  const apiKey = await readApiKey({ ...process.env, ...shellEnv });
+  const apiKey = await getLocalOpenCodeApiKey('opencode-go');
   if (!apiKey) return [];
   const response = await fetch('https://opencode.ai/zen/go/v1/usage', {
     headers: { authorization: `Bearer ${apiKey}` },

--- a/apps/browser/src/backend/agents/providers/registry.ts
+++ b/apps/browser/src/backend/agents/providers/registry.ts
@@ -14,6 +14,7 @@ import {
   xiaomiMimoApiType,
   mistralApiType,
   xAiApiType,
+  opencodeApiType,
   OFFICIAL_API_TYPES,
 } from './official-api';
 import { codingPlanProviderType } from './coding-plan';
@@ -55,6 +56,7 @@ export const PROVIDER_TYPE_REGISTRY: Record<
   'xiaomi-mimo-api': xiaomiMimoApiType,
   'mistral-api': mistralApiType,
   'x-ai-api': xAiApiType,
+  'opencode-api': opencodeApiType,
   'coding-plan': codingPlanProviderType,
   'custom-anthropic': customAnthropicType,
   'custom-openai-chat': customOpenAIChatType,

--- a/apps/browser/src/backend/agents/providers/shared.ts
+++ b/apps/browser/src/backend/agents/providers/shared.ts
@@ -192,7 +192,10 @@ const VENDOR_REASONING_MODEL_IDS: Partial<Record<ModelProvider, Set<string>>> =
     'xiaomi-mimo': new Set(['mimo-v2.5-pro', 'mimo-v2.5', 'mimo-v2.5-think']),
     // OpenCode Go re-serves other vendors' models under their native IDs.
     // Listed here are the ones this repo already declares as reasoning
-    // models for their own vendor, so the two stay in agreement.
+    // models elsewhere — in a vendor set above, or in the model catalog
+    // (`available-models.ts`), which is where grok-4.5 and gpt-5.6-luna
+    // are declared. Nothing is asserted for OpenCode that is not already
+    // asserted somewhere else.
     opencode: new Set([
       'glm-5',
       'glm-5.1',

--- a/apps/browser/src/backend/agents/providers/shared.ts
+++ b/apps/browser/src/backend/agents/providers/shared.ts
@@ -190,6 +190,26 @@ const VENDOR_REASONING_MODEL_IDS: Partial<Record<ModelProvider, Set<string>>> =
       'minimax-m1',
     ]),
     'xiaomi-mimo': new Set(['mimo-v2.5-pro', 'mimo-v2.5', 'mimo-v2.5-think']),
+    // OpenCode Go re-serves other vendors' models under their native IDs.
+    // Listed here are the ones this repo already declares as reasoning
+    // models for their own vendor, so the two stay in agreement.
+    opencode: new Set([
+      'glm-5',
+      'glm-5.1',
+      'glm-5.2',
+      'kimi-k2.5',
+      'kimi-k2.6',
+      'kimi-k2.7-code',
+      'kimi-k3',
+      'deepseek-v4-flash',
+      'deepseek-v4-pro',
+      'minimax-m2.7',
+      'minimax-m3',
+      'mimo-v2.5',
+      'mimo-v2.5-pro',
+      'gpt-5.6-luna',
+      'grok-4.5',
+    ]),
     mistral: new Set([
       'mistral-medium-3-5',
       'mistral-small-2603',

--- a/apps/browser/src/backend/services/preferences.test.ts
+++ b/apps/browser/src/backend/services/preferences.test.ts
@@ -41,6 +41,12 @@ const validationMock = vi.hoisted(() => ({
 
 vi.mock('../utils/validate-api-keys', () => validationMock);
 
+const localAuthMock = vi.hoisted(() => ({
+  getLocalOpenCodeApiKey: vi.fn(),
+}));
+
+vi.mock('../agents/providers/opencode/local-auth', () => localAuthMock);
+
 const logger = {
   debug: vi.fn(),
   error: vi.fn(),
@@ -181,6 +187,46 @@ describe('PreferencesService local agent providers', () => {
         .get()
         .providerInstances.filter(({ typeId }) => typeId === 'claude-code'),
     ).toHaveLength(1);
+  });
+
+  it('imports a detected coding plan once under concurrent calls', async () => {
+    localAuthMock.getLocalOpenCodeApiKey.mockResolvedValue('go-key');
+    validationMock.validateCodingPlanApiKey.mockResolvedValue({
+      success: true,
+    });
+    const service = await createServiceWithPreferences();
+
+    const results = await Promise.all([
+      service.importDetectedCodingPlan('opencode-go'),
+      service.importDetectedCodingPlan('opencode-go'),
+    ]);
+
+    expect(results.every(({ success }) => success)).toBe(true);
+    expect(
+      service
+        .get()
+        .providerInstances.filter(
+          (instance) =>
+            instance.typeId === 'coding-plan' &&
+            (instance.config as { planId?: string }).planId === 'opencode-go',
+        ),
+    ).toHaveLength(1);
+  });
+
+  it('does not offer an import for an already connected plan', async () => {
+    localAuthMock.getLocalOpenCodeApiKey.mockResolvedValue('go-key');
+    validationMock.validateCodingPlanApiKey.mockResolvedValue({
+      success: true,
+    });
+    const service = await createServiceWithPreferences();
+
+    expect(await service.detectLocalSubscriptionImport('opencode-go')).toEqual({
+      available: true,
+    });
+    await service.importDetectedCodingPlan('opencode-go');
+    expect(await service.detectLocalSubscriptionImport('opencode-go')).toEqual({
+      available: false,
+    });
   });
 });
 

--- a/apps/browser/src/backend/services/preferences.ts
+++ b/apps/browser/src/backend/services/preferences.ts
@@ -2118,10 +2118,21 @@ export class PreferencesService extends DisposableService {
     return (await getProviderType(instance.typeId).getUsageLimits?.()) ?? [];
   }
 
+  private findCodingPlanInstance(
+    planId: CodingPlanId,
+  ): ProviderInstance | undefined {
+    return this.preferences.providerInstances.find(
+      (instance) =>
+        instance.typeId === 'coding-plan' &&
+        (instance.config as { planId?: string }).planId === planId,
+    );
+  }
+
   /**
    * Report whether a coding plan's credential can be imported from a local
    * CLI auth file on this machine. Only plans declaring `localImport` are
-   * detectable; the credential itself never leaves the backend.
+   * detectable; the credential itself never leaves the backend, and a plan
+   * that is already connected is not offered again.
    */
   public async detectLocalSubscriptionImport(
     planId: CodingPlanId,
@@ -2129,6 +2140,7 @@ export class PreferencesService extends DisposableService {
     this.assertNotDisposed();
     const localImport = CODING_PLANS[planId]?.localImport;
     if (!localImport) return { available: false };
+    if (this.findCodingPlanInstance(planId)) return { available: false };
     const apiKey = await getLocalOpenCodeApiKey(localImport.opencodeProviderId);
     return { available: !!apiKey };
   }
@@ -2150,6 +2162,12 @@ export class PreferencesService extends DisposableService {
       return {
         success: false,
         error: `Plan ${planId} does not support local import.`,
+      };
+    }
+    if (this.findCodingPlanInstance(planId)) {
+      return {
+        success: false,
+        error: `${plan.displayName} is already connected.`,
       };
     }
     const apiKey = await getLocalOpenCodeApiKey(
@@ -2623,6 +2641,12 @@ export class PreferencesService extends DisposableService {
       );
       this.uiKarton.removeServerProcedureHandler(
         'preferences.refreshInstanceModels',
+      );
+      this.uiKarton.removeServerProcedureHandler(
+        'preferences.detectLocalSubscriptionImport',
+      );
+      this.uiKarton.removeServerProcedureHandler(
+        'preferences.importDetectedCodingPlan',
       );
       this.uiKarton.removeServerProcedureHandler(
         'devToolbar.updateWidgetOrder',

--- a/apps/browser/src/backend/services/preferences.ts
+++ b/apps/browser/src/backend/services/preferences.ts
@@ -255,18 +255,11 @@ export class PreferencesService extends DisposableService {
   ): Promise<void> {
     if (this.preferences.providerInstances.length > 0) return;
 
-    const VENDORS: ModelProvider[] = [
-      'anthropic',
-      'openai',
-      'google',
-      'moonshotai',
-      'alibaba',
-      'deepseek',
-      'z-ai',
-      'minimax',
-      'xiaomi-mimo',
-      'mistral',
-    ];
+    // Every vendor with a providerConfig must be listed, or its legacy
+    // config is skipped here and `migrateLegacyCodingPlansToProviderInstances`
+    // has to repair it with a second write. Derive from the schema so adding
+    // a vendor cannot reintroduce that gap.
+    const VENDORS: ModelProvider[] = [...modelProviderSchema.options];
     const BUILT_IN_VENDOR_NAMES = new Set<string>(VENDORS);
 
     const instances: ProviderInstance[] = [];

--- a/apps/browser/src/backend/services/preferences.ts
+++ b/apps/browser/src/backend/services/preferences.ts
@@ -38,7 +38,10 @@ import {
 } from '../utils/validate-api-keys';
 import { getProviderType } from '../agents/providers/registry';
 import { computeDisabledModelIdsAfterDiscovery } from '@shared/flagship-models';
-import { apiSpecToTypeId } from '@shared/provider-instance-helpers';
+import {
+  apiSpecToTypeId,
+  findCodingPlanInstance,
+} from '@shared/provider-instance-helpers';
 import {
   prepareAcpProcess,
   resolveAcpEnvironment,
@@ -997,6 +1000,18 @@ export class PreferencesService extends DisposableService {
       providerInstances: this.preferences.providerInstances,
     };
   }
+
+  private readonly pendingCodingPlanImports = new Map<
+    CodingPlanId,
+    Promise<
+      | {
+          success: true;
+          instanceId: string;
+          discoveredModels: DiscoveredModel[];
+        }
+      | { success: false; error: string }
+    >
+  >();
 
   private async enqueuePreferenceWrite<T>(
     operation: () => Promise<T>,
@@ -2118,16 +2133,6 @@ export class PreferencesService extends DisposableService {
     return (await getProviderType(instance.typeId).getUsageLimits?.()) ?? [];
   }
 
-  private findCodingPlanInstance(
-    planId: CodingPlanId,
-  ): ProviderInstance | undefined {
-    return this.preferences.providerInstances.find(
-      (instance) =>
-        instance.typeId === 'coding-plan' &&
-        (instance.config as { planId?: string }).planId === planId,
-    );
-  }
-
   /**
    * Report whether a coding plan's credential can be imported from a local
    * CLI auth file on this machine. Only plans declaring `localImport` are
@@ -2140,7 +2145,9 @@ export class PreferencesService extends DisposableService {
     this.assertNotDisposed();
     const localImport = CODING_PLANS[planId]?.localImport;
     if (!localImport) return { available: false };
-    if (this.findCodingPlanInstance(planId)) return { available: false };
+    if (findCodingPlanInstance(this.preferences, planId)) {
+      return { available: false };
+    }
     const apiKey = await getLocalOpenCodeApiKey(localImport.opencodeProviderId);
     return { available: !!apiKey };
   }
@@ -2157,6 +2164,24 @@ export class PreferencesService extends DisposableService {
     | { success: false; error: string }
   > {
     this.assertNotDisposed();
+    // The existence check below cannot share the preference write queue —
+    // addProviderInstance enqueues onto it — so concurrent imports of the
+    // same plan share one run instead of both passing the check.
+    const inFlight = this.pendingCodingPlanImports.get(planId);
+    if (inFlight) return inFlight;
+    const run = this.runDetectedCodingPlanImport(planId).finally(() => {
+      this.pendingCodingPlanImports.delete(planId);
+    });
+    this.pendingCodingPlanImports.set(planId, run);
+    return run;
+  }
+
+  private async runDetectedCodingPlanImport(
+    planId: CodingPlanId,
+  ): Promise<
+    | { success: true; instanceId: string; discoveredModels: DiscoveredModel[] }
+    | { success: false; error: string }
+  > {
     const plan = CODING_PLANS[planId];
     if (!plan?.localImport) {
       return {
@@ -2164,7 +2189,7 @@ export class PreferencesService extends DisposableService {
         error: `Plan ${planId} does not support local import.`,
       };
     }
-    if (this.findCodingPlanInstance(planId)) {
+    if (findCodingPlanInstance(this.preferences, planId)) {
       return {
         success: false,
         error: `${plan.displayName} is already connected.`,

--- a/apps/browser/src/backend/services/preferences.ts
+++ b/apps/browser/src/backend/services/preferences.ts
@@ -45,6 +45,7 @@ import {
   resolveAgentExecutable,
 } from '../agents/acp/adapter';
 import { adapterForProviderType } from '../agents/acp/adapter-registry';
+import { getLocalOpenCodeApiKey } from '../agents/providers/opencode/local-auth';
 
 // Enable Immer patches support
 enablePatches();
@@ -658,6 +659,20 @@ export class PreferencesService extends DisposableService {
         apiKey: string,
       ) => {
         return this.connectProvider(provider, apiKey);
+      },
+    );
+
+    this.uiKarton.registerServerProcedureHandler(
+      'preferences.detectLocalSubscriptionImport',
+      async (_callingClientId: string, planId: CodingPlanId) => {
+        return this.detectLocalSubscriptionImport(planId);
+      },
+    );
+
+    this.uiKarton.registerServerProcedureHandler(
+      'preferences.importDetectedCodingPlan',
+      async (_callingClientId: string, planId: CodingPlanId) => {
+        return this.importDetectedCodingPlan(planId);
       },
     );
 
@@ -2101,6 +2116,56 @@ export class PreferencesService extends DisposableService {
     );
     if (!instance) throw new Error(`Provider instance ${instanceId} not found`);
     return (await getProviderType(instance.typeId).getUsageLimits?.()) ?? [];
+  }
+
+  /**
+   * Report whether a coding plan's credential can be imported from a local
+   * CLI auth file on this machine. Only plans declaring `localImport` are
+   * detectable; the credential itself never leaves the backend.
+   */
+  public async detectLocalSubscriptionImport(
+    planId: CodingPlanId,
+  ): Promise<{ available: boolean }> {
+    this.assertNotDisposed();
+    const localImport = CODING_PLANS[planId]?.localImport;
+    if (!localImport) return { available: false };
+    const apiKey = await getLocalOpenCodeApiKey(localImport.opencodeProviderId);
+    return { available: !!apiKey };
+  }
+
+  /**
+   * Import a locally detected subscription as a coding-plan provider
+   * instance. The key is read server-side and passed straight into
+   * `addProviderInstance`, so it never crosses the IPC boundary.
+   */
+  public async importDetectedCodingPlan(
+    planId: CodingPlanId,
+  ): Promise<
+    | { success: true; instanceId: string; discoveredModels: DiscoveredModel[] }
+    | { success: false; error: string }
+  > {
+    this.assertNotDisposed();
+    const plan = CODING_PLANS[planId];
+    if (!plan?.localImport) {
+      return {
+        success: false,
+        error: `Plan ${planId} does not support local import.`,
+      };
+    }
+    const apiKey = await getLocalOpenCodeApiKey(
+      plan.localImport.opencodeProviderId,
+    );
+    if (!apiKey) {
+      return {
+        success: false,
+        error: `No ${plan.displayName} subscription was found in the OpenCode CLI auth file.`,
+      };
+    }
+    return this.addProviderInstance({
+      typeId: 'coding-plan',
+      config: { planId },
+      validateApiKey: apiKey,
+    });
   }
 
   /**

--- a/apps/browser/src/backend/utils/validate-api-keys.ts
+++ b/apps/browser/src/backend/utils/validate-api-keys.ts
@@ -18,7 +18,8 @@ export type ApiKeyProvider =
   | 'minimax'
   | 'xiaomi-mimo'
   | 'mistral'
-  | 'x-ai';
+  | 'x-ai'
+  | 'opencode';
 
 export type ApiKeyValidationResult =
   | null
@@ -134,6 +135,11 @@ const providerConfigs: Record<
       apiKey,
       baseURL: baseURL ?? 'https://api.x.ai/v1',
     }).chat('grok-3-mini'),
+  opencode: (apiKey, baseURL) =>
+    createOpenAI({
+      apiKey,
+      baseURL: baseURL ?? 'https://opencode.ai/zen/go/v1',
+    }).chat('mimo-v2.5'),
 };
 
 async function validateModel(model: ValidationModel): Promise<void> {
@@ -238,6 +244,7 @@ export async function validateApiKeys(
     'xiaomi-mimo': null,
     mistral: null,
     'x-ai': null,
+    opencode: null,
   };
 
   const promises: Promise<void>[] = [];

--- a/apps/browser/src/shared/coding-plan-ids.ts
+++ b/apps/browser/src/shared/coding-plan-ids.ts
@@ -5,6 +5,7 @@ export const codingPlanIds = [
   'qwen-token-plan',
   'minimax-plan',
   'mimo-plan',
+  'opencode-go',
 ] as const;
 
 export type CodingPlanId = (typeof codingPlanIds)[number];

--- a/apps/browser/src/shared/coding-plans.test.ts
+++ b/apps/browser/src/shared/coding-plans.test.ts
@@ -43,9 +43,9 @@ describe('coding plan endpoint helpers', () => {
 describe('opencode-go plan', () => {
   const plan = CODING_PLANS['opencode-go'];
 
-  it('is registered', () => {
+  it('is registered and wired for local import', () => {
     expect(plan.id).toBe('opencode-go');
-    expect(plan.provider).toBe('opencode');
+    expect(plan.localImport?.opencodeProviderId).toBe('opencode-go');
   });
 
   it('routes through the Go subscription endpoint with a validation model', () => {

--- a/apps/browser/src/shared/coding-plans.test.ts
+++ b/apps/browser/src/shared/coding-plans.test.ts
@@ -39,3 +39,28 @@ describe('coding plan endpoint helpers', () => {
     });
   });
 });
+
+describe('opencode-go plan', () => {
+  const plan = CODING_PLANS['opencode-go'];
+
+  it('is registered', () => {
+    expect(plan.id).toBe('opencode-go');
+    expect(plan.provider).toBe('opencode');
+  });
+
+  it('routes through the Go subscription endpoint with a validation model', () => {
+    expect(resolveCodingPlanBaseUrl(plan)).toBe(
+      'https://opencode.ai/zen/go/v1',
+    );
+    expect(resolveCodingPlanValidationBaseUrl(plan)).toBe(
+      'https://opencode.ai/zen/go/v1',
+    );
+    expect(plan.validationModelId).toBe('mimo-v2.5');
+  });
+
+  it('curates featured models and relies on live model discovery', () => {
+    expect(plan.featuredModelIds).toContain('glm-5.2');
+    // The Go endpoint serves /models, so no documented fallback is needed.
+    expect(plan.fallbackModelIds).toBeUndefined();
+  });
+});

--- a/apps/browser/src/shared/coding-plans.ts
+++ b/apps/browser/src/shared/coding-plans.ts
@@ -179,6 +179,29 @@ export const CODING_PLANS: Record<CodingPlanId, CodingPlan> = {
       'MiMo Token Plan keys (tp-xxxxx) are routed through https://token-plan-cn.xiaomimimo.com/v1. Singapore and Europe clusters are also available (token-plan-sgp / token-plan-ams).',
     featuredModelIds: ['mimo-v2.5-pro', 'mimo-v2.5'],
   },
+  'opencode-go': {
+    id: 'opencode-go',
+    provider: 'opencode',
+    displayName: 'OpenCode Go',
+    tagline:
+      'GLM, Kimi K3, DeepSeek V4 and more via the OpenCode Go subscription',
+    subscribeUrl: 'https://opencode.ai/go',
+    apiKeyUrl: 'https://opencode.ai/auth',
+    helpText:
+      'Subscribe to OpenCode Go and copy your key at opencode.ai → Auth',
+    baseUrl: 'https://opencode.ai/zen/go/v1',
+    validationBaseUrl: 'https://opencode.ai/zen/go/v1',
+    validationModelId: 'mimo-v2.5',
+    endpointHelpText:
+      'Routed through the Go subscription endpoint at opencode.ai/zen/go/v1.',
+    featuredModelIds: [
+      'glm-5.2',
+      'kimi-k3',
+      'deepseek-v4-pro',
+      'qwen3.7-plus',
+      'minimax-m3',
+    ],
+  },
 };
 
 export type CodingPlanEndpointValidationResult =

--- a/apps/browser/src/shared/coding-plans.ts
+++ b/apps/browser/src/shared/coding-plans.ts
@@ -48,6 +48,13 @@ export type CodingPlan = {
   fallbackModelIds?: string[];
   /** Featured provider-native model IDs for card copy. */
   featuredModelIds: string[];
+  /**
+   * Credential importable from the OpenCode CLI's local `auth.json`, keyed
+   * by the provider ID that file stores it under.
+   */
+  localImport?: {
+    opencodeProviderId: string;
+  };
 };
 
 export const CODING_PLANS: Record<CodingPlanId, CodingPlan> = {
@@ -194,6 +201,7 @@ export const CODING_PLANS: Record<CodingPlanId, CodingPlan> = {
     validationModelId: 'mimo-v2.5',
     endpointHelpText:
       'Routed through the Go subscription endpoint at opencode.ai/zen/go/v1.',
+    localImport: { opencodeProviderId: 'opencode-go' },
     featuredModelIds: [
       'glm-5.2',
       'kimi-k3',

--- a/apps/browser/src/shared/karton-contracts/ui/index.ts
+++ b/apps/browser/src/shared/karton-contracts/ui/index.ts
@@ -2200,6 +2200,25 @@ export type KartonContract = {
       getLocalAgentAvailability: (
         typeId: ProviderInstanceTypeId,
       ) => Promise<{ installed: boolean; error?: string }>;
+      /**
+       * Report whether a coding plan's credential can be imported from a
+       * local CLI auth file on this machine.
+       */
+      detectLocalSubscriptionImport: (
+        planId: CodingPlanId,
+      ) => Promise<{ available: boolean }>;
+      /**
+       * Import a locally detected subscription as a coding-plan instance.
+       * The credential is resolved server-side and never sent to the UI.
+       */
+      importDetectedCodingPlan: (planId: CodingPlanId) => Promise<
+        | {
+            success: true;
+            instanceId: string;
+            discoveredModels: DiscoveredModel[];
+          }
+        | { success: false; error: string }
+      >;
       getProviderUsageLimits: (
         instanceId: string,
       ) => Promise<ProviderUsageLimits>;

--- a/apps/browser/src/shared/karton-contracts/ui/index.ts
+++ b/apps/browser/src/shared/karton-contracts/ui/index.ts
@@ -1646,13 +1646,7 @@ export type KartonContract = {
                   | 'coding-plan'
                   | 'unknown';
                 provider?: ModelProvider;
-                plan_id?:
-                  | 'glm-coding-plan'
-                  | 'kimi-plan'
-                  | 'qwen-plan'
-                  | 'qwen-token-plan'
-                  | 'minimax-plan'
-                  | 'mimo-plan';
+                plan_id?: CodingPlanId;
               };
               summary?: OnboardingCompletionSummary;
             },

--- a/apps/browser/src/shared/karton-contracts/ui/shared-types.ts
+++ b/apps/browser/src/shared/karton-contracts/ui/shared-types.ts
@@ -41,6 +41,7 @@ export const modelProviderSchema = z.enum([
   'xiaomi-mimo',
   'mistral',
   'x-ai',
+  'opencode',
 ]);
 export type ModelProvider = z.infer<typeof modelProviderSchema>;
 
@@ -89,6 +90,7 @@ export const providerConfigsSchema = z.object({
   'xiaomi-mimo': providerConfigSchema.default({ mode: 'stagewise' }),
   mistral: providerConfigSchema.default({ mode: 'stagewise' }),
   'x-ai': providerConfigSchema.default({ mode: 'stagewise' }),
+  opencode: providerConfigSchema.default({ mode: 'stagewise' }),
 });
 export type ProviderConfigs = z.infer<typeof providerConfigsSchema>;
 
@@ -240,6 +242,7 @@ export const providerInstanceTypeIds = [
   'xiaomi-mimo-api',
   'mistral-api',
   'x-ai-api',
+  'opencode-api',
   'coding-plan',
   'custom-anthropic',
   'custom-openai-chat',
@@ -405,6 +408,10 @@ export const providerInstanceSchema = z.discriminatedUnion('typeId', [
   }),
   providerInstanceBaseSchema.extend({
     typeId: z.literal('x-ai-api'),
+    config: officialApiConfigSchema,
+  }),
+  providerInstanceBaseSchema.extend({
+    typeId: z.literal('opencode-api'),
     config: officialApiConfigSchema,
   }),
   providerInstanceBaseSchema.extend({
@@ -643,6 +650,14 @@ export const PROVIDER_TYPE_DISPLAY_INFO: Record<
     helpText: 'Create one at console.mistral.ai → API Keys',
     getApiKeyUrl: 'https://console.mistral.ai/api-keys',
     defaultBaseUrl: 'https://api.mistral.ai/v1',
+    credentialType: 'api-key',
+  },
+  'opencode-api': {
+    displayName: 'OpenCode API',
+    description: 'Models served by the OpenCode Go subscription',
+    helpText: 'Get your key at opencode.ai → Auth',
+    getApiKeyUrl: 'https://opencode.ai/auth',
+    defaultBaseUrl: 'https://opencode.ai/zen/go/v1',
     credentialType: 'api-key',
   },
   'coding-plan': {
@@ -1290,6 +1305,7 @@ export const userPreferencesSchema = z.object({
     'xiaomi-mimo': { mode: 'stagewise' },
     mistral: { mode: 'stagewise' },
     'x-ai': { mode: 'stagewise' },
+    opencode: { mode: 'stagewise' },
   }),
   /** User-defined API endpoints */
   customEndpoints: z.array(customEndpointSchema).default([]),
@@ -1409,6 +1425,7 @@ export const defaultUserPreferences: UserPreferences = {
     'xiaomi-mimo': { mode: 'stagewise' },
     mistral: { mode: 'stagewise' },
     'x-ai': { mode: 'stagewise' },
+    opencode: { mode: 'stagewise' },
   },
   customEndpoints: [],
   customModels: [],

--- a/apps/browser/src/shared/model-thinking-capabilities.ts
+++ b/apps/browser/src/shared/model-thinking-capabilities.ts
@@ -182,6 +182,7 @@ export function getThinkingProviderForRoute({
     case 'xiaomi-mimo':
     case 'mistral':
     case 'x-ai':
+    case 'opencode':
       return 'openai-compatible';
     default:
       // Unknown routes have no proven provider-native reasoning contract.

--- a/apps/browser/src/ui/components/provider-logos/index.tsx
+++ b/apps/browser/src/ui/components/provider-logos/index.tsx
@@ -7,6 +7,7 @@ import { GoogleLogo } from './google';
 import { MinimaxLogo } from './minimax';
 import { MoonshotAiLogo } from './moonshotai';
 import { OpenAiLogo } from './openai';
+import { OpenCodeLogo } from './opencode';
 import { XiaomiMiMoLogo } from './xiaomi-mimo';
 import { ZAiLogo } from './z-ai';
 import { MistralLogo } from './mistral';
@@ -33,6 +34,7 @@ export const PROVIDER_LOGOS: Record<ModelProvider, ProviderLogoComponent> = {
   'xiaomi-mimo': XiaomiMiMoLogo,
   mistral: MistralLogo,
   'x-ai': XaiLogo,
+  opencode: OpenCodeLogo,
 };
 
 /**
@@ -55,6 +57,7 @@ export {
   MinimaxLogo,
   MoonshotAiLogo,
   OpenAiLogo,
+  OpenCodeLogo,
   XiaomiMiMoLogo,
   ZAiLogo,
   MistralLogo,

--- a/apps/browser/src/ui/components/provider-logos/opencode.tsx
+++ b/apps/browser/src/ui/components/provider-logos/opencode.tsx
@@ -1,0 +1,23 @@
+import type { SVGProps } from 'react';
+
+/**
+ * OpenCode brand mark.
+ *
+ * Sourced from @lobehub/icons-static-svg (MIT). Uses `currentColor` so it
+ * inherits the nearest `color` / `text-*` class.
+ */
+export function OpenCodeLogo(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      fill="currentColor"
+      fillRule="evenodd"
+      viewBox="0 0 24 24"
+      xmlns="http://www.w3.org/2000/svg"
+      role="img"
+      aria-label="OpenCode"
+      {...props}
+    >
+      <path d="M16 6H8v12h8V6zm4 16H4V2h16v20z" />
+    </svg>
+  );
+}

--- a/apps/browser/src/ui/screens/onboarding/steps/06-configure-providers.tsx
+++ b/apps/browser/src/ui/screens/onboarding/steps/06-configure-providers.tsx
@@ -417,6 +417,97 @@ export function ConnectionDetailView({
   const [isConnecting, setIsConnecting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  const detectLocalSubscriptionImport = useKartonProcedure(
+    (p) => p.preferences.detectLocalSubscriptionImport,
+  );
+  const importDetectedCodingPlan = useKartonProcedure(
+    (p) => p.preferences.importDetectedCodingPlan,
+  );
+
+  const plan = entry.planId ? CODING_PLANS[entry.planId] : undefined;
+  const supportsLocalImport =
+    entry.kind === 'coding-plan' && !!plan?.localImport;
+  const [localImportAvailable, setLocalImportAvailable] = useState(false);
+
+  useEffect(() => {
+    if (!supportsLocalImport || !entry.planId) {
+      setLocalImportAvailable(false);
+      return;
+    }
+    let cancelled = false;
+    void detectLocalSubscriptionImport(entry.planId)
+      .then(({ available }) => {
+        if (!cancelled) setLocalImportAvailable(available);
+      })
+      .catch(() => {
+        if (!cancelled) setLocalImportAvailable(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [detectLocalSubscriptionImport, entry.planId, supportsLocalImport]);
+
+  const handleImport = useCallback(async () => {
+    if (!supportsLocalImport || !entry.planId) return;
+    setIsConnecting(true);
+    setError(null);
+    const attemptNumber = getNextAttemptNumber(entry);
+    const startedAt = performance.now();
+    const identity = getTelemetryIdentity(entry);
+    void track('onboarding-provider-connect-attempted', {
+      onboarding_run_id: onboardingRunId,
+      ...identity,
+      attempt_number: attemptNumber,
+    });
+    try {
+      const result = await importDetectedCodingPlan(entry.planId);
+      if (!result.success) {
+        setError(result.error);
+        void track('onboarding-provider-connect-failed', {
+          onboarding_run_id: onboardingRunId,
+          ...identity,
+          attempt_number: attemptNumber,
+          duration_ms: performance.now() - startedAt,
+          failure_stage: 'credential-validation',
+          error_kind: 'validation-error',
+        });
+        onConnectionResult({ entry, success: false });
+        return;
+      }
+      void track('onboarding-provider-connected', {
+        onboarding_run_id: onboardingRunId,
+        ...identity,
+        attempt_number: attemptNumber,
+        duration_ms: performance.now() - startedAt,
+        discovered_model_count: result.discoveredModels.length,
+      });
+      onConnectionResult({ entry, success: true });
+      onBack();
+    } catch {
+      setError('Import failed. Please try again.');
+      void track('onboarding-provider-connect-failed', {
+        onboarding_run_id: onboardingRunId,
+        ...identity,
+        attempt_number: attemptNumber,
+        duration_ms: performance.now() - startedAt,
+        failure_stage: 'rpc',
+        error_kind: 'unknown-error',
+      });
+      onConnectionResult({ entry, success: false });
+    } finally {
+      setIsConnecting(false);
+    }
+  }, [
+    entry,
+    supportsLocalImport,
+    importDetectedCodingPlan,
+    getNextAttemptNumber,
+    onBack,
+    onConnectionResult,
+    onboardingRunId,
+    track,
+  ]);
+
   const handleConnect = useCallback(async () => {
     if (!apiKey.trim()) return;
     const endpointResult = entry.configurableEndpoint
@@ -558,6 +649,26 @@ export function ConnectionDetailView({
             )}
           </div>
         </div>
+
+        {supportsLocalImport && localImportAvailable && (
+          <div className="rounded-md border border-derived bg-surface-1 p-2 text-xs">
+            <p className="text-foreground">
+              {plan?.displayName} subscription detected in your OpenCode CLI on
+              this machine.
+            </p>
+            <button
+              type="button"
+              disabled={isConnecting}
+              onClick={() => void handleImport()}
+              className={cn(
+                buttonVariants({ variant: 'link', size: 'xs' }),
+                'mt-0.5 -ml-1',
+              )}
+            >
+              Import subscription
+            </button>
+          </div>
+        )}
 
         {entry.configurableEndpoint && (
           <div className="space-y-1">

--- a/apps/browser/src/ui/screens/settings/sections/models-providers-section.tsx
+++ b/apps/browser/src/ui/screens/settings/sections/models-providers-section.tsx
@@ -593,6 +593,12 @@ function AddProviderGrid({
   const setProviderInstanceGoogleCredentials = useKartonProcedure(
     (p) => p.preferences.setProviderInstanceGoogleCredentials,
   );
+  const detectLocalSubscriptionImport = useKartonProcedure(
+    (p) => p.preferences.detectLocalSubscriptionImport,
+  );
+  const importDetectedCodingPlan = useKartonProcedure(
+    (p) => p.preferences.importDetectedCodingPlan,
+  );
   const preferences = useKartonState((s) => s.preferences);
   const openExternalUrl = useKartonProcedure((p) => p.openExternalUrl);
   const [selected, setSelected] = useState<SelectionKey | null>(null);
@@ -605,6 +611,7 @@ function AddProviderGrid({
     useState<LocalAgentStatus | null>(null);
   const [localAgentError, setLocalAgentError] = useState<string | null>(null);
   const [availabilityCheck, setAvailabilityCheck] = useState(0);
+  const [localImportAvailable, setLocalImportAvailable] = useState(false);
   const searchInputRef = useRef<HTMLInputElement>(null);
 
   // Auto-focus the search input when the dialog opens.
@@ -754,6 +761,49 @@ function AddProviderGrid({
     getLocalAgentAvailability,
     localAgent,
     selectedVendorType,
+  ]);
+
+  const supportsLocalImport = !!selectedPlan?.localImport;
+
+  useEffect(() => {
+    if (!selectedPlanId || !supportsLocalImport) {
+      setLocalImportAvailable(false);
+      return;
+    }
+    let cancelled = false;
+    void detectLocalSubscriptionImport(selectedPlanId)
+      .then(({ available }) => {
+        if (!cancelled) setLocalImportAvailable(available);
+      })
+      .catch(() => {
+        if (!cancelled) setLocalImportAvailable(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [detectLocalSubscriptionImport, selectedPlanId, supportsLocalImport]);
+
+  const handleImportDetectedPlan = useCallback(async () => {
+    if (!selectedPlanId || !supportsLocalImport) return;
+    setIsConnecting(true);
+    setError(null);
+    try {
+      const result = await importDetectedCodingPlan(selectedPlanId);
+      if (!result.success) {
+        setError(result.error);
+        return;
+      }
+      onConnected(result.instanceId);
+    } catch {
+      setError('Import failed. Please try again.');
+    } finally {
+      setIsConnecting(false);
+    }
+  }, [
+    importDetectedCodingPlan,
+    onConnected,
+    selectedPlanId,
+    supportsLocalImport,
   ]);
 
   const handleBack = useCallback(() => {
@@ -961,6 +1011,26 @@ function AddProviderGrid({
               )}
 
               {error && <TruncatedErrorText text={error} />}
+
+              {supportsLocalImport && localImportAvailable && (
+                <div className="rounded-md border border-derived bg-surface-1 p-2 text-xs">
+                  <p className="text-foreground">
+                    {selectedPlan?.displayName} subscription detected in your
+                    OpenCode CLI on this machine.
+                  </p>
+                  <button
+                    type="button"
+                    disabled={isConnecting}
+                    onClick={() => void handleImportDetectedPlan()}
+                    className={cn(
+                      buttonVariants({ variant: 'link', size: 'xs' }),
+                      'mt-0.5 -ml-1',
+                    )}
+                  >
+                    Import subscription
+                  </button>
+                </div>
+              )}
 
               {localAgent && localAgentStatus === 'missing' && (
                 <div


### PR DESCRIPTION
Closes #1127.

Adds OpenCode Go as a coding plan, connectable during onboarding and from settings. When the OpenCode CLI on the machine is already signed in to Go, the key is read from its `auth.json` in the backend and passed straight to `addProviderInstance` — it never crosses the IPC boundary, and detection returns only a boolean.

@glenntws the issue is assigned to @jakobFNF, so I checked before starting: no branch, no PR, and no comments since it was opened in May. Happy to close if there is work in flight I can't see.

Commits are ordered so each one builds and tests green on its own. 


## Screenshots

<img width="1448" height="1086" alt="go" src="https://github.com/user-attachments/assets/c5afc69c-46ba-47b8-b0af-5f021967d83f" />


## Design notes

**Chat Completions is correct for every model.** Automated review flagged a P1 — that OpenCode Go routes models to Anthropic Messages or Responses, so validation would pass and inference would fail. All three routes exist on `/zen/go/v1`, and the format gate runs before the auth check, so an unauthenticated POST distinguishes "model invalid for this format" from "valid, bad key":

| model | `/messages` | `/responses` | `/chat/completions` |
|---|---|---|---|
| `qwen3.7-plus` | ok | rejected | **ok** |
| `minimax-m3` | ok | rejected | **ok** |
| `kimi-k3` | ok | rejected | **ok** |
| `gpt-5.6-luna` | ok | ok | **ok** |
| `grok-4.5` | rejected | ok | **ok** |

`rejected` is `{"error":{"message":"Model <id> is not supported for format <fmt>"}}`; `ok` is reaching `AuthError`. Chat Completions accepts all of them. The flagged claims invert the real behaviour: `grok-4.5` was said to require Responses, and it is the one model the Anthropic route rejects.

**The migration fix is load-bearing.** The legacy `providerInstances` migration walked a hardcoded vendor list, so a vendor added to the schema later was skipped and `migrateLegacyCodingPlansToProviderInstances` repaired it with a second write on first launch. `preferences.test.ts` fails its idempotency assertion without it, which is why it lands before the plan commit. It also picks up `x-ai`, already missing from that list.

**`opencode-api` is deliberately not in `ADDABLE_VENDOR_TYPES`.** It exists so the coding plan can resolve an API spec and display info — `OFFICIAL_API_TYPES` is `Record<ModelProvider, …>` and `vendorMeta()` reads `PROVIDER_TYPE_DISPLAY_INFO['opencode-api']`. It adds no card to the provider grid.

**No `fallbackModelIds`** — `GET /zen/go/v1/models` serves the catalog. The documented fallback exists for plans whose upstream restricts that route.

**Reasoning support** lists only model IDs this repo already declares as reasoning models, in a vendor set or in `available-models.ts`. `glm-5.3` and the `qwen3.x` line are declared nowhere here (`z-ai`'s own set stops at `glm-5.2`), so they are not asserted for OpenCode alone — worth a separate fix at the `z-ai` source.

## Review findings

Fixed: non-string keys in `auth.json` are rejected before reaching validation or encryption; both Karton handlers are removed in `onTeardown()`; an already-connected plan is neither offered nor importable, and concurrent imports of one plan share a single run (covered by a test that fails without it); the shared `findCodingPlanInstance` helper is reused rather than duplicated; reasoning-set comment and README display name corrected.

Not changed: renaming `VENDORS` (pre-existing name, `BUILT_IN_VENDOR_NAMES` sits beside it in the same style); the `onBack()` race during import (`handleConnect` does the same five lines up, so a guard belongs on both paths); extracting a shared import hook (`handleConnect` is already inlined three times in that file). Happy to take any of these.

General coding-plan de-duplication is pre-existing — `addProviderInstanceRecord` only de-dups singleton local-agent types, so pasting a key twice does the same on `main`. Left as a separate change across all six plans.

## Verification

`pnpm check` clean; typecheck 4/4 at every commit; 1106 tests pass. `release-notes.test.tsx` fails identically on `main` with none of this branch applied (`environmentMatchGlobs` deprecated in vitest 3.2.4).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OpenCode and OpenCode Go support, including API-key configuration and model listings.
  * Added automatic detection and import of locally available OpenCode Go subscriptions during onboarding and provider setup.
  * Added OpenCode branding throughout provider selection and settings.
* **Bug Fixes**
  * Corrected the featured model name to “Qwen 3.7 Plus.”
  * Improved handling of invalid or unsupported local authentication credentials.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->